### PR TITLE
Actualizando preguntas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ frontend/www/coverage/
 frontend/www/img/
 frontend/www/js/google-analytics.js
 frontend/www/pmamini.php
-frontend/www/preguntas/
 frontend/www/templates/
 
 #ignore sublime sftp config

--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 	path = frontend/server/libs/third_party/phpmailer
 	url = https://github.com/PHPMailer/PHPMailer.git
 	shallow = true
+[submodule "q2a"]
+	path = frontend/www/preguntas
+	url = https://github.com/omegaup/question2answer.git

--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -2,6 +2,15 @@ location /api/ {
     rewrite ^/api/(.*)$ /api/ApiEntryPoint.php last;
 }
 
+location /preguntas/ {
+    index index.php
+    autoindex off;
+    rewrite ^(.*)//(.*)$ /$1/$2 redirect;
+    if (!-e $request_filename) {
+        rewrite ^/preguntas/(.+)$ /preguntas/?qa-rewrite=$1&$query_string last;
+    }
+}
+
 rewrite ^/login/?$ /login.php last;
 rewrite ^/login/password/reset/?$ /loginpasswordreset.php last;
 rewrite ^/login/password/recover/?$ /loginpasswordrecover.php last;


### PR DESCRIPTION
En vez de tener un checkout inmenso para preguntas, es mejor tenerlo
como submódulo. Este cambio también mueve los rewrites al archivo
nginx.rewrites para tener más centralizada la configuración.