### PR TITLE
Arreglando errores de producción

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -1635,7 +1635,7 @@ class ContestController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        if (is_null($contest)) {
+        if (is_null($r['contest'])) {
             throw new NotFoundException('contestNotFound');
         }
 

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -875,7 +875,7 @@ class ContestController extends Controller {
                 throw new InvalidDatabaseOperationException($e);
             }
 
-            if (is_null($r['contest_alias'])) {
+            if (is_null($r['contest'])) {
                 throw new NotFoundException('contestNotFound');
             }
 

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -1635,6 +1635,10 @@ class ContestController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
+        if (is_null($contest)) {
+            throw new NotFoundException('contestNotFound');
+        }
+
         // If true, will override Scoreboard Pertentage to 100%
         $showAllRuns = false;
 

--- a/frontend/www/arena/contestprint.php
+++ b/frontend/www/arena/contestprint.php
@@ -20,7 +20,7 @@ try {
 $problems = $contest['problems'];
 foreach ($problems as &$problem) {
     $r = new Request(array(
-        'contest_alias' => $_REQUEST['contest'],
+        'contest_alias' => $_REQUEST['alias'],
         'problem_alias' => $problem['alias'],
         'auth_token' => $smarty->getTemplateVars('CURRENT_USER_AUTH_TOKEN'),
     ));


### PR DESCRIPTION
* Un par de API calls de ContestController que deberían regresar 404
  están causando errores porque el objeto Contests es null.
* No estamos regresando el alias del concurso al momento de imprimir un
  concurso porque estamos regresando un elemento equivocado.