### PR TITLE
Documentando mejor los git hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ script:
   - phpunit --bootstrap frontend/tests/bootstrap.php --configuration frontend/tests/phpunit.xml frontend/tests/controllers
   - python stuff/i18n.py --validate
   - python stuff/update-templates.py --validate
-  - python stuff/whitespace-purge.py --validate
-  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then python stuff/php-format.py --validate; fi
+  - python3 stuff/whitespace-purge.py validate
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then python3 stuff/php-format.py validate; fi
 
 notifications:
   slack:

--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -28,7 +28,7 @@ class StatusBase {
             if ($cache['min'] <= $status && $status <= $cache['max']) {
                 return $status;
             }
-        } else if (is_string($status)) {
+        } elseif (is_string($status)) {
             if (in_array($status, $cache['constants'])) {
                 return $cache['constants'][$status];
             }

--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -28,5 +28,5 @@ fi
 
 /usr/bin/python $OMEGAUP_ROOT/stuff/i18n.py --validate
 /usr/bin/python $OMEGAUP_ROOT/stuff/update-templates.py --validate
-/usr/bin/python $OMEGAUP_ROOT/stuff/whitespace-purge.py --validate --from-commit=$REMOTE_HASH
-/usr/bin/python $OMEGAUP_ROOT/stuff/php-format.py --validate --from-commit=$REMOTE_HASH
+/usr/bin/python3 $OMEGAUP_ROOT/stuff/whitespace-purge.py validate $REMOTE_HASH $LOCAL_HASH
+/usr/bin/python3 $OMEGAUP_ROOT/stuff/php-format.py validate $REMOTE_HASH $LOCAL_HASH

--- a/stuff/git_tools.py
+++ b/stuff/git_tools.py
@@ -1,27 +1,89 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os.path
+import re
 import subprocess
 
+GIT_DIFF_TREE_PATTERN = re.compile(
+    br'^:\d+ \d+ [0-9a-f]+ [0-9a-f]+ [ACDMRTUX]\d*\t([^\t]+)(?:\t([^\t]+))?$')
+GIT_LS_TREE_PATTERN = re.compile(br'^\d* blob [0-9a-f]+\t(.*)$')
 NULL_HASH = '0000000000000000000000000000000000000000'
 
+class COLORS:
+  HEADER = '\033[95m'
+  OKGREEN = '\033[92m'
+  FAIL = '\033[91m'
+  NORMAL = '\033[0m'
+
+def validate_args(args):
+  '''Validates whether args.commits is valid.
+
+  args.commits is valid if it has no commits (shorthand for diffing from the
+  creation of the repository until HEAD), or two commits.
+  '''
+  if len(args.commits) not in (0, 2):
+    print('%sCan only specify zero or two commits.%s' %
+          (COLORS.FAIL, COLORS.NORMAL),
+          file=sys.stderr)
+    return False
+  if not args.commits:
+    args.commits = [NULL_HASH, 'HEAD']
+  return True
+
+def file_at_commit(commit, filename):
+  return subprocess.check_output(['/usr/bin/git', 'show',
+    '%s:%s' % (commit, filename)])
+
 def root_dir():
-	return subprocess.check_output(['/usr/bin/git', 'rev-parse',
-		'--show-toplevel']).strip()
+  '''Returns the top-level directory of the project.'''
+  return subprocess.check_output(['/usr/bin/git', 'rev-parse',
+    '--show-toplevel'], universal_newlines=True).strip()
 
-def changed_files(from_commit):
-	root = root_dir()
-	if from_commit and from_commit != NULL_HASH:
-		try:
-			changed_files = filter(
-					lambda x: 'frontend' in x and x.endswith('.php') and os.path.exists(x),
-					[os.path.join(root, x) for x in subprocess.check_output(
-						['/usr/bin/git', 'diff', '--name-only', from_commit, '--']
-					).strip().split('\n')]
-			)
-		except subprocess.CalledProcessError:
-			pass
-	return [os.path.join(root, 'frontend')]
+def changed_files(commits, whitelist=(), blacklist=()):
+  '''Returns the list of changed files between commits.
 
+  If the first commit is the null hash, all files present in the second commit
+  will be considered.
 
-# vim: noexpandtab shiftwidth=2 tabstop=2
+  Only files that matched against at least one of the regular expressions in
+  |whitelist|, and match against no regular expressions in |blacklist| will be
+  present in the result.
+  '''
+  root = root_dir()
+
+  # Get all files in the latter commit.
+  result = set()
+  for line in subprocess.check_output(['/usr/bin/git', 'ls-tree', '-r',
+                                       commits[1]], cwd=root).splitlines():
+    m = GIT_LS_TREE_PATTERN.match(line)
+    if not m:
+      continue
+    result.add(m.groups()[0])
+
+  # Only keep files that were modified in the specified range.
+  if commits[0] != NULL_HASH:
+    modified = set()
+    for line in subprocess.check_output(['/usr/bin/git', 'diff-tree', '-r',
+                                         '--diff-filter=d'] +
+                                         commits, cwd=root).splitlines():
+      m = GIT_DIFF_TREE_PATTERN.match(line)
+      src, dest = m.groups()
+      if dest:
+        modified.add(dest)
+      else:
+        modified.add(src)
+    result = result & modified
+
+  # And in the whitelist.
+  whitelist = [re.compile(r) for r in whitelist]
+  result = [filename for filename in result if any(r.match(filename)
+    for r in whitelist)]
+
+  # And not in the blacklist.
+  blacklist = [re.compile(r) for r in blacklist]
+  result = [filename for filename in result if all(not r.match(filename)
+    for r in blacklist)]
+
+  return result
+
+# vim: expandtab shiftwidth=2 tabstop=2

--- a/stuff/git_tools.py
+++ b/stuff/git_tools.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python3
 
+'''
+Tools used to write git hooks.
+'''
+
 import os.path
 import re
 import subprocess
@@ -31,6 +35,7 @@ def validate_args(args):
   return True
 
 def file_at_commit(commit, filename):
+  '''Returns the contents of |filename| at git commit |commit|.'''
   return subprocess.check_output(['/usr/bin/git', 'show',
     '%s:%s' % (commit, filename)])
 

--- a/stuff/php-format.py
+++ b/stuff/php-format.py
@@ -1,72 +1,89 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import argparse
 import git_tools
+import io
 import os.path
 import subprocess
 import sys
 
-IGNORE_LIST = ['frontend/server/libs/dao/base/',
-	'frontend/server/libs/dao/Estructura.php', 'frontend/server/libs/third_party/',
-	'frontend/server/config.php', 'frontend/server/test/test_config.php',
-	'frontend/tests/templates_c']
-
-class colors:
-	HEADER = '\033[95m'
-	OKGREEN = '\033[92m'
-	FAIL = '\033[91m'
-	NORMAL = '\033[0m'
+from git_tools import COLORS
 
 def which(program):
-	for path in os.environ["PATH"].split(os.pathsep):
-		exe_file = os.path.join(path.strip('"'), program)
-		if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-			return exe_file
-	raise Exception('`%s` not found' % program)
+  for path in os.environ["PATH"].split(os.pathsep):
+    exe_file = os.path.join(path.strip('"'), program)
+    if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+      return exe_file
+  raise Exception('`%s` not found' % program)
 
 def main():
-	parser = argparse.ArgumentParser(description='PHP linter')
-	parser.add_argument('--from-commit', dest='from_commit', type=str,
-			help='Only include files changed from a certain commit')
-	parser.add_argument('--validate', dest='validate', action='store_true',
-			default=False, help='Only validates, does not make changes')
+  parser = argparse.ArgumentParser(description='PHP linter')
+  subparsers = parser.add_subparsers(dest='tool')
 
-	args = parser.parse_args()
+  validate_parser = subparsers.add_parser('validate',
+      help='Only validates, does not make changes')
+  validate_parser.add_argument('commits', metavar='commit', nargs='*',
+      type=str, help='Only include files changed between commits')
 
-	root_dir = git_tools.root_dir()
-	changed_files = git_tools.changed_files(args.from_commit)
+  fix_parser = subparsers.add_parser('fix',
+      help='Only validates, does not make changes')
+  fix_parser.add_argument('commits', metavar='commit', nargs='*',
+      type=str, help='Only include files changed between commits')
 
-	if not changed_files:
-		return 0
+  args = parser.parse_args()
+  if not git_tools.validate_args(args):
+    return 1
 
-	if args.validate:
-		# TODO(lhchavez): Remove the -n to also enforce being warning-free.
-		phpcs_args = [which('phpcs'), '-n', '-s']
-	else:
-		phpcs_args = [which('phpcbf')]
+  changed_files = git_tools.changed_files(args.commits,
+      whitelist=[br'^frontend.*\.php$'],
+      blacklist=[br'.*third_party.*', br'.*dao/base.*',
+                 br'frontend/server/libs/dao/Estructura.php'])
+  if not changed_files:
+    return 0
 
-	phpcs_args += ['--extensions=php', '--encoding=utf-8', '--standard=%s' %
-			os.path.join(root_dir, 'stuff/omegaup-standard.xml'), '--ignore=%s' %
-			','.join([os.path.join(root_dir, f) for f in IGNORE_LIST])] + changed_files
+  root = git_tools.root_dir()
+  phpcs_args = [which('phpcbf'), '--encoding=utf-8',
+      '--standard=%s' % os.path.join(root, 'stuff/omegaup-standard.xml')]
 
-	errors = False
+  validate_only = args.tool == 'validate'
+  validation_passed = True
 
-	try:
-		subprocess.check_call(phpcs_args)
-	except subprocess.CalledProcessError:
-		errors = True
+  for filename in changed_files:
+    filename = str(filename, encoding='utf-8')
+    contents = git_tools.file_at_commit(args.commits[1], filename)
+    cmd = phpcs_args + ['--stdin-path=%s' % filename]
+    with subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        cwd=root) as p:
+      replaced = p.communicate(contents)[0]
+      if p.returncode != 0 and not replaced:
+        validation_passed = False
+        print('Execution of "%s" %sfailed with return code %d%s.' % (
+              ' '.join(cmd), COLORS.FAIL, COLORS.NORMAL), file=sys.stderr)
+    if contents != replaced:
+      validation_passed = False
+      if validate_only:
+        print('File %s%s%s has %slint errors%s.' % (COLORS.HEADER, filename,
+          COLORS.NORMAL, COLORS.FAIL, COLORS.NORMAL), file=sys.stderr)
+      else:
+        print('Fixing %s%s%s for %slint errors%s.' % (COLORS.HEADER, filename,
+          COLORS.NORMAL, COLORS.FAIL, COLORS.NORMAL), file=sys.stderr)
+        with open(os.path.join(root, filename), 'wb') as f:
+          f.write(replaced)
 
