### PR TITLE
Arreglando un NPE en /api/profile/

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1075,7 +1075,12 @@ class UserController extends Controller {
         }
 
         try {
-            $response['userinfo']['email'] = EmailsDAO::getByPK($user->getMainEmailId())->getEmail();
+            $email = EmailsDAO::getByPK($user->getMainEmailId());
+            if (is_null($email)) {
+                $response['userinfo']['email'] = null;
+            } else {
+                $response['userinfo']['email'] = $email->email;
+            }
 
             $country = CountriesDAO::getByPK($user->getCountryId());
             $response['userinfo']['country'] = is_null($country) ? null : $country->getName();


### PR DESCRIPTION
Si un usuario no tiene un email (digamos, uno de los autogenerados), el
perfil arroja una excepción. Este cambio previene eso. Fixes #827.