### PR TITLE
Separando admin de concurso y problema

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -531,7 +531,9 @@ class RunController extends Controller {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
-        $response = array();
+        $response = array(
+            'problem' => $r['problem']->alias,
+        );
 
         // Get the error
         $grade_dir = RunController::getGradePath($r['run']);
@@ -547,8 +549,9 @@ class RunController extends Controller {
 
         // Get the source
         $response['source'] = file_get_contents(RunController::getSubmissionPath($r['run']));
+        $response['admin'] = Authorization::IsProblemAdmin($r['current_user_id'], $r['problem']);
 
-        if (Authorization::IsProblemAdmin($r['current_user_id'], $r['problem'])) {
+        if ($response['admin']) {
             if (file_exists("$grade_dir/details.json")) {
                 $response['groups'] = json_decode(file_get_contents("$grade_dir/details.json"), true);
             }

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -531,9 +531,7 @@ class RunController extends Controller {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
-        $response = array(
-            'problem' => $r['problem']->alias,
-        );
+        $response = array();
 
         // Get the error
         $grade_dir = RunController::getGradePath($r['run']);

--- a/frontend/templates/arena.adminpractice.tpl
+++ b/frontend/templates/arena.adminpractice.tpl
@@ -1,5 +1,5 @@
 {include file='arena.head.tpl' jsfile='/ux/admin.js?ver=d65a4c'}
-			<script type="text/javascript" src="/ux/libadmin.js?ver=4ef011"></script>
+			<script type="text/javascript" src="/ux/libadmin.js?ver=cbed96"></script>
 			<div id="title">
 				<h1 class="contest-title">Envíos globales</h1>
 			</div>

--- a/frontend/templates/arena.contest.tpl
+++ b/frontend/templates/arena.contest.tpl
@@ -1,7 +1,7 @@
 {include file='arena.head.tpl' jsfile=$jsfile inContest=!$practice}
 
 {if $admin}
-			<script type="text/javascript" src="/ux/libadmin.js?ver=4ef011"></script>
+			<script type="text/javascript" src="/ux/libadmin.js?ver=cbed96"></script>
 			<audio id="notification_audio">
 				<source src="/media/notification.mp3" type="audio/mpeg" />
 			</audio>

--- a/frontend/templates/arena.head.tpl
+++ b/frontend/templates/arena.head.tpl
@@ -14,7 +14,7 @@
 
 		<script type="text/javascript" src="/js/omegaup.js?ver=0ff160"></script>
 		<script type="text/javascript" src="/js/lang.{#locale#}.js?ver=9f6f64,87ec3e,c924c0,4379f1"></script>
-		<script type="text/javascript" src="/ux/libarena.js?ver=6857e4"></script>
+		<script type="text/javascript" src="/ux/libarena.js?ver=9263da"></script>
 
 		{if isset($jsfile)}
 		<script type="text/javascript" src="{$jsfile}"></script>

--- a/frontend/templates/arena.problem.tpl
+++ b/frontend/templates/arena.problem.tpl
@@ -1,6 +1,6 @@
 {include file='arena.head.tpl' jsfile='/ux/contest.js?ver=14637d' bodyid='only-problem'}
 			{if $problem_admin}
-			<script type="text/javascript" src="/ux/libadmin.js?ver=4ef011"></script>
+			<script type="text/javascript" src="/ux/libadmin.js?ver=cbed96"></script>
 			<ul class="tabs">
 				<li><a href="#problems" class="active">{#wordsProblem#}</a></li>
 				<li><a href="#runs">{#wordsRuns#}</a></li>

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -27,8 +27,8 @@
 <script type="text/javascript" src="/js/knockout-4.3.0.js?ver=059d58"></script>
 <script type="text/javascript" src="/js/knockout-secure-binding.min.js?ver=81a2a3"></script>
 
-<script type="text/javascript" src="/ux/libadmin.js?ver=4ef011"></script>
-<script type="text/javascript" src="/ux/libarena.js?ver=6857e4"></script>
+<script type="text/javascript" src="/ux/libadmin.js?ver=cbed96"></script>
+<script type="text/javascript" src="/ux/libarena.js?ver=9263da"></script>
 <script type="text/javascript" src="/ux/admin.js?ver=d65a4c"></script>
 
 <script type="text/javascript" src="/js/interviews.results.js?ver=b7b5b4"></script>

--- a/frontend/www/ux/libadmin.js
+++ b/frontend/www/ux/libadmin.js
@@ -1,6 +1,6 @@
 function ArenaAdmin(arena, onlyProblemAlias) {
 	this.arena = arena;
-	this.arena.admin = true;
+	this.arena.contestAdmin = true;
 	this.onlyProblemAlias = onlyProblemAlias;
 
 	this.setUpPagers();

--- a/frontend/www/ux/libarena.js
+++ b/frontend/www/ux/libarena.js
@@ -73,7 +73,7 @@ function Arena() {
 	this.enableSockets = window.location.search.indexOf('ws=off') === -1;
 
 	// If we have admin powers in this contest.
-	this.admin = false;
+	this.contestAdmin = false;
 	this.answeredClarifications = 0;
 	this.clarificationsOffset = 0;
 	this.clarificationsRowcount = 20;
@@ -239,7 +239,7 @@ Arena.prototype.initClock = function(start, finish, deadline) {
 Arena.prototype.initProblems = function(contest) {
 	var self = this;
 	self.currentContest = contest;
-	self.admin = contest.admin;
+	self.contestAdmin = contest.admin;
 	var problems = contest.problems;
 	for (var i = 0; i < problems.length; i++) {
 		var problem = problems[i];
@@ -659,7 +659,7 @@ Arena.prototype.updateClarification = function(clarification) {
 			.removeClass('template')
 			.addClass('inserted');
 
-		if (self.admin) {
+		if (self.contestAdmin) {
 			(function(id, answerNode) {
 				var responseFormNode = $('#create-response-form', answerNode).removeClass('template');
 				if (clarification.public == 1) {
@@ -683,7 +683,7 @@ Arena.prototype.updateClarification = function(clarification) {
 
 	$('.contest', r).html(clarification.contest_alias);
 	$('.problem', r).html(clarification.problem_alias);
-	if (self.admin) $('.author', r).html(clarification.author);
+	if (self.contestAdmin) $('.author', r).html(clarification.author);
 	$('.time', r).html(Highcharts.dateFormat('%Y-%m-%d %H:%M:%S', clarification.time.getTime()));
 	$('.message', r).html(omegaup.escape(clarification.message));
 	$('.answer pre', r).html(omegaup.escape(clarification.answer));
@@ -691,7 +691,7 @@ Arena.prototype.updateClarification = function(clarification) {
 		self.answeredClarifications++;
 	}
 
-	if (self.admin != !!clarification.answer) {
+	if (self.contestAdmin != !!clarification.answer) {
 		self.notify(
 			(clarification.author ? clarification.author + " - " : '') + clarification.problem_alias,
 			omegaup.escape(clarification.message) +
@@ -906,6 +906,7 @@ Arena.prototype.hideOverlay = function() {
 
 Arena.prototype.displayRunDetails = function(guid, data) {
 	var self = this;
+	var problemAdmin = data.admin;
 
 	if (data.status == 'error') {
 		self.hideOverlay();
@@ -947,7 +948,7 @@ Arena.prototype.displayRunDetails = function(guid, data) {
 
 	$('#run-details .cases div').remove();
 	$('#run-details .cases table').remove();
-	if (self.admin) {
+	if (problemAdmin) {
 		$('#run-details .download a').attr('href', '/api/run/download/run_alias/' + data.guid + '/');
 		$('#run-details .download a.details').attr('href', '/api/run/download/run_alias/' + data.guid + '/complete/true/');
 		$('#run-details .download').show();
@@ -1044,7 +1045,7 @@ Arena.prototype.displayRunDetails = function(guid, data) {
 					.append('<td class="center" width="10">' + (c.max_score !== undefined ? '/' : '') + '</td>')
 					.append('<td>' + (c.max_score !== undefined ? c.max_score : '') + '</td>')
 				cases.append(caseRow);
-				if (self.admin && c.meta) {
+				if (problemAdmin && c.meta) {
 					var metaRow = $('<tr class="meta"></tr>')
 						.append('<td colspan="6"><pre>' + JSON.stringify(c.meta, null, 2) + '</pre></td>')
 						.hide();


### PR DESCRIPTION
Antes existía un único concepto de admin en concursos: administrador.
Ahora puedes ser administrador de concurso o de problema. Este cambio
propaga la información de administrador en /api/run/details/ para poder
saber si es necesario mostrar los links de descarga y la tabla de
detalles. Fixed #865.