### PR TITLE
Corrigiendo la consulta de apiAdminList

### DIFF
--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -209,25 +209,40 @@ class ContestsDAO extends ContestsDAOBase
                 c.*
             FROM
                 Contests c
-            INNER JOIN
-                ACLs a ON a.acl_id = c.acl_id
-            LEFT JOIN
-                User_Roles ur ON ur.acl_id = c.acl_id
-            LEFT JOIN
-                Group_Roles gr ON gr.acl_id = c.acl_id
-            LEFT JOIN
-                Groups_Users gu ON gu.group_id = gr.group_id
             WHERE
-                a.owner_id = ? OR
-                (ur.role_id = ? AND ur.user_id = ?) OR
-                (gr.role_id = ? AND gu.user_id = ?)
+                c.acl_id IN (
+                    SELECT
+                        ur.acl_id
+                    FROM
+                        User_Roles ur
+                    WHERE
+                        ur.role_id = ? AND ur.user_id = ?
+                UNION DISTINCT
+                    SELECT
+                        a.acl_id
+                    FROM
+                        ACLs a
+                    WHERE
+                        a.owner_id = ?
+                UNION DISTINCT
+                    SELECT
+                        gr.acl_id
+                    FROM
+                        Group_Roles gr
+                    INNER JOIN
+                        Groups_Users gu
+                    ON
+                        gu.group_id = gr.group_id
+                    WHERE
+                        gr.role_id = ? AND gu.user_id = ?
+                )
             ORDER BY
                 c.contest_id DESC
             LIMIT ?, ?;';
 
         $params = array(
-            $user_id,
             Authorization::ADMIN_ROLE,
+            $user_id,
             $user_id,
             Authorization::ADMIN_ROLE,
             $user_id,

--- a/frontend/tests/controllers/UserContestsTest.php
+++ b/frontend/tests/controllers/UserContestsTest.php
@@ -36,20 +36,30 @@ class UserContestsTest extends OmegaupTestCase {
         $director = UserFactory::createUser();
         $contestAdminData = array();
 
+        // Create a group with two arbitrary users.
+        $helperGroup = GroupsFactory::createGroup($director);
+        GroupsFactory::addUserToGroup($helperGroup, UserFactory::createUser());
+        GroupsFactory::addUserToGroup($helperGroup, UserFactory::createUser());
+
         // Get two contests with another director, add $director to their
         // admin list
         $contestAdminData[0] = ContestsFactory::createContest();
         ContestsFactory::addAdminUser($contestAdminData[0], $director);
+        ContestsFactory::addGroupAdmin($contestAdminData[0], $helperGroup['group']);
 
         // Get two contests with another director, add $director to their
         // group admin list
         $contestAdminData[1] = ContestsFactory::createContest();
         $group = GroupsFactory::createGroup($contestAdminData[1]['director']);
         GroupsFactory::addUserToGroup($group, $director);
+        GroupsFactory::addUserToGroup($group, UserFactory::createUser());
         ContestsFactory::addGroupAdmin($contestAdminData[1], $group['group']);
+        ContestsFactory::addGroupAdmin($contestAdminData[1], $helperGroup['group']);
 
         $contestDirectorData[0] = ContestsFactory::createContest(null /*title*/, 1 /*public*/, $director);
+        ContestsFactory::addGroupAdmin($contestDirectorData[0], $helperGroup['group']);
         $contestDirectorData[1] = ContestsFactory::createContest(null /*title*/, 0 /*public*/, $director);
+        ContestsFactory::addGroupAdmin($contestDirectorData[1], $helperGroup['group']);
 
         // Call api
         $login = self::login($director);


### PR DESCRIPTION
La consulta anterior estaba escrita horriblemente: combinaba LEFT e
INNER JOINs (de maneras equivocadas), y estaba haciendo el filtrado
hasta el final en el WHERE, en vez de en los JOINs. Además, por culpa de
la optimización prematura y el miedo a los UNIONs, no se exploró la
versión más correcta de esta consulta usando una subconsulta e UNIONs.

Fixes #953 