### PR TITLE
Agregando un timeout global al cache de APC

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -103,6 +103,7 @@ try_define('OMEGAUP_EMAIL_SENDY_LIST', 'xxx');
 # CACHE CONFIG
 # #########################
 try_define('APC_USER_CACHE_ENABLED', true);
+try_define('APC_USER_CACHE_TIMEOUT', 7 * 24 * 3600); // in seconds
 try_define('APC_USER_CACHE_CONTEST_INFO_TIMEOUT', 10);
 try_define('APC_USER_CACHE_PROBLEM_STATEMENT_TIMEOUT', 60); // in seconds
 try_define('APC_USER_CACHE_PROBLEM_STATS_TIMEOUT', 0); // in seconds

--- a/frontend/server/libs/Cache.php
+++ b/frontend/server/libs/Cache.php
@@ -54,7 +54,7 @@ class Cache {
      * @param int $timeout
      * @return boolean
      */
-    public function set($value, $timeout = 0) {
+    public function set($value, $timeout = APC_USER_CACHE_TIMEOUT) {
         if ($this->enabled === true) {
             if (apc_store($this->key, $value, $timeout) === true) {
                 $this->log->debug('apc_stored successful for key: ' . $this->key);


### PR DESCRIPTION
Resulta que PHP/HHVM no tiene un mecanismo para obligar la expiración
automática de las cosas que tengan ttl = 0, así que es mejor dejar un
timeout global pero que pueda ser cambiado explícitamente a cero si se
necesita. Este cambio hace que las cosas expiren una semana después de
haber sido agregadas al cache.