### PR TITLE
Fix #1129: Vue + typeahead.js no se llevan

### DIFF
--- a/frontend/www/js/omegaup/components/course/AddStudents.vue
+++ b/frontend/www/js/omegaup/components/course/AddStudents.vue
@@ -5,7 +5,7 @@
         <div class="form-group">
           <label for="member-username">{{ T.wordsStudent }}</label>
           <span data-toggle="tooltip" data-placement="top" v-bind:title="T.courseEditAddStudentsTooltip"  class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-          <input v-model="studentUsername" type="text" size="20" class="form-control" autocomplete="off" />
+          <input id="student-username" v-model="studentUsername" type="text" size="20" class="form-control" autocomplete="off" />
         </div>
         <div class="form-group pull-right">
           <button class="btn btn-primary" type="submit">{{ T.wordsAddStudent }}</button>

--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -262,7 +262,7 @@ OmegaUp.on('ready', function() {
           'add-student': function(username) {
             API.Course.addStudent({
                         course_alias: courseAlias,
-                        usernameOrEmail: username,
+                        usernameOrEmail: $('#student-username').val(),
                       })
                 .then(function(data) {
                   refreshStudentList();


### PR DESCRIPTION
Por ahorita, pedir el valor del input por id.
TODO: La verdadera solucion es usar [vuejs-typeahead](https://www.npmjs.com/package/vuejs-typeahead)