### PR TITLE
Ocultando la clarifications en OfS 

### DIFF
--- a/frontend/templates/arena.contest.admin.tpl
+++ b/frontend/templates/arena.contest.admin.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile={version_hash src='/ux/admin.js'} admin=true showDeadlines=true showNavigation=true showPoints=true showRanking=true}
+{include file='arena.contest.tpl' jsfile={version_hash src='/ux/admin.js'} admin=true showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true}
 

--- a/frontend/templates/arena.contest.contestant.tpl
+++ b/frontend/templates/arena.contest.contestant.tpl
@@ -1,1 +1,1 @@
-{include file='arena.contest.tpl' jsfile={version_hash src='/ux/contest.js'} admin=false showDeadlines=true showNavigation=true showPoints=true showRanking=true}
+{include file='arena.contest.tpl' jsfile={version_hash src='/ux/contest.js'} admin=false showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true}

--- a/frontend/templates/arena.contest.practice.tpl
+++ b/frontend/templates/arena.contest.practice.tpl
@@ -1,1 +1,1 @@
-{include file='arena.contest.tpl' jsfile={version_hash src='/ux/contest.js'} admin=false showDeadlines=true showNavigation=false showPoints=false showRanking=false bodyid='practice'}
+{include file='arena.contest.tpl' jsfile={version_hash src='/ux/contest.js'} admin=false showClarifications=true showDeadlines=true showNavigation=false showPoints=false showRanking=false bodyid='practice'}

--- a/frontend/templates/arena.contest.tpl
+++ b/frontend/templates/arena.contest.tpl
@@ -18,7 +18,9 @@
 {if $admin}
 				<li><a href="#runs">{#wordsRuns#}</a></li>
 {/if}
+{if $showClarifications}
 				<li><a href="#clarifications">{#wordsClarifications#}<span id="clarifications-count"></span></a></li>
+{/if}
 			</ul>
 {/if}
 			<div id="problems" class="tab navleft">

--- a/frontend/www/course.php
+++ b/frontend/www/course.php
@@ -47,6 +47,7 @@ if ($show_intro) {
     $showScoreboard = $session['valid'] && Authorization::isCourseAdmin($session['user']->user_id, $course);
     $smarty->assign('jsfile', '/ux/assignment.js');
     $smarty->assign('admin', false);
+    $smarty->assign('showClarifications', false);
     $smarty->assign('showDeadlines', true);
     $smarty->assign('showNavigation', true);
     $smarty->assign('showPoints', true);

--- a/frontend/www/interviews/arena.php
+++ b/frontend/www/interviews/arena.php
@@ -22,6 +22,7 @@ if ($show_intro) {
     $smarty->assign('jsfile', '/js/interviews.arena.contest.js');
     $smarty->assign('admin', false);
     $smarty->assign('showDeadlines', false);
+    $smarty->assign('showClarifications', true);
     $smarty->assign('showNavigation', false);
     $smarty->assign('showPoints', true);
     $smarty->assign('showRanking', false);


### PR DESCRIPTION
Al no funcionar correctamente las clarifications, se agrega una condición para que en los cursos no aparezca el link.

Fixes #1419 