### PR TITLE
Este cambio arregla los 404 htmlizados

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -1,5 +1,9 @@
 location /api/ {
-    rewrite ^/api/(.*)$ /api/ApiEntryPoint.php last;
+	rewrite ^/api/(.*)$ /api/ApiEntryPoint.php last;
+}
+
+location ~ ^/(?!/api.*\.(hh|php))$ {
+	fastcgi_intercept_errors on;
 }
 
 # Backendv1 WebSockets endpoint.


### PR DESCRIPTION
Nótese que hay que eliminar el `fastcgi_intercept_errors on;` de la
configuración global de nginx.