### PR TITLE
Arreglando los logins en las pruebas

### DIFF
--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -173,10 +173,11 @@ class CourseController extends Controller {
         }
 
         // Create the associated group
-        $groupRequest = new Request(array(
+        $groupRequest = new Request([
+            'auth_token' => $r['auth_token'],
             'alias' => $r['alias'],
             'name' => 'for-' . $r['alias']
-        ));
+        ]);
 
         GroupController::apiCreate($groupRequest);
         $group = GroupsDAO::FindByAlias($groupRequest['alias']);

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1873,15 +1873,18 @@ class UserController extends Controller {
                     if (count($tokens) < 3) {
                         throw new InvalidParameterException('parameterInvalid', 'filter');
                     }
-                    $r = new Request(array(
+                    $r2 = new Request(array(
                         'contest_alias' => $tokens[2],
                     ));
-                    if (count($tokens) >= 4) {
-                        $r['token'] = $tokens[3];
+                    if (isset($r['auth_token'])) {
+                        $r2['auth_token'] = $r['auth_token'];
                     }
-                    ContestController::validateDetails($r);
-                    if ($r['contest_admin']) {
-                        $response['contest_admin'][] = $r['contest_alias'];
+                    if (count($tokens) >= 4) {
+                        $r2['token'] = $tokens[3];
+                    }
+                    ContestController::validateDetails($r2);
+                    if ($r2['contest_admin']) {
+                        $response['contest_admin'][] = $r2['contest_alias'];
                     }
                     break;
                 case 'problem':

--- a/frontend/tests/controllers/AssignmentAddProblemTest.php
+++ b/frontend/tests/controllers/AssignmentAddProblemTest.php
@@ -1,20 +1,21 @@
 <?php
 
 class AssignmentAddProblemTest extends OmegaupTestCase {
-    public function testAddProbemToAssignment() {
+    public function testAddProblemToAssignment() {
         $user = UserFactory::createUser();
+        $login = self::login($user);
 
-        $courseData = CoursesFactory::createCourseWithOneAssignment($user);
+        $courseData = CoursesFactory::createCourseWithOneAssignment($user, $login);
         $assignmentAlias = $courseData['assignment_alias'];
 
-        $probData = ProblemsFactory::createProblem(null, null, 1, $user);
+        $probData = ProblemsFactory::createProblem(null, null, 1, $user, null, $login);
 
-        $r = new Request(array(
+        $r = new Request([
+            'auth_token' => $login->auth_token,
             'course_alias' => $courseData['course_alias'],
             'assignment_alias' => $assignmentAlias,
             'problem_alias' => $probData['problem']->alias,
-            'auth_token' => self::login($user)
-        ));
+        ]);
 
         $response = CourseController::apiAddProblem($r);
         $this->assertEquals('ok', $response['status']);

--- a/frontend/tests/controllers/ContestAddProblemTest.php
+++ b/frontend/tests/controllers/ContestAddProblemTest.php
@@ -36,17 +36,15 @@ class AddProblemToContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Build request
-        $r['contest_alias'] = $contestData['request']['alias'];
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['points'] = 100;
-        $r['order_in_contest'] = 1;
+        $directorLogin = self::login($contestData['director']);
+        $r = new Request(array(
+            'auth_token' => $directorLogin->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'problem_alias' => $problemData['request']['alias'],
+            'points' => 100,
+            'order_in_contest' => 1,
+        ));
 
         // Call API
         $response = ContestController::apiAddProblem($r);
@@ -68,18 +66,15 @@ class AddProblemToContestTest extends OmegaupTestCase {
 
         // Get a contest
         $contestData = ContestsFactory::createContest();
-
-        // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Build request
-        $r['contest_alias'] = $contestData['request']['alias'];
-        $r['problem_alias'] = 'this problem doesnt exists';
-        $r['points'] = 100;
-        $r['order_in_contest'] = 1;
+        $directorLogin = self::login($contestData['director']);
+        $r = new Request(array(
+            'auth_token' => $directorLogin->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'problem_alias' => 'this problem doesnt exists',
+            'points' => 100,
+            'order_in_contest' => 1,
+        ));
 
         // Call API
         $response = ContestController::apiAddProblem($r);
@@ -98,16 +93,14 @@ class AddProblemToContestTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
-        // Build request
-        $r['contest_alias'] = 'invalid problem';
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['points'] = 100;
-        $r['order_in_contest'] = 1;
+        $directorLogin = self::login($contestData['director']);
+        $r = new Request(array(
+            'auth_token' => $directorLogin->auth_token,
+            'contest_alias' => 'invalid problem',
+            'problem_alias' => $problemData['request']['alias'],
+            'points' => 100,
+            'order_in_contest' => 1,
+        ));
 
         // Call API
         $response = ContestController::apiAddProblem($r);
@@ -125,18 +118,18 @@ class AddProblemToContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        // Create an empty request
-        $r = new Request();
-
         // Log in as another random user
         $user = UserFactory::createUser();
-        $r['auth_token'] = self::login($user);
 
         // Build request
-        $r['contest_alias'] = $contestData['request']['alias'];
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['points'] = 100;
-        $r['order_in_contest'] = 1;
+        $userLogin = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $userLogin->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'problem_alias' => $problemData['request']['alias'],
+            'points' => 100,
+            'order_in_contest' => 1,
+        ));
 
         // Call API
         $response = ContestController::apiAddProblem($r);
@@ -148,13 +141,13 @@ class AddProblemToContestTest extends OmegaupTestCase {
     public function testAddTooManyProblemsToContest() {
         // Get a contest
         $contestData = ContestsFactory::createContest();
+        $login = self::login($contestData['director']);
 
         for ($i = 0; $i < MAX_PROBLEMS_IN_CONTEST + 1; $i++) {
             // Get a problem
-            $problemData = ProblemsFactory::createProblemWithAuthor($contestData['director']);
+            $problemData = ProblemsFactory::createProblemWithAuthor($contestData['director'], $login);
 
             // Build request
-            $login = self::login($contestData['director']);
             $r = new Request(array(
                 'auth_token' => $login->auth_token,
                 'contest_alias' => $contestData['contest']->alias,

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -584,10 +584,10 @@ class ContestDetailsTest extends OmegaupTestCase {
 
         // Prepare our request
         $login = self::login($contestant);
-        $r = new Request(array(
+        $r = new Request([
             'auth_token' => $login->auth_token,
             'contest_alias' => $contestData['request']['alias'],
-        ));
+        ]);
 
         // Call api. This should fail.
         try {
@@ -600,12 +600,11 @@ class ContestDetailsTest extends OmegaupTestCase {
 
         // Get details from a problem in that contest. This should also fail.
         try {
-            $login2 = self::login($contestant);
-            $problem_request = new Request(array(
-                'auth_token' => $login2->auth_token,
+            $problem_request = new Request([
+                'auth_token' => $login->auth_token,
                 'contest_alias' => $contestData['request']['alias'],
-                'problem_alias' => $problems[0]['request']['alias']
-            ));
+                'problem_alias' => $problems[0]['request']['alias'],
+            ]);
 
             ProblemController::apiDetails($problem_request);
             $this->assertTrue(false, 'User with no access could see the problem');

--- a/frontend/tests/controllers/ContestUpdateTest.php
+++ b/frontend/tests/controllers/ContestUpdateTest.php
@@ -13,15 +13,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
-        // Update title
-        $r['title'] = Utils::CreateRandomString();
+        // Update title.
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'title' => Utils::CreateRandomString(),
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);
@@ -40,16 +38,13 @@ class UpdateContestTest extends OmegaupTestCase {
     public function testUpdateContestNonDirector() {
         // Get a contest
         $contestData = ContestsFactory::createContest();
-
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login(UserFactory::createUser());
-
         // Update title
-        $r['title'] = Utils::CreateRandomString();
+        $login = self::login(UserFactory::createUser());
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'title' => Utils::CreateRandomString(),
+        ]);
 
         // Call API
         ContestController::apiUpdate($r);
@@ -64,15 +59,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest(null, 0 /* private */);
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Update public
-        $r['public'] = 1;
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'public' => 1,
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);
@@ -92,15 +85,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Add the problem to the contest
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Update public
-        $r['public'] = 1;
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'public' => 1,
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);
@@ -116,15 +107,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with site admin
-        $r['auth_token'] = self::login(UserFactory::createAdminUser());
-
-        // Update value to TRUE
-        $r['value'] = 1;
+        // Update value
+        $login = self::login(UserFactory::createAdminUser());
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'value' => 1,
+        ]);
 
         // Call API
         ContestController::apiSetRecommended($r);
@@ -153,15 +142,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest owner
-        $r['auth_token'] = self::login($contestData['director']);
-
-        // Update value to TRUE
-        $r['value'] = 1;
+        // Update value
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'value' => 1,
+        ]);
 
         // Call API
         ContestController::apiSetRecommended($r);
@@ -176,15 +163,14 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Update length
-        $r['finish_time'] = $r['start_time'] + (60 * 60 * 24 * 32);
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'start_time' => 0,
+            'finish_time' => 60 * 60 * 24 * 32,
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);
@@ -213,17 +199,14 @@ class UpdateContestTest extends OmegaupTestCase {
         ContestsFactory::openProblemInContest($contestData, $problemData, $contestant);
 
         // STEP 3: Send a new run
-        // Create an empty request
-        $r = new Request();
-
-        // Log in as contestant
-        $r['auth_token'] = self::login($contestant);
-
-        // Build request
-        $r['contest_alias'] = $contestData['request']['alias'];
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['language'] = 'c';
-        $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        $login = self::login($contestant);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'problem_alias' => $problemData['request']['alias'],
+            'language' => 'c',
+            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+        ]);
 
         RunController::apiCreate($r);
     }
@@ -240,14 +223,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Submit a run
         $this->createRunInContest($contestData);
 
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Update length
-        $r['start_time'] = $contestData['request']['start_time'] + 1;
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'start_time' => $contestData['request']['start_time'] + 1,
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);
@@ -261,14 +243,13 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
         // Update length
-        $r['start_time'] = $contestData['request']['start_time'] + 1;
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'start_time' => $contestData['request']['start_time'] + 1,
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);
@@ -289,15 +270,14 @@ class UpdateContestTest extends OmegaupTestCase {
         // Submit a run
         $this->createRunInContest($contestData);
 
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
-        // Log in with contest director
-        $r['auth_token'] = self::login($contestData['director']);
-
-        // Update length
-        $r['start_time'] = $contestData['request']['start_time'];
-        $r['title'] = 'New title';
+        // Update title
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'start_time' => $contestData['request']['start_time'],
+            'title' => 'New title',
+        ]);
 
         // Call API
         $response = ContestController::apiUpdate($r);

--- a/frontend/tests/controllers/ContestUsersTest.php
+++ b/frontend/tests/controllers/ContestUsersTest.php
@@ -28,12 +28,12 @@ class ContestUsersTest extends OmegaupTestCase {
         $nonRegisteredUser = UserFactory::createUser();
         ContestsFactory::openContest($contestData, $nonRegisteredUser);
 
-        // Prepare request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-
         // Log in with the admin of the contest
-        $r['auth_token'] = self::login($contestData['director']);
+        $login = self::login($contestData['director']);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+        ]);
 
         // Call API
         $response = ContestController::apiUsers($r);
@@ -49,16 +49,18 @@ class ContestUsersTest extends OmegaupTestCase {
         $user = UserFactory::createUser();
         ContestsFactory::openContest($contestData, $user);
 
-        ContestController::apiDetails(new Request(array(
+        $userLogin = self::login($user);
+        ContestController::apiDetails(new Request([
+            'auth_token' => $userLogin->auth_token,
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($user),
-        )));
+        ]));
 
         // Call API
-        $response = ContestController::apiActivityReport(new Request(array(
+        $directorLogin = self::login($contestData['director']);
+        $response = ContestController::apiActivityReport(new Request([
+            'auth_token' => $directorLogin->auth_token,
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestData['director']),
-        )));
+        ]));
 
         // Check that we have entries in the log.
         $this->assertEquals(1, count($response['events']));

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -7,14 +7,15 @@ class CourseCreateTest extends OmegaupTestCase {
     public function testCreateSchoolCourse() {
         $user = UserFactory::createUser();
 
-        $r = new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
             'name' => Utils::CreateRandomString(),
             'alias' => Utils::CreateRandomString(),
             'description' => Utils::CreateRandomString(),
             'start_time' => (Utils::GetPhpUnixTimestamp() + 60),
             'finish_time' => (Utils::GetPhpUnixTimestamp() + 120)
-        ));
+        ]);
 
         $response = CourseController::apiCreate($r);
 
