### PR TITLE
Eliminando excepción que aparecía cuando no habían datos de coder del mes

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1204,17 +1204,20 @@ class UserController extends Controller {
                 // Generate the coder
                 $retArray = CoderOfTheMonthDAO::calculateCoderOfTheMonth($firstDay);
                 if ($retArray == null) {
-                    return $retArray;
-                } else {
-                    $user = $retArray['user'];
-
-                    // Save it
-                    $c = new CoderOfTheMonth([
-                        'user_id' => $user->user_id,
-                        'time' => $firstDay,
-                        ]);
-                    CoderOfTheMonthDAO::save($c);
+                    return [
+                    'status' => 'ok',
+                    'userinfo' => null,
+                    'problems' => null
+                     ];
                 }
+                $user = $retArray['user'];
+
+                // Save it
+                $c = new CoderOfTheMonth([
+                    'user_id' => $user->user_id,
+                    'time' => $firstDay,
+                    ]);
+                CoderOfTheMonthDAO::save($c);
             } else {
                 // Grab the user info
                 $user = UsersDAO::getByPK($coderOfTheMonth->user_id);

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1204,19 +1204,17 @@ class UserController extends Controller {
                 // Generate the coder
                 $retArray = CoderOfTheMonthDAO::calculateCoderOfTheMonth($firstDay);
                 if ($retArray == null) {
-                    self::$log->error('Missing paramer when calling apiCoderOfTheMonth.');
-                    throw new InvalidParameterException('parameterInvalid', 'date');
+                    return $retArray;
+                } else {
+                    $user = $retArray['user'];
+
+                    // Save it
+                    $c = new CoderOfTheMonth([
+                        'user_id' => $user->user_id,
+                        'time' => $firstDay,
+                        ]);
+                    CoderOfTheMonthDAO::save($c);
                 }
-
-                $user = $retArray['user'];
-
-                // Save it
-                $c = new CoderOfTheMonth([
-                    'user_id' => $user->user_id,
-                    'time' => $firstDay,
-
-                ]);
-                CoderOfTheMonthDAO::save($c);
             } else {
                 // Grab the user info
                 $user = UsersDAO::getByPK($coderOfTheMonth->user_id);

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1205,10 +1205,10 @@ class UserController extends Controller {
                 $retArray = CoderOfTheMonthDAO::calculateCoderOfTheMonth($firstDay);
                 if ($retArray == null) {
                     return [
-                    'status' => 'ok',
-                    'userinfo' => null,
-                    'problems' => null
-                     ];
+                        'status' => 'ok',
+                        'userinfo' => null,
+                        'problems' => null,
+                    ];
                 }
                 $user = $retArray['user'];
 
@@ -1216,7 +1216,7 @@ class UserController extends Controller {
                 $c = new CoderOfTheMonth([
                     'user_id' => $user->user_id,
                     'time' => $firstDay,
-                    ]);
+                ]);
                 CoderOfTheMonthDAO::save($c);
             } else {
                 // Grab the user info

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -37,7 +37,6 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
 
     public function testCoderOfTheMonthAfterYear() {
         $userLastYear = UserFactory::createUser();
-        $userThisYear = UserFactory::createUser();
 
         $today = date('Y-m-d');
 
@@ -50,7 +49,6 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         date_add($runCreationDate, date_interval_create_from_date_string('1 month'));
         $runCreationDate = date_format($runCreationDate, 'Y-m-d');
         $this->createRuns($userLastYear, $runCreationDate, 2 /*numRuns*/);
-        $this->createRuns($userThisYear, $runCreationDate, 1 /*numRuns*/);
 
         $this->createRuns($userLastYear, $today, 2 /*numRuns*/);
 


### PR DESCRIPTION
Se elimina una excepción que no debería ir en el apiCoderOfTheMonth, ya que esto no debe considerarse como error. 

Fixes: #1427 