### PR TITLE
Prendiendo event_scheduler en mysql

### DIFF
--- a/frontend/private/bd.sql
+++ b/frontend/private/bd.sql
@@ -9,6 +9,7 @@
 
 BEGIN;
 
+SET GLOBAL event_scheduler = ON;
 SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = '+00:00';
 


### PR DESCRIPTION
event_scheduler es necesario en mysql para que el evento que refresca el Rank corra automáticamente. 