### PR TITLE
Opinionated Smarty changes

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -204,7 +204,7 @@ if (!defined('IS_TEST') || IS_TEST !== true) {
         $smarty->assign('CURRENT_USER_GRAVATAR_URL_32', '<img src="https://secure.gravatar.com/avatar/' . md5($session['email']) . '?s=32">');
         $smarty->assign('CURRENT_USER_GRAVATAR_URL_51', '<img src="https://secure.gravatar.com/avatar/' . md5($session['email']) . '?s=51">');
 
-        UITools::$isAdmin = $session['is_admin'];
+        UITools::$IsAdmin = $session['is_admin'];
         $userRequest['username'] = $session['user']->username;
     } else {
         $smarty->assign('CURRENT_USER_GRAVATAR_URL_128', '<img src="/media/avatar_92.png">');

--- a/frontend/server/libs/UITools.php
+++ b/frontend/server/libs/UITools.php
@@ -10,21 +10,7 @@ require_once(OMEGAUP_ROOT . '/www/api/ApiCaller.php');
 
 class UITools {
     public static $IsLoggedIn = false;
-    public static $isAdmin = false;
-
-    /**
-     * Set rank by problems solved
-     *
-     * @param Smarty smarty
-     * @param int $offset
-     * @param int $rowcount
-     */
-    public static function setRankByProblemsSolved(Smarty $smarty, $offset, $rowcount) {
-        $rankRequest = new Request(array('offset' => $offset, 'rowcount' => $rowcount));
-        $response = UserController::getRankByProblemsSolved2($rankRequest);
-
-        $smarty->assign('rank', $response);
-    }
+    public static $IsAdmin = false;
 
     /**
      * If user is not logged in, redirect to login page
@@ -40,7 +26,7 @@ class UITools {
      * If user is not logged in or isn't an admin, redirect to home page
      */
     public static function redirectIfNoAdmin() {
-        if (self::$isAdmin !== true) {
+        if (self::$IsAdmin !== true) {
             header('Location: /');
             die();
         }

--- a/frontend/templates/admin.changepassword.tpl
+++ b/frontend/templates/admin.changepassword.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleAdminChangePassword#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleAdminChangePassword#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/admin.changepassword.tpl
+++ b/frontend/templates/admin.changepassword.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleAdminChangePassword#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="panel panel-primary">
 	<div class="panel-heading">

--- a/frontend/templates/admin.changepassword.tpl
+++ b/frontend/templates/admin.changepassword.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleAdminChangePassword#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleAdminChangePassword#}"}
 
 <div class="panel panel-primary">
 	<div class="panel-heading">

--- a/frontend/templates/admin.verifyuser.tpl
+++ b/frontend/templates/admin.verifyuser.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="panel panel-primary">
 	<div class="panel-heading">

--- a/frontend/templates/admin_index.tpl
+++ b/frontend/templates/admin_index.tpl
@@ -1,5 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleAdminIndex#}'}
-{include file='mainmenu.tpl'}
 
 <div class="post" >
 	<div class="copy" >

--- a/frontend/templates/admin_index.tpl
+++ b/frontend/templates/admin_index.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleAdminIndex#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleAdminIndex#}'}
 {include file='mainmenu.tpl'}
 
 <div class="post" >

--- a/frontend/templates/admin_index.tpl
+++ b/frontend/templates/admin_index.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleAdminIndex#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleAdminIndex#}"}
 
 <div class="post" >
 	<div class="copy" >

--- a/frontend/templates/api.tpl
+++ b/frontend/templates/api.tpl
@@ -1,5 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleApi#}'}
-{include file='mainmenu.tpl'}
 <div style="width: 920px; position: relative; margin: 0 auto 0 auto; ">
 	<table>
 	<tr>

--- a/frontend/templates/api.tpl
+++ b/frontend/templates/api.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleApi#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleApi#}'}
 {include file='mainmenu.tpl'}
 <div style="width: 920px; position: relative; margin: 0 auto 0 auto; ">
 	<table>

--- a/frontend/templates/api.tpl
+++ b/frontend/templates/api.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleApi#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleApi#}"}
 <div style="width: 920px; position: relative; margin: 0 auto 0 auto; ">
 	<table>
 	<tr>

--- a/frontend/templates/arena.contest.intro.tpl
+++ b/frontend/templates/arena.contest.intro.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' jsfile={version_hash src='/js/contestintro.js'} htmlTitle='{#enterContest#}'}
+{include file='head.tpl' jsfile={version_hash src='/js/contestintro.js'} htmlTitle="{#enterContest#}"}
 
 <div id="intro-page" class="contest panel hidden">
 	<div class="panel-body">

--- a/frontend/templates/arena.contest.intro.tpl
+++ b/frontend/templates/arena.contest.intro.tpl
@@ -1,7 +1,6 @@
-{assign var="htmlTitle" value="{#enterContest#}"}
-{include file="head.tpl" jsfile={version_hash src="/js/contestintro.js"}}
-{include file="mainmenu.tpl"}
-{include file="status.tpl"}
+{include file='head.tpl' jsfile={version_hash src='/js/contestintro.js'} htmlTitle='{#enterContest#}'}
+{include file='mainmenu.tpl'}
+{include file='status.tpl'}
 
 <div id="intro-page" class="contest panel hidden">
 	<div class="panel-body">

--- a/frontend/templates/arena.contest.intro.tpl
+++ b/frontend/templates/arena.contest.intro.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' jsfile={version_hash src='/js/contestintro.js'} htmlTitle='{#enterContest#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div id="intro-page" class="contest panel hidden">
 	<div class="panel-body">

--- a/frontend/templates/arena.course.intro.tpl
+++ b/frontend/templates/arena.course.intro.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#enterCourse#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div id="intro-page" class="course">
 	<div class="panel panel-default">

--- a/frontend/templates/arena.course.intro.tpl
+++ b/frontend/templates/arena.course.intro.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#enterCourse#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#enterCourse#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/arena.course.intro.tpl
+++ b/frontend/templates/arena.course.intro.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#enterCourse#}'}
+{include file='head.tpl' htmlTitle="{#enterCourse#}"}
 
 <div id="intro-page" class="course">
 	<div class="panel panel-default">

--- a/frontend/templates/arena.course.tpl
+++ b/frontend/templates/arena.course.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#courseDetails#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <script src="{version_hash src="/js/course.js"}"></script>
 

--- a/frontend/templates/arena.course.tpl
+++ b/frontend/templates/arena.course.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#courseDetails#}'}
+{include file='head.tpl' htmlTitle="{#courseDetails#}"}
 
 <script src="{version_hash src="/js/course.js"}"></script>
 

--- a/frontend/templates/arena.course.tpl
+++ b/frontend/templates/arena.course.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#courseDetails#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#courseDetails#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/codersofthemonth.tpl
+++ b/frontend/templates/codersofthemonth.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleCodersofthemonth#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleCodersofthemonth#}"}
 
 <div class="wait_for_ajax panel panel-default" id="coders_list" >
 	<div class="panel-heading">

--- a/frontend/templates/codersofthemonth.tpl
+++ b/frontend/templates/codersofthemonth.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleCodersofthemonth#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="wait_for_ajax panel panel-default" id="coders_list" >
 	<div class="panel-heading">

--- a/frontend/templates/codersofthemonth.tpl
+++ b/frontend/templates/codersofthemonth.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleCodersofthemonth#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleCodersofthemonth#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/contest.activity.tpl
+++ b/frontend/templates/contest.activity.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' jsfile={version_hash src="/js/contest.activity.js"} htmlTitle='{#contestActivityReport#}'}
+{include file='head.tpl' jsfile={version_hash src="/js/contest.activity.js"} htmlTitle="{#contestActivityReport#}"}
 
 <div class="post">
   <div class="copy">

--- a/frontend/templates/contest.activity.tpl
+++ b/frontend/templates/contest.activity.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' jsfile={version_hash src="/js/contest.activity.js"} htmlTitle='{#contestActivityReport#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="post">
   <div class="copy">

--- a/frontend/templates/contest.activity.tpl
+++ b/frontend/templates/contest.activity.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#contestActivityReport#}"}
-{include file='head.tpl' jsfile={version_hash src="/js/contest.activity.js"}}
+{include file='head.tpl' jsfile={version_hash src="/js/contest.activity.js"} htmlTitle='{#contestActivityReport#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/contest.edit.tpl
+++ b/frontend/templates/contest.edit.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleContestEdit#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleContestEdit#}"}
 
 <div class="page-header">
 	<h1><span>{#frontPageLoading#}</span> <small></small></h1>

--- a/frontend/templates/contest.edit.tpl
+++ b/frontend/templates/contest.edit.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleContestEdit#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="page-header">
 	<h1><span>{#frontPageLoading#}</span> <small></small></h1>

--- a/frontend/templates/contest.edit.tpl
+++ b/frontend/templates/contest.edit.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleContestEdit#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleContestEdit#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/contest.mine.tpl
+++ b/frontend/templates/contest.mine.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' navbarSection='contests' htmlTitle='{#omegaupTitleContest#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 {if $PRIVATE_CONTESTS_ALERT eq 1}
 	<div class="alert alert-info">

--- a/frontend/templates/contest.mine.tpl
+++ b/frontend/templates/contest.mine.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' navbarSection='contests' htmlTitle='{#omegaupTitleContest#}'}
+{include file='head.tpl' navbarSection='contests' htmlTitle="{#omegaupTitleContest#}"}
 
 {if $PRIVATE_CONTESTS_ALERT eq 1}
 	<div class="alert alert-info">

--- a/frontend/templates/contest.mine.tpl
+++ b/frontend/templates/contest.mine.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleContest#}"}
-{include file='head.tpl' navbarSection="contests"}
+{include file='head.tpl' navbarSection='contests' htmlTitle='{#omegaupTitleContest#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/contest.new.tpl
+++ b/frontend/templates/contest.new.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleContestNew#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleContestNew#}"}
 
 {include file='contest.new.form.tpl'}
 

--- a/frontend/templates/contest.new.tpl
+++ b/frontend/templates/contest.new.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleContestNew#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleContestNew#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/contest.new.tpl
+++ b/frontend/templates/contest.new.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleContestNew#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 {include file='contest.new.form.tpl'}
 

--- a/frontend/templates/contest.stats.tpl
+++ b/frontend/templates/contest.stats.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleContestStats#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleContestStats#}"}
 
 <div class="post">
 	<div class="copy">

--- a/frontend/templates/contest.stats.tpl
+++ b/frontend/templates/contest.stats.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleContestStats#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleContestStats#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/contest.stats.tpl
+++ b/frontend/templates/contest.stats.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleContestStats#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="post">
 	<div class="copy">

--- a/frontend/templates/course.edit.tpl
+++ b/frontend/templates/course.edit.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleCourseEdit#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleCourseEdit#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/course.edit.tpl
+++ b/frontend/templates/course.edit.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleCourseEdit#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class='panel'>
 	<div class="page-header">

--- a/frontend/templates/course.edit.tpl
+++ b/frontend/templates/course.edit.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleCourseEdit#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleCourseEdit#}"}
 
 <div class='panel'>
 	<div class="page-header">

--- a/frontend/templates/course.list.tpl
+++ b/frontend/templates/course.list.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var='htmlTitle' value='My courses'}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='My courses'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/course.list.tpl
+++ b/frontend/templates/course.list.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='My courses'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <script type="text/javascript" src="{version_hash src="/js/course.list.js"}"></script>
 

--- a/frontend/templates/course.list.tpl
+++ b/frontend/templates/course.list.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='My courses'}
+{include file='head.tpl' htmlTitle="My courses"}
 
 <script type="text/javascript" src="{version_hash src="/js/course.list.js"}"></script>
 

--- a/frontend/templates/course.new.tpl
+++ b/frontend/templates/course.new.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleCourseNew#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleCourseNew#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/course.new.tpl
+++ b/frontend/templates/course.new.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleCourseNew#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleCourseNew#}"}
 
 {include file='course.new.form.tpl'}
 <script type="text/javascript" src="{version_hash src="/js/course.new.js"}"></script>

--- a/frontend/templates/course.new.tpl
+++ b/frontend/templates/course.new.tpl
@@ -1,10 +1,7 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleCourseNew#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 {include file='course.new.form.tpl'}
-
 <script type="text/javascript" src="{version_hash src="/js/course.new.js"}"></script>
 
 {include file='footer.tpl'}

--- a/frontend/templates/group.edit.tpl
+++ b/frontend/templates/group.edit.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleGroupsEdit#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleGroupsEdit#}"}
 
 <span id="form-data" data-name="groups" data-page="edit" data-alias="{$smarty.get.group}"></span>
 <script src="{version_hash src="/js/groups.js"}"></script>

--- a/frontend/templates/group.edit.tpl
+++ b/frontend/templates/group.edit.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleGroupsEdit#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleGroupsEdit#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/group.edit.tpl
+++ b/frontend/templates/group.edit.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleGroupsEdit#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <span id="form-data" data-name="groups" data-page="edit" data-alias="{$smarty.get.group}"></span>
 <script src="{version_hash src="/js/groups.js"}"></script>

--- a/frontend/templates/group.list.tpl
+++ b/frontend/templates/group.list.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleGroups#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleGroups#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/group.list.tpl
+++ b/frontend/templates/group.list.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleGroups#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleGroups#}"}
 
 <span id="form-data" data-name="groups" data-page="list"></span>
 <script src="{version_hash src="/js/groups.js"}"></script>

--- a/frontend/templates/group.list.tpl
+++ b/frontend/templates/group.list.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleGroups#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <span id="form-data" data-name="groups" data-page="list"></span>
 <script src="{version_hash src="/js/groups.js"}"></script>

--- a/frontend/templates/group.new.tpl
+++ b/frontend/templates/group.new.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleGroupsNew#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleGroupsNew#}"}
 
 {if !isset($IS_UPDATE)}
 	{assign "IS_UPDATE" 0}

--- a/frontend/templates/group.new.tpl
+++ b/frontend/templates/group.new.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleGroupsNew#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 {if !isset($IS_UPDATE)}
 	{assign "IS_UPDATE" 0}

--- a/frontend/templates/group.new.tpl
+++ b/frontend/templates/group.new.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleGroupsNew#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleGroupsNew#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/group.scoreboard.edit.tpl
+++ b/frontend/templates/group.scoreboard.edit.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleGroupsScoreboardEdit#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <span id="form-data" data-name="group-scoreboards" data-page="edit" data-alias="{$smarty.get.scoreboard}" data-group-alias="{$smarty.get.group}"></span>
 <script src="{version_hash src="/js/groups.scoreboards.js"}"></script>

--- a/frontend/templates/group.scoreboard.edit.tpl
+++ b/frontend/templates/group.scoreboard.edit.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleGroupsScoreboardEdit#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleGroupsScoreboardEdit#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/group.scoreboard.edit.tpl
+++ b/frontend/templates/group.scoreboard.edit.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleGroupsScoreboardEdit#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleGroupsScoreboardEdit#}"}
 
 <span id="form-data" data-name="group-scoreboards" data-page="edit" data-alias="{$smarty.get.scoreboard}" data-group-alias="{$smarty.get.group}"></span>
 <script src="{version_hash src="/js/groups.scoreboards.js"}"></script>

--- a/frontend/templates/hackathon.tpl
+++ b/frontend/templates/hackathon.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='Hackathon omegaUp'}
+{include file='head.tpl' htmlTitle="Hackathon omegaUp"}
 
 <script src="https://www.google.com/jsapi?key=AIzaSyA5m1Nc8ws2BbmPRwKu5gFradvD_hgq6G0" type="text/javascript"></script>
 <div class="row">

--- a/frontend/templates/hackathon.tpl
+++ b/frontend/templates/hackathon.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="Hackathon omegaUp"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='Hackathon omegaUp'}
 {include file='mainmenu.tpl'}
 
 <script src="https://www.google.com/jsapi?key=AIzaSyA5m1Nc8ws2BbmPRwKu5gFradvD_hgq6G0" type="text/javascript"></script>

--- a/frontend/templates/hackathon.tpl
+++ b/frontend/templates/hackathon.tpl
@@ -1,5 +1,4 @@
 {include file='head.tpl' htmlTitle='Hackathon omegaUp'}
-{include file='mainmenu.tpl'}
 
 <script src="https://www.google.com/jsapi?key=AIzaSyA5m1Nc8ws2BbmPRwKu5gFradvD_hgq6G0" type="text/javascript"></script>
 <div class="row">

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -86,6 +86,7 @@
 {/if}
 		<div id="root">
 {include file='common.navbar.tpl'}
-{if $inArena}
-{include file='status.tpl'}
+{if !$inArena}
+{include file='mainmenu.tpl'}
 {/if}
+{include file='status.tpl'}

--- a/frontend/templates/index.tpl
+++ b/frontend/templates/index.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleIndex#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleIndex#}"}
 
 <script src="https://www.google.com/jsapi?key=AIzaSyA5m1Nc8ws2BbmPRwKu5gFradvD_hgq6G0" type="text/javascript"></script>
 <div class="row">

--- a/frontend/templates/index.tpl
+++ b/frontend/templates/index.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleIndex#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleIndex#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/index.tpl
+++ b/frontend/templates/index.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleIndex#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <script src="https://www.google.com/jsapi?key=AIzaSyA5m1Nc8ws2BbmPRwKu5gFradvD_hgq6G0" type="text/javascript"></script>
 <div class="row">

--- a/frontend/templates/interviews.arena.intro.tpl
+++ b/frontend/templates/interviews.arena.intro.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#enterContest#}'}
+{include file='head.tpl' htmlTitle="{#enterContest#}"}
 
 <div id="intro-page" class="contest">
 	<div class="panel panel-default">

--- a/frontend/templates/interviews.arena.intro.tpl
+++ b/frontend/templates/interviews.arena.intro.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#enterContest#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div id="intro-page" class="contest">
 	<div class="panel panel-default">

--- a/frontend/templates/interviews.arena.intro.tpl
+++ b/frontend/templates/interviews.arena.intro.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#enterContest#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#enterContest#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/interviews.edit.tpl
+++ b/frontend/templates/interviews.edit.tpl
@@ -1,6 +1,4 @@
-
-{assign var="htmlTitle" value="{#interviews#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#interviews#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/interviews.edit.tpl
+++ b/frontend/templates/interviews.edit.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#interviews#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="page-header">
 	<h1><span>{#frontPageLoading#}</span> <small></small></h1>

--- a/frontend/templates/interviews.edit.tpl
+++ b/frontend/templates/interviews.edit.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#interviews#}'}
+{include file='head.tpl' htmlTitle="{#interviews#}"}
 
 <div class="page-header">
 	<h1><span>{#frontPageLoading#}</span> <small></small></h1>

--- a/frontend/templates/interviews.list.tpl
+++ b/frontend/templates/interviews.list.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#interviewList#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <span id="form-data" data-name="interviews" data-page="new"></span>
 <script src="{version_hash src="/js/alias.generate.js"}"></script>

--- a/frontend/templates/interviews.list.tpl
+++ b/frontend/templates/interviews.list.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#interviewList#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#interviewList#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/interviews.list.tpl
+++ b/frontend/templates/interviews.list.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#interviewList#}'}
+{include file='head.tpl' htmlTitle="{#interviewList#}"}
 
 <span id="form-data" data-name="interviews" data-page="new"></span>
 <script src="{version_hash src="/js/alias.generate.js"}"></script>

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#interviewList#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="page-header">
 	<h1><span>{#frontPageLoading#}</span><small></small></h1>

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#interviewList#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#interviewList#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#interviewList#}'}
+{include file='head.tpl' htmlTitle="{#interviewList#}"}
 
 <div class="page-header">
 	<h1><span>{#frontPageLoading#}</span><small></small></h1>

--- a/frontend/templates/libinteractive.gen.tpl
+++ b/frontend/templates/libinteractive.gen.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="libinteractive"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='libinteractive'}
 {include file='mainmenu.tpl'}
 
 <div class="panel panel-default">

--- a/frontend/templates/libinteractive.gen.tpl
+++ b/frontend/templates/libinteractive.gen.tpl
@@ -1,5 +1,4 @@
 {include file='head.tpl' htmlTitle='libinteractive'}
-{include file='mainmenu.tpl'}
 
 <div class="panel panel-default">
   <div class="panel-body">

--- a/frontend/templates/libinteractive.gen.tpl
+++ b/frontend/templates/libinteractive.gen.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='libinteractive'}
+{include file='head.tpl' htmlTitle="libinteractive"}
 
 <div class="panel panel-default">
   <div class="panel-body">

--- a/frontend/templates/login.password.recover.tpl
+++ b/frontend/templates/login.password.recover.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#passwordResetRequestTitle#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#passwordResetRequestTitle#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 <div id="password-reset" class="container">

--- a/frontend/templates/login.password.recover.tpl
+++ b/frontend/templates/login.password.recover.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#passwordResetRequestTitle#}'}
+{include file='head.tpl' htmlTitle="{#passwordResetRequestTitle#}"}
 <div id="password-reset" class="container">
 	<h1>{#passwordResetRequestTitle#}</h1>
 	<div class="row">

--- a/frontend/templates/login.password.recover.tpl
+++ b/frontend/templates/login.password.recover.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#passwordResetRequestTitle#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 <div id="password-reset" class="container">
 	<h1>{#passwordResetRequestTitle#}</h1>
 	<div class="row">

--- a/frontend/templates/login.password.reset.tpl
+++ b/frontend/templates/login.password.reset.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#passwordResetResetTitle#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 <div id="password-reset" class="container">
 	<h1>{#passwordResetResetTitle#}</h1>
 	<div class="row">

--- a/frontend/templates/login.password.reset.tpl
+++ b/frontend/templates/login.password.reset.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#passwordResetResetTitle#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#passwordResetResetTitle#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 <div id="password-reset" class="container">

--- a/frontend/templates/login.password.reset.tpl
+++ b/frontend/templates/login.password.reset.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#passwordResetResetTitle#}'}
+{include file='head.tpl' htmlTitle="{#passwordResetResetTitle#}"}
 <div id="password-reset" class="container">
 	<h1>{#passwordResetResetTitle#}</h1>
 	<div class="row">

--- a/frontend/templates/login.tpl
+++ b/frontend/templates/login.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleLogin#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div id="login-page">
 	<div class="panel panel-default">

--- a/frontend/templates/login.tpl
+++ b/frontend/templates/login.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleLogin#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleLogin#}"}
 
 <div id="login-page">
 	<div class="panel panel-default">

--- a/frontend/templates/login.tpl
+++ b/frontend/templates/login.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleLogin#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleLogin#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/problem.edit.tpl
+++ b/frontend/templates/problem.edit.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleProblemEdit#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleProblemEdit#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/problem.edit.tpl
+++ b/frontend/templates/problem.edit.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleProblemEdit#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <script src="{version_hash src="/js/problem.edit.js"}" type="text/javascript"></script>
 

--- a/frontend/templates/problem.edit.tpl
+++ b/frontend/templates/problem.edit.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleProblemEdit#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleProblemEdit#}"}
 
 <script src="{version_hash src="/js/problem.edit.js"}" type="text/javascript"></script>
 

--- a/frontend/templates/problem.mine.tpl
+++ b/frontend/templates/problem.mine.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleMyProblemsList#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 {if $PRIVATE_PROBLEMS_ALERT eq 1}
 	<div class="alert alert-info">

--- a/frontend/templates/problem.mine.tpl
+++ b/frontend/templates/problem.mine.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleMyProblemsList#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleMyProblemsList#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/problem.mine.tpl
+++ b/frontend/templates/problem.mine.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleMyProblemsList#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleMyProblemsList#}"}
 
 {if $PRIVATE_PROBLEMS_ALERT eq 1}
 	<div class="alert alert-info">

--- a/frontend/templates/problem.new.tpl
+++ b/frontend/templates/problem.new.tpl
@@ -1,8 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleProblemNew#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
-
 {include file='problem.edit.form.tpl' new='true'}
 <span id="form-data" data-name="problems"></span>
 <script src="{version_hash src="/js/alias.generate.js"}"></script>

--- a/frontend/templates/problem.new.tpl
+++ b/frontend/templates/problem.new.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleProblemNew#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleProblemNew#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/problem.new.tpl
+++ b/frontend/templates/problem.new.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleProblemNew#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleProblemNew#}"}
 {include file='problem.edit.form.tpl' new='true'}
 <span id="form-data" data-name="problems"></span>
 <script src="{version_hash src="/js/alias.generate.js"}"></script>

--- a/frontend/templates/problem.stats.tpl
+++ b/frontend/templates/problem.stats.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleProblemStats#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleProblemStats#}"}
 
 <div class="post">
 	<div class="copy">

--- a/frontend/templates/problem.stats.tpl
+++ b/frontend/templates/problem.stats.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleProblemStats#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="post">
 	<div class="copy">

--- a/frontend/templates/problem.stats.tpl
+++ b/frontend/templates/problem.stats.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleProblemStats#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleProblemStats#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/problems.tpl
+++ b/frontend/templates/problems.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' navbarSection='problems' htmlTitle='{#omegaupTitleProblems#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div id="parent_problems_list">
 	{include file='problem.list.tpl'}

--- a/frontend/templates/problems.tpl
+++ b/frontend/templates/problems.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' navbarSection='problems' htmlTitle='{#omegaupTitleProblems#}'}
+{include file='head.tpl' navbarSection='problems' htmlTitle="{#omegaupTitleProblems#}"}
 
 <div id="parent_problems_list">
 	{include file='problem.list.tpl'}

--- a/frontend/templates/problems.tpl
+++ b/frontend/templates/problems.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleProblems#}"}
-{include file='head.tpl' navbarSection='problems'}
+{include file='head.tpl' navbarSection='problems' htmlTitle='{#omegaupTitleProblems#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/profile.tpl
+++ b/frontend/templates/profile.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleProfile#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleProfile#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/profile.tpl
+++ b/frontend/templates/profile.tpl
@@ -1,6 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleProfile#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 {if !isset($STATUS_ERROR)}
 

--- a/frontend/templates/profile.tpl
+++ b/frontend/templates/profile.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleProfile#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleProfile#}"}
 
 {if !isset($STATUS_ERROR)}
 

--- a/frontend/templates/rank.tpl
+++ b/frontend/templates/rank.tpl
@@ -1,3 +1,3 @@
-{include file='head.tpl' navbarSection='rank' htmlTitle='{#omegaupTitleRank#}'}
+{include file='head.tpl' navbarSection='rank' htmlTitle="{#omegaupTitleRank#}"}
 {include file='rank.table.tpl' page=$page}
 {include file='footer.tpl'}

--- a/frontend/templates/rank.tpl
+++ b/frontend/templates/rank.tpl
@@ -1,7 +1,3 @@
 {include file='head.tpl' navbarSection='rank' htmlTitle='{#omegaupTitleRank#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
-
 {include file='rank.table.tpl' page=$page}
-
 {include file='footer.tpl'}

--- a/frontend/templates/rank.tpl
+++ b/frontend/templates/rank.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleRank#}"}
-{include file='head.tpl' navbarSection="rank"}
+{include file='head.tpl' navbarSection='rank' htmlTitle='{#omegaupTitleRank#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/redaccion.tpl
+++ b/frontend/templates/redaccion.tpl
@@ -1,5 +1,4 @@
-{assign var="htmlTitle" value="{#omegaupTitleRedaccion#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleRedaccion#}'}
 {include file='mainmenu.tpl'}
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}"></script>

--- a/frontend/templates/redaccion.tpl
+++ b/frontend/templates/redaccion.tpl
@@ -1,5 +1,4 @@
 {include file='head.tpl' htmlTitle='{#omegaupTitleRedaccion#}'}
-{include file='mainmenu.tpl'}
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}"></script>
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}"></script>

--- a/frontend/templates/redaccion.tpl
+++ b/frontend/templates/redaccion.tpl
@@ -1,4 +1,4 @@
-{include file='head.tpl' htmlTitle='{#omegaupTitleRedaccion#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleRedaccion#}"}
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}"></script>
 <script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}"></script>

--- a/frontend/templates/scoreboardmerge.tpl
+++ b/frontend/templates/scoreboardmerge.tpl
@@ -1,7 +1,5 @@
 {include file='redirect.tpl'}
 {include file='head.tpl' htmlTitle='{#omegaupTitleScoreboardmerge#}'}
-{include file='mainmenu.tpl'}
-{include file='status.tpl'}
 
 <div class="post">
 	<div class="copy">

--- a/frontend/templates/scoreboardmerge.tpl
+++ b/frontend/templates/scoreboardmerge.tpl
@@ -1,6 +1,5 @@
 {include file='redirect.tpl'}
-{assign var="htmlTitle" value="{#omegaupTitleScoreboardmerge#}"}
-{include file='head.tpl'}
+{include file='head.tpl' htmlTitle='{#omegaupTitleScoreboardmerge#}'}
 {include file='mainmenu.tpl'}
 {include file='status.tpl'}
 

--- a/frontend/templates/scoreboardmerge.tpl
+++ b/frontend/templates/scoreboardmerge.tpl
@@ -1,5 +1,5 @@
 {include file='redirect.tpl'}
-{include file='head.tpl' htmlTitle='{#omegaupTitleScoreboardmerge#}'}
+{include file='head.tpl' htmlTitle="{#omegaupTitleScoreboardmerge#}"}
 
 <div class="post">
 	<div class="copy">


### PR DESCRIPTION
AKA simplificando el boilerplate de los templates

* Mover assign(htmlTitle) a ser un attributo de include-head

Ahorita todos los templates incluyen head.tpl
* head.tpl en modo arena, incluye status.tpl
* todos los tpls que *no* son modo arena, incluyen mainmenu.tpl
* casi todos los includes no-arena que incluyen mainmenu incluyen status.tpl

Asi que simplificamos a:
* status.tpl => siempre
* mainmenu.tpl => modo no-arena