### PR TITLE
Fix EvalError en /arena/

### DIFF
--- a/frontend/www/ux/arena.js
+++ b/frontend/www/ux/arena.js
@@ -1,48 +1,42 @@
-$(document)
-    .ready(function() {
-      Date.setLocale(omegaup.T.locale);
+omegaup.OmegaUp.on('ready', function() {
+  Date.setLocale(omegaup.T.locale);
 
-      var contestLists = [
-        // List Id, Active, Recommended, List header
-        [
-          '#current-contests',
-          'ACTIVE',
-          'NOT_RECOMMENDED',
-          omegaup.T.arenaCurrentContests
-        ],
-        [
-          '#recommended-current-contests',
-          'ACTIVE',
-          'RECOMMENDED',
-          omegaup.T.arenaRecommendedCurrentContests
-        ],
-        [
-          '#past-contests',
-          'PAST',
-          'NOT_RECOMMENDED',
-          omegaup.T.arenaOldContests
-        ],
-        [
-          '#recommended-past-contests',
-          'PAST',
-          'RECOMMENDED',
-          omegaup.T.arenaRecommendedOldContests
-        ],
-      ];
+  var contestLists = [
+    // List Id, Active, Recommended, List header
+    [
+      '#current-contests',
+      'ACTIVE',
+      'NOT_RECOMMENDED',
+      omegaup.T.arenaCurrentContests
+    ],
+    [
+      '#recommended-current-contests',
+      'ACTIVE',
+      'RECOMMENDED',
+      omegaup.T.arenaRecommendedCurrentContests
+    ],
+    ['#past-contests', 'PAST', 'NOT_RECOMMENDED', omegaup.T.arenaOldContests],
+    [
+      '#recommended-past-contests',
+      'PAST',
+      'RECOMMENDED',
+      omegaup.T.arenaRecommendedOldContests
+    ],
+  ];
 
-      var requests = [];
-      for (var i = 0, len = contestLists.length; i < len; i++) {
-        var contestList = new omegaup.arena.ContestList(
-            contestLists[i][0],
-            {active: contestLists[i][1], recommended: contestLists[i][2]},
-            {header: contestLists[i][3]});
-        requests.push(contestList.deferred);
-      }
+  var requests = [];
+  for (var i = 0, len = contestLists.length; i < len; i++) {
+    var contestList = new omegaup.arena.ContestList(
+        contestLists[i][0],
+        {active: contestLists[i][1], recommended: contestLists[i][2]},
+        {header: contestLists[i][3]});
+    requests.push(contestList.deferred);
+  }
 
-      // Wait until all of the calls above finish before showing the contents.
-      $.when.apply($, requests)
-          .done(function() {
-            $('#root').show();
-            $('#loading').fadeOut('slow');
-          });
-    });
+  // Wait until all of the calls above finish before showing the contents.
+  $.when.apply($, requests)
+      .done(function() {
+        $('#root').show();
+        $('#loading').fadeOut('slow');
+      });
+});


### PR DESCRIPTION
La centralización de los KO bindings causa que los templates se puedan ejecutar antes de la inicialización provocando errores de unsafe-eval. El fix es asegurarse de que la inicialización suceda primero y colgarse de `omegaup.OmegaUp.on('ready'` en vez de `$(document).ready(`.

```
knockout-4.3.0.js?ver=b60c2c:68 Uncaught EvalError: Unable to parse bindings.
Bindings value: template: { name: 'contest-list', if: page().length > 0 }
Message: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' https://www.google.com https://apis.google.com https://www.gstatic.com https://js-agent.newrelic.com https://bam.nr-data.net https://ssl.google-analytics.com".


    at new Function (<anonymous>)
    at a.Q.parseBindingsString (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:68:90)
    at a.Q.getBindingAccessors (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:67:223)
    at a.B.i (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:71:34)
    at Function.Pc (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:51:355)
    at Function.Qc (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:51:133)
    at Function.aa (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:50:482)
    at Object.a.m.a.B (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:49:39)
    at m (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:71:7)
    at k (http://localhost:8080/third_party/js/knockout-4.3.0.js?ver=b60c2c:69:387)
```