@@ -33,14 +34,15 @@ class CourseCreateTest extends OmegaupTestCase {
 
         $user = UserFactory::createUser();
 
-        $r = new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
             'name' => $sameName,
             'alias' => $sameAlias,
             'description' => Utils::CreateRandomString(),
             'start_time' => (Utils::GetPhpUnixTimestamp() + 60),
             'finish_time' => (Utils::GetPhpUnixTimestamp() + 120)
-        ));
+        ]);
 
         $response = CourseController::apiCreate($r);
 
@@ -50,14 +52,15 @@ class CourseCreateTest extends OmegaupTestCase {
         // Create a new Course with different alias and name
         $user = UserFactory::createUser();
 
-        $r = new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
             'name' => $sameName,
             'alias' => $sameAlias,
             'description' => Utils::CreateRandomString(),
             'start_time' => (Utils::GetPhpUnixTimestamp() + 60),
             'finish_time' => (Utils::GetPhpUnixTimestamp() + 120)
-        ));
+        ]);
 
         CourseController::apiCreate($r);
     }
@@ -68,22 +71,24 @@ class CourseCreateTest extends OmegaupTestCase {
 
         $courseAlias = Utils::CreateRandomString();
 
-        $r = new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
             'name' => Utils::CreateRandomString(),
             'alias' => $courseAlias,
             'description' => Utils::CreateRandomString(),
             'start_time' => (Utils::GetPhpUnixTimestamp() + 60),
             'finish_time' => (Utils::GetPhpUnixTimestamp() + 120)
-        ));
+        ]);
 
         // Call api
         $course = CourseController::apiCreate($r);
         $this->assertEquals('ok', $course['status']);
 
         // Create a test course
-        $r = new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
             'name' => Utils::CreateRandomString(),
             'alias' => Utils::CreateRandomString(),
             'description' => Utils::CreateRandomString(),
@@ -91,7 +96,7 @@ class CourseCreateTest extends OmegaupTestCase {
             'finish_time' => (Utils::GetPhpUnixTimestamp() + 120),
             'course_alias' => $courseAlias,
             'assignment_type' => 'homework'
-        ));
+        ]);
         $course = CourseController::apiCreateAssignment($r);
 
         // There should exist 1 assignment with this alias
