### PR TITLE
Permitir buscar por tags no-publicos en mis problemas

### DIFF
--- a/frontend/server/libs/Authorization.php
+++ b/frontend/server/libs/Authorization.php
@@ -198,4 +198,8 @@ class Authorization {
 
         return !is_null($groupUsers) && count($groupUsers) > 0;
     }
+
+    public static function clearSystemAdminCache() {
+        self::$is_system_admin = null;
+    }
 }

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -351,5 +351,6 @@ class ScopedLoginToken {
 
     public function __destruct() {
         OmegaUpTestCase::logout();
+        Authorization::clearSystemAdminCache();
     }
 }

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -147,7 +147,6 @@ class ProblemList extends OmegaupTestCase {
             0,      // Random user can't see any problem at all
         ];
         for ($i = 0; $i < 4; $i++) {
-            Authorization::clearSystemAdminCache();
             $login = self::login($all_users[$i]);
 
             $response = ProblemController::apiList(new Request([

--- a/frontend/tests/factories/ProblemsFactory.php
+++ b/frontend/tests/factories/ProblemsFactory.php
@@ -149,12 +149,12 @@ class ProblemsFactory {
         ProblemController::apiAddGroupAdmin($r);
     }
 
-    public static function addTag($problemData, $tag) {
+    public static function addTag($problemData, $tag, $public) {
         // Prepare our request
         $r = new Request(array(
             'problem_alias' => $problemData['request']['alias'],
             'name' => $tag,
-            'public' => 1
+            'public' => $public
         ));
 
         // Log in the problem author


### PR DESCRIPTION
Ahorita la busqueda por tags requiere que los tags sean publicos aun para problemas de los que el usuario es owner.
Despues de este cambio las busquedas por tags son:
* Admin: ve todos los tags
* User: tags publicos en problemas non-owned y todos los tags en problemas owned
* Anonymous: tags publicos en problemas publicos

El motivating use case es un maestro subiendo problemas privados y etiquetandolos (e.g. para un examen) y no los etiqueta publicamente, pero igual quiere buscarlos por tag en la interfaz de agregar problemas a tareas.