### PR TITLE
Dejar de normalizar las fechas en el API de detalles de concursos

### DIFF
--- a/frontend/www/js/contest.edit.js
+++ b/frontend/www/js/contest.edit.js
@@ -14,49 +14,51 @@ omegaup.OmegaUp.on('ready', function() {
   var contestAlias =
       /\/contest\/([^\/]+)\/edit\/?.*/.exec(window.location.pathname)[1];
 
-  omegaup.API.getContestAdminDetails(contestAlias, function(contest) {
-    $('.page-header h1 span')
-        .html(omegaup.T['contestEdit'] + ' ' + contest.title);
-    $('.page-header h1 small')
-        .html('&ndash; <a href="/arena/' + contestAlias + '/">' +
-              omegaup.T['contestDetailsGoToContest'] + '</a>');
-    $('.new_contest_form #title').val(contest.title);
-    $('.new_contest_form #alias').val(contest.alias);
-    $('.new_contest_form #description').val(contest.description);
-    $('.new_contest_form #start-time')
-        .val(omegaup.UI.formatDateTime(contest.start_time));
-    $('.new_contest_form #finish-time')
-        .val(omegaup.UI.formatDateTime(contest.finish_time));
+  omegaup.API.getContestAdminDetails({contest_alias: contestAlias})
+      .then(function(contest) {
+        $('.page-header h1 span')
+            .html(omegaup.T['contestEdit'] + ' ' + contest.title);
+        $('.page-header h1 small')
+            .html('&ndash; <a href="/arena/' + contestAlias + '/">' +
+                  omegaup.T['contestDetailsGoToContest'] + '</a>');
+        $('.new_contest_form #title').val(contest.title);
+        $('.new_contest_form #alias').val(contest.alias);
+        $('.new_contest_form #description').val(contest.description);
+        $('.new_contest_form #start-time')
+            .val(omegaup.UI.formatDateTime(contest.start_time));
+        $('.new_contest_form #finish-time')
+            .val(omegaup.UI.formatDateTime(contest.finish_time));
 
-    if (contest.window_length === null) {
-      // Disable window length
-      $('#window-length-enabled').removeAttr('checked');
-      $('#window-length').val('');
-    } else {
-      $('#window-length-enabled').attr('checked', 'checked');
-      $('#window-length').removeAttr('disabled');
-      $('#window-length').val(contest.window_length);
-    }
+        if (contest.window_length === null) {
+          // Disable window length
+          $('#window-length-enabled').removeAttr('checked');
+          $('#window-length').val('');
+        } else {
+          $('#window-length-enabled').attr('checked', 'checked');
+          $('#window-length').removeAttr('disabled');
+          $('#window-length').val(contest.window_length);
+        }
 
-    $('.new_contest_form #points-decay-factor')
-        .val(contest.points_decay_factor);
-    $('.new_contest_form #submissions-gap').val(contest.submissions_gap / 60);
-    $('.new_contest_form #feedback').val(contest.feedback);
-    $('.new_contest_form #penalty').val(contest.penalty);
-    $('.new_contest_form #public').val(contest.public);
-    $('.new_contest_form #register').val(contest.contestant_must_register);
-    $('.new_contest_form #scoreboard').val(contest.scoreboard);
-    $('.new_contest_form #penalty-type').val(contest.penalty_type);
-    $('.new_contest_form #show-scoreboard-after')
-        .val(contest.show_scoreboard_after);
+        $('.new_contest_form #points-decay-factor')
+            .val(contest.points_decay_factor);
+        $('.new_contest_form #submissions-gap')
+            .val(contest.submissions_gap / 60);
+        $('.new_contest_form #feedback').val(contest.feedback);
+        $('.new_contest_form #penalty').val(contest.penalty);
+        $('.new_contest_form #public').val(contest.public);
+        $('.new_contest_form #register').val(contest.contestant_must_register);
+        $('.new_contest_form #scoreboard').val(contest.scoreboard);
+        $('.new_contest_form #penalty-type').val(contest.penalty_type);
+        $('.new_contest_form #show-scoreboard-after')
+            .val(contest.show_scoreboard_after);
 
-    $('.contest-publish-form #public').val(contest.public);
+        $('.contest-publish-form #public').val(contest.public);
 
-    if (contest.contestant_must_register == null ||
-        contest.contestant_must_register == '0') {
-      $('#requests').hide();
-    }
-  });
+        if (contest.contestant_must_register == null ||
+            contest.contestant_must_register == '0') {
+          $('#requests').hide();
+        }
+      });
 
   omegaup.API.getProblems(function(problems) {
     // Got the problems, lets populate the dropdown with them

--- a/frontend/www/js/interviews.edit.js
+++ b/frontend/www/js/interviews.edit.js
@@ -48,16 +48,17 @@ omegaup.OmegaUp.on('ready', function() {
         return false;  // Prevent page refresh on submit
       });
 
-  omegaup.API.getContestAdminDetails(interviewAlias, function(contest) {
-    $('.page-header h1 span')
-        .html(omegaup.T['interviewEdit'] + ' ' + contest.title);
-    $('.page-header h1 small')
-        .html('&ndash; <a href="/interview/' + interviewAlias + '/arena">' +
-              omegaup.T['interviewGoToInterview'] + '</a>');
-    $('.new_interview_form #title').val(contest.title);
-    $('.new_interview_form #description').val(contest.description);
-    $('#window_length').val(contest.window_length);
-  });
+  omegaup.API.getContestAdminDetails({contest_alias: contestAlias})
+      .then(function(contest) {
+        $('.page-header h1 span')
+            .html(omegaup.T['interviewEdit'] + ' ' + contest.title);
+        $('.page-header h1 small')
+            .html('&ndash; <a href="/interview/' + interviewAlias + '/arena">' +
+                  omegaup.T['interviewGoToInterview'] + '</a>');
+        $('.new_interview_form #title').val(contest.title);
+        $('.new_interview_form #description').val(contest.description);
+        $('#window_length').val(contest.window_length);
+      });
 
   function fillCandidatesTable() {
     omegaup.API.getInterview(interviewAlias, function(interview) {

--- a/frontend/www/js/omegaup/api.js
+++ b/frontend/www/js/omegaup/api.js
@@ -270,22 +270,24 @@ omegaup.API = {
         });
   },
 
-  getContestAdminDetails: function(alias, callback) {
-    $.get('/api/contest/admindetails/contest_alias/' +
-              encodeURIComponent(alias) + '/',
-          function(contest) {
-            if (contest.status == 'ok') {
-              omegaup.API._normalizeContestFields(contest);
-            }
-            callback(contest);
-          },
-          'json')
-        .fail(function(j, status, errorThrown) {
-          try {
-            callback(JSON.parse(j.responseText));
-          } catch (err) {
-            callback({status: 'error', 'error': undefined});
-          }
+  getContestAdminDetails: function(params) {
+    return omegaup.API._wrapDeferred(
+        $.ajax({
+          url: '/api/contest/admindetails/',
+          method: 'POST',
+          data: params,
+          dataType: 'json',
+        }),
+        function(contest) {
+          // We cannot use |_normalizeContestFields| because admins need to be
+          // able to get the unmodified times.
+          contest.start_time = new Date(contest.start_time * 1000);
+          contest.finish_time = new Date(contest.finish_time * 1000);
+          contest.submission_deadline =
+              omegaup.OmegaUp.time(contest.submission_deadline * 1000);
+          contest.show_penalty =
+              (contest.penalty != 0 || contest.penalty_type != 'none');
+          return contest;
         });
   },
 


### PR DESCRIPTION
Esto causa que la fecha no coincida con la fecha que tiene guardado el
backend, causando que rechace cualquier edición porque eso causaría que
la hora de fin del concurso cambie. Fixed #1017.