@@ -108,10 +113,10 @@ class CourseCreateTest extends OmegaupTestCase {
         $courseData = CoursesFactory::createCourseWithOneAssignment();
 
         $adminLogin = self::login($courseData['admin']);
-        $response = CourseController::apiListAssignments(new Request(array(
+        $response = CourseController::apiListAssignments(new Request([
             'auth_token' => $adminLogin->auth_token,
             'course_alias' => $courseData['course_alias']
-        )));
+        ]));
 
         $this->assertEquals(1, count($response['assignments']));
 
@@ -119,10 +124,10 @@ class CourseCreateTest extends OmegaupTestCase {
         $courseData = CoursesFactory::createCourseWithAssignments(5);
 
         $adminLogin = self::login($courseData['admin']);
-        $response = CourseController::apiListAssignments(new Request(array(
+        $response = CourseController::apiListAssignments(new Request([
             'auth_token' => $adminLogin->auth_token,
             'course_alias' => $courseData['course_alias']
-        )));
+        ]));
 
         $this->assertEquals(5, count($response['assignments']));
     }

--- a/frontend/tests/controllers/GroupsTest.php
+++ b/frontend/tests/controllers/GroupsTest.php
@@ -16,12 +16,13 @@ class GroupsTest extends OmegaupTestCase {
         $description = Utils::CreateRandomString();
         $alias = Utils::CreateRandomString();
 
-        $response = GroupController::apiCreate(new Request(array(
-            'auth_token' => self::login($owner),
+        $login = self::login($owner);
+        $response = GroupController::apiCreate(new Request([
+            'auth_token' => $login->auth_token,
             'name' => $name,
             'alias' => $alias,
             'description' => $description
-        )));
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
@@ -41,11 +42,12 @@ class GroupsTest extends OmegaupTestCase {
         $group = GroupsFactory::createGroup();
         $user = UserFactory::createUser();
 
-        $response = GroupController::apiAddUser(new Request(array(
-            'auth_token' => self::login($group['owner']),
+        $login = self::login($group['owner']);
+        $response = GroupController::apiAddUser(new Request([
+            'auth_token' => $login->auth_token,
             'usernameOrEmail' => $user->username,
             'group_alias' => $group['group']->alias
-        )));
+        ]));
         $this->assertEquals('ok', $response['status']);
 
         $group_users = GroupsUsersDAO::getByPK($group['group']->group_id, $user->user_id);
@@ -62,11 +64,12 @@ class GroupsTest extends OmegaupTestCase {
         $user = UserFactory::createUser();
         $userCalling = UserFactory::createUser();
 
-        $response = GroupController::apiAddUser(new Request(array(
-            'auth_token' => self::login($userCalling),
+        $login = self::login($userCalling);
+        $response = GroupController::apiAddUser(new Request([
+            'auth_token' => $login->auth_token,
             'usernameOrEmail' => $user->username,
             'group_alias' => $group['group']->alias
-        )));
+        ]));
     }
 
     /**
@@ -77,11 +80,12 @@ class GroupsTest extends OmegaupTestCase {
         $user = UserFactory::createUser();
         GroupsFactory::addUserToGroup($groupData, $user);
 
-        $response = GroupController::apiRemoveUser(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupController::apiRemoveUser(new Request([
+            'auth_token' => $login->auth_token,
             'usernameOrEmail' => $user->username,
             'group_alias' => $groupData['group']->alias
-        )));
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
@@ -98,11 +102,12 @@ class GroupsTest extends OmegaupTestCase {
         $groupData = GroupsFactory::createGroup();
         $user = UserFactory::createUser();
 
-        GroupController::apiRemoveUser(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        GroupController::apiRemoveUser(new Request([
+            'auth_token' => $login->auth_token,
             'usernameOrEmail' => $user->username,
             'group_alias' => $groupData['group']->alias
-        )));
+        ]));
     }
 
     /**
@@ -114,11 +119,12 @@ class GroupsTest extends OmegaupTestCase {
         $groupData = GroupsFactory::createGroup();
         $user = UserFactory::createUser();
 
-        GroupController::apiRemoveUser(new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        GroupController::apiRemoveUser(new Request([
+            'auth_token' => $login->auth_token,
             'usernameOrEmail' => $user->username,
             'group_alias' => $groupData['group']->alias
-        )));
+        ]));
     }
 
     /**
@@ -137,9 +143,10 @@ class GroupsTest extends OmegaupTestCase {
         GroupsFactory::createGroup();
 
         // Call API
-        $response = GroupController::apiMyList(new Request(array(
-            'auth_token' => self::login($owner),
-        )));
+        $login = self::login($owner);
+        $response = GroupController::apiMyList(new Request([
+            'auth_token' => $login->auth_token,
+        ]));
 
         $this->assertEquals($n, count($response['groups']));
     }
@@ -158,16 +165,17 @@ class GroupsTest extends OmegaupTestCase {
         }
 
         // Call API
-        $response = GroupController::apiDetails(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
-            'group_alias' => $groupData['group']->alias
-        )));
+        $login = self::login($groupData['owner']);
+        $response = GroupController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
+            'group_alias' => $groupData['group']->alias,
+        ]));
         $this->assertEquals($groupData['group']->group_id, $response['group']['group_id']);
 
-        $response = GroupController::apiMembers(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $response = GroupController::apiMembers(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['group']->alias
-        )));
+        ]));
         $this->assertEquals($nUsers, count($response['users']));
     }
 
@@ -180,19 +188,20 @@ class GroupsTest extends OmegaupTestCase {
         $description = Utils::CreateRandomString();
         $alias = Utils::CreateRandomString();
 
-        $response = GroupController::apiCreateScoreboard(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupController::apiCreateScoreboard(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['group']->alias,
             'name' => $name,
             'alias' => $alias,
             'description' => $description
-        )));
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
-        $groupScoreboards = GroupsScoreboardsDAO::search(new GroupsScoreboards(array(
+        $groupScoreboards = GroupsScoreboardsDAO::search(new GroupsScoreboards([
             'alias' => $alias
-        )));
+        ]));
 
         $groupScoreboard = $groupScoreboards[0];
         $this->assertNotNull($groupScoreboard);
@@ -209,21 +218,22 @@ class GroupsTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
         ContestsFactory::addAdminUser($contestData, $groupData['owner']);
 
-        $response = GroupScoreboardController::apiAddContest(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupScoreboardController::apiAddContest(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['request']['alias'],
             'scoreboard_alias' => $scoreboardData['request']['alias'],
             'contest_alias' => $contestData['request']['alias'],
             'weight' => 1,
             'only_ac' => 0
-        )));
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
-        $gscs = GroupsScoreboardsContestsDAO::search(new GroupsScoreboardsContests(array(
+        $gscs = GroupsScoreboardsContestsDAO::search(new GroupsScoreboardsContests([
             'group_scoreboard_id' => $scoreboardData['scoreboard']->group_scoreboard_id,
             'contest_id' => $contestData['contest']->contest_id
-        )));
+        ]));
         $gsc = $gscs[0];
 
         $this->assertNotNull($gsc);
@@ -239,12 +249,13 @@ class GroupsTest extends OmegaupTestCase {
         $scoreboardData = GroupsFactory::createGroupScoreboard($groupData);
         $contestData = ContestsFactory::createContest(null /*title*/, 0 /*public*/);
 
-        GroupScoreboardController::apiAddContest(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        GroupScoreboardController::apiAddContest(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['request']['alias'],
             'scoreboard_alias' => $scoreboardData['request']['alias'],
             'contest_alias' => $contestData['request']['alias']
-        )));
+        ]));
     }
 
     /**
@@ -258,19 +269,20 @@ class GroupsTest extends OmegaupTestCase {
 
         GroupsFactory::addContestToScoreboard($contestData, $scoreboardData, $groupData);
 
-        $response = GroupScoreboardController::apiRemoveContest(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupScoreboardController::apiRemoveContest(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['request']['alias'],
             'scoreboard_alias' => $scoreboardData['request']['alias'],
             'contest_alias' => $contestData['request']['alias']
-        )));
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
-        $gscs = GroupsScoreboardsContestsDAO::search(new GroupsScoreboardsContests(array(
+        $gscs = GroupsScoreboardsContestsDAO::search(new GroupsScoreboardsContests([
             'group_scoreboard_id' => $scoreboardData['scoreboard']->group_scoreboard_id,
             'contest_id' => $contestData['contest']->contest_id
-        )));
+        ]));
 
         $this->assertEquals(0, count($gscs));
     }
@@ -306,11 +318,12 @@ class GroupsTest extends OmegaupTestCase {
             RunsFactory::gradeRun($run2);
         }
 
-        $response = GroupScoreboardController::apiDetails(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupScoreboardController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['request']['alias'],
             'scoreboard_alias' => $scoreboardData['request']['alias'],
-        )));
+        ]));
 
         $this->assertEquals($n, count($response['contests']));
         $this->assertEquals($scoreboardData['request']['alias'], $response['scoreboard']['alias']);
@@ -331,10 +344,11 @@ class GroupsTest extends OmegaupTestCase {
             $scoreboardsData[] = GroupsFactory::createGroupScoreboard($groupData);
         }
 
-        $response = GroupScoreboardController::apiList(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupScoreboardController::apiList(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['request']['alias'],
-        )));
+        ]));
 
         $this->assertEquals($n, count($response['scoreboards']));
     }
@@ -371,11 +385,12 @@ class GroupsTest extends OmegaupTestCase {
             RunsFactory::gradeRun($run2, 0.5, 'PA');
         }
 
-        $response = GroupScoreboardController::apiDetails(new Request(array(
-            'auth_token' => self::login($groupData['owner']),
+        $login = self::login($groupData['owner']);
+        $response = GroupScoreboardController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
             'group_alias' => $groupData['request']['alias'],
             'scoreboard_alias' => $scoreboardData['request']['alias'],
-        )));
+        ]));
 
         $this->assertEquals($n, count($response['contests']));
         $this->assertEquals($scoreboardData['request']['alias'], $response['scoreboard']['alias']);

--- a/frontend/tests/controllers/InterviewCreateTest.php
+++ b/frontend/tests/controllers/InterviewCreateTest.php
@@ -5,20 +5,19 @@
  */
 class InterviewCreateTest extends OmegaupTestCase {
     public function testCreateAndListInterview() {
-        $r = new Request();
-
         $interviewer = UserFactory::createInterviewerUser();
 
         // Verify I started with nothing
         $interviews = InterviewsDAO::getMyInterviews($interviewer->user_id);
         $this->assertEquals(0, count($interviews));
 
-        $r['auth_token'] = self::login($interviewer);
-        $r['title'] = 'My second interview';
-        $r['alias'] = 'my-first-interview';
-        $r['duration'] = 60;
-
-        $response = InterviewController::apiCreate($r);
+        $login = self::login($interviewer);
+        $response = InterviewController::apiCreate(new Request([
+            'auth_token' => $login->auth_token,
+            'title' => 'My first interview',
+            'alias' => 'my-first-interview',
+            'duration' => 60,
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
@@ -29,16 +28,15 @@ class InterviewCreateTest extends OmegaupTestCase {
     }
 
     public function testInterviewsMustBePrivate() {
-        $r = new Request();
-
         $contestant = UserFactory::createInterviewerUser();
 
-        $r['auth_token'] = self::login($contestant);
-        $r['title'] = 'My second interview';
-        $r['alias'] = 'my-second-interview';
-        $r['duration'] = 60;
-
-        $response = InterviewController::apiCreate($r);
+        $login = self::login($contestant);
+        $response = InterviewController::apiCreate(new Request([
+            'auth_token' => $login->auth_token,
+            'title' => 'My second interview',
+            'alias' => 'my-second-interview',
+            'duration' => 60,
+        ]));
 
         $interview = InterviewsDAO::getMyInterviews($contestant->user_id);
 
@@ -48,17 +46,17 @@ class InterviewCreateTest extends OmegaupTestCase {
     }
 
     public function testAddUsersToInterview() {
-        $r = new Request();
-
-        // Create an interview
+        // Create an interviewer
         $interviewer = UserFactory::createInterviewerUser();
 
-        $r['auth_token'] = self::login($interviewer);
-        $r['title'] = 'My third interview';
-        $r['alias'] = 'my-third-interview';
-        $r['duration'] = 60;
-
-        $response = InterviewController::apiCreate($r);
+        $login = self::login($interviewer);
+        $interviewAlias = 'my-third-interview';
+        $response = InterviewController::apiCreate(new Request([
+            'auth_token' => $login->auth_token,
+            'title' => 'My third interview',
+            'alias' => $interviewAlias,
+            'duration' => 60,
+        ]));
 
         $this->assertEquals('ok', $response['status']);
 
@@ -66,12 +64,11 @@ class InterviewCreateTest extends OmegaupTestCase {
         $email1 = Utils::CreateRandomString() . 'a@foobar.net';
         $email2 = Utils::CreateRandomString() . 'b@foobar.net';
 
-        $r1 = new Request();
-        $r1['auth_token'] = self::login($interviewer);
-        $r1['interview_alias'] = $r['alias'];
-        $r1['usernameOrEmailsCSV'] = $email1 . ',' . $email2;
-
-        $response = InterviewController::apiAddUsers($r1);
+        $response = InterviewController::apiAddUsers(new Request([
+            'auth_token' => $login->auth_token,
+            'interview_alias' => $interviewAlias,
+            'usernameOrEmailsCSV' => $email1 . ',' . $email2,
+        ]));
         $this->assertEquals('ok', $response['status']);
 
         $this->assertNotNull($createdUser1 = UsersDAO::FindByEmail($email1), 'user should have been created by adding email to interview');
@@ -86,24 +83,22 @@ class InterviewCreateTest extends OmegaupTestCase {
         $emailFor2 = Utils::CreateRandomString().'@mail.com';
         $interviewee2 = UserFactory::createUser(null, null, $emailFor2);
 
-        $r2 = new Request();
-        $r2['auth_token'] = self::login($interviewer);
-        $r2['interview_alias'] = $r['alias'];
-        $r2['usernameOrEmailsCSV'] = $emailFor1 . ',' . $emailFor2;
-
-        $response = InterviewController::apiAddUsers($r2);
+        $response = InterviewController::apiAddUsers(new Request([
+            'auth_token' => $login->auth_token,
+            'interview_alias' => $interviewAlias,
+            'usernameOrEmailsCSV' => $emailFor1 . ',' . $emailFor2,
+        ]));
         $this->assertEquals('ok', $response['status']);
 
         // add 2 users that are already omegaup users (using registered username)
         $interviewee3 = UserFactory::createUser();
         $interviewee4 = UserFactory::createUser();
 
-        $r3 = new Request();
-        $r3['auth_token'] = self::login($interviewer);
-        $r3['interview_alias'] = $r['alias'];
-        $r3['usernameOrEmailsCSV'] = $interviewee3->username . ',' . $interviewee4->username;
-
-        $response = InterviewController::apiAddUsers($r3);
+        $response = InterviewController::apiAddUsers(new Request([
+            'auth_token' => $login->auth_token,
+            'interview_alias' => $interviewAlias,
+            'usernameOrEmailsCSV' => $interviewee3->username . ',' . $interviewee4->username,
+        ]));
         $this->assertEquals('ok', $response['status']);
     }
 
@@ -119,11 +114,12 @@ class InterviewCreateTest extends OmegaupTestCase {
         // Create an interview
         $interviewer = UserFactory::createUser();
 
-        $r['auth_token'] = self::login($interviewer);
-        $r['title'] = 'My 4th interview';
-        $r['alias'] = 'my-4-interview';
-        $r['duration'] = 60;
-
-        $response = InterviewController::apiCreate($r);
+        $login = self::login($interviewer);
+        $response = InterviewController::apiCreate(new Request([
+            'auth_token' => $login->auth_token,
+            'title' => 'My fourth interview',
+            'alias' => 'my-fourth-interview',
+            'duration' => 60,
+        ]));
     }
 }

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -352,11 +352,4 @@ class ScopedLoginToken {
     public function __destruct() {
         OmegaUpTestCase::logout();
     }
-
-    // TODO: Delete this function. The existence of this allows for sessions to
-    // be stored longer than intended since they will be added to Request
-    // objects and then still maybe not cleaned up.
-    public function __toString() {
-        return $this->auth_token;
-    }
 }

--- a/frontend/tests/controllers/ProblemBestScoreTest.php
+++ b/frontend/tests/controllers/ProblemBestScoreTest.php
@@ -22,10 +22,11 @@ class ProblemBestScoreTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataPA, 0.5, 'PA');
 
         // Call API
-        $response = ProblemController::apiBestScore(new Request(array(
-            'auth_token' => self::login($contestant),
+        $login = self::login($contestant);
+        $response = ProblemController::apiBestScore(new Request([
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias']
-        )));
+        ]));
 
         $this->assertEquals(100.00, $response['score']);
     }
@@ -49,11 +50,12 @@ class ProblemBestScoreTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataInsideContest, 0.5, 'PA');
 
         // Call API
-        $response = ProblemController::apiBestScore(new Request(array(
-            'auth_token' => self::login($contestant),
+        $login = self::login($contestant);
+        $response = ProblemController::apiBestScore(new Request([
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'contest_alias' => $contestData['request']['alias']
-        )));
+        ]));
 
         $this->assertEquals(50.00, $response['score']);
     }
@@ -78,11 +80,12 @@ class ProblemBestScoreTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataPA, 0.5, 'PA');
 
         // Call API
-        $response = ProblemController::apiBestScore(new Request(array(
-            'auth_token' => self::login($user),
+        $login = self::login($user);
+        $response = ProblemController::apiBestScore(new Request([
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'username' => $contestant->username
-        )));
+        ]));
 
         $this->assertEquals(100.00, $response['score']);
     }

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -18,7 +18,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -87,7 +88,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -128,7 +130,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -167,7 +170,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -215,7 +219,8 @@ class CreateProblemTest extends OmegaupTestCase {
             $problemAuthor = $problemData['author'];
 
             // Login user
-            $r['auth_token'] = self::login($problemAuthor);
+            $login = self::login($problemAuthor);
+            $r['auth_token'] = $login->auth_token;
 
             // Unset key
             unset($r[$key]);
@@ -247,7 +252,8 @@ class CreateProblemTest extends OmegaupTestCase {
             $problemAuthor = $problemData['author'];
 
             // Login user
-            $r['auth_token'] = self::login($problemAuthor);
+            $login = self::login($problemAuthor);
+            $r['auth_token'] = $login->auth_token;
             $r['languages'] = $languages;
             try {
                 // Call the API
@@ -271,7 +277,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -334,7 +341,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -384,7 +392,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -433,7 +442,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $r['title'] = 'Lá Venganza Del Malvado Dr. Liraaa';
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -482,7 +492,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -503,7 +514,8 @@ class CreateProblemTest extends OmegaupTestCase {
         $problemAuthor = $problemData['author'];
 
         // Login user
-        $r['auth_token'] = self::login($problemAuthor);
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -26,15 +26,13 @@ class ProblemDetailsTest extends OmegaupTestCase {
         // Get a user for our scenario
         $contestant = UserFactory::createUser();
 
-        // Prepare our request
-        $r = new Request();
-        $r['contest_alias'] = $contestData['request']['alias'];
-        $r['problem_alias'] = $problemData['request']['alias'];
-
-        // Log in the user
-        $r['auth_token'] = self::login($contestant);
-
         // Explicitly join contest
+        $login = self::login($contestant);
+        $r = new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'problem_alias' => $problemData['request']['alias'],
+        ]);
         ContestController::apiOpen($r);
 
         // Call api
@@ -92,30 +90,27 @@ class ProblemDetailsTest extends OmegaupTestCase {
         // Get a user for our scenario
         $contestant = UserFactory::createUser();
 
-        // Prepare our request
-        $r = new Request();
-        $r['problem_alias'] = $problemData['request']['alias'];
-
-        // Log in the user
-        $r['auth_token'] = self::login($contestant);
-
         // Call api
-        $r['statement_type'] = $type;
-        $response = ProblemController::apiDetails($r);
+        $login = self::login($contestant);
+        $response = ProblemController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['alias'],
+            'statement_type' => $type,
+        ]));
 
-                // Assert data
-                $this->assertContains($expected_text, $response['problem_statement']);
+        // Assert data
+        $this->assertContains($expected_text, $response['problem_statement']);
     }
 
     /**
-     * Problem statmeent is returned in HTML.
+     * Problem statement is returned in HTML.
      */
     public function testViewProblemStatementHtml() {
         $this->internalViewProblemStatement('html', '<h1>Entrada</h1>');
     }
 
     /**
-     * Problem statmeent is returned in Markdown.
+     * Problem statement is returned in Markdown.
      */
     public function testViewProblemStatementMarkdown() {
         $this->internalViewProblemStatement('markdown', '# Entrada');
@@ -135,15 +130,12 @@ class ProblemDetailsTest extends OmegaupTestCase {
         // Get a user for our scenario
         $contestant = UserFactory::createUser();
 
-        // Prepare our request
-        $r = new Request();
-        $r['problem_alias'] = $problemData['request']['alias'];
-
-        // Log in the user
-        $r['auth_token'] = self::login($contestant);
-
         // Call api
-        $response = ProblemController::apiDetails($r);
+        $login = self::login($contestant);
+        $response = ProblemController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['alias'],
+        ]));
 
         $this->assertEquals($response['alias'], $problemData['request']['alias']);
     }
