### PR TITLE
Warning de go-to-practice se muestra antes de que el concurso termine por completo

### DIFF
--- a/frontend/templates/arena.head.tpl
+++ b/frontend/templates/arena.head.tpl
@@ -14,7 +14,7 @@
 
 		<script type="text/javascript" src="/js/omegaup.js?ver=0ff160"></script>
 		<script type="text/javascript" src="/js/lang.{#locale#}.js?ver=9f6f64,87ec3e,c924c0,4379f1"></script>
-		<script type="text/javascript" src="/ux/libarena.js?ver=b48fbf"></script>
+		<script type="text/javascript" src="/ux/libarena.js?ver=21857e"></script>
 
 		{if isset($jsfile)}
 		<script type="text/javascript" src="{$jsfile}"></script>

--- a/frontend/templates/arena.head.tpl
+++ b/frontend/templates/arena.head.tpl
@@ -14,7 +14,7 @@
 
 		<script type="text/javascript" src="/js/omegaup.js?ver=0ff160"></script>
 		<script type="text/javascript" src="/js/lang.{#locale#}.js?ver=9f6f64,87ec3e,c924c0,4379f1"></script>
-		<script type="text/javascript" src="/ux/libarena.js?ver=1e7344"></script>
+		<script type="text/javascript" src="/ux/libarena.js?ver=b48fbf"></script>
 
 		{if isset($jsfile)}
 		<script type="text/javascript" src="{$jsfile}"></script>

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -28,7 +28,7 @@
 <script type="text/javascript" src="/js/knockout-secure-binding.min.js?ver=81a2a3"></script>
 
 <script type="text/javascript" src="/ux/libadmin.js?ver=4ef011"></script>
-<script type="text/javascript" src="/ux/libarena.js?ver=b48fbf"></script>
+<script type="text/javascript" src="/ux/libarena.js?ver=21857e"></script>
 <script type="text/javascript" src="/ux/admin.js?ver=d65a4c"></script>
 
 <script type="text/javascript" src="/js/interviews.results.js?ver=b7b5b4"></script>

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -28,7 +28,7 @@
 <script type="text/javascript" src="/js/knockout-secure-binding.min.js?ver=81a2a3"></script>
 
 <script type="text/javascript" src="/ux/libadmin.js?ver=4ef011"></script>
-<script type="text/javascript" src="/ux/libarena.js?ver=1e7344"></script>
+<script type="text/javascript" src="/ux/libarena.js?ver=b48fbf"></script>
 <script type="text/javascript" src="/ux/admin.js?ver=d65a4c"></script>
 
 <script type="text/javascript" src="/js/interviews.results.js?ver=b7b5b4"></script>

--- a/frontend/www/ux/libarena.js
+++ b/frontend/www/ux/libarena.js
@@ -273,7 +273,7 @@ Arena.prototype.updateClock = function() {
 		this.clockInterval = null;
 
 		// Show go-to-practice-mode messages on contest end
-		if (date > this.finishTime) {
+		if (date > this.finishTime.getTime()) {
 			OmegaUp.ui.warning('<a href="/arena/' + this.contestAlias + '/practice/">' + OmegaUp.T.arenaContestEndedUsePractice + '</a>');
 			$('#new-run').hide();
 			$('#new-run-practice-msg').show();

--- a/frontend/www/ux/libarena.js
+++ b/frontend/www/ux/libarena.js
@@ -267,15 +267,18 @@ Arena.prototype.updateClock = function() {
 	if (date < this.startTime.getTime()) {
 		clock = "-" + Arena.formatDelta(this.startTime.getTime() - (date + omegaup.deltaTime));
 	} else if (date > countdownTime.getTime()) {
+		// Contest for this user is over
 		clock = "00:00:00";
 		clearInterval(this.clockInterval);
 		this.clockInterval = null;
 
-		// Handle practice mode warnings on contests end
-		OmegaUp.ui.warning('<a href="/arena/' + this.contestAlias + '/practice/">' + OmegaUp.T.arenaContestEndedUsePractice + '</a>');
-		$('#new-run').hide();
-		$('#new-run-practice-msg').show();
-		$('#new-run-practice-msg a').prop('href', '/arena/' + this.contestAlias + '/practice/');
+		// Show go-to-practice-mode messages on contest end
+		if (date > this.finishTime) {
+			OmegaUp.ui.warning('<a href="/arena/' + this.contestAlias + '/practice/">' + OmegaUp.T.arenaContestEndedUsePractice + '</a>');
+			$('#new-run').hide();
+			$('#new-run-practice-msg').show();
+			$('#new-run-practice-msg a').prop('href', '/arena/' + this.contestAlias + '/practice/');
+		}
 	} else {
 		clock = Arena.formatDelta(countdownTime.getTime() - (date + omegaup.deltaTime));
 	}


### PR DESCRIPTION
El nuevo warning de go-to-practice se está mostrando antes de que el concurso termine por completo - se muestra cuando el tiempo del concursante termina. Esto significa que para concursos con windowlength estamos sugiriendo ir a modo práctica cuando aún no está abierto. El fix checa que el concurso haya terminado por completo.