### PR TITLE
Arreglar el orden de rewrites para /profile

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -75,7 +75,7 @@ rewrite ^/problem/mine/?$ /problemmine.php last;
 rewrite ^/problem/new/?$ /problemnew.php last;
 rewrite ^/problem/([a-zA-Z0-9_+-]+)/edit/?$ /problemedit.php?problem=$1 last;
 rewrite ^/problem/([a-zA-Z0-9_+-]+)/stats/?$ /problemstats.php?problem=$1 last;
-rewrite ^/profile/([a-zA-Z0-9_+.-]+)/?$ /profile.php?username=$1 last;
 rewrite ^/profile/?$ /profile.php last;
 rewrite ^/profile/edit/?$ /profileedit.php last;
+rewrite ^/profile/([a-zA-Z0-9_+.-]+)/?$ /profile.php?username=$1 last;
 rewrite ^/rank/?$ /rank.php last;


### PR DESCRIPTION
Fix #1177 
El bicho nacio en https://github.com/omegaup/omegaup/commit/a897a56818ea90d2b53f0f7f37598d34217f0a7c al reordenar los nginx.rewrites para perfil. Ahorita /profile/edit apunta a ver el perfil del usuario "edit" 😞 