@@ -160,15 +152,12 @@ class ProblemDetailsTest extends OmegaupTestCase {
         // Get a user for our scenario
         $contestant = UserFactory::createUser();
 
-        // Prepare our request
-        $r = new Request();
-        $r['problem_alias'] = $problemData['request']['alias'];
-
-        // Log in the user
-        $r['auth_token'] = self::login($contestant);
-
         // Call api
-        $response = ProblemController::apiDetails($r);
+        $login = self::login($contestant);
+        $response = ProblemController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['alias'],
+        ]));
     }
 
     /**
@@ -188,10 +177,11 @@ class ProblemDetailsTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataPA, 0.5, 'PA');
 
         // Call API
-        $response = ProblemController::apiDetails(new Request(array(
-            'auth_token' => self::login($contestant),
+        $login = self::login($contestant);
+        $response = ProblemController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias']
-        )));
+        ]));
 
         $this->assertEquals(100.00, $response['score']);
     }
@@ -215,11 +205,12 @@ class ProblemDetailsTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataInsideContest, 0.5, 'PA');
 
         // Call API
-        $response = ProblemController::apiDetails(new Request(array(
-            'auth_token' => self::login($contestant),
+        $login = self::login($contestant);
+        $response = ProblemController::apiDetails(new Request([
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'contest_alias' => $contestData['request']['alias']
-        )));
+        ]));
 
         $this->assertEquals(50.00, $response['score']);
     }

--- a/frontend/tests/controllers/ProblemStatsTest.php
+++ b/frontend/tests/controllers/ProblemStatsTest.php
@@ -49,9 +49,11 @@ class ProblemStatsTest extends OmegaupTestCase {
         }
 
         // Create request
-        $r = new Request();
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['auth_token'] = self::login($problemData['author']);
+        $login = self::login($problemData['author']);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['alias'],
+        ));
 
         // Call API
         $response = ProblemController::apiStats($r);

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -35,19 +35,18 @@ class UpdateProblemTest extends OmegaupTestCase {
         // We will submit 2 runs to the problem, a call to grader to rejudge them
         $this->detourGraderCalls($this->exactly(1));
 
-        // Prepare request
-        $r = new Request();
-        $r['title'] = 'new title';
-        $r['time_limit'] = 12345;
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['stack_limit'] = 12345;
-        $r['message'] = 'Changed some properties';
+        $login = self::login($problemData['author']);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'title' => 'new title',
+            'time_limit' => 12345,
+            'problem_alias' => $problemData['request']['alias'],
+            'stack_limit' => 12345,
+            'message' => 'Changed some properties',
+        ));
 
         // Set file upload context
         $_FILES['problem_contents']['tmp_name'] = OMEGAUP_RESOURCES_ROOT.'triangulos.zip';
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($problemData['author']);
 
         // Call API
         $response = ProblemController::apiUpdate($r);
@@ -90,14 +89,13 @@ class UpdateProblemTest extends OmegaupTestCase {
         // Get a problem
         $problemData = ProblemsFactory::createProblem(null, 'valid-languages');
 
-        // Prepare request
-        $r = new Request();
-        $r['languages'] = 'hs,java,pl';
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['message'] = 'Changed alias and languages';
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($problemData['author']);
+        $login = self::login($problemData['author']);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'languages' => 'hs,java,pl',
+            'problem_alias' => $problemData['request']['alias'],
+            'message' => 'Changed alias and languages',
+        ));
 
         //Call API
         $response = ProblemController::apiUpdate($r);
@@ -122,14 +120,15 @@ class UpdateProblemTest extends OmegaupTestCase {
         // Get a problem
         $problemData = ProblemsFactory::createProblem();
 
-        // Prepare request
-        $r = new Request();
-        $r['languages'] = 'cows,hs,java,pl';
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['message'] = 'Changed invalid languages';
+        $login = self::login($problemData['author']);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'languages' => 'cows,hs,java,pl',
+            'problem_alias' => $problemData['request']['alias'],
+            'message' => 'Changed invalid languages',
+        ));
 
         // Log in as contest director
-        $r['auth_token'] = self::login($problemData['author']);
 
         //Call API
         $response = ProblemController::apiUpdate($r);
@@ -144,8 +143,9 @@ class UpdateProblemTest extends OmegaupTestCase {
 
         // Update statement
         $statement = 'This is the new statement \$x\$';
+        $login = self::login($problemData['author']);
         $response = ProblemController::apiUpdateStatement(new Request(array(
-            'auth_token' => self::login($problemData['author']),
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'message' => 'Statement is now more fun',
             'statement' => $statement
@@ -174,8 +174,9 @@ class UpdateProblemTest extends OmegaupTestCase {
         $imgFilename = 'af6a4603e039cca2f6823d287f6c87e561aa6e68.png';
 
         $statement = "This is the new statement with an image omg ![Alt text]($imgUri \"Optional title\")";
+        $login = self::login($problemData['author']);
         $response = ProblemController::apiUpdateStatement(new Request(array(
-            'auth_token' => self::login($problemData['author']),
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'message' => 'Statement now contains images',
             'statement' => $statement
@@ -210,17 +211,17 @@ class UpdateProblemTest extends OmegaupTestCase {
         $this->detourGraderCalls($this->exactly(0));
 
         // Prepare request
-        $r = new Request();
-        $r['title'] = 'new title';
-        $r['time_limit'] = 12345;
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['message'] = 'This shoudl fail';
+        $login = self::login($problemData['author']);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'title' => 'new title',
+            'time_limit' => 12345,
+            'problem_alias' => $problemData['request']['alias'],
+            'message' => 'This shoudl fail',
+        ));
 
         // Set file upload context. This problem should fail
         $_FILES['problem_contents']['tmp_name'] = OMEGAUP_RESOURCES_ROOT.'nostmt.zip';
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($problemData['author']);
 
         // Call API. Should fail
         try {
@@ -253,21 +254,23 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemAdmin = UserFactory::createUser();
 
         // Add admin to the problem
+        $adminLogin = self::login($problemData['author']);
         $response = ProblemController::apiAddAdmin(new Request(array(
+            'auth_token' => $adminLogin->auth_token,
             'usernameOrEmail' => $problemAdmin->username,
             'problem_alias' => $problemData['request']['alias'],
-            'auth_token' => self::login($problemData['author'])
         )));
 
         $this->assertEquals('ok', $response['status']);
 
         //Call API
         $newTitle = 'new title coadmin';
+        $login = self::login($problemAdmin);
         $response = ProblemController::apiUpdate(new Request(array(
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'title' => $newTitle,
             'message' => 'Admin powers',
-            'auth_token' => self::login($problemAdmin)
         )));
 
         // Verify data in DB
@@ -291,29 +294,31 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemAdmin = UserFactory::createUser();
 
         // Add admin to the problem
+        $adminLogin = self::login($problemData['author']);
         $response = ProblemController::apiAddAdmin(new Request(array(
+            'auth_token' => $adminLogin->auth_token,
             'usernameOrEmail' => $problemAdmin->username,
             'problem_alias' => $problemData['request']['alias'],
-            'auth_token' => self::login($problemData['author'])
         )));
 
         $this->assertEquals('ok', $response['status']);
 
         // Then remove the user
         $response = ProblemController::apiRemoveAdmin(new Request(array(
+            'auth_token' => $adminLogin->auth_token,
             'usernameOrEmail' => $problemAdmin->username,
             'problem_alias' => $problemData['request']['alias'],
-            'auth_token' => self::login($problemData['author'])
         )));
         $this->assertEquals('ok', $response['status']);
 
         //Call API
         $newTitle = 'new title coadmin';
+        $login = self::login($problemAdmin);
         $response = ProblemController::apiUpdate(new Request(array(
+            'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'title' => $newTitle,
             'message' => 'Non-admin powers',
-            'auth_token' => self::login($problemAdmin)
         )));
 
         // Verify data in DB
@@ -333,10 +338,11 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemAdmin = UserFactory::createUser();
 
         // Add admin to the problem
+        $login = self::login($problemData['author']);
         $response = ProblemController::apiAddAdmin(new Request(array(
             'usernameOrEmail' => $problemAdmin->username,
             'problem_alias' => $problemData['request']['alias'],
-            'auth_token' => self::login($problemData['author'])
+            'auth_token' => $login->auth_token,
         )));
 
         $this->assertEquals('ok', $response['status']);
@@ -344,7 +350,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         // Get the list of admins
         $response = ProblemController::apiAdmins(new Request(array(
             'problem_alias' => $problemData['request']['alias'],
-            'auth_token' => self::login($problemData['author'])
+            'auth_token' => $login->auth_token,
         )));
 
         $adminFound = false;

--- a/frontend/tests/controllers/RegisterToContestTest.php
+++ b/frontend/tests/controllers/RegisterToContestTest.php
@@ -15,9 +15,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
 
         // Contest will start in the future:
+        $adminLogin = self::login($contestAdmin);
         $request = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestAdmin),
+            'auth_token' => $adminLogin->auth_token,
             'start_time' => Utils::GetPhpUnixTimestamp() + 60 * 60,
         ));
         $request['finish_time'] = $request['start_time'] + 60;
@@ -26,9 +27,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         // Contestant will try to open the contes, this should fail
         $contestant = UserFactory::createUser();
 
+        $contestantLogin = self::login($contestant);
         $request2 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
         ));
 
         try {
@@ -42,9 +44,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         $this->assertEquals($show_intro, ContestController::SHOW_INTRO);
 
         // Contest is going on right now
+        $adminLogin = self::login($contestAdmin);
         $request = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestAdmin),
+            'auth_token' => $adminLogin->auth_token,
             'start_time' => Utils::GetPhpUnixTimestamp() - 1,
         ));
         $request['finish_time'] = $request['start_time'] + 60;
@@ -53,9 +56,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         $show_intro = ContestController::showContestIntro($request2);
         $this->assertEquals($show_intro, ContestController::SHOW_INTRO);
 
+        $contestantLogin = self::login($contestant);
         $request2 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
         ));
 
         // Join this contest
@@ -75,18 +79,20 @@ class RegisterToContestTest extends OmegaupTestCase {
 
         // make it "registrable"
         self::log('Update contest to make it registrable');
+        $adminLogin = self::login($contestAdmin);
         $r1 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
             'contestant_must_register' => true,
-            'auth_token' => self::login($contestAdmin),
+            'auth_token' => $adminLogin->auth_token,
         ));
         ContestController::apiUpdate($r1);
 
         // some user asks for contest
         $contestant = UserFactory::createUser();
+        $contestantLogin = self::login($contestant);
         $r2 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
         ));
         try {
             $response = ContestController::apiDetails($r2);
@@ -99,9 +105,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         ContestController::apiRegisterForContest($r2);
 
         // admin lists registrations
+        $adminLogin = self::login($contestAdmin);
         $r3 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestAdmin),
+            'auth_token' => $adminLogin->auth_token,
         ));
         $result = ContestController::apiRequests($r3);
         $this->assertEquals(sizeof($result['users']), 1);
@@ -112,9 +119,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         ContestController::apiArbitrateRequest($r3);
 
         // ask for details again, this should fail again
+        $contestantLogin = self::login($contestant);
         $r2 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
         ));
         try {
             $response = ContestController::apiDetails($r2);
@@ -129,9 +137,10 @@ class RegisterToContestTest extends OmegaupTestCase {
         ContestController::apiArbitrateRequest($r3);
 
         // user can now submit to contest
+        $contestantLogin = self::login($contestant);
         $r2 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
         ));
 
         // Explicitly join contest
@@ -147,25 +156,26 @@ class RegisterToContestTest extends OmegaupTestCase {
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
 
         // make it "registrable"
+        $adminLogin = self::login($contestAdmin);
         $r1 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
             'contestant_must_register' => true,
-            'auth_token' => self::login($contestAdmin),
+            'auth_token' => $adminLogin->auth_token,
         ));
         ContestController::apiUpdate($r1);
 
         // some user asks for contest
         $contestant = UserFactory::createUser();
-        $login = self::login($contestant);
+        $contestantLogin = self::login($contestant);
         $r2 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
         ));
         ContestController::apiRegisterForContest($r2);
 
         $r3 = new Request(array(
             'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => self::login($contestant),
+            'auth_token' => $contestantLogin->auth_token,
             'username' => $contestant->username,
             'resolution' => true,
         ));

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -41,16 +41,14 @@ class RunCreateTest extends OmegaupTestCase {
         ContestsFactory::openProblemInContest($this->contestData, $problemData, $this->contestant);
 
         // Create an empty request
-        $r = new Request();
-
-        // Log in as contestant
-        $r['auth_token'] = self::login($this->contestant);
-
-        // Build request
-        $r['contest_alias'] = $this->contestData['request']['alias'];
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['language'] = 'c';
-        $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        $login = self::login($this->contestant);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $this->contestData['request']['alias'],
+            'problem_alias' => $problemData['request']['alias'],
+            'language' => 'c',
+            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+        ));
 
         return $r;
     }
@@ -165,7 +163,8 @@ class RunCreateTest extends OmegaupTestCase {
         $contestant2 = UserFactory::createUser();
 
         // Log in this second user
-        $r['auth_token'] = self::login($contestant2);
+        $login = self::login($contestant2);
+        $r['auth_token'] = $login->auth_token;
 
         // Call API
         RunController::apiCreate($r);
@@ -357,7 +356,8 @@ class RunCreateTest extends OmegaupTestCase {
         $this->detourGraderCalls();
 
         // Log as contest director
-        $r['auth_token'] = self::login($this->contestData['director']);
+        $login = self::login($this->contestData['director']);
+        $r['auth_token'] = $login->auth_token;
 
         // Manually set the contest	start 10 mins in the future
         $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -380,7 +380,8 @@ class RunCreateTest extends OmegaupTestCase {
         $this->detourGraderCalls($this->exactly(2));
 
         // Log as contest director
-        $r['auth_token'] = self::login($this->contestData['director']);
+        $login = self::login($this->contestData['director']);
+        $r['auth_token'] = $login->auth_token;
 
         // Set submissions gap of 20 seconds
         $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -419,16 +420,14 @@ class RunCreateTest extends OmegaupTestCase {
         $this->contestant = UserFactory::createUser();
 
         // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($this->contestant);
-
-        // Build request
-        $r['contest_alias'] = ''; // Not inside a contest
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['language'] = 'c';
-        $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        $login = self::login($this->contestant);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'contest_alias' => '', // Not inside a contest
+            'problem_alias' => $problemData['request']['alias'],
+            'language' => 'c',
+            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+        ));
 
         // Call API
         $this->detourGraderCalls($this->exactly(1));
@@ -451,15 +450,13 @@ class RunCreateTest extends OmegaupTestCase {
         $contestant = UserFactory::createUser();
 
         // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($contestant);
-
-        // Build request
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['language'] = 'c';
-        $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        $login = self::login($contestant);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['alias'],
+            'language' => 'c',
+            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+        ));
 
         // Call API
         $response = RunController::apiCreate($r);
@@ -488,17 +485,14 @@ class RunCreateTest extends OmegaupTestCase {
         // Then we need to open the problem
         ContestsFactory::openProblemInContest($contestData, $problemData, $contestant);
 
-        // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($contestant);
-
-        // Build request
-        $r['contest_alias'] = $contestData['request']['alias'];
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['language'] = 'c';
-        $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        $login = self::login($contestant);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $contestData['request']['alias'],
+            'problem_alias' => $problemData['request']['alias'],
+            'language' => 'c',
+            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+        ));
 
         // Call API
         $response = RunController::apiCreate($r);
@@ -524,17 +518,14 @@ class RunCreateTest extends OmegaupTestCase {
         // Create our contestant
         $this->contestant = UserFactory::createUser();
 
-        // Create an empty request
-        $r = new Request();
-
-        // Log in as contest director
-        $r['auth_token'] = self::login($this->contestant);
-
-        // Build request
-        $r['contest_alias'] = ''; // Not inside a contest
-        $r['problem_alias'] = $problemData['request']['alias'];
-        $r['language'] = 'c';
-        $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        $login = self::login($this->contestant);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'contest_alias' => '', // Not inside a contest
+            'problem_alias' => $problemData['request']['alias'],
+            'language' => 'c',
+            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+        ));
 
         // Call API
         $response = RunController::apiCreate($r);
@@ -558,14 +549,14 @@ class RunCreateTest extends OmegaupTestCase {
             // Create an empty request
             $r = new Request();
 
-            // Log in as contest director
-            $r['auth_token'] = self::login($this->contestant);
-
-            // Build request
-            $r['contest_alias'] = ''; // Not inside a contest
-            $r['problem_alias'] = $problemData['request']['alias'];
-            $r['language'] = 'c';
-            $r['source'] = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+            $login = self::login($this->contestant);
+            $r = new Request(array(
+                'auth_token' => $login->auth_token,
+                'contest_alias' => '', // Not inside a contest
+                'problem_alias' => $problemData['request']['alias'],
+                'language' => 'c',
+                'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+            ));
 
             // Call API
             $this->detourGraderCalls($this->exactly(1));

--- a/frontend/tests/controllers/RunRejudgeTest.php
+++ b/frontend/tests/controllers/RunRejudgeTest.php
@@ -33,9 +33,11 @@ class RunRejudgeTest extends OmegaupTestCase {
         $this->detourGraderCalls($this->once());
 
         // Build request
-        $r = new Request();
-        $r['run_alias'] = $runData['response']['guid'];
-        $r['auth_token'] = self::login($contestData['director']);
+        $login = self::login($contestData['director']);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'run_alias' => $runData['response']['guid'],
+        ));
 
         // Call API
         $response = RunController::apiRejudge($r);

--- a/frontend/tests/controllers/RunStatusTest.php
+++ b/frontend/tests/controllers/RunStatusTest.php
@@ -28,9 +28,11 @@ class RunStatusTest extends OmegaupTestCase {
         $runData = RunsFactory::createRun($problemData, $contestData, $contestant);
 
         // Prepare request
-        $r = new Request();
-        $r['auth_token'] = self::login($contestant);
-        $r['run_alias'] = $runData['response']['guid'];
+        $login = self::login($contestant);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'run_alias' => $runData['response']['guid'],
+        ));
 
         // Call API
         $response = RunController::apiStatus($r);

--- a/frontend/tests/controllers/SchoolCreateTest.php
+++ b/frontend/tests/controllers/SchoolCreateTest.php
@@ -12,9 +12,10 @@ class SchoolCreateTest extends OmegaupTestCase {
     public function testCreateSchool() {
         $user = UserFactory::createUser();
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user),
-            'name' => Utils::CreateRandomString()
+            'auth_token' => $login->auth_token,
+            'name' => Utils::CreateRandomString(),
         ));
 
         // Call api
@@ -30,8 +31,9 @@ class SchoolCreateTest extends OmegaupTestCase {
     public function testCreateSchoolDuplicatedName() {
         $user = UserFactory::createUser();
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user),
+            'auth_token' => $login->auth_token,
             'name' => Utils::CreateRandomString()
         ));
 

--- a/frontend/tests/controllers/UserContestsTest.php
+++ b/frontend/tests/controllers/UserContestsTest.php
@@ -17,8 +17,9 @@ class UserContestsTest extends OmegaupTestCase {
         $contestData[1] = ContestsFactory::createContest(null /*title*/, 1 /*public*/, $director);
 
         // Call api
