### PR TITLE
Haciendo que el estado sea no-obligatorio

### DIFF
--- a/frontend/www/js/user.edit.js
+++ b/frontend/www/js/user.edit.js
@@ -441,7 +441,7 @@ omegaup.OmegaUp.on('ready', function() {
                           name: $('#name').val(),
                           birth_date: birth_date.getTime() / 1000,
                           country_id: $('#country_id').val(),
-                          state_id: $('#state_id').val(),
+                          state_id: $('#state_id').val() || undefined,
                           scholar_degree: $('#scholar_degree').val(),
                           graduation_date: graduation_date.getTime() / 1000,
                           school_id: $('#school_id').val(),


### PR DESCRIPTION
Este cambio no manda `state_id` si no se tiene uno. Esta es la primer
parte de un cambio para tratar correctamente las subdivisiones
administrativas de todos los países del mundo.

Primera parte de #1228.