### PR TITLE
Eliminando padding de las pestañas

### DIFF
--- a/frontend/templates/problem.mine.tpl
+++ b/frontend/templates/problem.mine.tpl
@@ -26,7 +26,6 @@
 				<ul class="dropdown-menu" role="menu">
 				  <li><a id="bulk-make-public">{#makePublic#}</a></li>
 				  <li><a id="bulk-make-private">{#makePrivate#}</a></li>
-				  <li class="divider"></li>
 				</ul>
 			  </div>
 		</div>

--- a/frontend/www/css/common.css
+++ b/frontend/www/css/common.css
@@ -9,8 +9,13 @@
 #header .navbar-nav > li > a {
 	color: #fff;
 }
+
 #header .navbar-nav > li > a:hover,
-.nav .open>a, .nav .open>a:hover, .nav .open>a:focus {
+#header .nav > li > a:hover,
+#header .nav > li > a:focus,
+.nav .open>a,
+.nav .open>a:hover,
+.nav .open>a:focus {
 	background-color: #577DC7;
 }
 

--- a/frontend/www/css/style.css
+++ b/frontend/www/css/style.css
@@ -614,3 +614,13 @@ iframe.embedded-doc {
     transform:scale(0.90);
     transform-origin:0 0;
 }
+
+/* Hacks */
+/* Este estilo evita el desbordamiento de las pestañas toggle tabs (tabs.js)
+de bootstrap. Sólo afecta a los .nav-tabs, ya que el "padding" horizontal
+con un valor distinto de 0 en el ancho provoca un error de alineación,
+También es bueno aclarar que las listas tienen el texto alineado
+al centro por lo que el texto siempre se verá en orden. */
+.nav-tabs.nav-justified > li > a {
+	padding: 14px 0;
+}


### PR DESCRIPTION
Evitando el desborde de las pestañas
de toggle tabs (tabs.js) de bootstrap para
su correcta visualización en el idioma español
en: http://omegaup.com/problem/[problem]/edit/