+        $login = self::login($director);
         $r = new Request(array(
-            'auth_token' => self::login($director)
+            'auth_token' => $login->auth_token,
         ));
         $response = ContestController::apiMyList($r);
 

--- a/frontend/tests/controllers/UserCreateTest.php
+++ b/frontend/tests/controllers/UserCreateTest.php
@@ -203,9 +203,10 @@ class CreateUserTest extends OmegaupTestCase {
         $admin = UserFactory::createAdminUser();
 
         // Call api using admin
+        $adminLogin = self::login($admin);
         $response = UserController::apiVerifyEmail(new Request(array(
-            'auth_token' => self::login($admin),
-            'usernameOrEmail' => $user->username
+            'auth_token' => $adminLogin->auth_token,
+            'usernameOrEmail' => $user->username,
         )));
 
         // Get user from db again to pick up verification changes
@@ -226,9 +227,10 @@ class CreateUserTest extends OmegaupTestCase {
         $admin = UserFactory::createAdminUser();
 
         // Call api using admin
+        $adminLogin = self::login($admin);
         $response = UserController::apiVerifyEmail(new Request(array(
-            'auth_token' => self::login($admin),
-            'usernameOrEmail' => Utils::CreateRandomString()
+            'auth_token' => $adminLogin->auth_token,
+            'usernameOrEmail' => Utils::CreateRandomString(),
         )));
     }
 
@@ -245,9 +247,10 @@ class CreateUserTest extends OmegaupTestCase {
         $user2 = UserFactory::createUser();
 
         // Call api using admin
+        $login = self::login($user2);
         $response = UserController::apiVerifyEmail(new Request(array(
-            'auth_token' => self::login($user2),
-            'usernameOrEmail' => $user->username
+            'auth_token' => $login->auth_token,
+            'usernameOrEmail' => $user->username,
         )));
     }
 
@@ -259,8 +262,9 @@ class CreateUserTest extends OmegaupTestCase {
     public function testMailingListBackfillNotAdmin() {
         $user = UserFactory::createUser();
 
+        $login = self::login($user);
         $response = UserController::apiMailingListBackfill(new Request(array(
-            'auth_token' => self::login($user)
+            'auth_token' => $login->auth_token,
         )));
     }
 
@@ -278,8 +282,9 @@ class CreateUserTest extends OmegaupTestCase {
 
         UserController::$urlHelper = $urlHelperMock;
 
+        $adminLogin = self::login(UserFactory::createAdminUser());
         $response = UserController::apiMailingListBackfill(new Request(array(
-            'auth_token' => self::login(UserFactory::createAdminUser())
+            'auth_token' => $adminLogin->auth_token,
         )));
 
         $this->assertEquals('ok', $response['status']);
@@ -299,8 +304,9 @@ class CreateUserTest extends OmegaupTestCase {
 
         UserController::$urlHelper = $urlHelperMock;
 
+        $adminLogin = self::login(UserFactory::createAdminUser());
         $response = UserController::apiMailingListBackfill(new Request(array(
-            'auth_token' => self::login(UserFactory::createAdminUser())
+            'auth_token' => $adminLogin->auth_token,
         )));
 
         // Check user was not added into the mailing list

--- a/frontend/tests/controllers/UserFilterTest.php
+++ b/frontend/tests/controllers/UserFilterTest.php
@@ -100,8 +100,8 @@ class UserFilterTest extends OmegaupTestCase {
 
         $login = self::login($user);
         $r = new Request(array(
-            'filter' => '/contest/' . $contest->alias,
             'auth_token' => $login->auth_token,
+            'filter' => '/contest/' . $contest->alias,
         ));
         UserController::apiValidateFilter($r);
     }

--- a/frontend/tests/controllers/UserProblemsTest.php
+++ b/frontend/tests/controllers/UserProblemsTest.php
@@ -14,9 +14,9 @@ class UserProblemsTest extends OmegaupTestCase {
         $problemData[2] = ProblemsFactory::createProblemWithAuthor($author);
 
         // Call API
-        // Call api
+        $login = self::login($author);
         $r = new Request(array(
-            'auth_token' => self::login($author)
+            'auth_token' => $login->auth_token,
         ));
         $response = ProblemController::apiMyList($r);
 
@@ -30,9 +30,9 @@ class UserProblemsTest extends OmegaupTestCase {
         $author = UserFactory::createUser();
 
         // Call API
-        // Call api
+        $login = self::login($author);
         $r = new Request(array(
-            'auth_token' => self::login($author)
+            'auth_token' => $login->auth_token,
         ));
         $response = ProblemController::apiMyList($r);
 

--- a/frontend/tests/controllers/UserProfileTest.php
+++ b/frontend/tests/controllers/UserProfileTest.php
@@ -12,8 +12,9 @@ class UserProfileTest extends OmegaupTestCase {
     public function testUserData() {
         $user = UserFactory::createUser('testuser1');
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user)
+            'auth_token' => $login->auth_token,
         ));
         $response = UserController::apiProfile($r);
 
@@ -28,8 +29,9 @@ class UserProfileTest extends OmegaupTestCase {
         $user = UserFactory::createUser('testuser3');
         $user2 = UserFactory::createUser('testuser4');
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user),
+            'auth_token' => $login->auth_token,
             'username' => $user2->username
         ));
         $response = UserController::apiProfile($r);
@@ -46,8 +48,9 @@ class UserProfileTest extends OmegaupTestCase {
         $user = UserFactory::createUser();
         $admin = UserFactory::createAdminUser();
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($admin),
+            'auth_token' => $login->auth_token,
             'username' => $user->username
         ));
         $response = UserController::apiProfile($r);
@@ -61,8 +64,9 @@ class UserProfileTest extends OmegaupTestCase {
     public function testUserCanSeeSelfEmail() {
         $user = UserFactory::createUser();
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user),
+            'auth_token' => $login->auth_token,
             'username' => $user->username
         ));
         $response = UserController::apiProfile($r);
@@ -90,9 +94,10 @@ class UserProfileTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runData);
 
         // Get ContestStats
