### PR TITLE
Arreglando Travis

### DIFF
--- a/stuff/i18n.py
+++ b/stuff/i18n.py
@@ -53,7 +53,7 @@ def generate_json(lang):
 	json_map = {}
 	for key in sorted(strings.keys()):
 		json_map[key] = strings[key][lang]
-	return json.dumps(json_map, lang_file, sort_keys=True, indent='\t')
+	return json.dumps(json_map, sort_keys=True, indent='\t')
 
 for lang_path in glob(os.path.join(templates_dir, '*.lang')):
 	lang_filename = os.path.basename(lang_path)
@@ -118,8 +118,12 @@ if args.validate:
 				errors = True
 		json_lang_path = os.path.join(js_templates_dir, 'lang.%s.json' % lang)
 		with open(json_lang_path, 'r') as lang_file:
-			if lang_file.read() != generate_json(lang):
+			obtained = lang_file.read().strip()
+			expected = generate_json(lang).strip()
+			if obtained != expected:
 				print('Entries in %s do not match the .lang file.' % json_lang_path, file=sys.stderr)
+				print(base64.b64encode(gzip.compress(expected.encode('utf-8'))), file=sys.stderr)
+				print(base64.b64encode(gzip.compress(obtained.encode('utf-8'))), file=sys.stderr)
 				errors = True
 
 if errors:

--- a/stuff/i18n.py
+++ b/stuff/i18n.py
@@ -121,6 +121,8 @@ if args.validate:
 			obtained = lang_file.read().strip()
 			expected = generate_json(lang).strip()
 			if obtained != expected:
+				import base64
+				import gzip
 				print('Entries in %s do not match the .lang file.' % json_lang_path, file=sys.stderr)
 				print(base64.b64encode(gzip.compress(expected.encode('utf-8'))), file=sys.stderr)
 				print(base64.b64encode(gzip.compress(obtained.encode('utf-8'))), file=sys.stderr)

--- a/stuff/i18n.py
+++ b/stuff/i18n.py
@@ -53,7 +53,7 @@ def generate_json(lang):
 	json_map = {}
 	for key in sorted(strings.keys()):
 		json_map[key] = strings[key][lang]
-	return json.dumps(json_map, sort_keys=True, indent='\t')
+	return json_map
 
 for lang_path in glob(os.path.join(templates_dir, '*.lang')):
 	lang_filename = os.path.basename(lang_path)
@@ -118,14 +118,8 @@ if args.validate:
 				errors = True
 		json_lang_path = os.path.join(js_templates_dir, 'lang.%s.json' % lang)
 		with open(json_lang_path, 'r') as lang_file:
-			obtained = lang_file.read().strip()
-			expected = generate_json(lang).strip()
-			if obtained != expected:
-				import base64
-				import gzip
+			if generate_json(lang) != json.load(lang_file):
 				print('Entries in %s do not match the .lang file.' % json_lang_path, file=sys.stderr)
-				print(base64.b64encode(gzip.compress(expected.encode('utf-8'))), file=sys.stderr)
-				print(base64.b64encode(gzip.compress(obtained.encode('utf-8'))), file=sys.stderr)
 				errors = True
 
 if errors:
@@ -165,6 +159,6 @@ for lang in languages:
 		lang_file.write(generate_javascript(lang))
 	json_lang_path = os.path.join(js_templates_dir, 'lang.%s.json' % lang)
 	with open(json_lang_path, 'w') as lang_file:
-		lang_file.write(generate_json(lang))
+		json.dump(generate_json(lang), lang_file, sort_keys=True, indent='\t')
 
 # vim: noexpandtab


### PR DESCRIPTION
Por alguna razón, Travis agrega espacios adicionales al final de cada línea
cuando se usa `json.dumps`, haciendo que la validación fallara. Este cambio
en vez compara el JSON _decodificado_ contra el mapa esperado.