### PR TITLE
Haciendo visibles los errores de ReCAPTCHA

### DIFF
--- a/frontend/www/js/login.js
+++ b/frontend/www/js/login.js
@@ -10,7 +10,8 @@ omegaup.OmegaUp.on('ready', function() {
       return false;
     }
 
-    if (grecaptcha.getResponse().length == 0) {
+    if (typeof(grecaptcha) === 'undefined' ||
+        grecaptcha.getResponse().length == 0) {
       omegaup.UI.error(omegaup.T.unableToVerifyCaptcha);
       return false;
     }

--- a/frontend/www/login.php
+++ b/frontend/www/login.php
@@ -23,6 +23,11 @@ if (isset($_POST['request']) && ($_POST['request'] == 'login')) {
     }
 
     $triedToLogin = true;
+} elseif (isset($_POST['request']) && $_POST['request'] == 'register') {
+    // Something failed in the JavaScript side. This definitely will not have
+    // ReCAPTCHA validation, so let's error out with that.
+    $smarty->assign('ERROR_TO_USER', 'NATIVE_LOGIN_FAILED');
+    $smarty->assign('ERROR_MESSAGE', $smarty->getConfigVars('unableToVerifyCaptcha'));
 }
 
 if (isset($_GET['linkedin'])) {


### PR DESCRIPTION
Si por alguna razón ReCAPTCHA no se pudo cargar (digamos, bloqueo del
ISP o algo), JavaScript no puede proceder a crear la cuenta. Este cambio
atrapa ese error tanto en JavaScript como en el frontend por si algo aún
más catastrófico ocurre en el JavaScript, para que al menos tengamos
_algo_ qué culpar.