+        $login = self::login($contestant);
         $response = UserController::apiContestStats(new Request(
             array(
-                    'auth_token' => self::login($contestant)
+                    'auth_token' => $login->auth_token,
                 )
         ));
 
@@ -122,10 +127,11 @@ class UserProfileTest extends OmegaupTestCase {
 
         $externalUser = UserFactory::createUser();
 
+        $login = self::login($externalUser);
         // Get ContestStats
         $response = UserController::apiContestStats(new Request(
             array(
-                    'auth_token' => self::login($externalUser),
+                    'auth_token' => $login->auth_token,
                     'username' => $contestant->username
                 )
         ));
@@ -159,8 +165,9 @@ class UserProfileTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runs[1]);
         RunsFactory::gradeRun($runs[2]);
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user)
+            'auth_token' => $login->auth_token,
         ));
 
         $response = UserController::apiProblemsSolved($r);
@@ -174,8 +181,9 @@ class UserProfileTest extends OmegaupTestCase {
     public function testUpdateMainEmail() {
         $user = UserFactory::createUser();
 
+        $login = self::login($user);
         $r = new Request(array(
-            'auth_token' => self::login($user),
+            'auth_token' => $login->auth_token,
             'email' => 'new@email.com'
         ));
         $response = UserController::apiUpdateMainEmail($r);

--- a/frontend/tests/controllers/UserRankTest.php
+++ b/frontend/tests/controllers/UserRankTest.php
@@ -2,10 +2,12 @@
 
 class UserRankTest extends OmegaupTestCase {
     private function refreshUserRank() {
-        $r = new Request();
         $admin = UserFactory::createAdminUser();
 
-        $r['auth_token'] = self::login($admin);
+        $adminLogin = self::login($admin);
+        $r = new Request(array(
+            'auth_token' => $adminLogin->auth_token,
+        ));
         UserController::apiRefreshUserRank($r);
     }
 

--- a/frontend/tests/controllers/UserResetPasswordTest.php
+++ b/frontend/tests/controllers/UserResetPasswordTest.php
@@ -16,10 +16,12 @@ class UserResetPasswordTest extends OmegaupTestCase {
         // Create the admin who will change the password
         $admin = UserFactory::createAdminUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($admin);
-        $r['username'] = $user->username;
-        $r['password'] = Utils::CreateRandomString();
+        $adminLogin = self::login($admin);
+        $r = new Request(array(
+            'auth_token' => $adminLogin->auth_token,
+            'username' => $user->username,
+            'password' => Utils::CreateRandomString(),
+        ));
 
         // Call api
         UserController::apiChangePassword($r);
@@ -47,11 +49,13 @@ class UserResetPasswordTest extends OmegaupTestCase {
         // Create an user in omegaup
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-        $r['username'] = $user->username;
-        $r['password'] = Utils::CreateRandomString();
-        $r['old_password'] = $user->password;
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'username' => $user->username,
+            'password' => Utils::CreateRandomString(),
+            'old_password' => $user->password,
+        ));
 
         // Call api
         UserController::apiChangePassword($r);
@@ -78,11 +82,13 @@ class UserResetPasswordTest extends OmegaupTestCase {
         // Create an user in omegaup
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-        $r['username'] = $user->username;
-        $r['password'] = Utils::CreateRandomString();
-        $r['old_password'] = 'bad old password';
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'username' => $user->username,
+            'password' => Utils::CreateRandomString(),
+            'old_password' => 'bad old password',
+        ));
 
         // Call api
         UserController::apiChangePassword($r);

--- a/frontend/tests/controllers/UserUpdateTest.php
+++ b/frontend/tests/controllers/UserUpdateTest.php
@@ -12,22 +12,18 @@ class UserUpdateTest extends OmegaupTestCase {
         // Create the user to edit
         $user = UserFactory::createUser();
 
-        $r = new Request();
-
-        // Login
-        $r['auth_token'] = self::login($user);
-
-        // Change values
-        $r['name'] = Utils::CreateRandomString();
-        $r['country_id'] = 'MX';
-
-        $states = StatesDAO::search(array('country_id' => $r['country_id']));
-        $r['state_id'] = $states[0]->state_id;
-
-        $r['scholar_degree'] = 'Maestría';
-        $r['birth_date'] = strtotime('1988-01-01');
-        $r['graduation_date'] = strtotime('2016-02-02');
-        $r['recruitment_optin'] = 1;
+        $states = StatesDAO::search(array('country_id' => 'MX'));
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'name' => Utils::CreateRandomString(),
+            'country_id' => 'MX',
+            'state_id' => $states[0]->state_id,
+            'scholar_degree' => 'Maestría',
+            'birth_date' => strtotime('1988-01-01'),
+            'graduation_date' => strtotime('2016-02-02'),
+            'recruitment_optin' => 1,
+        ));
 
         // Call api
         $response = UserController::apiUpdate($r);
@@ -50,13 +46,14 @@ class UserUpdateTest extends OmegaupTestCase {
     public function testNegativeStateUpdate() {
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-        $r['name'] = Utils::CreateRandomString();
-        $r['recruitment_optin'] = 1;
-
-        // Invalid state_id
-        $r['state_id'] = -1;
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'name' => Utils::CreateRandomString(),
+            'recruitment_optin' => 1,
+            // Invalid state_id
+            'state_id' => -1,
+        ));
 
         UserController::apiUpdate($r);
     }
