### PR TITLE
Arreglando dos errores en MySQL 5.7

### DIFF
--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -231,6 +231,7 @@ class ContestListTest extends OmegaupTestCase {
             null,
             0,
             null,
+            null,
             $recommendedContestData['request']['finish_time'] + 1
         );
 

--- a/stuff/bootstrap.json
+++ b/stuff/bootstrap.json
@@ -19,7 +19,7 @@
 					"source": "omegaUp classics",
 					"languages": "c,cpp,cpp11,cs,hs,java,pas,py,rb,lua",
 					"stack_limit": 33554432,
-					"email_clarifications": true
+					"email_clarifications": 1
 				},
 				"files": {
 					"problem_contents": "frontend/tests/resources/testproblem.zip"
@@ -41,7 +41,7 @@
 					"source": "omegaUp classics",
 					"languages": "c,cpp,cpp11,cs,hs,java,pas,py,rb,lua",
 					"stack_limit": 33554432,
-					"email_clarifications": true
+					"email_clarifications": 1
 				},
 				"files": {
 					"problem_contents": "frontend/tests/resources/triangulos.zip"


### PR DESCRIPTION
Este cambio:

* Pasa correctamente `null` como `languages` en una prueba de
  ContestListTest.php. Antes estaba pasando un timestamp como
  `languages` y MySQL 5.6 lo estaba convenientemente convirtiendo al
  tipo `SET` sin decir nada al respecto.
* Cambia un `True` por `1` en el script de bootstrapping, porque MySQL
  5.7 ya lo toma a mal.