### PR TITLE
Mostrando por default los problemas públicos

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1667,7 +1667,7 @@ class ProblemController extends Controller {
             $query,
             $author_id,
             $r['tag'],
-            is_null($r['min_visibility']) ? ProblemController::VISIBILITY_PROMOTED : (int) $r['min_visibility'],
+            is_null($r['min_visibility']) ? ProblemController::VISIBILITY_PUBLIC : (int) $r['min_visibility'],
             $total
         );
         $response['total'] = $total;


### PR DESCRIPTION
Realísticamente no vamos a poder terminar de implementar todo lo de
problemas de calidad, así que mejor regresemos al comportamiento
anterior de mostrar problemas públicos. Regresemos a mostrar los de
calidad una vez que _tengamos_ problemas de calidad :P