-	if errors:
-		if args.validate:
-			if args.from_commit:
-				extra_args = ' --from-commit=%s' % args.from_commit
-			else:
-				extra_args = ''
-			print >> sys.stderr, '%sPHP validation errors.%s Please run `%s%s` to fix them.' % (colors.FAIL, colors.NORMAL, sys.argv[0], extra_args)
-		return 1
-	return 0
+  if not validation_passed:
+    if validate_only:
+      print('%sPHP validation errors.%s '
+            'Please run `%s fix %s` to fix them.' % (git_tools.COLORS.FAIL,
+              git_tools.COLORS.NORMAL, sys.argv[0], ' '.join(args.commits)),
+              file=sys.stderr)
+    else:
+      print('Files written to working directory. '
+          '%sPlease commit them before pushing.%s' % (COLORS.HEADER,
+          COLORS.NORMAL), file=sys.stderr)
+    return 1
+  return 0
 
 if __name__ == '__main__':
-	sys.exit(main())
+  sys.exit(main())
 
-# vim: noexpandtab shiftwidth=2 tabstop=2
+# vim: expandtab shiftwidth=2 tabstop=2

--- a/stuff/php-format.py
+++ b/stuff/php-format.py
@@ -31,7 +31,7 @@ def main():
       type=str, help='Only include files changed between commits')
 
   fix_parser = subparsers.add_parser('fix',
-      help='Only validates, does not make changes')
+      help='Fixes all violations and leaves the results in the working tree.')
   fix_parser.add_argument('commits', metavar='commit', nargs='*',
       type=str, help='Only include files changed between commits')
 

