### PR TITLE
Subiendo corrección de bug que ocasionaba que no se mostraba el ranking de escuelas

### DIFF
--- a/frontend/www/js/omegaup/components/CountryFlag.vue
+++ b/frontend/www/js/omegaup/components/CountryFlag.vue
@@ -11,7 +11,10 @@ export default {
   props: ['country'],
   computed: {
     flagUrl: function() {
-      return '/media/flags/' + this.country.toLowerCase() + '.png';
+      if (this.country != null) {
+        return '/media/flags/' + this.country.toLowerCase() + '.png';
+      }
+      return '';
     }
   },
   data: function() { return {};},

--- a/frontend/www/js/omegaup/components/CountryFlag.vue
+++ b/frontend/www/js/omegaup/components/CountryFlag.vue
@@ -11,10 +11,8 @@ export default {
   props: ['country'],
   computed: {
     flagUrl: function() {
-      if (this.country != null) {
-        return '/media/flags/' + this.country.toLowerCase() + '.png';
-      }
-      return '';
+      if (this.country == null) return '';
+      return '/media/flags/' + this.country.toLowerCase() + '.png';
     }
   },
   data: function() { return {};},


### PR DESCRIPTION
Se agrega una validación para determinar que una escuela está asociada a un país, de lo contrario, no muestra bandera.

Fixes #1441 