### PR TITLE
El apiRemoveProblem no checa si los runs del problema son del concurso

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -1152,7 +1152,7 @@ class ContestController extends Controller {
             throw new InvalidParameterException('parameterNotFound', 'problem_alias');
         }
 
-        // Can't remove problem from contest if it already has runs within the contest
+        // Disallow removing problem from contest if it already has runs within the contest
         if (RunsDAO::CountTotalRunsOfProblemInContest($problem->problem_id, $contest->contest_id) > 0 &&
             !Authorization::IsSystemAdmin($r['current_user_id'])) {
             throw new ForbiddenAccessException('cannotRemoveProblem');

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -1152,7 +1152,8 @@ class ContestController extends Controller {
             throw new InvalidParameterException('parameterNotFound', 'problem_alias');
         }
 
-        if (RunsDAO::CountTotalRunsOfProblem($problem->problem_id) > 0 &&
+        // Can't remove problem from contest if it already has runs within the contest
+        if (RunsDAO::CountTotalRunsOfProblemInContest($problem->problem_id, $contest->contest_id) > 0 &&
             !Authorization::IsSystemAdmin($r['current_user_id'])) {
             throw new ForbiddenAccessException('cannotRemoveProblem');
         }

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -267,7 +267,6 @@ class RunsDAO extends RunsDAOBase {
      *
      * @param string  $problem_id
      * @param string  $contest_id
-     * @param boolean $showAllRuns [TRUE to include test runs]
      */
     final public static function CountTotalRunsOfProblemInContest($problem_id, $contest_id) {
         // Build SQL statement.

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -262,6 +262,26 @@ class RunsDAO extends RunsDAOBase {
         return $conn->GetOne($sql, $val);
     }
 
+    /**
+     * Get the count of runs of a problem in a given contest
+     *
+     * @param string  $problem_id
+     * @param string  $contest_id
+     * @param boolean $showAllRuns [TRUE to include test runs]
+     */
+    final public static function CountTotalRunsOfProblemInContest($problem_id, $contest_id, $showAllRuns = false) {
+        // Build SQL statement.
+        $sql = 'SELECT COUNT(*) FROM Runs WHERE problem_id = ? AND contest_id = ?';
+        $val = array($problem_id, $contest_id);
+
+        if (!$showAllRuns) {
+            $sql .= ' AND test = 0';
+        }
+
+        global $conn;
+        return $conn->GetOne($sql, $val);
+    }
+
     /*
 	 * Gets the count of total runs sent to a given contest by verdict
 	 */

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -269,14 +269,10 @@ class RunsDAO extends RunsDAOBase {
      * @param string  $contest_id
      * @param boolean $showAllRuns [TRUE to include test runs]
      */
-    final public static function CountTotalRunsOfProblemInContest($problem_id, $contest_id, $showAllRuns = false) {
+    final public static function CountTotalRunsOfProblemInContest($problem_id, $contest_id) {
         // Build SQL statement.
-        $sql = 'SELECT COUNT(*) FROM Runs WHERE problem_id = ? AND contest_id = ?';
+        $sql = 'SELECT COUNT(*) FROM Runs WHERE problem_id = ? AND contest_id = ? AND test = 0';
         $val = array($problem_id, $contest_id);
-
-        if (!$showAllRuns) {
-            $sql .= ' AND test = 0';
-        }
 
         global $conn;
         return $conn->GetOne($sql, $val);

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -295,7 +295,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
 
     /**
      * Removes a problem with runs only from admins from a private contest
-     * while loged in with a user that is sysadmin.
+     * while logged in with a user that is sysadmin.
      */
     public function testRemoveProblemWithAdminRunsFromContestBeingSysAdmin() {
         $contestData = ContestsFactory::createContest(null, 0 /* private */);

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -384,6 +384,54 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
     }
 
     /**
+     * Removes a problem with runs made outside the contest from a private contest
+     * while loged in as Contest Admin
+     *
+     */
+    public function testRemoveProblemWithRunsOutsideContestFromPrivateContest() {
+        $contestData = ContestsFactory::createContest(null, 0 /* private */);
+        $problemData = ProblemsFactory::createProblem();
+        ContestsFactory::addProblemToContest($problemData, $contestData);
+        $contestant = UserFactory::createUser();
+
+        ContestsFactory::addUser($contestData, $contestant);
+
+        // Create a run not related to the contest
+        RunsFactory::createRunToProblem($problemData, $contestant);
+
+        // Remove problem, should succeed.
+        $response = ContestsFactory::removeProblemFromContest(
+            $problemData,
+            $contestData
+        );
+
+        $this->assertEquals('ok', $response['status']);
+    }
+
+    /**
+     * Removes a problem with runs made outside and inside the contest from a private contest
+     * while loged in as Contest Admin. Should fail.
+     *
+     * @expectedException ForbiddenAccessException
+     */
+    public function testRemoveProblemWithRunsOutsideAndInsideContestFromPrivateContest() {
+        $contestData = ContestsFactory::createContest(null, 0 /* private */);
+        $problemData = ProblemsFactory::createProblem();
+        ContestsFactory::addProblemToContest($problemData, $contestData);
+        $contestant = UserFactory::createUser();
+
+        ContestsFactory::addUser($contestData, $contestant);
+
+        RunsFactory::createRunToProblem($problemData, $contestant);
+        RunsFactory::createRun($problemData, $contestData, $contestant);
+
+        $response = ContestsFactory::removeProblemFromContest(
+            $problemData,
+            $contestData
+        );
+    }
+
+    /**
      * Removes a problem with runs only from admins from a private contest
      * while loged in with a user that is not sysadmin.
      */

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -385,7 +385,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
 
     /**
      * Removes a problem with runs made outside the contest from a private contest
-     * while loged in as Contest Admin
+     * while logged in as Contest Admin
      *
      */
     public function testRemoveProblemWithRunsOutsideContestFromPrivateContest() {

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -410,7 +410,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
 
     /**
      * Removes a problem with runs made outside and inside the contest from a private contest
-     * while loged in as Contest Admin. Should fail.
+     * while logged in as Contest Admin. Should fail.
      *
      * @expectedException ForbiddenAccessException
      */
@@ -433,7 +433,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
 
     /**
      * Removes a problem with runs only from admins from a private contest
-     * while loged in with a user that is not sysadmin.
+     * while logged in with a user that is not sysadmin.
      */
     public function testRemoveProblemWithMixedRunsFromContestBeingSysAdmin() {
         $contestData = ContestsFactory::createContest(null, 0 /* private */);

--- a/stuff/git_tools.py
+++ b/stuff/git_tools.py
@@ -182,8 +182,7 @@ def verify_toolchain(binaries):
   for path, install_cmd in binaries.items():
     if not os.path.isfile(path):
       print('%s%s not found.%s ' 'Please run `%s` to install.' %
-          (git_tools.COLORS.FAIL, path, git_tools.COLORS.NORMAL,
-           install_cmd), file=sys.stderr)
+          (COLORS.FAIL, path, COLORS.NORMAL, install_cmd), file=sys.stderr)
       success = False
   return success
 


### PR DESCRIPTION
Arreglando un bug en apiRemoveProblem - la intención es no permitir borrar problemas si ya tienen runs *dentro del concurso*. La lógica anterior bloqueaba la eliminación si el problema ya tenía un run en la plataforma. 

Este fue el reporte en facebook:
_"Hola! Parece que hay un bug en el editor de concursos. No permite eliminar problemas bajo el texto "No puedes eliminar problemas porque no eres el director del concurso."
Esto pasa en concursos que yo mismo he creado. 
Incluso probé con darme de alta a mi mismo como administrador del concurso."_