@@ -68,12 +65,13 @@ class UserUpdateTest extends OmegaupTestCase {
     public function testNameUpdateTooLong() {
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-
-        // Invalid name
-        $r['name'] = 'TThisIsWayTooLong ThisIsWayTooLong ThisIsWayTooLong ThisIsWayTooLong hisIsWayTooLong ';
-        $r['country_id'] = 'MX';
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            // Invalid name
+            'name' => 'TThisIsWayTooLong ThisIsWayTooLong ThisIsWayTooLong ThisIsWayTooLong hisIsWayTooLong ',
+            'country_id' => 'MX',
+        ));
 
         UserController::apiUpdate($r);
     }
@@ -85,11 +83,12 @@ class UserUpdateTest extends OmegaupTestCase {
     public function testEmptyNameUpdate() {
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-
-        // Invalid name
-        $r['name'] = '';
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            // Invalid name
+            'name' => '',
+        ));
 
         UserController::apiUpdate($r);
     }
@@ -101,12 +100,13 @@ class UserUpdateTest extends OmegaupTestCase {
     public function testNullRecruitmentOptinUpdate() {
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-        $r['name'] = Utils::CreateRandomString();
-
-        // Null recruitment_optin
-        $r['recruitment_optin'] = null;
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'name' => Utils::CreateRandomString(),
+            // Null recruitment_optin
+            'recruitment_optin' => null,
+        ));
 
         UserController::apiUpdate($r);
     }
