### PR TITLE
Mejor manejo de la lista de concursantes

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -266,9 +266,10 @@ class ContestController extends Controller {
 		$cs = SessionController::apiCurrentSession();
 
 		// You already started the contest.
-		$contestOpened = null;
-		if (!is_null($contestOpened = ContestsUsersDAO::getByPK($cs["id"], $r["contest"]->getContestId()))
-				&& ($contestOpened->access_time != "0000-00-00 00:00:00")) {
+		$contestOpened = ContestsUsersDAO::getByPK($r['current_user_id'],
+			$r["contest"]->getContestId());
+		if (!is_null($contestOpened) &&
+			$contestOpened->access_time != "0000-00-00 00:00:00") {
 			self::$log->debug("Not intro because you already started the contest");
 			return !ContestController::SHOW_INTRO;
 		}
@@ -391,6 +392,7 @@ class ContestController extends Controller {
 		self::validateDetails($r);
 		ContestsUsersDAO::CheckAndSaveFirstTimeAccess(
 			$r["current_user_id"], $r["contest"]->contest_id, true);
+		self::$log->info("User '{$r['current_user']->username}' joined contest '{$r['contest']->alias}'");
 		return array("status" => "ok");
 	}
 

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -263,13 +263,6 @@ class ContestController extends Controller {
 			return ContestController::SHOW_INTRO;
 		}
 
-		// You are admin
-		if (!is_null($r['current_user_id']) &&
-			Authorization::IsContestAdmin($r["current_user_id"], $r["contest"])) {
-			self::$log->debug("Not intro because you are admin");
-			return !ContestController::SHOW_INTRO;
-		}
-
 		$cs = SessionController::apiCurrentSession();
 
 		// You already started the contest.
@@ -389,6 +382,17 @@ class ContestController extends Controller {
 		return array("status" => "ok");
 	}
 
+	/**
+	 * Joins a contest - explicitly adds a user to a contest.
+	 *
+	 * @param Request $r
+	 */
+	public static function apiOpen(Request $r) {
+		self::validateDetails($r);
+		ContestsUsersDAO::CheckAndSaveFirstTimeAccess(
+			$r["current_user_id"], $r["contest"]->contest_id, true);
+		return array("status" => "ok");
+	}
 
 	/**
 	 * Returns details of a Contest
@@ -398,7 +402,6 @@ class ContestController extends Controller {
 	 * @throws InvalidDatabaseOperationException
 	 */
 	public static function apiDetails(Request $r) {
-
 		self::validateDetails($r);
 
 		Cache::getFromCacheOrSet(Cache::CONTEST_INFO, $r["contest_alias"], $r, function(Request $r) {
@@ -498,7 +501,9 @@ class ContestController extends Controller {
 			// Save the time of the first access
 			try {
 				$contest_user = ContestsUsersDAO::CheckAndSaveFirstTimeAccess(
-								$r["current_user_id"], $r["contest"]->getContestId());
+					$r["current_user_id"], $r["contest"]->contest_id);
+			} catch (ApiException $e) {
+				throw $e;
 			} catch (Exception $e) {
 				// Operation failed in the data layer
 				throw new InvalidDatabaseOperationException($e);
@@ -509,7 +514,7 @@ class ContestController extends Controller {
 				$result['submission_deadline'] = strtotime($r["contest"]->getFinishTime());
 			} else {
 				$result['submission_deadline'] = min(
-						strtotime($r["contest"]->getFinishTime()), strtotime($contest_user->getAccessTime()) + $r["contest"]->getWindowLength() * 60);
+						strtotime($r["contest"]->getFinishTime()), strtotime($contest_user->access_time) + $r["contest"]->getWindowLength() * 60);
 			}
 			$result['admin'] = Authorization::IsContestAdmin($r["current_user_id"], $r["contest"]);
 		}

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1025,8 +1025,10 @@ class ProblemController extends Controller {
 		if (!is_null($r["contest"])) {
 			// At this point, contestant_user relationship should be established.
 			try {
-				$contest_user = ContestsUsersDAO::CheckAndSaveFirstTimeAccess(
-									$r["current_user_id"], $r["contest"]->contest_id);
+				ContestsUsersDAO::CheckAndSaveFirstTimeAccess(
+					$r["current_user_id"], $r["contest"]->contest_id);
+			} catch (ApiException $e) {
+				throw $e;
 			} catch (Exception $e) {
 				// Operation failed in the data layer
 				throw new InvalidDatabaseOperationException($e);

--- a/frontend/server/libs/dao/Contests_Users.dao.php
+++ b/frontend/server/libs/dao/Contests_Users.dao.php
@@ -3,46 +3,44 @@
 require_once("base/Contests_Users.dao.base.php");
 require_once("base/Contests_Users.vo.base.php");
 /** Page-level DocBlock .
-  * 
+  *
   * @author alanboy
   * @package docs
-  * 
+  *
   */
 /** ContestsUsers Data Access Object (DAO).
-  * 
-  * Esta clase contiene toda la manipulacion de bases de datos que se necesita para 
-  * almacenar de forma permanente y recuperar instancias de objetos {@link ContestsUsers }. 
+  *
+  * Esta clase contiene toda la manipulacion de bases de datos que se necesita para
+  * almacenar de forma permanente y recuperar instancias de objetos {@link ContestsUsers }.
   * @author alanboy
   * @access public
   * @package docs
-  * 
+  *
   */
-class ContestsUsersDAO extends ContestsUsersDAOBase
-{
-    public static function CheckAndSaveFirstTimeAccess($user_id, $contest_id)
-    {
-        $contest_user = self::getByPK($user_id, $contest_id);
-        
-        // If is null, add our contest_user relationship 
-        if(is_null($contest_user))
-        {
-            $contest_user = new ContestsUsers();
-            $contest_user->setUserId($user_id);
-            $contest_user->setContestId($contest_id);
-            $contest_user->setAccessTime(date("Y-m-d H:i:s"));
-            $contest_user->setScore(0);
-            $contest_user->setTime(0);
+class ContestsUsersDAO extends ContestsUsersDAOBase {
+    public static function CheckAndSaveFirstTimeAccess($user_id, $contest_id, $grant_access = false) {
+			$contest_user = self::getByPK($user_id, $contest_id);
 
-            ContestsUsersDAO::save($contest_user);                                         
-        }
-        else if($contest_user->getAccessTime() === "0000-00-00 00:00:00")
-        {
-            // If its set to default time, update it
-            $contest_user->setAccessTime(date("Y-m-d H:i:s"));
-            
-            ContestsUsersDAO::save($contest_user);            
-        }
-        
-        return $contest_user;
-    }    
+			if(is_null($contest_user)) {
+				if (!$grant_access) {
+					// User was not authorized to do this.
+					throw new ForbiddenAccessException();
+				}
+				$contest_user = new ContestsUsers();
+				$contest_user->setUserId($user_id);
+				$contest_user->setContestId($contest_id);
+				$contest_user->setAccessTime(date("Y-m-d H:i:s"));
+				$contest_user->setScore(0);
+				$contest_user->setTime(0);
+
+				ContestsUsersDAO::save($contest_user);
+			} else if($contest_user->getAccessTime() === "0000-00-00 00:00:00") {
+				// If its set to default time, update it
+				$contest_user->setAccessTime(date("Y-m-d H:i:s"));
+
+				ContestsUsersDAO::save($contest_user);
+			}
+
+			return $contest_user;
+		}
 }

--- a/frontend/templates/arena.contest.intro.tpl
+++ b/frontend/templates/arena.contest.intro.tpl
@@ -152,6 +152,6 @@
 		</div><!-- row -->
 	</div><!-- panel panel-default -->
 
-<script src="/js/contestintro.js?ver=038efa"></script>
+<script src="/js/contestintro.js?ver=6627a8"></script>
 {include file='footer.tpl'}
 

--- a/frontend/templates/arena.head.tpl
+++ b/frontend/templates/arena.head.tpl
@@ -10,7 +10,7 @@
 		<script type="text/javascript" src="/js/highstock.js?ver=6e7575"></script>
 		<script type="text/javascript" src="/js/sugar.js?ver=171bac"></script>
 
-		<script type="text/javascript" src="/js/omegaup.js?ver=70f478"></script>
+		<script type="text/javascript" src="/js/omegaup.js?ver=8d5147"></script>
 		<script type="text/javascript" src="/js/lang.{#locale#}.js?ver=373624,b2ffb0,8e3d50,6384ab"></script>
 		<script type="text/javascript" src="/ux/libarena.js?ver=b34d0a"></script>
 		{if isset($jsfile)}

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -9,7 +9,7 @@
 
 		<script type="text/javascript" src="/js/jquery.js?ver=198b3f"></script>
 
-		<script type="text/javascript" src="/js/omegaup.js?ver=70f478"></script>
+		<script type="text/javascript" src="/js/omegaup.js?ver=8d5147"></script>
 		<script type="text/javascript" src="/js/lang.{#locale#}.js?ver=373624,b2ffb0,8e3d50,6384ab"></script>
 
 		<script type="text/javascript" src="/js/sugar.js?ver=171bac"></script>

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -102,6 +102,9 @@ class ContestDetailsTest extends OmegaupTestCase {
 		// Log in the user
 		$r["auth_token"] = $this->login($contestant);
 
+		// Explicitly join contest
+		ContestController::apiOpen($r);
+
 		// Call api
 		$response = ContestController::apiDetails($r);
 
@@ -128,6 +131,9 @@ class ContestDetailsTest extends OmegaupTestCase {
 
 		// Log in the user
 		$r["auth_token"] = $this->login($contestant);
+
+		// Explicitly join contest
+		ContestController::apiOpen($r);
 
 		// Call api
 		$response = ContestController::apiDetails($r);
@@ -218,6 +224,9 @@ class ContestDetailsTest extends OmegaupTestCase {
 		// Log in the user
 		$r["auth_token"] = $this->login($contestant);
 
+		// Explicitly join contest
+		ContestController::apiOpen($r);
+
 		// Call api
 		$response = ContestController::apiDetails($r);
 
@@ -250,6 +259,9 @@ class ContestDetailsTest extends OmegaupTestCase {
 
 		// Log in the user
 		$r["auth_token"] = $this->login($contestant);
+
+		// Explicitly join contest
+		ContestController::apiOpen($r);
 
 		// Call api
 		$response = ContestController::apiDetails($r);

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -36,6 +36,9 @@ class ProblemDetailsTest extends OmegaupTestCase {
 		// Log in the user
 		$r["auth_token"] = $this->login($contestant);
 
+		// Explicitly join contest
+		ContestController::apiOpen($r);
+
 		// Call api
 		$response = ProblemController::apiDetails($r);
 

--- a/frontend/tests/controllers/RegisterToContestTest.php
+++ b/frontend/tests/controllers/RegisterToContestTest.php
@@ -73,8 +73,10 @@ class RegisterToContestTest extends OmegaupTestCase {
 		$r2 = new Request();
 		$r2["contest_alias"] = $contestData["request"]["alias"];
 		$r2["auth_token"] = $this->login($contestant);
-		$response = ContestController::apiDetails($r2);
+
+		// Explicitly join contest
+		ContestController::apiOpen($r2);
+
+		ContestController::apiDetails($r2);
 	}
-
 }
-

--- a/frontend/tests/factories/ContestsFactory.php
+++ b/frontend/tests/factories/ContestsFactory.php
@@ -10,7 +10,7 @@ class ContestsFactory {
 
 	/**
 	 * Returns a Request object with complete context to create a contest
-	 * 
+	 *
 	 * @param string $title
 	 * @param string $public
 	 * @param Users $contestDirector
@@ -44,7 +44,7 @@ class ContestsFactory {
 		$r["penalty_type"] = "contest_start";
 		$r["penalty_calc_policy"] = "sum";
 		$r['languages'] = $languages;
-		
+
 		return array(
 			"request" => $r,
 			"director" => $contestDirector);
@@ -67,9 +67,9 @@ class ContestsFactory {
 			self::forcePublic($contestData);
 			$r["public"] = 1;
 		}
-		
+
 		$contest = ContestsDAO::getByAlias($r["alias"]);
-		
+
 		return array(
 			"director" => $contestData["director"],
 			"request" => $r,
@@ -78,45 +78,44 @@ class ContestsFactory {
 	}
 
 	public static function addProblemToContest($problemData, $contestData) {
-		
+
 		// Create an empty request
 		$r = new Request();
-		
-		// Log in as contest director		
+
+		// Log in as contest director
 		$r["auth_token"] = OmegaupTestCase::login($contestData["director"]);
-		
+
 		// Build request
 		$r["contest_alias"] = $contestData["request"]["alias"];
 		$r["problem_alias"] = $problemData["request"]["alias"];
 		$r["points"] = 100;
-		$r["order_in_contest"] = 1;				
-		
+		$r["order_in_contest"] = 1;
+
 		// Call API
-		$response = ContestController::apiAddProblem($r);				
-		
+		$response = ContestController::apiAddProblem($r);
+
 		// Clean up
 		unset($_REQUEST);
 	}
-	
+
 	public static function openContest($contestData, $user) {
-		
 		// Create an empty request
 		$r = new Request();
-		
-		// Log in as contest director		
+
+		// Log in as contest director
 		$r["auth_token"] = OmegaupTestCase::login($user);
-		
+
 		// Prepare our request
 		$r["contest_alias"] = $contestData["request"]["alias"];
-		
+
 		// Call api
-		ContestController::apiDetails($r);
-		
+		ContestController::apiOpen($r);
+
 		unset($_REQUEST);
 	}
-	
+
 	public static function openProblemInContest($contestData, $problemData, $user) {
-		
+
 		// Prepare our request
 		$r = new Request();
 		$r["contest_alias"] = $contestData["request"]["alias"];
@@ -124,58 +123,58 @@ class ContestsFactory {
 
 		// Log in the user
 		$r["auth_token"] = OmegaupTestCase::login($user);
-		
+
 		// Call api
 		ProblemController::apiDetails($r);
-		
+
 		unset($_REQUEST);
 	}
-	
+
 	public static function addUser($contestData, $user) {
-		
+
 		// Prepare our request
 		$r = new Request();
 		$r["contest_alias"] = $contestData["request"]["alias"];
 		$r["usernameOrEmail"] = $user->getUsername();
-		
+
 		// Log in the contest director
 		$r["auth_token"] = OmegaupTestCase::login($contestData["director"]);
-		
+
 		// Call api
 		ContestController::apiAddUser($r);
-		
-		unset($_REQUEST);		
+
+		unset($_REQUEST);
 	}
-	
+
 	public static function addAdminUser($contestData, $user) {
-		
+
 		// Prepare our request
 		$r = new Request();
 		$r["contest_alias"] = $contestData["request"]["alias"];
 		$r["usernameOrEmail"] = $user->getUsername();
-		
+
 		// Log in the contest director
 		$r["auth_token"] = OmegaupTestCase::login($contestData["director"]);
-		
+
 		// Call api
 		ContestController::apiAddAdmin($r);
-		
-		unset($_REQUEST);		
+
+		unset($_REQUEST);
 	}
-	
+
 	public static function makeContestWindowLength($contestData, $windowLength = 20) {
-		
+
 		$contest = ContestsDAO::getByAlias($contestData["request"]["alias"]);
         $contest->setWindowLength($windowLength);
-        ContestsDAO::save($contest);		
+        ContestsDAO::save($contest);
 	}
-	
+
 	public static function forcePublic($contestData) {
 		$contest = ContestsDAO::getByAlias($contestData["request"]["alias"]);
         $contest->setPublic(1);
-        ContestsDAO::save($contest);		
+        ContestsDAO::save($contest);
 	}
-	
+
 	public static function setScoreboardPercentage($contestData, $percentage) {
 		$contest = ContestsDAO::getByAlias($contestData["request"]["alias"]);
 		$contest->setScoreboard($percentage);

--- a/frontend/www/js/contestintro.js
+++ b/frontend/www/js/contestintro.js
@@ -6,8 +6,8 @@ $(document).ready(function() {
 		$("#request-access-form").hide();
 		$('#start-contest-submit').prop('disabled', true);
 
-		// Getting contest details will mark the contest as opened
-		omegaup.getContest(
+		// Explicitly join the contest.
+		omegaup.openContest(
 			contestAlias,
 			function(result) {
 				if (result.status == "error") {

--- a/frontend/www/js/omegaup.js
+++ b/frontend/www/js/omegaup.js
@@ -428,6 +428,24 @@ OmegaUp.prototype.getContests = function(callback) {
 	});
 };
 
+OmegaUp.prototype.openContest = function(alias, callback) {
+	var self = this;
+
+	$.get(
+		'/api/contest/open/contest_alias/' + encodeURIComponent(alias) + '/',
+		function (contest) {
+			callback(contest);
+		},
+		'json'
+	).fail(function(j, status, errorThrown) {
+		try {
+			callback(JSON.parse(j.responseText));
+		} catch (err) {
+			callback({status:'error', 'error':undefined});
+		}
+	});
+};
+
 OmegaUp.prototype.getContest = function(alias, callback) {
 	var self = this;
 


### PR DESCRIPTION
Ahora ya no es posible implícitamente agregar un concursante a un
concurso mediante acciones como ver el concurso o abrir un problema.
Ahora es necesario que _todos_ los usuarios (incluso los admins) pasen
por el intro para poder explícitamente agregarse al concurso.