--- a/stuff/php-format.py
+++ b/stuff/php-format.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python3
 
+'''
+Runs the PHP Code Beautifier against files that will be uploaded through git.
+'''
+
 import argparse
 import git_tools
 import io
@@ -10,6 +14,7 @@ import sys
 from git_tools import COLORS
 
 def which(program):
+  '''Looks for |program| in $PATH. Similar to UNIX's `which` command.'''
   for path in os.environ["PATH"].split(os.pathsep):
     exe_file = os.path.join(path.strip('"'), program)
     if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
@@ -56,6 +61,8 @@ def main():
         cwd=root) as p:
       replaced = p.communicate(contents)[0]
       if p.returncode != 0 and not replaced:
+        # phpcbf returns 1 if there was no change to the file. If there was an
+        # actual error, there won't be anything in stdout.
         validation_passed = False
         print('Execution of "%s" %sfailed with return code %d%s.' % (
               ' '.join(cmd), COLORS.FAIL, COLORS.NORMAL), file=sys.stderr)

--- a/stuff/whitespace-purge.py
+++ b/stuff/whitespace-purge.py
@@ -69,7 +69,7 @@ def main():
       type=str, help='Only include files changed between commits')
 
   fix_parser = subparsers.add_parser('fix',
-      help='Only validates, does not make changes')
+      help='Fixes all violations and leaves the results in the working tree.')
   fix_parser.add_argument('commits', metavar='commit', nargs='*',
       type=str, help='Only include files changed between commits')
 

--- a/stuff/whitespace-purge.py
+++ b/stuff/whitespace-purge.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python3
 
+'''
+Removes annoying superfluous whitespace.
+'''
+
 import argparse
 import git_tools
 import os


### PR DESCRIPTION
En un comentario de la revisión pasada, se sugirió documentar mejor los
git hooks. Este cambio hace eso, los convierte a Python3 y de paso
arregla un montón de errores que tenían para hacerlos más robustos.

También se arregló un error de lint que se le pasaba al script anterior.