### PR TITLE
Actualizando versiones para Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 dist: trusty
 
+group: edge
+
 sudo: false
 
 branches:
@@ -10,7 +12,7 @@ branches:
 
 php:
   - 7.0
-  - hhvm-3.15
+  - hhvm-3.19
 
 env:
   - DB=mysql
@@ -72,7 +74,7 @@ before_script:
           mysql -uroot -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('');"
   - |
       ! [[ "${TRAVIS_PHP_VERSION}" != hhvm* ]] || \
-         (pear install pear/PHP_CodeSniffer-2.6.2 && phpenv rehash && \
+         (pear install pear/PHP_CodeSniffer-2.9.1 && phpenv rehash && \
           echo "include_path='.:/home/travis/.phpenv/versions/$(phpenv version-name)/lib/php/pear/:/home/travis/.phpenv/versions/$(phpenv version-name)/share/pear'" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini)
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ cache:
 
 before_script:
   # Workaround for Travis' flaky MySQL connection.
-  - for _ in `seq 10`; do mysql -e 'SELECT 1;' --batch --skip-column-names || sleep 1; done
+  - for _ in `seq 10`; do mysql -e ';' && break || sleep 1 ; done
   - |
       ! [[ "${TRAVIS_PHP_VERSION}" == hhvm* ]] || \
           mysql -e 'CREATE DATABASE IF NOT EXISTS `omegaup-test`'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 
 php:
   - 7.0
-  - hhvm-3.19
+  - hhvm-nightly
 
 env:
   - DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 
 php:
   - 7.0
-  - hhvm-nightly
+  - hhvm-3.6
 
 env:
   - DB=mysql
@@ -59,6 +59,8 @@ cache:
   - $HOME/.yarn-cache
 
 before_script:
+  # Workaround for Travis' flaky MySQL connection.
+  - for _ in `seq 10`; do mysql -e 'SELECT 1;' --batch --skip-column-names || sleep 1; done
   - |
       ! [[ "${TRAVIS_PHP_VERSION}" == hhvm* ]] || \
           mysql -e 'CREATE DATABASE IF NOT EXISTS `omegaup-test`'


### PR DESCRIPTION
hhvm-3.15 es lentísimo. hhvm-3.18 tiene un bug que no le permite correr
`.phar`. Hay que ver si es posible usar otra versión.