### PR TITLE
Agregando los ACLs para los jueces de problemas de calidad

### DIFF
--- a/frontend/database/21_qualitynomination_groups.sql
+++ b/frontend/database/21_qualitynomination_groups.sql
@@ -17,7 +17,7 @@ INSERT INTO `Groups` (`acl_id`, `alias`, `name`, `description`) VALUES (
 	3,
 	'omegaup:quality-reviewer',
 	'omegaup:quality-reviewer',
-	'Administradores de omegaup:quality-reviewer'
+	'Jueces del programa de Problemas de Calidad'
 );
 
 INSERT INTO `Group_Roles` VALUES(@quality_reviewer_admin_id, 1, 3);

--- a/frontend/database/21_qualitynomination_groups.sql
+++ b/frontend/database/21_qualitynomination_groups.sql
@@ -1,0 +1,23 @@
+-- omegaup:quality-reviewer-admin
+INSERT INTO `ACLs` (`acl_id`, `owner_id`) VALUES (2, 1);
+
+INSERT INTO `Groups` (`acl_id`, `alias`, `name`, `description`) VALUES (
+	2,
+	'omegaup:quality-reviewer-admin',
+	'omegaup:quality-reviewer-admin',
+	'Administradores de omegaup:quality-reviewer'
+);
+
+SET @quality_reviewer_admin_id = LAST_INSERT_ID();
+
+-- omegaup:quality-reviewer
+INSERT INTO `ACLs` (`acl_id`, `owner_id`) VALUES (3, 1);
+
+INSERT INTO `Groups` (`acl_id`, `alias`, `name`, `description`) VALUES (
+	3,
+	'omegaup:quality-reviewer',
+	'omegaup:quality-reviewer',
+	'Administradores de omegaup:quality-reviewer'
+);
+
+INSERT INTO `Group_Roles` VALUES(@quality_reviewer_admin_id, 1, 3);

--- a/frontend/database/ACLs.md
+++ b/frontend/database/ACLs.md
@@ -1,0 +1,7 @@
+Este archivo tiene la lista de todos los well-known ACLs.
+
+ID    | Descripción
+-----:| ----------------------------------------------
+1     | ACL reservado para el sistema. Los miembros de este ACL tienen capacidad de administradores del sistema.
+2     | `omegaup:quality-reviewer-admin`. Puede administrar `omegaup:quality-reviewer`.
+3     | `omegaup:quality-reviewer`. Los miembros de este grupo son jueces de calidad de problemas.

--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -56,10 +56,10 @@ rewrite ^/course/([a-zA-Z0-9_+-]+)/student/([a-zA-Z0-9_+-]+)/?$ /coursestudent.p
 rewrite ^/course/([a-zA-Z0-9_+-]+)/students/?$ /coursestudents.php?course=$1 last;
 rewrite ^/group/?$ /grouplist.php last;
 rewrite ^/group/new/?$ /groupnew.php last;
-rewrite ^/group/([a-zA-Z0-9_+-]+)/edit/?$ /groupedit.php?group=$1 last;
-rewrite ^/group/([a-zA-Z0-9_+-]+)/scoreboard/([a-zA-Z0-9_+-]+)/?$ /groupscoreboard.php?group=$1&scoreboard=$2 last;
-rewrite ^/group/([a-zA-Z0-9_+-]+)/scoreboard/([a-zA-Z0-9_+-]+)/edit/?$ /groupscoreboardedit.php?group=$1&scoreboard=$2 last;
-rewrite ^/group/([a-zA-Z0-9_+-]+)/stats/?$ /groupstats.php?group=$1 last;
+rewrite ^/group/([a-zA-Z0-9_+:-]+)/edit/?$ /groupedit.php?group=$1 last;
+rewrite ^/group/([a-zA-Z0-9_+:-]+)/scoreboard/([a-zA-Z0-9_+-]+)/?$ /groupscoreboard.php?group=$1&scoreboard=$2 last;
+rewrite ^/group/([a-zA-Z0-9_+:-]+)/scoreboard/([a-zA-Z0-9_+-]+)/edit/?$ /groupscoreboardedit.php?group=$1&scoreboard=$2 last;
+rewrite ^/group/([a-zA-Z0-9_+:-]+)/stats/?$ /groupstats.php?group=$1 last;
 rewrite ^/interview/list/?$ /interviews/list.php last;
 rewrite ^/interview/([a-zA-Z0-9_+-]+)/arena?$ /interviews/arena.php?contest_alias=$1 last;
 rewrite ^/interview/([a-zA-Z0-9_+-]+)/edit?$ /interviews/edit.php?alias=$1 last;


### PR DESCRIPTION
Este cambio agrega el grupo de usuarios que son jueces
(`omegaup:quality-reviewer`) y el grupo de usuarios que pueden
administrarlos (`omegaup:quality-reviewer-admin`). Se eligió el prefijo
`omegaup:` porque son grupos de sistema y nadie puede crear grupos con
ese nombre porque `:` no es un caracter válido en un alias.

Fixes: #1243