### PR TITLE
Bugfix: Arreglar Back button en la arena

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -916,7 +916,8 @@ omegaup.arena.Arena.prototype.onHashChanged = function() {
   }
 
   if (!foundHash) {
-    window.location.hash = '#' + self.activeTab;
+    // Change the URL to the deafult tab but don't break the back button.
+    window.history.replaceState({}, '', '#' + self.activeTab);
   }
 
   var problem = /#problems\/([^\/]+)(\/new-run)?/.exec(window.location.hash);


### PR DESCRIPTION
Al entrar a la arena sin un tab seleccionado (en la forma de un hash en el URL) se agrega el hash del tab default al URL. Pero eso crea un nuevo elemento en el stack del historial. Darle click a Back regresa al URL sin hash, que lo primero que hace es agregarlo.. y uno se queda atorado ahi para siempre!