### PR TITLE
Fix agregar locales es y pt a DateTimePicker

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -52,6 +52,8 @@
 		<!-- Bootstrap datetimepicker plugin from http://www.malot.fr/bootstrap-datetimepicker/demo.php -->
 		<link rel="stylesheet" href="/third_party/css/bootstrap-datetimepicker.css">
 		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datetimepicker.min.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.es.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js"}"></script>
 
 {if isset($inArena) && $inArena}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/ux/arena.css"}" />

--- a/frontend/www/js/omegaup/components/DateTimePicker.vue
+++ b/frontend/www/js/omegaup/components/DateTimePicker.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+import {T} from '../omegaup.js';
 export default {
   props: {
     value: Date,
@@ -25,6 +26,7 @@ export default {
         .datetimepicker({
           format: self.format,
           defaultDate: self.value,
+          language: T.locale,
         })
         .change(function(e) {
           self.$emit('input', $(self.$el).data('datetimepicker').getDate());

--- a/frontend/www/third_party/js/locales/bootstrap-datetimepicker.es.js
+++ b/frontend/www/third_party/js/locales/bootstrap-datetimepicker.es.js
@@ -1,0 +1,16 @@
+/**
+ * Spanish translation for bootstrap-datetimepicker
+ * Bruno Bonamin <bruno.bonamin@gmail.com>
+ */
+;(function($){
+	$.fn.datetimepicker.dates['es'] = {
+		days: ["Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"],
+		daysShort: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"],
+		daysMin: ["Do", "Lu", "Ma", "Mi", "Ju", "Vi", "Sa", "Do"],
+		months: ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"],
+		monthsShort: ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"],
+		today: "Hoy",
+		suffix: [],
+		meridiem: []
+	};
+}(jQuery));

--- a/frontend/www/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js
+++ b/frontend/www/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js
@@ -1,0 +1,17 @@
+/**
+ * Brazilian translation for bootstrap-datetimepicker
+ * Cauan Cabral <cauan@radig.com.br>
+ */
+;(function($){
+	$.fn.datetimepicker.dates['pt-BR'] = {
+        format: 'dd/mm/yyyy',
+		days: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"],
+		daysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"],
+		daysMin: ["Do", "Se", "Te", "Qu", "Qu", "Se", "Sa", "Do"],
+		months: ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
+		monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"],
+		today: "Hoje",
+		suffix: [],
+		meridiem: []
+	};
+}(jQuery));


### PR DESCRIPTION
Arregla una parte de #1067
Lo que falta:
* DatePicker parece que no tiene soporte para localizacion.
* Otros usos de DateTimePicker (fuera de Schools)
