### PR TITLE
Primer parte del editor de problem statements

### DIFF
--- a/frontend/templates/problem.edit.form.tpl
+++ b/frontend/templates/problem.edit.form.tpl
@@ -89,6 +89,24 @@
 		{/if}
 		</div>
 	</div>
+
+	<div class="row">
+		<ul class="nav nav-tabs">
+			<li class="active"><a href="#statement-source" data-toggle="tab">Source</a></li>
+			<li><a href="#statement-preview" data-toggle="tab">Preview</a></li>
+		</ul>
+		
+		<div class="tab-content">
+			<div class="tab-pane active" id="statement-source">
+				<div id="wmd-button-bar-statement"></div>
+				<textarea class="wmd-input" id="wmd-input-statement"></textarea>
+			</div>
+
+			<div class="tab-pane" id="statement-preview">
+				<div class="no-bottom-margin" id="wmd-preview-statement"></div>
+			</div>
+		</div>
+	</div>
 </form>
 	<p>
 		<a href="https://github.com/omegaup/omegaup/wiki/C%C3%B3mo-escribir-problemas-para-Omegaup">{#navHelp#}</a>

--- a/frontend/templates/problem.edit.tpl
+++ b/frontend/templates/problem.edit.tpl
@@ -45,6 +45,13 @@
 				});
 			{/IF}
 		});
+		
+		var md_converter = Markdown.getSanitizingConverter();
+		md_editor = new Markdown.Editor(md_converter, '-statement');		// Global.
+		md_editor.hooks.chain("onPreviewRefresh", function() {ldelim}
+			MathJax.Hub.Queue(["Typeset", MathJax.Hub, $('#wmd-preview').get(0)]);
+		{rdelim});
+		md_editor.run();
 	})();
 	
 	function refreshEditForm(problemAlias) {
@@ -66,7 +73,9 @@
 			$('select[name=validator]').val(problem.validator);
 			$('select[name=public]').val(problem.public);
 			$('input[name=alias]').val(problemAlias);
-		});
+			$('#wmd-input-statement').val(problem.problem_statement);
+			md_editor.refreshPreview();
+		}, "markdown");
 	}
 </script>
 

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -72,6 +72,60 @@ class ProblemDetailsTest extends OmegaupTestCase {
 
 	}
 
+	/**
+	 * Common code for testing the statement's source.
+	 */
+	public function internalViewProblemStatement($type, $expected_text) {
+		
+		// Get a contest 
+		$contestData = ContestsFactory::createContest();
+		
+		// Get a problem
+		$problemData = ProblemsFactory::createProblem();
+		
+		// Add the problem to the contest
+		ContestsFactory::addProblemToContest($problemData, $contestData);
+		
+		// Get a user for our scenario
+		$contestant = UserFactory::createUser();
+		
+		// Prepare our request
+		$r = new Request();
+		$r["problem_alias"] = $problemData["request"]["alias"];
+
+		// Log in the user
+		$r["auth_token"] = $this->login($contestant);
+
+		
+		// Call api
+		$r["statement_type"] = $type;
+		$response = ProblemController::apiDetails($r);
+		
+				// Assert data
+				$this->assertContains($expected_text, $response["problem_statement"]);				
+	}
+
+	/**
+	 * Problem statmeent is returned in HTML.
+	 */
+	public function testViewProblemStatementHtml() {
+		$this->internalViewProblemStatement("html", "<h1>Entrada</h1>");
+	}
+
+	/**
+	 * Problem statmeent is returned in Markdown.
+	 */
+	public function testViewProblemStatementMarkdown() {
+		$this->internalViewProblemStatement("markdown", "# Entrada");
+	}
+
+	/**
+	 * @expectedException NotFoundException
+	 */
+	public function testViewProblemStatementInvalidType() {
+		$this->internalViewProblemStatement("not_html_or_markdown", "");
+	}
+
 	public function testProblemDetailsNotInContest() {
 		
 		// Get 1 problem public

--- a/frontend/www/js/omegaup.js
+++ b/frontend/www/js/omegaup.js
@@ -650,14 +650,16 @@ OmegaUp.prototype.getMyContests = function(callback) {
 	});
 };
 
-OmegaUp.prototype.getProblem = function(contestAlias, problemAlias, callback) {
+OmegaUp.prototype.getProblem = function(contestAlias, problemAlias, callback, statement_type) {
 	var self = this;
-
+	if (statement_type === undefined) {
+		statement_type = "html";
+	}
 	$.post(
 		contestAlias === null ? 
 			'/api/problem/details/problem_alias/' + encodeURIComponent(problemAlias) + '/' :
 			'/api/problem/details/contest_alias/' + encodeURIComponent(contestAlias) + '/problem_alias/' + encodeURIComponent(problemAlias) + '/',
-		{lang:"es"},
+		{lang:"es", statement_type:statement_type},
 		function (problem) {
 			if (problem.runs) {
 				for (var i = 0; i < problem.runs.length; i++) {

--- a/frontend/www/problemedit.php
+++ b/frontend/www/problemedit.php
@@ -35,4 +35,6 @@ if (isset($_POST["request"]) && ($_POST["request"] == "submit")) {
 }
 
 $smarty->assign('IS_UPDATE', 1);
+$smarty->assign('LOAD_MATHJAX', 1);
+$smarty->assign('LOAD_PAGEDOWN', 1);
 $smarty->display('../templates/problem.edit.tpl');


### PR DESCRIPTION
- Enseniarle a ProblemController a regresar Markdown o HTML, segun diga el request.
- Enseniarle a problemedit.php a
  - Pedir el enunciado del problema en Markdown
  - Usar Pagedown para editar el enunciado
  - Mostrar el preview del enunciado editado.

*\* Todavia no se manda la redaccion a la API para actualizar el enunciado. Solo se puede jugar con el editor en el Browser.
