### PR TITLE
Bugifx: Declarar $smarty como global en SessionController

### DIFF
--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -357,6 +357,7 @@ class SessionController extends Controller {
         self::$log->info('User is logged in via facebook !!');
         if (!isset($fb_user_profile['email'])) {
             self::$log->error('Facebook email empty');
+            global $smarty;
             return [
                 'status' => 'error',
                 'error' => $smarty->getConfigVariable(


### PR DESCRIPTION
Git se comio a "$smarty" en el commit message.
Deberia arreglar el problema que reporto @alanboy al intentar hacer login con FB.