### PR TITLE
Agregando soporte para experimentos por-usuario

### DIFF
--- a/frontend/database/11_experiments.sql
+++ b/frontend/database/11_experiments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `Users_Experiments` (
+  `user_id` int(11) NOT NULL,
+  `experiment` varchar(256) NOT NULL,
+  KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Guarda los experimentos habilitados para un usuario.';
+
+ALTER TABLE `Users_Experiments`
+  ADD CONSTRAINT `fk_ueu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -678,6 +678,17 @@ CREATE TABLE IF NOT EXISTS `User_Roles` (
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `Users_Experiments`
+--
+CREATE TABLE IF NOT EXISTS `Users_Experiments` (
+  `user_id` int(11) NOT NULL,
+  `experiment` varchar(256) NOT NULL,
+  KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Guarda los experimentos habilitados para un usuario.';
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `User_Permissions`
 --
 
@@ -1027,6 +1038,12 @@ ALTER TABLE `User_Roles`
 ALTER TABLE `Users_Permissions`
   ADD CONSTRAINT `fk_up_permission_id` FOREIGN KEY (`permission_id`) REFERENCES `Permissions` (`permission_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   ADD CONSTRAINT `fk_up_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+--
+-- Filtros para la tabla `Users_Experiments`
+--
+ALTER TABLE `Users_Experiments`
+  ADD CONSTRAINT `fk_ueu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 ALTER TABLE `Groups`
   ADD CONSTRAINT `fk_g_user_id` FOREIGN KEY (`owner_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -221,10 +221,14 @@ if (!defined('IS_TEST') || IS_TEST !== true) {
 } else {
     // During testing We need smarty to load strings from *.lang files
     $lang = 'pseudo';
+    $session = ['valid' => false];
 }
 
 $smarty->configLoad(__DIR__ . '/../templates/'. $lang . '.lang');
 $smarty->addPluginsDir(__DIR__ . '/../smarty_plugins/');
 
-$experiments = new Experiments($_REQUEST);
+$experiments = new Experiments(
+    $_REQUEST,
+    array_key_exists('user', $session) ? $session['user'] : null
+);
 $smarty->assign('ENABLED_EXPERIMENTS', $experiments->getEnabledExperiments());

--- a/frontend/server/libs/ExperimentHashCmd.php
+++ b/frontend/server/libs/ExperimentHashCmd.php
@@ -11,5 +11,5 @@ if (count($argv) < 2) {
     die(1);
 }
 
-$experiments = new Experiments(array());
+$experiments = new Experiments([], null);
 echo $experiments->getExperimentHash($argv[1]) . "\n";

--- a/frontend/server/libs/dao/Users_Experiments.dao.php
+++ b/frontend/server/libs/dao/Users_Experiments.dao.php
@@ -1,0 +1,14 @@
+<?php
+
+include('base/Users_Experiments.dao.base.php');
+include('base/Users_Experiments.vo.base.php');
+/** UsersExperiments Data Access Object (DAO).
+  *
+  * Esta clase contiene toda la manipulacion de bases de datos que se necesita para
+  * almacenar de forma permanente y recuperar instancias de objetos {@link UsersExperiments }.
+  * @access public
+  *
+  */
+class UsersExperimentsDAO extends UsersExperimentsDAOBase
+{
+}

--- a/frontend/server/libs/dao/base/Users_Experiments.dao.base.php
+++ b/frontend/server/libs/dao/base/Users_Experiments.dao.base.php
@@ -1,0 +1,235 @@
+<?php
+
+/** ******************************************************************************* *
+  *                    !ATENCION!                                                   *
+  *                                                                                 *
+  * Este codigo es generado automaticamente. Si lo modificas tus cambios seran      *
+  * reemplazados la proxima vez que se autogenere el codigo.                        *
+  *                                                                                 *
+  * ******************************************************************************* */
+
+/** UsersExperiments Data Access Object (DAO) Base.
+  *
+  * Esta clase contiene toda la manipulacion de bases de datos que se necesita para
+  * almacenar de forma permanente y recuperar instancias de objetos {@link UsersExperiments }.
+  * @access public
+  * @abstract
+  *
+  */
+abstract class UsersExperimentsDAOBase extends DAO
+{
+	/**
+	  *	Guardar registros.
+	  *
+	  *	Este metodo guarda el estado actual del objeto {@link UsersExperiments} pasado en la base de datos.
+	  *	save() siempre creara una nueva fila.
+	  *
+	  *	@static
+	  * @throws Exception si la operacion fallo.
+	  * @param UsersExperiments [$Users_Experiments] El objeto de tipo UsersExperiments
+	  * @return Un entero mayor o igual a cero denotando las filas afectadas.
+	  **/
+	public static final function save( $Users_Experiments )
+	{
+		return UsersExperimentsDAOBase::create( $Users_Experiments);
+	}
+
+	/**
+	  *	Obtener todas las filas.
+	  *
+	  * Esta funcion leera todos los contenidos de la tabla en la base de datos y construira
+	  * un vector que contiene objetos de tipo {@link UsersExperiments}. Tenga en cuenta que este metodo
+	  * consumen enormes cantidades de recursos si la tabla tiene muchas filas.
+	  * Este metodo solo debe usarse cuando las tablas destino tienen solo pequenas cantidades de datos o se usan sus parametros para obtener un menor numero de filas.
+	  *
+	  *	@static
+	  * @param $pagina Pagina a ver.
+	  * @param $columnas_por_pagina Columnas por pagina.
+	  * @param $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+	  * @param $tipo_de_orden 'ASC' o 'DESC' el default es 'ASC'
+	  * @return Array Un arreglo que contiene objetos del tipo {@link UsersExperiments}.
+	  **/
+	public static final function getAll( $pagina = NULL, $columnas_por_pagina = NULL, $orden = NULL, $tipo_de_orden = 'ASC' )
+	{
+		$sql = "SELECT * from Users_Experiments";
+		if( ! is_null ( $orden ) )
+		{ $sql .= " ORDER BY `" . $orden . "` " . $tipo_de_orden;	}
+		if( ! is_null ( $pagina ) )
+		{
+			$sql .= " LIMIT " . (( $pagina - 1 )*$columnas_por_pagina) . "," . $columnas_por_pagina;
+		}
+		global $conn;
+		$rs = $conn->Execute($sql);
+		$allData = array();
+		foreach ($rs as $foo) {
+			$bar = new UsersExperiments($foo);
+    		array_push( $allData, $bar);
+		}
+		return $allData;
+	}
+
+	/**
+	  *	Buscar registros.
+	  *
+	  * Este metodo proporciona capacidad de busqueda para conseguir un juego de objetos {@link UsersExperiments} de la base de datos.
+	  * Consiste en buscar todos los objetos que coinciden con las variables permanentes instanciadas de objeto pasado como argumento.
+	  * Aquellas variables que tienen valores NULL seran excluidos en busca de criterios.
+	  *
+	  * <code>
+	  *  /**
+	  *   * Ejemplo de uso - buscar todos los clientes que tengan limite de credito igual a 20000
+	  *   {@*}
+	  *	  $cliente = new Cliente();
+	  *	  $cliente->setLimiteCredito("20000");
+	  *	  $resultados = ClienteDAO::search($cliente);
+	  *
+	  *	  foreach($resultados as $c ){
+	  *	  	echo $c->nombre . "<br>";
+	  *	  }
+	  * </code>
+	  *	@static
+	  * @param UsersExperiments [$Users_Experiments] El objeto de tipo UsersExperiments
+	  * @param $orderBy Debe ser una cadena con el nombre de una columna en la base de datos.
+	  * @param $orden 'ASC' o 'DESC' el default es 'ASC'
+	  **/
+	public static final function search( $Users_Experiments , $orderBy = null, $orden = 'ASC', $offset = 0, $rowcount = NULL, $likeColumns = NULL)
+	{
+		if (!($Users_Experiments instanceof UsersExperiments)) {
+			return self::search(new UsersExperiments($Users_Experiments));
+		}
+
+		$sql = "SELECT * from Users_Experiments WHERE (";
+		$val = array();
+		if (!is_null( $Users_Experiments->user_id)) {
+			$sql .= " `user_id` = ? AND";
+			array_push( $val, $Users_Experiments->user_id );
+		}
+		if (!is_null( $Users_Experiments->experiment)) {
+			$sql .= " `experiment` = ? AND";
+			array_push( $val, $Users_Experiments->experiment );
+		}
+		if (!is_null($likeColumns)) {
+			foreach ($likeColumns as $column => $value) {
+				$escapedValue = mysql_real_escape_string($value);
+				$sql .= "`{$column}` LIKE '%{$value}%' AND";
+			}
+		}
+		if(sizeof($val) == 0) {
+			return self::getAll();
+		}
+		$sql = substr($sql, 0, -3) . " )";
+		if( ! is_null ( $orderBy ) ){
+			$sql .= " ORDER BY `" . $orderBy . "` " . $orden;
+		}
+		// Add LIMIT offset, rowcount if rowcount is set
+		if (!is_null($rowcount)) {
+			$sql .= " LIMIT ". $offset . "," . $rowcount;
+		}
+		global $conn;
+		$rs = $conn->Execute($sql, $val);
+		$ar = array();
+		foreach ($rs as $foo) {
+			$bar =  new UsersExperiments($foo);
+			array_push( $ar,$bar);
+		}
+		return $ar;
+	}
+
+	/**
+	  *	Crear registros.
+	  *
+	  * Este metodo creara una nueva fila en la base de datos de acuerdo con los
+	  * contenidos del objeto UsersExperiments suministrado. Asegurese
+	  * de que los valores para todas las columnas NOT NULL se ha especificado
+	  * correctamente. Despues del comando INSERT, este metodo asignara la clave
+	  * primaria generada en el objeto UsersExperiments dentro de la misma transaccion.
+	  *
+	  * @return Un entero mayor o igual a cero identificando las filas afectadas, en caso de error, regresara una cadena con la descripcion del error
+	  * @param UsersExperiments [$Users_Experiments] El objeto de tipo UsersExperiments a crear.
+	  **/
+	private static final function create( $Users_Experiments )
+	{
+		$sql = "INSERT INTO Users_Experiments ( `user_id`, `experiment` ) VALUES ( ?, ?);";
+		$params = array(
+			$Users_Experiments->user_id,
+			$Users_Experiments->experiment,
+		 );
+		global $conn;
+		$conn->Execute($sql, $params);
+		$ar = $conn->Affected_Rows();
+		if($ar == 0) return 0;
+
+		return $ar;
+	}
+
+	/**
+	  *	Buscar por rango.
+	  *
+	  * Este metodo proporciona capacidad de busqueda para conseguir un juego de objetos {@link UsersExperiments} de la base de datos siempre y cuando
+	  * esten dentro del rango de atributos activos de dos objetos criterio de tipo {@link UsersExperiments}.
+	  *
+	  * Aquellas variables que tienen valores NULL seran excluidos en la busqueda (los valores 0 y false no son tomados como NULL) .
+	  * No es necesario ordenar los objetos criterio, asi como tambien es posible mezclar atributos.
+	  * Si algun atributo solo esta especificado en solo uno de los objetos de criterio se buscara que los resultados conicidan exactamente en ese campo.
+	  *
+	  * <code>
+	  *  /**
+	  *   * Ejemplo de uso - buscar todos los clientes que tengan limite de credito
+	  *   * mayor a 2000 y menor a 5000. Y que tengan un descuento del 50%.
+	  *   {@*}
+	  *	  $cr1 = new Cliente();
+	  *	  $cr1->limite_credito = "2000";
+	  *	  $cr1->descuento = "50";
+	  *
+	  *	  $cr2 = new Cliente();
+	  *	  $cr2->limite_credito = "5000";
+	  *	  $resultados = ClienteDAO::byRange($cr1, $cr2);
+	  *
+	  *	  foreach($resultados as $c ){
+	  *	  	echo $c->nombre . "<br>";
+	  *	  }
+	  * </code>
+	  *	@static
+	  * @param UsersExperiments [$Users_Experiments] El objeto de tipo UsersExperiments
+	  * @param UsersExperiments [$Users_Experiments] El objeto de tipo UsersExperiments
+	  * @param $orderBy Debe ser una cadena con el nombre de una columna en la base de datos.
+	  * @param $orden 'ASC' o 'DESC' el default es 'ASC'
+	  **/
+	public static final function byRange( $Users_ExperimentsA , $Users_ExperimentsB , $orderBy = null, $orden = 'ASC')
+	{
+		$sql = "SELECT * from Users_Experiments WHERE (";
+		$val = array();
+		if( ( !is_null (($a = $Users_ExperimentsA->user_id) ) ) & ( ! is_null ( ($b = $Users_ExperimentsB->user_id) ) ) ){
+				$sql .= " `user_id` >= ? AND `user_id` <= ? AND";
+				array_push( $val, min($a,$b));
+				array_push( $val, max($a,$b));
+		}elseif( !is_null ( $a ) || !is_null ( $b ) ){
+			$sql .= " `user_id` = ? AND";
+			$a = is_null ( $a ) ? $b : $a;
+			array_push( $val, $a);
+		}
+
+		if( ( !is_null (($a = $Users_ExperimentsA->experiment) ) ) & ( ! is_null ( ($b = $Users_ExperimentsB->experiment) ) ) ){
+				$sql .= " `experiment` >= ? AND `experiment` <= ? AND";
+				array_push( $val, min($a,$b));
+				array_push( $val, max($a,$b));
+		}elseif( !is_null ( $a ) || !is_null ( $b ) ){
+			$sql .= " `experiment` = ? AND";
+			$a = is_null ( $a ) ? $b : $a;
+			array_push( $val, $a);
+		}
+
+		$sql = substr($sql, 0, -3) . " )";
+		if( !is_null ( $orderBy ) ){
+		    $sql .= " order by `" . $orderBy . "` " . $orden ;
+		}
+		global $conn;
+		$rs = $conn->Execute($sql, $val);
+		$ar = array();
+		foreach ($rs as $row) {
+			array_push( $ar, $bar = new UsersExperiments($row));
+		}
+		return $ar;
+	}
+
+}

--- a/frontend/server/libs/dao/base/Users_Experiments.vo.base.php
+++ b/frontend/server/libs/dao/base/Users_Experiments.vo.base.php
@@ -1,0 +1,82 @@
+<?php
+
+/** ******************************************************************************* *
+  *                    !ATENCION!                                                   *
+  *                                                                                 *
+  * Este codigo es generado automaticamente. Si lo modificas tus cambios seran      *
+  * reemplazados la proxima vez que se autogenere el codigo.                        *
+  *                                                                                 *
+  * ******************************************************************************* */
+
+/** Value Object file for table Users_Experiments.
+  *
+  * VO does not have any behaviour.
+  * @access public
+  *
+  */
+
+class UsersExperiments extends VO
+{
+	/**
+	  * Constructor de UsersExperiments
+	  *
+	  * Para construir un objeto de tipo UsersExperiments debera llamarse a el constructor
+	  * sin parametros. Es posible, construir un objeto pasando como parametro un arreglo asociativo
+	  * cuyos campos son iguales a las variables que constituyen a este objeto.
+	  */
+	function __construct($data = NULL)
+	{
+		if (isset($data))
+		{
+			if (is_string($data))
+				$data = self::object_to_array(json_decode($data));
+
+			if (isset($data['user_id'])) {
+				$this->user_id = $data['user_id'];
+			}
+			if (isset($data['experiment'])) {
+				$this->experiment = $data['experiment'];
+			}
+		}
+	}
+
+	/**
+	  * Obtener una representacion en String
+	  *
+	  * Este metodo permite tratar a un objeto UsersExperiments en forma de cadena.
+	  * La representacion de este objeto en cadena es la forma JSON (JavaScript Object Notation) para este objeto.
+	  * @return String
+	  */
+	public function __toString( )
+	{
+		$vec = array(
+			"user_id" => $this->user_id,
+			"experiment" => $this->experiment
+		);
+	return json_encode($vec);
+	}
+
+	/**
+	 * Converts date fields to timestamps
+	 **/
+	public function toUnixTime(array $fields = array()) {
+		if (count($fields) > 0)
+			parent::toUnixTime($fields);
+		else
+			parent::toUnixTime(array());
+	}
+
+	/**
+	  *  [Campo no documentado]
+	  * @access public
+	  * @var int(11)
+	  */
+	public $user_id;
+
+	/**
+	  *  [Campo no documentado]
+	  * @access public
+	  * @var varchar(256)
+	  */
+	public $experiment;
+}

--- a/frontend/tests/controllers/ExperimentTest.php
+++ b/frontend/tests/controllers/ExperimentTest.php
@@ -3,26 +3,26 @@
 class ExperimentsTest extends PHPUnit_Framework_TestCase {
     const TEST = 'experiment_test';
 
-    private static $kKnownExperiments = array(
+    private static $kKnownExperiments = [
         self::TEST,
-    );
+    ];
 
     private static function getRequestForExperiments(array $experiments) {
-        $kvp = array();
+        $kvp = [];
         foreach ($experiments as $name) {
             $kvp[] = $name . '=' . Experiments::getExperimentHash($name);
         }
-        return array(
+        return [
             Experiments::EXPERIMENT_REQUEST_NAME => implode(',', $kvp),
-        );
+        ];
     }
 
     public function testConfigExperiments() {
-        $defines = array(
+        $defines = [
             Experiments::EXPERIMENT_PREFIX . strtoupper(self::TEST) => true,
-        );
+        ];
         $experiments = new
-            Experiments(array(), $defines, self::$kKnownExperiments);
+            Experiments([], null, $defines, self::$kKnownExperiments);
 
         $this->assertEquals(
             self::$kKnownExperiments,
@@ -34,8 +34,9 @@ class ExperimentsTest extends PHPUnit_Framework_TestCase {
     public function testRequestExperiments() {
         $experiments = new
             Experiments(
-                self::getRequestForExperiments(array(self::TEST)),
-                array(),
+                self::getRequestForExperiments([self::TEST]),
+                null,
+                [],
                 self::$kKnownExperiments
             );
 
@@ -49,8 +50,9 @@ class ExperimentsTest extends PHPUnit_Framework_TestCase {
     public function testRequestUnknownExperiments() {
         $experiments = new
             Experiments(
-                self::getRequestForExperiments(array('foo')),
-                array(),
+                self::getRequestForExperiments(['foo']),
+                null,
+                [],
                 self::$kKnownExperiments
             );
 
@@ -61,15 +63,51 @@ class ExperimentsTest extends PHPUnit_Framework_TestCase {
     public function testRequestInvalidExperiments() {
         $experiments = new
             Experiments(
-                array(
+                [
                     Experiments::EXPERIMENT_REQUEST_NAME =>
                         self::TEST . '=invalid_hash',
-                ),
-                array(),
+                ],
+                null,
+                [],
                 self::$kKnownExperiments
             );
 
         $this->assertEmpty($experiments->getEnabledExperiments());
         $this->assertFalse($experiments->isEnabled(self::TEST));
+    }
+
+    public function testUserExperiments() {
+        $user = UserFactory::createUser();
+        $experiments = new
+            Experiments(
+                [],
+                $user,
+                [],
+                self::$kKnownExperiments
+            );
+
+        $this->assertEmpty($experiments->getEnabledExperiments());
+        $this->assertFalse($experiments->isEnabled(self::TEST));
+
+        // After adding the user-experiment relationship to the database, the
+        // experiment should be enabled.
+        UsersExperimentsDAO::save(new UsersExperiments([
+            'user_id' => $user->user_id,
+            'experiment' => self::TEST,
+        ]));
+
+        $experiments = new
+            Experiments(
+                [],
+                $user,
+                [],
+                self::$kKnownExperiments
+            );
+
+        $this->assertEquals(
+            self::$kKnownExperiments,
+            $experiments->getEnabledExperiments()
+        );
+        $this->assertTrue($experiments->isEnabled(self::TEST));
     }
 }


### PR DESCRIPTION
Este cambio agrega una tabla en la base de datos (Users_Experiments)
para almacenar los experimentos que se han aprobado para usuarios
individuales. También hace los cambios necesarios a Experiments para
cargar los experimentos que se han habilitado para cada usuario.