### PR TITLE
Agrega APIs para ver nominaciones

### DIFF
--- a/frontend/database/22_qualitynomination_reviewer_fixup.sql
+++ b/frontend/database/22_qualitynomination_reviewer_fixup.sql
@@ -1,0 +1,7 @@
+-- QualityNomination_Reviewers
+ALTER TABLE `QualityNomination_Reviewers`
+  DROP FOREIGN KEY `fk_qnr_qualitynomination_id`;
+
+ALTER TABLE `QualityNomination_Reviewers`
+  MODIFY COLUMN `qualitynomination_id` int(11) NOT NULL,
+  ADD CONSTRAINT `fk_qnr_qualitynomination_id` FOREIGN KEY (`qualitynomination_id`) REFERENCES `QualityNominations` (`qualitynomination_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -821,9 +821,9 @@ CREATE TABLE IF NOT EXISTS `QualityNominations` (
 --
 
 CREATE TABLE IF NOT EXISTS `QualityNomination_Reviewers` (
-  `qualitynomination_id` int(11) NOT NULL AUTO_INCREMENT,
+  `qualitynomination_id` int(11) NOT NULL,
   `user_id` int(11) NOT NULL COMMENT 'El revisor al que fue asignado esta nominación',
-  PRIMARY KEY (`qualitynomination_id`, `user_id`)
+  PRIMARY KEY (`qualitynomination_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='La lista de revisores para cada nominación';
 
 -- --------------------------------------------------------

--- a/frontend/server/controllers/QualityNominationController.php
+++ b/frontend/server/controllers/QualityNominationController.php
@@ -123,14 +123,10 @@ class QualityNominationController extends Controller {
     }
 
     /**
-     * Displays all the nominations.
-     *
-     * @param Request $r
-     * @return array
-     * @throws DuplicatedEntryInDatabaseException
-     * @throws InvalidDatabaseOperationException
+     * Returns the list of nominations assigned to $user_id (if non-null) or
+     * all nominations (if $user_id is null).
      */
-    public static function apiList(Request $r) {
+    private static function getAssignedListImpl(Request $r, $user_id) {
         if (OMEGAUP_LOCKDOWN) {
             throw new ForbiddenAccessException('lockdown');
         }
@@ -154,7 +150,7 @@ class QualityNominationController extends Controller {
         $nominations = null;
         try {
             $nominations = QualityNominationsDAO::getAllNominationsAssignedToUser(
-                null,
+                $user_id,
                 $page,
                 $pageSize
             );
@@ -169,48 +165,26 @@ class QualityNominationController extends Controller {
     }
 
     /**
+     * Displays all the nominations.
+     *
+     * @param Request $r
+     * @return array
+     * @throws ForbiddenAccessException
+     * @throws InvalidDatabaseOperationException
+     */
+    public static function apiList(Request $r) {
+        return self::getAssignedListImpl($r, null);
+    }
+
+    /**
      * Displays the nominations that this user has been assigned.
      *
      * @param Request $r
      * @return array
-     * @throws DuplicatedEntryInDatabaseException
+     * @throws ForbiddenAccessException
      * @throws InvalidDatabaseOperationException
      */
     public static function apiMyAssignedList(Request $r) {
-        if (OMEGAUP_LOCKDOWN) {
-            throw new ForbiddenAccessException('lockdown');
-        }
-
-        // Validate request
-        self::authenticateRequest($r);
-
-        $quality_reviewer_group = GroupsDAO::findByAlias(
-            Authorization::QUALITY_REVIEWER_GROUP_ALIAS
-        );
-        if (!Authorization::isGroupMember($r['current_user_id'], $quality_reviewer_group)) {
-            throw new ForbiddenAccessException('userNotAllowed');
-        }
-
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
-
-        $page = (isset($r['page']) ? intval($r['page']) : 1);
-        $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
-
-        $nominations = null;
-        try {
-            $nominations = QualityNominationsDAO::getAllNominationsAssignedToUser(
-                $r['current_user_id'],
-                $page,
-                $pageSize
-            );
-        } catch (Exception $e) {
-            throw new InvalidDatabaseOperationException($e);
-        }
-
-        return [
-            'status' => 'ok',
-            'nominations' => $nominations,
-        ];
+        return self::getAssignedListImpl($r, $r['current_user_id']);
     }
 }

--- a/frontend/server/libs/Authorization.php
+++ b/frontend/server/libs/Authorization.php
@@ -23,6 +23,9 @@ class Authorization {
     // System-level ACL.
     const SYSTEM_ACL = 1;
 
+    // Group for quality reviewers.
+    const QUALITY_REVIEWER_GROUP_ALIAS = 'omegaup:quality-reviewer';
+
     public static function canViewRun($user_id, Runs $run) {
         if (is_null($run) || !is_a($run, 'Runs')) {
             return false;

--- a/frontend/server/libs/dao/Groups.dao.php
+++ b/frontend/server/libs/dao/Groups.dao.php
@@ -105,7 +105,7 @@ class GroupsDAO extends GroupsDAOBase {
 
         $users = [];
         foreach ($conn->Execute($sql, [$group->group_id, $n]) as $row) {
-            array_push($users, new Users($row));
+            $users[] = new Users($row);
         }
         return $users;
     }

--- a/frontend/server/libs/dao/Groups.dao.php
+++ b/frontend/server/libs/dao/Groups.dao.php
@@ -83,4 +83,30 @@ class GroupsDAO extends GroupsDAOBase {
         }
         return $groups;
     }
+
+    /**
+     * Gets a random sample (of up to size $n) of group members.
+     */
+    final public static function sampleMembers(Groups $group, $n) {
+        $sql = '
+            SELECT
+                u.*
+            FROM
+                Groups_Users gu
+            INNER JOIN
+                Users u ON u.user_id = gu.user_id
+            WHERE
+                gu.group_id = ?
+            ORDER BY
+                RAND()
+            LIMIT
+                0, ?;';
+        global $conn;
+
+        $users = [];
+        foreach ($conn->Execute($sql, [$group->group_id, $n]) as $row) {
+            array_push($users, new Users($row));
+        }
+        return $users;
+    }
 }

--- a/frontend/server/libs/dao/QualityNominations.dao.php
+++ b/frontend/server/libs/dao/QualityNominations.dao.php
@@ -28,6 +28,14 @@ class QualityNominationsDAO extends QualityNominationsDAOBase {
         return $conn->GetRow($sql, [$problem->problem_id, $user->user_id]);
     }
 
+    /**
+     * Returns the votes from all the assigned reviewers for a particular
+     * nomination.
+     *
+     * If no votes have been cast by a reviewer, a default of 0 will be
+     * returned. "drive-by" reviewers are not considered for this, only
+     * assigned reviewers.
+     */
     private static function getVotesForNomination($qualitynomination_id) {
         $sql = '
         SELECT
@@ -43,6 +51,7 @@ class QualityNominationsDAO extends QualityNominationsDAOBase {
             qnc.qualitynomination_id = qnr.qualitynomination_id AND
             qnc.user_id = qnr.user_id AND
             qnc.qualitynomination_comment_id = (
+                -- Gets the last vote per qualitynomination_id, user_id.
                 SELECT
                     MAX(qualitynomination_comment_id)
                 FROM

--- a/frontend/server/libs/dao/QualityNominations.dao.php
+++ b/frontend/server/libs/dao/QualityNominations.dao.php
@@ -11,7 +11,8 @@ include_once('base/QualityNominations.vo.base.php');
   */
 class QualityNominationsDAO extends QualityNominationsDAOBase {
     public static function getNominationStatusForProblem(Problems $problem, Users $user) {
-        $sql = 'SELECT
+        $sql = '
+        SELECT
             COUNT(r.run_id) > 0 as solved,
             COUNT(qn.quality_nomination_id) > 0 as nominated
         FROM
@@ -25,5 +26,126 @@ class QualityNominationsDAO extends QualityNominationsDAOBase {
 
         global $conn;
         return $conn->GetRow($sql, [$problem->problem_id, $user->user_id]);
+    }
+
+    private static function getVotesForNomination($qualitynomination_id) {
+        $sql = '
+        SELECT
+            u.username,
+            u.name,
+            COALESCE(qnc.vote, 0) AS vote,
+            UNIX_TIMESTAMP(qnc.time) AS time
+        FROM
+            QualityNomination_Reviewers qnr
+        LEFT JOIN
+            QualityNomination_Comments qnc
+        ON
+            qnc.qualitynomination_id = qnr.qualitynomination_id AND
+            qnc.user_id = qnr.user_id AND
+            qnc.qualitynomination_comment_id = (
+                SELECT
+                    MAX(qualitynomination_comment_id)
+                FROM
+                    QualityNomination_Comments
+                WHERE
+                    qualitynomination_id = qnr.qualitynomination_id AND
+                    user_id = qnr.user_id
+                GROUP BY
+                    user_id
+            )
+        INNER JOIN
+            Users u
+        ON
+            u.user_id = qnr.user_id
+        WHERE
+            qnr.qualitynomination_id = ?
+        ORDER BY
+            u.username;';
+        global $conn;
+
+        $votes = [];
+        foreach ($conn->GetAll($sql, [$qualitynomination_id]) as $vote) {
+            if (is_string($vote['time'])) {
+                $vote['time'] = (int)$vote['time'];
+            }
+            $vote['vote'] = (int)$vote['vote'];
+            $vote['user'] = [
+                'username' => $vote['username'],
+                'name' => $vote['name'],
+            ];
+            unset($vote['username']);
+            unset($vote['name']);
+
+            $votes[] = $vote;
+        }
+        return $votes;
+    }
+
+    public static function getAllNominationsAssignedToUser(
+        $user_id,
+        $page = 1,
+        $pageSize = 1000
+    ) {
+        $page = max(0, $page - 1);
+        $sql = '
+        SELECT
+            qn.qualitynomination_id,
+            qn.nomination,
+            UNIX_TIMESTAMP(qn.time) as time,
+            qn.status,
+            nominator.username,
+            nominator.name,
+            p.alias,
+            p.title
+        FROM
+            QualityNominations qn
+        INNER JOIN
+            Problems p
+        ON
+            p.problem_id = qn.problem_id
+        INNER JOIN
+            Users nominator
+        ON
+            nominator.user_id = qn.user_id
+        INNER JOIN
+            QualityNomination_Reviewers qnr
+        ON
+            qnr.qualitynomination_id = qn.qualitynomination_id';
+        $params = [];
+
+        if (!is_null($user_id)) {
+            $sql .= ' WHERE qnr.user_id = ?';
+            $params[] = $user_id;
+        }
+        $sql .= ' LIMIT ?, ?;';
+        $params[] = $page * $pageSize;
+        $params[] = ($page + 1) * $pageSize;
+
+        global $conn;
+        $nominations = [];
+        foreach ($conn->GetAll($sql, $params) as $nomination) {
+            $nomination['time'] = (int)$nomination['time'];
+            $nomination['nominator'] = [
+                'username' => $nomination['username'],
+                'name' => $nomination['name'],
+            ];
+            unset($nomination['username']);
+            unset($nomination['name']);
+            $nomination['problem'] = [
+                'alias' => $nomination['alias'],
+                'title' => $nomination['title'],
+            ];
+            unset($nomination['alias']);
+            unset($nomination['title']);
+
+            $nomination['votes'] = self::getVotesForNomination(
+                $nomination['qualitynomination_id']
+            );
+            unset($nomination['qualitynomination_id']);
+
+            $nominations[] = $nomination;
+        }
+
+        return $nominations;
     }
 }

--- a/frontend/server/libs/dao/base/QualityNomination_Reviewers.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Reviewers.dao.base.php
@@ -36,7 +36,7 @@ abstract class QualityNominationReviewersDAOBase extends DAO {
      * @return Un entero mayor o igual a cero denotando las filas afectadas.
      */
     final public static function save(QualityNominationReviewers $QualityNomination_Reviewers) {
-        if (!is_null(self::getByPK($QualityNomination_Reviewers->qualitynomination_id))) {
+        if (!is_null(self::getByPK($QualityNomination_Reviewers->qualitynomination_id, $QualityNomination_Reviewers->user_id))) {
             return QualityNominationReviewersDAOBase::update($QualityNomination_Reviewers);
         } else {
             return QualityNominationReviewersDAOBase::create($QualityNomination_Reviewers);
@@ -52,12 +52,12 @@ abstract class QualityNominationReviewersDAOBase extends DAO {
      * @static
      * @return @link QualityNominationReviewers Un objeto del tipo {@link QualityNominationReviewers}. NULL si no hay tal registro.
      */
-    final public static function getByPK($qualitynomination_id) {
-        if (is_null($qualitynomination_id)) {
+    final public static function getByPK($qualitynomination_id, $user_id) {
+        if (is_null($qualitynomination_id) || is_null($user_id)) {
             return null;
         }
-        $sql = 'SELECT `QualityNomination_Reviewers`.`qualitynomination_id`, `QualityNomination_Reviewers`.`user_id` FROM QualityNomination_Reviewers WHERE (qualitynomination_id = ?) LIMIT 1;';
-        $params = [$qualitynomination_id];
+        $sql = 'SELECT `QualityNomination_Reviewers`.`qualitynomination_id`, `QualityNomination_Reviewers`.`user_id` FROM QualityNomination_Reviewers WHERE (qualitynomination_id = ? AND user_id = ?) LIMIT 1;';
+        $params = [$qualitynomination_id, $user_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
         if (count($rs) == 0) {
@@ -169,14 +169,6 @@ abstract class QualityNominationReviewersDAOBase extends DAO {
       * @param QualityNominationReviewers [$QualityNomination_Reviewers] El objeto de tipo QualityNominationReviewers a actualizar.
       */
     final private static function update(QualityNominationReviewers $QualityNomination_Reviewers) {
-        $sql = 'UPDATE `QualityNomination_Reviewers` SET `user_id` = ? WHERE `qualitynomination_id` = ?;';
-        $params = [
-            $QualityNomination_Reviewers->user_id,
-            $QualityNomination_Reviewers->qualitynomination_id,
-        ];
-        global $conn;
-        $conn->Execute($sql, $params);
-        return $conn->Affected_Rows();
     }
 
     /**
@@ -203,7 +195,6 @@ abstract class QualityNominationReviewersDAOBase extends DAO {
         if ($ar == 0) {
             return 0;
         }
-        $QualityNomination_Reviewers->qualitynomination_id = $conn->Insert_ID();
 
         return $ar;
     }
@@ -293,11 +284,11 @@ abstract class QualityNominationReviewersDAOBase extends DAO {
      * @param QualityNominationReviewers [$QualityNomination_Reviewers] El objeto de tipo QualityNominationReviewers a eliminar
      */
     final public static function delete(QualityNominationReviewers $QualityNomination_Reviewers) {
-        if (is_null(self::getByPK($QualityNomination_Reviewers->qualitynomination_id))) {
+        if (is_null(self::getByPK($QualityNomination_Reviewers->qualitynomination_id, $QualityNomination_Reviewers->user_id))) {
             throw new Exception('Registro no encontrado.');
         }
-        $sql = 'DELETE FROM `QualityNomination_Reviewers` WHERE qualitynomination_id = ?;';
-        $params = [$QualityNomination_Reviewers->qualitynomination_id];
+        $sql = 'DELETE FROM `QualityNomination_Reviewers` WHERE qualitynomination_id = ? AND user_id = ?;';
+        $params = [$QualityNomination_Reviewers->qualitynomination_id, $QualityNomination_Reviewers->user_id];
         global $conn;
 
         $conn->Execute($sql, $params);

--- a/frontend/server/libs/dao/base/QualityNomination_Reviewers.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Reviewers.vo.base.php
@@ -48,7 +48,6 @@ class QualityNominationReviewers extends VO {
     /**
       *  [Campo no documentado]
       * Llave Primaria
-      * Auto Incremento
       * @access public
       * @var int(11)
       */
@@ -56,6 +55,7 @@ class QualityNominationReviewers extends VO {
 
     /**
       * El revisor al que fue asignado esta nominación
+      * Llave Primaria
       * @access public
       * @var int(11)
       */

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -101,7 +101,6 @@ class Utils {
             'Courses',
             'Emails',
             'Group_Roles',
-            'Groups',
             'Groups_Scoreboards',
             'Groups_Scoreboards_Contests',
             'Groups_Users',
@@ -133,9 +132,11 @@ class Utils {
             $conn->Execute('SET foreign_key_checks = 0;');
 
             foreach ($tables as $t) {
-                $sql = 'TRUNCATE TABLE `' . $t . '`; ';
-                $conn->Execute($sql);
+                $conn->Execute("TRUNCATE TABLE `$t`;");
             }
+
+            // Tables with special entries.
+            $conn->Execute('DELETE FROM `Groups` WHERE `alias` NOT LIKE "%:%";');
         } catch (Exception $e) {
             echo 'Cleanup DB error. Tests will continue anyways:';
             var_dump($sql);


### PR DESCRIPTION
Este cambio permite ver la cola de nominaciones.
También se auto-agregan dos revisores a cada nominación creada.

Fixes: #1241