### PR TITLE
Agregando una manera de obtener code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,6 @@ frontend/log/omegaup.log
 frontend/server/api/tests/problems/
 frontend/server/api/tests/submissions/
 frontend/tests/controllers/img/
-frontend/www/img/
-frontend/www/templates/
 omegaup_test.log
 
 # Ignore runtime and test stuff
@@ -70,6 +68,9 @@ frontend/.DS_Store
 
 # Ignore stuff in www
 frontend/www/apc.php
-frontend/www/preguntas/
+frontend/www/coverage/
+frontend/www/img/
 frontend/www/js/google-analytics.js
 frontend/www/pmamini.php
+frontend/www/preguntas/
+frontend/www/templates/

--- a/frontend/tests/phpunit-coverage.xml
+++ b/frontend/tests/phpunit-coverage.xml
@@ -1,0 +1,32 @@
+<phpunit 
+	backupGlobals="false"
+	bootstrap="bootstrap.php"
+	backupStaticAttributes="true"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	stopOnFailure="false"
+	syntaxCheck="false">
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">../server/</directory>
+			<exclude>
+				<file>../server/config.php</file>
+				<file>../server/libs/PasswordHashCmd.php</file>
+				<directory>../server/libs/Mailchimp/</directory>
+				<directory>../server/libs/Markdown/</directory>
+				<directory>../server/libs/adodb/</directory>
+				<directory>../server/libs/dao/base/</directory>
+				<directory>../server/libs/facebook-php-sdk/</directory>
+				<directory>../server/libs/google-api-php-client/</directory>
+				<directory>../server/libs/log4php/</directory>
+				<directory>../server/libs/phpmailer/</directory>
+				<directory>../server/libs/smarty/</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+	<logging>
+		<log type="coverage-html" target="../www/coverage" showUncoveredFiles="true"/>
+	</logging>
+</phpunit>

--- a/stuff/coverage.sh
+++ b/stuff/coverage.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+OMEGAUP_ROOT=`/usr/bin/git rev-parse --show-toplevel`
+
+hhvm /usr/bin/phpunit --bootstrap $OMEGAUP_ROOT/frontend/tests/bootstrap.php --configuration $OMEGAUP_ROOT/frontend/tests/phpunit-coverage.xml $OMEGAUP_ROOT/frontend/tests/controllers/


### PR DESCRIPTION
No lo voy a prender por default porque es bastante más lento que correr
las pruebas, pero ya podemos tener un poco más de tranquilidad de que el
~60% del código del frontend tiene coverage!