### PR TITLE
Modificando el atributo de Título por el de Nombre en Nuevo Curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -9,7 +9,7 @@
             v-on:submit.prevent="onSubmit">
         <div class="row">
           <div class="form-group col-md-8">
-            <label>{{ T.wordsTitle }} <input class="form-control"
+            <label>{{ T.wordsName }} <input class="form-control"
                    type="text"
                    v-model="name"></label>
           </div>


### PR DESCRIPTION
En la pantalla de Agregar curso, aparecía Título del curso y en la validación indicaba que era Nombre, así que se sustituye el texto.

Fixes #1344 