### PR TITLE
Mostrando el progreso de los alumnos con los puntos

### DIFF
--- a/frontend/server/libs/dao/Courses.dao.php
+++ b/frontend/server/libs/dao/Courses.dao.php
@@ -104,7 +104,7 @@ class CoursesDAO extends CoursesDAOBase {
                 LEFT JOIN (
                     SELECT bpr.alias, bpr.user_id, sum(best_score_of_problem) as assignment_score
                     FROM (
-                        SELECT a.alias, a.assignment_id, psp.problem_id, r.user_id, max(r.score) as best_score_of_problem
+                        SELECT a.alias, a.assignment_id, psp.problem_id, r.user_id, max(r.contest_score) as best_score_of_problem
                         FROM Assignments a
                         INNER JOIN Problemsets ps
                             ON a.problemset_id = ps.problemset_id

--- a/frontend/tests/factories/CoursesFactory.php
+++ b/frontend/tests/factories/CoursesFactory.php
@@ -170,7 +170,7 @@ class CoursesFactory {
                             'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
                         ]));
                         RunsFactory::gradeRun(null /*runData*/, 0.5, 'PA', null, $runResponsePA['guid']);
-                        $expectedScores[$studentUsername][$assignmentAlias] += 0.5;
+                        $expectedScores[$studentUsername][$assignmentAlias] += 50;
 
                         if (($s + $p) % 3 == 0) {
                             // 100 pts run
@@ -182,7 +182,7 @@ class CoursesFactory {
                                 'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
                             ]));
                             RunsFactory::gradeRun(null /*runData*/, 1, 'AC', null, $runResponseAC['guid']);
-                            $expectedScores[$studentUsername][$assignmentAlias] += 0.5;
+                            $expectedScores[$studentUsername][$assignmentAlias] += 50;
                         }
                     }
                 }

--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -19,8 +19,7 @@
               }}</a>
             </td>
             <td class="score"
-                v-for="assignment in assignments">{{ score(student, assignment).toPrecision(2)
-                }}</td>
+                v-for="assignment in assignments">{{ Math.round(score(student, assignment)) }}</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Es un poco confuso que se muestre el progreso de los alumnos como
proporción de 1.0. Mejor hay que usar |contest_score|, porque los
profesores están más acostumbrados a las cosas escaladas a 100.