### PR TITLE
Eliminando funciones redundantes

### DIFF
--- a/frontend/server/libs/Authorization.php
+++ b/frontend/server/libs/Authorization.php
@@ -114,8 +114,8 @@ class Authorization {
             return true;
         }
 
-        return GroupRolesDAO::isContestAdmin($user_id, $contest) ||
-               UserRolesDAO::isContestAdmin($user_id, $contest);
+        return GroupRolesDAO::isAdmin($user_id, $contest->acl_id) ||
+               UserRolesDAO::isAdmin($user_id, $contest->acl_id);
     }
 
     public static function isProblemAdmin($user_id, Problems $problem) {
@@ -127,8 +127,8 @@ class Authorization {
             return true;
         }
 
-        return GroupRolesDAO::isProblemAdmin($user_id, $problem) ||
-               UserRolesDAO::isProblemAdmin($user_id, $problem);
+        return GroupRolesDAO::isAdmin($user_id, $problem->acl_id) ||
+               UserRolesDAO::isAdmin($user_id, $problem->acl_id);
     }
 
     public static function isSystemAdmin($user_id) {

--- a/frontend/server/libs/dao/Group_Roles.dao.php
+++ b/frontend/server/libs/dao/Group_Roles.dao.php
@@ -42,7 +42,7 @@ class GroupRolesDAO extends GroupRolesDAOBase
         return $admins;
     }
 
-    private static function isAdmin($user_id, $acl_id) {
+    public static function isAdmin($user_id, $acl_id) {
         $sql = '
             SELECT
                 COUNT(*)
@@ -68,14 +68,6 @@ class GroupRolesDAO extends GroupRolesDAOBase
 
     public static function getProblemAdmins(Problems $problem) {
         return self::getAdmins($problem->acl_id);
-    }
-
-    public static function isContestAdmin($user_id, Contests $contest) {
-        return self::isAdmin($user_id, $contest->acl_id);
-    }
-
-    public static function isProblemAdmin($user_id, Problems $problem) {
-        return self::isAdmin($user_id, $problem->acl_id);
     }
 
     public static function isSystemAdmin($user_id) {

--- a/frontend/server/libs/dao/User_Roles.dao.php
+++ b/frontend/server/libs/dao/User_Roles.dao.php
@@ -69,7 +69,7 @@ class UserRolesDAO extends UserRolesDAOBase {
         return $admins;
     }
 
-    private static function isAdmin($user_id, $acl_id) {
+    public static function isAdmin($user_id, $acl_id) {
         $sql = '
             SELECT
                 COUNT(*)
@@ -93,14 +93,6 @@ class UserRolesDAO extends UserRolesDAOBase {
 
     public static function getProblemAdmins(Problems $problem) {
         return self::getAdmins($problem->acl_id);
-    }
-
-    public static function isContestAdmin($user_id, Contests $contest) {
-        return self::isAdmin($user_id, $contest->acl_id);
-    }
-
-    public static function isProblemAdmin($user_id, Problems $problem) {
-        return self::isAdmin($user_id, $problem->acl_id);
     }
 
     public static function isSystemAdmin($user_id) {


### PR DESCRIPTION
{Group,User}Roles tenían varios wrappers de isAdmin. Ahora con las
clases para las escuelas, la cantidad va a crecer y es innecesario
tenerlos.