### PR TITLE
Arreglar async que descompuso OfS.ViewProgress

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "babel-core": "^6.23.1",
     "babel-loader": "^6.2.10",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "cross-env": "^3.1.4",
     "css-loader": "^0.26.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,10 +4,10 @@ var webpack = require('webpack')
 module.exports = {
   entry: {
     omegaup: './frontend/www/js/omegaup/omegaup.js',
-    course_edit: './frontend/www/js/omegaup/course/edit.js',
+    course_edit: ['babel-polyfill', './frontend/www/js/omegaup/course/edit.js'],
     course_new: './frontend/www/js/omegaup/course/new.js',
     course_student: './frontend/www/js/omegaup/course/student.js',
-    course_students: './frontend/www/js/omegaup/course/students.js',
+    course_students: ['babel-polyfill', './frontend/www/js/omegaup/course/students.js'],
     schools_intro: './frontend/www/js/omegaup/schools/intro.js',
   },
   output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,14 @@ babel-plugin-transform-strict-mode@^6.22.0:
     babel-runtime "^6.22.0"
     babel-types "^6.22.0"
 
+babel-polyfill@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-es2015@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz#af5a98ecb35eb8af764ad8a5a05eb36dc4386835"


### PR DESCRIPTION
Async necesita babel-polyfill.
babel-polyfill necesita cargarse primero en todos los exports que lo utilicen.

No se si falte algo mas, pero esto resolvio el problema en mi VM local