### PR TITLE
Últimos shims de compatibilidad con backendv1

### DIFF
--- a/frontend/server/libs/Broadcaster.php
+++ b/frontend/server/libs/Broadcaster.php
@@ -27,9 +27,12 @@ class Broadcaster {
             $this->log->debug("Sending update $message");
             $grader->broadcast(
                 is_null($r['contest']) ? null : $r['contest']->alias,
+                is_null($r['problem']) ? null : $r['problem']->alias,
                 $message,
                 $r['clarification']->public != '0',
-                $r['clarification']->author_id
+                $r['user']->username,
+                $r['clarification']->author_id,
+                false  // user_only
             );
         } catch (Exception $e) {
             $this->log->error('Failed to send to broadcaster ' . $e->getMessage());

--- a/frontend/server/libs/Grader.php
+++ b/frontend/server/libs/Grader.php
@@ -120,15 +120,19 @@ class Grader {
         return $this->executeCurl($curl);
     }
 
-    public function broadcast($contest_alias, $message, $broadcast, $user_id = -1, $user_only = false) {
+    public function broadcast($contest_alias, $problem_alias, $message, $public, $username, $user_id = -1, $user_only = false) {
         $curl = $this->initGraderCall(OMEGAUP_GRADER_BROADCAST_URL);
-        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode(array(
+        curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode([
             'contest' => $contest_alias,
+            'problem' => $problem_alias,
             'message' => $message,
-            'broadcast' => $broadcast,
+            'public' => $public,
+            'user' => $username,
+            // TODO(lhchavez): Remove the backendv1-compat fields.
+            'broadcast' => $public,
             'targetUser' => (int)$user_id,
-            'userOnly' => $user_only
-        )));
+            'userOnly' => $user_only,
+        ]));
         return $this->executeCurl($curl);
     }
 }

--- a/frontend/server/libs/Scoreboard.php
+++ b/frontend/server/libs/Scoreboard.php
@@ -272,23 +272,29 @@ class Scoreboard {
             $log->debug('Sending updated scoreboards');
             $grader->broadcast(
                 $contest->alias,
+                null,
                 json_encode(array(
                     'message' => '/scoreboard/update/',
+                    'scoreboard_type' => 'admin',
                     'scoreboard' => $adminScoreboard
                 )),
-                false,
-                -1,
-                false
+                false,  // public
+                null,  // username
+                -1,  // user_id
+                false  // user_only
             );
             $grader->broadcast(
                 $contest->alias,
+                null,
                 json_encode(array(
                     'message' => '/scoreboard/update/',
+                    'scoreboard_type' => 'contestant',
                     'scoreboard' => $contestantScoreboard
                 )),
-                true,
-                -1,
-                true
+                true,  // public
+                null,  // username
+                -1,  // user_id
+                true  // user_only
             );
         } catch (Exception $e) {
             $log->error('Error broadcasting scoreboard: ' . $e);

--- a/frontend/server/libs/Scoreboard.php
+++ b/frontend/server/libs/Scoreboard.php
@@ -273,11 +273,11 @@ class Scoreboard {
             $grader->broadcast(
                 $contest->alias,
                 null,
-                json_encode(array(
+                json_encode([
                     'message' => '/scoreboard/update/',
                     'scoreboard_type' => 'admin',
                     'scoreboard' => $adminScoreboard
-                )),
+                ]),
                 false,  // public
                 null,  // username
                 -1,  // user_id
@@ -286,11 +286,11 @@ class Scoreboard {
             $grader->broadcast(
                 $contest->alias,
                 null,
-                json_encode(array(
+                json_encode([
                     'message' => '/scoreboard/update/',
                     'scoreboard_type' => 'contestant',
                     'scoreboard' => $contestantScoreboard
-                )),
+                ]),
                 true,  // public
                 null,  // username
                 -1,  // user_id


### PR DESCRIPTION
Este cambio agrega campos a los mensajes enviados a Broadcaster para que
sean compatibles con tanto backendv1 como backendv2. En teoría con este
cambio ya podemos empezar a hacer la migración.