### PR TITLE
Checando errores en file_put_contents

### DIFF
--- a/frontend/server/libs/FileHandler.php
+++ b/frontend/server/libs/FileHandler.php
@@ -164,6 +164,12 @@ class FileHandler {
         self::$log->info("Deleting $old _old dir");
         self::DeleteDirRecursive($old.'_old');
     }
+
+    public static function FilePutContents($filename, $contents) {
+        if (file_put_contents($filename, $contents) === false) {
+            throw new RuntimeException("Not able to create file. $filename");
+        }
+    }
 }
 
 FileHandler::$log = Logger::getLogger('FileHandler');

--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -807,10 +807,10 @@ class ProblemDeployer {
             $localDestination = IMAGES_PATH . $filename;
             $globalDestination = IMAGES_URL_PATH . $filename;
 
-            file_put_contents("$this->tmpDir/statements/$filename", $imagedata);
+            FileHandler::FilePutContents("$this->tmpDir/statements/$filename", $imagedata);
             $this->log->info("Deploying image: to $localDestination");
             if (!file_exists($localDestination)) {
-                file_put_contents($localDestination, $imagedata);
+                FileHandler::FilePutContents($localDestination, $imagedata);
             }
 
             $replacement = $globalDestination;


### PR DESCRIPTION
Después de la migración al nuevo omegaup.com, crear problemas con imágenes estaba fallando silenciosamente al copiar los contenidos de las imágenes en /img/ (permisos). Este cambio avienta una exception si file_put_contents falla. 