### PR TITLE
Bugfix: el cambio de convencion pageSize vs page_size rompio paginacion

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_list.js
+++ b/frontend/www/js/omegaup/arena/contest_list.js
@@ -10,7 +10,7 @@ omegaup.arena.ContestList = function(element, apiParams, uiParams) {
     active: 'ALL',
     recommended: 'ALL',
     // TODO: Make this match uiParams.pageSize and do smaller requests.
-    pageSize: 1000,
+    page_size: 1000,
   }, apiParams);
   var actualUiParams = $.extend({
     header: omegaup.T.wordsContests,


### PR DESCRIPTION
PHP espera el argumento en snake case.
Javascript habla en camelCase.

Entonces ahorita todas las listas de concursos en prod son de a lo mas 20 concursos.