### PR TITLE
Hotfix en ContestController::apiPublicDetails

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -373,7 +373,7 @@ class ContestController extends Controller {
      * Temporal hotfix wrapper
      */
     public static function apiIntroDetails(Request $r) {
-        return self::apiPublicDetails($r)
+        return self::apiPublicDetails($r);
     }
     
     public static function apiPublicDetails(Request $r) {

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -369,7 +369,7 @@ class ContestController extends Controller {
         }
     }
 
-    public static function apiIntroDetails(Request $r) {
+    public static function apiPublicDetails(Request $r) {
         Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $result = [];

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -369,6 +369,13 @@ class ContestController extends Controller {
         }
     }
 
+     /**
+     * Temporal hotfix wrapper
+     */
+    public static function apiIntroDetails(Request $r) {
+        return self::apiPublicDetails($r)
+    }
+    
     public static function apiPublicDetails(Request $r) {
         Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
 

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -375,7 +375,7 @@ class ContestController extends Controller {
     public static function apiIntroDetails(Request $r) {
         return self::apiPublicDetails($r);
     }
-    
+
     public static function apiPublicDetails(Request $r) {
         Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
 


### PR DESCRIPTION
Un refactor excesivo en un PR anterior cambió `ContestController::apiPublicDetails` por `ContestController::apiIntroDetails` sin cambiar las dependencias. Este hotfix regresa la api a su estado original.