### PR TITLE
Exponiendo la lista de experimentos a JavaScript

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -226,3 +226,4 @@ $smarty->configLoad(__DIR__ . '/../templates/'. $lang . '.lang');
 $smarty->addPluginsDir(__DIR__ . '/../smarty_plugins/');
 
 $experiments = new Experiments($_REQUEST);
+$smarty->assign('ENABLED_EXPERIMENTS', $experiments->getEnabledExperiments());

--- a/frontend/templates/arena.head.tpl
+++ b/frontend/templates/arena.head.tpl
@@ -46,6 +46,9 @@
 		<link rel="stylesheet" href="/css/common.css" />
 		<link rel="stylesheet" href="{version_hash src="/ux/arena.css"}" />
 		<link rel="shortcut icon" href="/favicon.ico" />
+{if !empty($ENABLED_EXPERIMENTS)}
+		<script type="text/plain" id="omegaup-enabled-experiments">{','|implode:$ENABLED_EXPERIMENTS}</script>
+{/if}
 	</head>
 	<body{if isset($bodyid) and $bodyid} id="{$bodyid|escape}"{/if}{if $smarty.const.OMEGAUP_LOCKDOWN} class="lockdown"{/if}>
 

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -63,6 +63,9 @@
 		{if isset($jsfile)}
 			<script type="text/javascript" src="{$jsfile}"></script>
 		{/if}
+{if !empty($ENABLED_EXPERIMENTS)}
+		<script type="text/plain" id="omegaup-enabled-experiments">{','|implode:$ENABLED_EXPERIMENTS}</script>
+{/if}
 	</head>
 	<body>
 

--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -2,12 +2,42 @@ var omegaup = typeof global === 'undefined' ?
                   (window.omegaup = window.omegaup || {}) :
                   (global.omegaup = global.omegaup || {});
 
+// This is the JavaScript version of the frontend's Experiments class.
+omegaup.Experiments = function(experimentList) {
+  var self = this;
+  self.enabledExperiments = {};
+  if (!experimentList)
+    return;
+  for (var i = 0; i < experimentList.length; i++)
+    self.enabledExperiments[experimentList[i]] = true;
+};
+
+// Current frontend-available experiments:
+omegaup.Experiments.SCHOOLS = 'schools';
+
+// The list of all enabled experiments for a particular request should have
+// been injected into the DOM by Smarty.
+omegaup.Experiments.loadGlobal = function() {
+  var experimentsNode = $('#omegaup-enabled-experiments');
+  var experimentsList = null;
+  if (experimentsNode.length == 1)
+    experimentsList = experimentsNode[0].innerText.split(',');
+  return new omegaup.Experiments(experimentsList);
+};
+
+omegaup.Experiments.prototype.isEnabled = function(name) {
+  var self = this;
+  return self.enabledExperiments.hasOwnProperty(name);
+};
+
 omegaup.OmegaUp = {
   loggedIn: false,
 
   username: null,
 
   ready: false,
+
+  experiments: null,
 
   _documentReady: false,
 
@@ -16,7 +46,9 @@ omegaup.OmegaUp = {
   _deltaTime: undefined,
 
   _listeners: {
-    'ready': [],
+    'ready': [function() {
+      omegaup.OmegaUp.experiments = omegaup.Experiments.loadGlobal();
+    }],
   },
 
   _onDocumentReady: function() {

--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -6,8 +6,7 @@ var omegaup = typeof global === 'undefined' ?
 omegaup.Experiments = function(experimentList) {
   var self = this;
   self.enabledExperiments = {};
-  if (!experimentList)
-    return;
+  if (!experimentList) return;
   for (var i = 0; i < experimentList.length; i++)
     self.enabledExperiments[experimentList[i]] = true;
 };
@@ -46,9 +45,11 @@ omegaup.OmegaUp = {
   _deltaTime: undefined,
 
   _listeners: {
-    'ready': [function() {
-      omegaup.OmegaUp.experiments = omegaup.Experiments.loadGlobal();
-    }],
+    'ready': [
+      function() {
+        omegaup.OmegaUp.experiments = omegaup.Experiments.loadGlobal();
+      }
+    ],
   },
 
   _onDocumentReady: function() {

--- a/frontend/www/js/omegaup/omegaup.test.js
+++ b/frontend/www/js/omegaup/omegaup.test.js
@@ -14,4 +14,3 @@ describe('omegaup', function() {
     });
   });
 });
-

--- a/frontend/www/js/omegaup/omegaup.test.js
+++ b/frontend/www/js/omegaup/omegaup.test.js
@@ -1,0 +1,17 @@
+'use strict';
+require('./omegaup.js');
+
+describe('omegaup', function() {
+  describe('experiments', function() {
+    it('Should handle unknown experiments', function() {
+      var experiments = new omegaup.Experiments();
+      expect(experiments.isEnabled('foo')).toEqual(false);
+    });
+
+    it('Should handle known experiments', function() {
+      var experiments = new omegaup.Experiments(['foo']);
+      expect(experiments.isEnabled('foo')).toEqual(true);
+    });
+  });
+});
+

--- a/frontend/www/tests/index.html
+++ b/frontend/www/tests/index.html
@@ -26,6 +26,7 @@
 		<script type="text/javascript" src="/tests/require_helper.js"></script>
 
 		<!-- specs -->
+		<script type="text/javascript" src="/js/omegaup/omegaup.test.js"></script>
 		<script type="text/javascript" src="/js/omegaup/ui.test.js"></script>
 		<script type="text/javascript" src="/js/omegaup/arena/arena.test.js"></script>
 		<script type="text/javascript" src="/js/omegaup/arena/admin_arena.test.js"></script>


### PR DESCRIPTION
Este cambio agrega un objeto global (omegaup.OmegaUp.experiments) que
contiene la lista de experimentos activos para el request actual. La
intención es que el API sea idéntico al del Frontend. Por default, nadie
tiene ningún experimento, así que el DOM no va a tener nada.