### PR TITLE
Usando `null` como sentinela en `Problemset_Users.access_time`

### DIFF
--- a/frontend/database/17_datetime.sql
+++ b/frontend/database/17_datetime.sql
@@ -21,4 +21,4 @@ CALL `Problemset_Users_Migrate`();
 DROP PROCEDURE `Problemset_Users_Migrate`;
 
 ALTER TABLE `Problemset_User_Request`
-  MODIFY COLUMN `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;
+  MODIFY COLUMN `last_update` timestamp NULL DEFAULT NULL;

--- a/frontend/database/17_datetime.sql
+++ b/frontend/database/17_datetime.sql
@@ -1,0 +1,24 @@
+ALTER TABLE `Problemset_Users`
+  MODIFY COLUMN `access_time` datetime NULL DEFAULT NULL COMMENT 'Hora a la que entró el usuario al concurso';
+
+DELIMITER $$
+CREATE PROCEDURE `Problemset_Users_Migrate`()
+BEGIN
+  DECLARE sentinel VARCHAR(20);
+
+  SET sentinel = '0000-00-00 00:00:00';
+
+  -- MySQL 5.7+ considers directly assigning `sentinel` to a `DATETIME` column
+  -- to be a fatal error. Guard against it by checking if it's a valid value
+  -- with the DAY() function.
+  IF DAY(sentinel) IS NOT NULL THEN
+    UPDATE `Problemset_Users` SET `access_time` = NULL WHERE `access_time` = sentinel;
+  END IF;
+END$$
+DELIMITER ;
+
+CALL `Problemset_Users_Migrate`();
+DROP PROCEDURE `Problemset_Users_Migrate`;
+
+ALTER TABLE `Problemset_User_Request`
+  MODIFY COLUMN `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/frontend/database/1_initial_schema.sql
+++ b/frontend/database/1_initial_schema.sql
@@ -240,7 +240,7 @@ CREATE TABLE IF NOT EXISTS `Contest_User_Request` (
 	`user_id` int(11) NOT NULL,
 	`contest_id` int(11) NOT NULL,
 	`request_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	`last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_update` timestamp NULL DEFAULT NULL,
 	`accepted` tinyint(1) DEFAULT NULL,
 	`extra_note` text,
 	PRIMARY KEY (`user_id`,`contest_id`)

--- a/frontend/database/1_initial_schema.sql
+++ b/frontend/database/1_initial_schema.sql
@@ -141,7 +141,7 @@ CREATE TABLE IF NOT EXISTS `Contests` (
 CREATE TABLE IF NOT EXISTS `Contests_Users` (
   `user_id` int(11) NOT NULL,
   `contest_id` int(11) NOT NULL,
-  `access_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Hora a la que entró el usuario al concurso',
+  `access_time` datetime NULL DEFAULT NULL COMMENT 'Hora a la que entró el usuario al concurso',
   `score` int(11) NOT NULL DEFAULT '1' COMMENT 'Indica el puntaje que obtuvo el usuario en el concurso',
   `time` int(11) NOT NULL DEFAULT '1' COMMENT 'Indica el tiempo que acumulo en usuario en el concurso',
   PRIMARY KEY (`user_id`,`contest_id`),
@@ -240,7 +240,7 @@ CREATE TABLE IF NOT EXISTS `Contest_User_Request` (
 	`user_id` int(11) NOT NULL,
 	`contest_id` int(11) NOT NULL,
 	`request_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	`last_update` timestamp NOT NULL ,
+	`last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	`accepted` tinyint(1) DEFAULT NULL,
 	`extra_note` text,
 	PRIMARY KEY (`user_id`,`contest_id`)

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -287,7 +287,7 @@ CREATE TABLE IF NOT EXISTS `Problemset_User_Request` (
 	`user_id` int(11) NOT NULL,
 	`problemset_id` int(11) NOT NULL,
 	`request_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	`last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`last_update` timestamp NULL DEFAULT NULL,
 	`accepted` tinyint(1) DEFAULT NULL,
 	`extra_note` text,
 	PRIMARY KEY (`user_id`,`problemset_id`)

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE IF NOT EXISTS `Contests` (
 CREATE TABLE IF NOT EXISTS `Problemset_Users` (
   `user_id` int(11) NOT NULL,
   `problemset_id` int(11) NOT NULL,
-  `access_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Hora a la que entró el usuario al concurso',
+  `access_time` datetime NULL DEFAULT NULL COMMENT 'Hora a la que entró el usuario al concurso',
   `score` int(11) NOT NULL DEFAULT '1' COMMENT 'Indica el puntaje que obtuvo el usuario en el concurso',
   `time` int(11) NOT NULL DEFAULT '1' COMMENT 'Indica el tiempo que acumulo en usuario en el concurso',
   PRIMARY KEY (`user_id`,`problemset_id`),
@@ -287,7 +287,7 @@ CREATE TABLE IF NOT EXISTS `Problemset_User_Request` (
 	`user_id` int(11) NOT NULL,
 	`problemset_id` int(11) NOT NULL,
 	`request_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	`last_update` timestamp NOT NULL ,
+	`last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	`accepted` tinyint(1) DEFAULT NULL,
 	`extra_note` text,
 	PRIMARY KEY (`user_id`,`problemset_id`)

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -324,9 +324,8 @@ class ContestController extends Controller {
             $r['current_user_id'],
             $r['contest']->problemset_id
         );
-        if (!is_null($contestOpened) &&
-            $contestOpened->access_time != '0000-00-00 00:00:00') {
-            self::$log->debug('Not intro because you already started the contest');
+        if (!is_null($contestOpened) && !is_null($contestOpened->access_time)) {
+            self::$log->debug('No intro because you already started the contest');
             return !ContestController::SHOW_INTRO;
         }
 
@@ -811,7 +810,7 @@ class ContestController extends Controller {
                     $temp_user_contest = new ProblemsetUsers([
                                 'problemset_id' => $problemset->problemset_id,
                                 'user_id' => $userkey,
-                                'access_time' => '0000-00-00 00:00:00',
+                                'access_time' => null,
                                 'score' => 0,
                                 'time' => 0
                             ]);
@@ -1291,7 +1290,7 @@ class ContestController extends Controller {
             ProblemsetUsersDAO::save(new ProblemsetUsers([
                 'problemset_id' => $r['contest']->problemset_id,
                 'user_id' => $r['user']->user_id,
-                'access_time' => '0000-00-00 00:00:00',
+                'access_time' => null,
                 'score' => '0',
                 'time' => '0',
             ]));
@@ -2127,7 +2126,7 @@ class ContestController extends Controller {
                     $temp_user_contest = new ProblemsetUsers([
                                 'problemset_id' => $r['contest']->problemset_id,
                                 'user_id' => $userkey,
-                                'access_time' => '0000-00-00 00:00:00',
+                                'access_time' => null,
                                 'score' => 0,
                                 'time' => 0
                             ]);

--- a/frontend/server/controllers/InterviewController.php
+++ b/frontend/server/controllers/InterviewController.php
@@ -165,7 +165,7 @@ class InterviewController extends Controller {
             ProblemsetUsersDAO::save(new ProblemsetUsers([
                 'problemset_id' => $r['interview']->problemset_id,
                 'user_id' => $r['user']->user_id,
-                'access_time' => '0000-00-00 00:00:00',
+                'access_time' => null,
                 'score' => '0',
                 'time' => '0',
             ]));

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1256,7 +1256,7 @@ class UserController extends Controller {
         // User already started the problemset.
         $problemsetOpened = ProblemsetUsersDAO::getByPK($user_id, $problemset_id);
 
-        if (!is_null($problemsetOpened) && $problemsetOpened->access_time != '0000-00-00 00:00:00') {
+        if (!is_null($problemsetOpened) && !is_null($problemsetOpened->access_time)) {
             return true;
         }
 

--- a/frontend/server/libs/dao/Problemset_Users.dao.php
+++ b/frontend/server/libs/dao/Problemset_Users.dao.php
@@ -24,7 +24,7 @@ class ProblemsetUsersDAO extends ProblemsetUsersDAOBase {
             $problemset_user->score = 0;
             $problemset_user->time = 0;
             ProblemsetUsersDAO::save($problemset_user);
-        } elseif ($problemset_user->access_time === '0000-00-00 00:00:00') {
+        } elseif (is_null($problemset_user->access_time)) {
             // If its set to default time, update it
             $problemset_user->access_time = date('Y-m-d H:i:s');
             ProblemsetUsersDAO::save($problemset_user);

--- a/frontend/server/libs/dao/base/Problemset_User_Request.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_User_Request.dao.base.php
@@ -214,9 +214,6 @@ abstract class ProblemsetUserRequestDAOBase extends DAO {
         if (is_null($Problemset_User_Request->request_time)) {
             $Problemset_User_Request->request_time = gmdate('Y-m-d H:i:s');
         }
-        if (is_null($Problemset_User_Request->last_update)) {
-            $Problemset_User_Request->last_update = gmdate('Y-m-d H:i:s');
-        }
         $sql = 'INSERT INTO Problemset_User_Request (`user_id`, `problemset_id`, `request_time`, `last_update`, `accepted`, `extra_note`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
             $Problemset_User_Request->user_id,

--- a/frontend/server/libs/dao/base/Problemset_User_Request.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_User_Request.dao.base.php
@@ -214,6 +214,9 @@ abstract class ProblemsetUserRequestDAOBase extends DAO {
         if (is_null($Problemset_User_Request->request_time)) {
             $Problemset_User_Request->request_time = gmdate('Y-m-d H:i:s');
         }
+        if (is_null($Problemset_User_Request->last_update)) {
+            $Problemset_User_Request->last_update = gmdate('Y-m-d H:i:s');
+        }
         $sql = 'INSERT INTO Problemset_User_Request (`user_id`, `problemset_id`, `request_time`, `last_update`, `accepted`, `extra_note`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
             $Problemset_User_Request->user_id,

--- a/frontend/server/libs/dao/base/Problemset_Users.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Users.dao.base.php
@@ -206,9 +206,6 @@ abstract class ProblemsetUsersDAOBase extends DAO {
      * @param ProblemsetUsers [$Problemset_Users] El objeto de tipo ProblemsetUsers a crear.
      */
     final private static function create(ProblemsetUsers $Problemset_Users) {
-        if (is_null($Problemset_Users->access_time)) {
-            $Problemset_Users->access_time = '0000-00-00 00:00:00';
-        }
         if (is_null($Problemset_Users->score)) {
             $Problemset_Users->score = '1';
         }


### PR DESCRIPTION
Usar `0000-00-00 00:00:00` como valor sentinela en un `DATETIME` es mala
idea. Además fue deprecado en MySQL 5.7 así que ya no va a funcionar a
partir de Xenial.

Este cambio además incluye un script de migración que se aprovecha del
comportamiento de la función `DAY()` para detectar si el viejo valor sentinela
es válido en MySQL, que es un no-op en MySQL 5.7.