### PR TITLE
Permitiendo especificar los puntos al agregar problemas a un curso

### DIFF
--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -163,6 +163,10 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         self::validateCreateOrUpdate($r);
 
+        if ($r['alias'] == 'new') {
+            throw new DuplicatedEntryInDatabaseException('aliasInUse');
+        }
+
         if (!is_null(CoursesDAO::findByAlias($r['alias']))) {
             throw new DuplicatedEntryInDatabaseException('aliasInUse');
         }
@@ -337,11 +341,16 @@ class CourseController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        $problemSetProblem = new ProblemsetProblems();
-        $problemSetProblem->problemset_id = $problemSet->problemset_id;
-        $problemSetProblem->problem_id = $problem->problem_id;
+        $points = 100;
+        if (is_numeric($r['points'])) {
+            $points = (int)$r['points'];
+        }
 
-        ProblemsetProblemsDAO::save($problemSetProblem);
+        ProblemsetProblemsDAO::save(new ProblemsetProblems([
+            'problemset_id' => $problemSet->problemset_id,
+            'problem_id' => $problem->problem_id,
+            'points' => $points,
+        ]));
 
         return ['status' => 'ok'];
     }


### PR DESCRIPTION
Este cambio:

a) Permite especificar el puntaje al agregar un problema.
b) Utiliza un default de 100 puntos si no se especifica algo.
c) Fixes #1074 de paso bicós juay not.