### PR TITLE
Arreglando el tiempo en ligas de scoreboard

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -485,8 +485,7 @@ export class Arena {
     var clock = '';
 
     if (date < self.startTime.getTime()) {
-      clock = '-' + FormatDelta(self.startTime.getTime() -
-                                (date + OmegaUp._deltaTime));
+      clock = '-' + FormatDelta(self.startTime.getTime() - OmegaUp.time(date));
     } else if (date > countdownTime.getTime()) {
       // Contest for self user is over
       clock = '00:00:00';
@@ -503,8 +502,7 @@ export class Arena {
             .prop('href', '/arena/' + self.options.contestAlias + '/practice/');
       }
     } else {
-      clock =
-          FormatDelta(countdownTime.getTime() - (date + OmegaUp._deltaTime));
+      clock = FormatDelta(countdownTime.getTime() - OmegaUp.time(date));
     }
 
     self.elements.clock.text(clock);


### PR DESCRIPTION
Cuando se accede a una liga de scoreboard (la que tiene un token de
acceso) sin haber iniciado sesión, `OmegaUp._deltaTime` es `undefined`,
lo cual hace que el scoreboard se despliegue como `NaN:NaN:NaN`, lo cual
es bastante molesto. Este cambio lo arregla al dejar de acceder
directamente a `OmegaUp._deltaTime` y en vez utiliza `OmegaUp.time()`,
que ya toma esto en cuenta.

Fixes: #1208