### PR TITLE
Haciendo que el .zip del problema no sea requerido al editar

### DIFF
--- a/frontend/www/js/problem.edit.form.js
+++ b/frontend/www/js/problem.edit.form.js
@@ -1,8 +1,10 @@
 $(document)
     .ready(function() {
-      var requiredFields = ['#source', '#title', '#problem_contents'];
+      var requiredFields = ['#source', '#title'];
       if (window.location.pathname.indexOf('/problem/new') !== 0) {
         requiredFields.push('#update-message');
+      } else {
+        requiredFields.push('#problem_contents');
       }
       requiredFields.each(addRemoveErrorClass);
 


### PR DESCRIPTION
Esto es una regresión reciente en un refactor que se hizo. Se está
agregando incondicionalmente `problem_contents` a la lista de campos
requeridos, cuando solo se debería agregar si se está escribiendo un
problema nuevo.