### PR TITLE
Fix time offset bug in DateTimePicker

### DIFF
--- a/frontend/www/js/omegaup/components/DateTimePicker.vue
+++ b/frontend/www/js/omegaup/components/DateTimePicker.vue
@@ -27,7 +27,7 @@ export default {
           defaultDate: self.value,
         })
         .change(function(e) {
-          self.$emit('input', $(self.$el).data('datetimepicker').date);
+          self.$emit('input', $(self.$el).data('datetimepicker').getDate());
         });
     $(this.$el).data('datetimepicker').setDate(this.value);
   },


### PR DESCRIPTION
Lack of encapsulation considered harmful.

Resulta que la forma correcta de accesar a la fecha es via getDate().
La variable date deberia ser privada para el componente y esta normalizada a horario UTC.
La funcion getDate() aplica el offset hacia la hora local correctamente.

Fix #1308
Fix de una parte de #1187