### PR TITLE
Agregando un log para los reportes de CSP

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -89,6 +89,12 @@ Logger::configure(array(
             'appenders' => array('default'),
             'level' => OMEGAUP_LOG_LEVEL
         ),
+        'loggers' => array(
+            'csp' => array(
+                'appenders' => array('csp'),
+                'additivity' => false,
+            ),
+        ),
         'appenders' => array(
             'default' => array(
                 'class' => 'LoggerAppenderFile',
@@ -102,6 +108,19 @@ Logger::configure(array(
                     'file' => OMEGAUP_LOG_FILE,
                     'append' => true
                 )
+            ),
+            'csp' => array(
+                'class' => 'LoggerAppenderFile',
+                'layout' => array(
+                    'class' => 'LoggerLayoutPattern',
+                    'params' => array(
+                        'conversionPattern' => '%date: %message %newline',
+                    ),
+                ),
+                'params' => array(
+                    'file' => OMEGAUP_CSP_LOG_FILE,
+                    'append' => true,
+                ),
             )
         )
     ));

--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -45,6 +45,7 @@ try_define('OMEGAUP_LOG_TO_FILE', true);
 try_define('OMEGAUP_LOG_DB_QUERYS', false);
 try_define('OMEGAUP_LOG_LEVEL', 'info');
 try_define('OMEGAUP_LOG_FILE', '/var/log/omegaup/omegaup.log');
+try_define('OMEGAUP_CSP_LOG_FILE', '/var/log/omegaup/csp.log');
 
 # ####################################
 # GRADER CONFIG


### PR DESCRIPTION
Hacer espeleología en el log principal para encontrar las violaciones de
CSP es horrible. Mejor hay que tener un log separado.