@@ -117,9 +117,11 @@ class UserUpdateTest extends OmegaupTestCase {
     public function testRecruitmentOptinUpdate() {
         $user = UserFactory::createUser();
 
-        $r = new Request();
-        $r['auth_token'] = self::login($user);
-        $r['name'] = Utils::CreateRandomString();
+        $login = self::login($user);
+        $r = new Request(array(
+            'auth_token' => $login->auth_token,
+            'name' => Utils::CreateRandomString(),
+        ));
 
         // Set recruitment_optin to true
         $r['recruitment_optin'] = 1;

--- a/frontend/tests/factories/CoursesFactory.php
+++ b/frontend/tests/factories/CoursesFactory.php
@@ -1,14 +1,14 @@
 <?php
 
 class CoursesFactory {
-    public static function createCourse(Users $admin = null) {
+    public static function createCourse(Users $admin = null, ScopedLoginToken $adminLogin = null) {
         if (is_null($admin)) {
             $admin = UserFactory::createUser();
+            $adminLogin = OmegaupTestCase::login($admin);
         }
 
         $courseAlias = Utils::CreateRandomString();
 
-        $adminLogin = OmegaupTestCase::login($admin);
         $r = new Request(array(
             'auth_token' => $adminLogin->auth_token,
             'name' => Utils::CreateRandomString(),
@@ -27,19 +27,19 @@ class CoursesFactory {
         );
     }
 
-    public static function createCourseWithOneAssignment(Users $admin = null) {
+    public static function createCourseWithOneAssignment(Users $admin = null, ScopedLoginToken $adminLogin = null) {
         if (is_null($admin)) {
             $admin = UserFactory::createUser();
+            $adminLogin = OmegaupTestCase::login($admin);
         }
 
         // Create the course
-        $courseFactoryResult = self::createCourse($admin);
+        $courseFactoryResult = self::createCourse($admin, $adminLogin);
         $courseAlias = $courseFactoryResult['course_alias'];
 
         // Create the assignment
         $assignmentAlias = Utils::CreateRandomString();
 
-        $adminLogin = OmegaupTestCase::login($admin);
         $r = new Request(array(
             'auth_token' => $adminLogin->auth_token,
             'name' => Utils::CreateRandomString(),
@@ -70,10 +70,10 @@ class CoursesFactory {
         $courseFactoryResult = self::createCourse();
         $courseAlias = $courseFactoryResult['course_alias'];
         $admin = $courseFactoryResult['admin'];
+        $adminLogin = OmegaupTestCase::login($admin);
 
         foreach ($assignmentsPerType as $assignmentType => $count) {
             for ($i = 0; $i < $count; $i++) {
-                $adminLogin = OmegaupTestCase::login($admin);
                 $r = new Request(array(
                     'auth_token' => $adminLogin->auth_token,
                     'name' => Utils::CreateRandomString(),

--- a/frontend/tests/factories/GroupsFactory.php
+++ b/frontend/tests/factories/GroupsFactory.php
@@ -8,7 +8,7 @@ class GroupsFactory {
      * @param type $name
      * @param type $description
      */
-    public static function createGroup($owner = null, $name = null, $description = null, $alias = null) {
+    public static function createGroup(Users $owner = null, $name = null, $description = null, $alias = null, ScopedLoginToken $login = null) {
         if (is_null($owner)) {
             $owner = UserFactory::createUser();
         }
@@ -25,7 +25,9 @@ class GroupsFactory {
             $alias = Utils::CreateRandomString();
         }
 
-        $login = OmegaupTestCase::login($owner);
+        if (is_null($login)) {
+            $login = OmegaupTestCase::login($owner);
+        }
         $r = new Request(array(
             'auth_token' => $login->auth_token,
             'name' => $name,
@@ -52,8 +54,10 @@ class GroupsFactory {
      * @param array $groupData
      * @param Users $user
      */
-    public static function addUserToGroup(array $groupData, Users $user) {
-        $login = OmegaupTestCase::login($groupData['owner']);
+    public static function addUserToGroup(array $groupData, Users $user, ScopedLoginToken $login = null) {
+        if (is_null($login)) {
+            $login = OmegaupTestCase::login($groupData['owner']);
+        }
         GroupController::apiAddUser(new Request(array(
             'auth_token' => $login->auth_token,
             'usernameOrEmail' => $user->username,

--- a/frontend/tests/factories/ProblemsFactory.php
+++ b/frontend/tests/factories/ProblemsFactory.php
@@ -79,14 +79,14 @@ class ProblemsFactory {
                 'zip_path' => $zipName);
     }
 
-    public static function createProblemWithAuthor(Users $author) {
-        return self::createProblem(null, null, 1, $author);
+    public static function createProblemWithAuthor(Users $author, ScopedLoginToken $login = null) {
+        return self::createProblem(null, null, 1, $author, null, $login);
     }
 
     /**
      *
      */
-    public static function createProblem($zipName = null, $title = null, $public = 1, Users $author = null, $languages = null) {
+    public static function createProblem($zipName = null, $title = null, $public = 1, Users $author = null, $languages = null, ScopedLoginToken $login = null) {
         if (is_null($zipName)) {
             $zipName = OMEGAUP_RESOURCES_ROOT.'testproblem.zip';
         }
@@ -96,8 +96,10 @@ class ProblemsFactory {
         $r = $problemData['request'];
         $problemAuthor = $problemData['author'];
 
-        // Login user
-        $login = OmegaupTestCase::login($problemAuthor);
+        if ($login == null) {
+            // Login user
+            $login = OmegaupTestCase::login($problemAuthor);
+        }
         $r['auth_token'] = $login->auth_token;
 
         // Get File Uploader Mock and tell Omegaup API to use it

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -51,6 +51,7 @@ try_define('BIN_PATH', OMEGAUP_ROOT . '/../bin');
 # CACHE CONFIG
 # #########################
 try_define('APC_USER_CACHE_ENABLED', false);
+try_define('OMEGAUP_SESSION_CACHE_ENABLED', false);
 
 # #########################
 # SMARTY USER CACHE


### PR DESCRIPTION
Este cambio gigante:

* Elimina el hack horrendo para permitir que un ScopedLoginToken sea
  convertible a cadena, obligando a la gente que escriba pruebas a
  usarlo bien.
* Arregla un par de bugs en los controllers, donde no se estaba
  propagando correctamente el auth_token, y eso podría causar errores en
  las consultas internas si se pasa el token mediante el Request y no
  hay cookies con el `ouat`.
* Arregla un par de pruebas erróneas.
* Fixes #854