### PR TITLE
Creando API para guardar información referente a idiomas de problemas

### DIFF
--- a/frontend/database/30_delete_translator_id.sql
+++ b/frontend/database/30_delete_translator_id.sql
@@ -1,0 +1,5 @@
+-- Problems_Languages
+ALTER TABLE `Problems_Languages`
+  DROP FOREIGN KEY `fk_pl_translator_id`,
+  DROP INDEX `translator_id`,
+  DROP COLUMN `translator_id`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -490,11 +490,9 @@ CREATE TABLE IF NOT EXISTS `Problems_Badges` (
 CREATE TABLE IF NOT EXISTS `Problems_Languages` (
   `problem_id` int(11) NOT NULL,
   `language_id` int(11) NOT NULL,
-  `translator_id` int(11) NOT NULL,
   PRIMARY KEY (`problem_id`,`language_id`),
   KEY `problem_id` (`problem_id`),
-  KEY `language_id` (`language_id`),
-  KEY `translator_id` (`translator_id`)
+  KEY `language_id` (`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Las traducciones viven en el filesystem y no en la bdd.';
 
 -- --------------------------------------------------------
@@ -1019,8 +1017,7 @@ ALTER TABLE `Problems_Badges`
 --
 ALTER TABLE `Problems_Languages`
   ADD CONSTRAINT `fk_pl_language_id` FOREIGN KEY (`language_id`) REFERENCES `Languages` (`language_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
-  ADD CONSTRAINT `fk_pl_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
-  ADD CONSTRAINT `fk_pl_translator_id` FOREIGN KEY (`translator_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+  ADD CONSTRAINT `fk_pl_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 --
 -- Filtros para la tabla `Problemset_User_Request`

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1801,8 +1801,7 @@ class ProblemController extends Controller {
     }
 
     /**
-     * Gets all the problems and save language data
-     * into the DB
+     * Save language data for a problem.
      * @param Request $r
      * @return Array
      * @throws InvalidDatabaseOperationException
@@ -1811,14 +1810,12 @@ class ProblemController extends Controller {
         try {
             ProblemsLanguagesDAO::transBegin();
 
-            $languages = LanguagesDAO::getAll();
-
             // Removing existing data
             $deletedLanguages = ProblemsLanguagesDAO::deleteProblemLanguages(new ProblemsLanguages([
                 'problem_id' => $problem->problem_id,
             ]));
 
-            foreach ($languages as $lang) {
+            foreach (LanguagesDAO::getAll() as $lang) {
                 if (!file_exists(self::getSourcePath($problem->alias, $lang->name, 'markdown'))) {
                     continue;
                 }
@@ -1833,6 +1830,5 @@ class ProblemController extends Controller {
             ProblemsLanguagesDAO::transRollback();
             throw new InvalidDatabaseOperationException($e);
         }
-        return ['status' => 'ok'];
     }
 }

--- a/frontend/server/libs/dao/Problems_Languages.dao.php
+++ b/frontend/server/libs/dao/Problems_Languages.dao.php
@@ -19,9 +19,6 @@ require_once('base/Problems_Languages.vo.base.php');
   */
 class ProblemsLanguagesDAO extends ProblemsLanguagesDAOBase {
     final public static function deleteProblemLanguages(ProblemsLanguages $Problems_Languages) {
-        if (is_null(self::search($Problems_Languages->problem_id))) {
-            throw new Exception('Registro no encontrado.');
-        }
         $sql = 'DELETE FROM `Problems_Languages` WHERE problem_id = ?;';
         $params = [$Problems_Languages->problem_id];
         global $conn;

--- a/frontend/server/libs/dao/Problems_Languages.dao.php
+++ b/frontend/server/libs/dao/Problems_Languages.dao.php
@@ -18,9 +18,9 @@ require_once('base/Problems_Languages.vo.base.php');
   *
   */
 class ProblemsLanguagesDAO extends ProblemsLanguagesDAOBase {
-    final public static function deleteProblemLanguages(ProblemsLanguages $Problems_Languages) {
+    final public static function deleteProblemLanguages(ProblemsLanguages $problems_languages) {
         $sql = 'DELETE FROM `Problems_Languages` WHERE problem_id = ?;';
-        $params = [$Problems_Languages->problem_id];
+        $params = [$problems_languages->problem_id];
         global $conn;
 
         $conn->Execute($sql, $params);

--- a/frontend/server/libs/dao/Problems_Languages.dao.php
+++ b/frontend/server/libs/dao/Problems_Languages.dao.php
@@ -18,4 +18,15 @@ require_once('base/Problems_Languages.vo.base.php');
   *
   */
 class ProblemsLanguagesDAO extends ProblemsLanguagesDAOBase {
+    final public static function deleteProblemLanguages(ProblemsLanguages $Problems_Languages) {
+        if (is_null(self::search($Problems_Languages->problem_id))) {
+            throw new Exception('Registro no encontrado.');
+        }
+        $sql = 'DELETE FROM `Problems_Languages` WHERE problem_id = ?;';
+        $params = [$Problems_Languages->problem_id];
+        global $conn;
+
+        $conn->Execute($sql, $params);
+        return $conn->Affected_Rows();
+    }
 }

--- a/frontend/server/libs/dao/base/Problems_Languages.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems_Languages.dao.base.php
@@ -20,7 +20,7 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
     /**
      * Campos de la tabla.
      */
-    const FIELDS = '`Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id`, `Problems_Languages`.`translator_id`';
+    const FIELDS = '`Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id`';
 
     /**
      * Guardar registros.
@@ -56,7 +56,7 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
         if (is_null($problem_id) || is_null($language_id)) {
             return null;
         }
-        $sql = 'SELECT `Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id`, `Problems_Languages`.`translator_id` FROM Problems_Languages WHERE (problem_id = ? AND language_id = ?) LIMIT 1;';
+        $sql = 'SELECT `Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id` FROM Problems_Languages WHERE (problem_id = ? AND language_id = ?) LIMIT 1;';
         $params = [$problem_id, $language_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
@@ -82,7 +82,7 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
      * @return Array Un arreglo que contiene objetos del tipo {@link ProblemsLanguages}.
      */
     final public static function getAll($pagina = null, $columnas_por_pagina = null, $orden = null, $tipo_de_orden = 'ASC') {
-        $sql = 'SELECT `Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id`, `Problems_Languages`.`translator_id` from Problems_Languages';
+        $sql = 'SELECT `Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id` from Problems_Languages';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipo_de_orden == 'DESC' ? 'DESC' : 'ASC');
@@ -135,10 +135,6 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
             $clauses[] = '`language_id` = ?';
             $params[] = $Problems_Languages->language_id;
         }
-        if (!is_null($Problems_Languages->translator_id)) {
-            $clauses[] = '`translator_id` = ?';
-            $params[] = $Problems_Languages->translator_id;
-        }
         global $conn;
         if (!is_null($likeColumns)) {
             foreach ($likeColumns as $column => $value) {
@@ -149,7 +145,7 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
         if (sizeof($clauses) == 0) {
             return self::getAll();
         }
-        $sql = 'SELECT `Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id`, `Problems_Languages`.`translator_id` FROM `Problems_Languages`';
+        $sql = 'SELECT `Problems_Languages`.`problem_id`, `Problems_Languages`.`language_id` FROM `Problems_Languages`';
         $sql .= ' WHERE (' . implode(' AND ', $clauses) . ')';
         if (!is_null($orderBy)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orderBy) . '` ' . ($orden == 'DESC' ? 'DESC' : 'ASC');
@@ -173,14 +169,6 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
       * @param ProblemsLanguages [$Problems_Languages] El objeto de tipo ProblemsLanguages a actualizar.
       */
     final private static function update(ProblemsLanguages $Problems_Languages) {
-        $sql = 'UPDATE `Problems_Languages` SET `translator_id` = ? WHERE `problem_id` = ? AND `language_id` = ?;';
-        $params = [
-            $Problems_Languages->translator_id,
-            $Problems_Languages->problem_id,$Problems_Languages->language_id,
-        ];
-        global $conn;
-        $conn->Execute($sql, $params);
-        return $conn->Affected_Rows();
     }
 
     /**
@@ -196,11 +184,10 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
      * @param ProblemsLanguages [$Problems_Languages] El objeto de tipo ProblemsLanguages a crear.
      */
     final private static function create(ProblemsLanguages $Problems_Languages) {
-        $sql = 'INSERT INTO Problems_Languages (`problem_id`, `language_id`, `translator_id`) VALUES (?, ?, ?);';
+        $sql = 'INSERT INTO Problems_Languages (`problem_id`, `language_id`) VALUES (?, ?);';
         $params = [
             $Problems_Languages->problem_id,
             $Problems_Languages->language_id,
-            $Problems_Languages->translator_id,
         ];
         global $conn;
         $conn->Execute($sql, $params);
@@ -266,17 +253,6 @@ abstract class ProblemsLanguagesDAOBase extends DAO {
             $params[] = max($a, $b);
         } elseif (!is_null($a) || !is_null($b)) {
             $clauses[] = '`language_id` = ?';
-            $params[] = is_null($a) ? $b : $a;
-        }
-
-        $a = $Problems_LanguagesA->translator_id;
-        $b = $Problems_LanguagesB->translator_id;
-        if (!is_null($a) && !is_null($b)) {
-            $clauses[] = '`translator_id` >= ? AND `translator_id` <= ?';
-            $params[] = min($a, $b);
-            $params[] = max($a, $b);
-        } elseif (!is_null($a) || !is_null($b)) {
-            $clauses[] = '`translator_id` = ?';
             $params[] = is_null($a) ? $b : $a;
         }
 

--- a/frontend/server/libs/dao/base/Problems_Languages.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Languages.vo.base.php
@@ -32,9 +32,6 @@ class ProblemsLanguages extends VO {
         if (isset($data['language_id'])) {
             $this->language_id = $data['language_id'];
         }
-        if (isset($data['translator_id'])) {
-            $this->translator_id = $data['translator_id'];
-        }
     }
 
     /**
@@ -63,11 +60,4 @@ class ProblemsLanguages extends VO {
       * @var int(11)
       */
     public $language_id;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var int(11)
-      */
-    public $translator_id;
 }

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -106,6 +106,7 @@ class Utils {
             'Groups_Users',
             'Interviews',
             'Problems',
+            'Problems_Languages',
             'Problems_Tags',
             'Problemset_Access_Log',
             'Problemset_Problem_Opened',

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -12,25 +12,26 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem(OMEGAUP_RESOURCES_ROOT . 'triangulos.zip', 'Problem Language');
 
         // Update statement
-        $statement = 'This is the new statement';
         $login = self::login($problemData['author']);
 
-        $problem_language = new ProblemsLanguages();
-        $problem_language->problem_id = $problemData['problem']->problem_id;
-        $problem_languages = ProblemsLanguagesDAO::search($problem_language);
+        $problem_languages = ProblemsLanguagesDAO::search([
+            'problem_id' => $problemData['problem']->problem_id,
+        ]);
         // This problem only has one language in this point
         $this->assertEquals(1, count($problem_languages));
 
-        $response = ProblemController::apiUpdateStatement(new Request([
+        ProblemController::apiUpdateStatement(new Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problemData['request']['alias'],
             'message' => 'New statement is now more fun',
-            'statement' => $statement,
+            'statement' => 'This is the new statement',
             'lang' => 'en'
         ]));
 
         // The problem has two languages in this point
-        $problem_languages = ProblemsLanguagesDAO::search($problem_language);
+        $problem_languages = ProblemsLanguagesDAO::search([
+            'problem_id' => $problemData['problem']->problem_id,
+        ]);
         $this->assertEquals(2, count($problem_languages));
     }
 

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -7,6 +7,33 @@
  */
 
 class UpdateProblemTest extends OmegaupTestCase {
+    public function testProblemUpdateLanguages() {
+        // Get a problem (with 'es' statements)
+        $problemData = ProblemsFactory::createProblem(OMEGAUP_RESOURCES_ROOT . 'triangulos.zip', 'Problem Language');
+
+        // Update statement
+        $statement = 'This is the new statement';
+        $login = self::login($problemData['author']);
+
+        $problem_language = new ProblemsLanguages();
+        $problem_language->problem_id = $problemData['problem']->problem_id;
+        $problem_languages = ProblemsLanguagesDAO::search($problem_language);
+        // This problem only has one language in this point
+        $this->assertEquals(1, count($problem_languages));
+
+        $response = ProblemController::apiUpdateStatement(new Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['alias'],
+            'message' => 'New statement is now more fun',
+            'statement' => $statement,
+            'lang' => 'en'
+        ]));
+
+        // The problem has two languages in this point
+        $problem_languages = ProblemsLanguagesDAO::search($problem_language);
+        $this->assertEquals(2, count($problem_languages));
+    }
+
     public function testUpdateProblemTitleAndContents() {
         // Get a problem
         $problemData = ProblemsFactory::createProblem();

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -17,7 +17,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problem_languages = ProblemsLanguagesDAO::search([
             'problem_id' => $problemData['problem']->problem_id,
         ]);
-        // This problem only has one language in this point
+        // This problem only has one language at this point
         $this->assertEquals(1, count($problem_languages));
 
         ProblemController::apiUpdateStatement(new Request([
@@ -28,7 +28,7 @@ class UpdateProblemTest extends OmegaupTestCase {
             'lang' => 'en'
         ]));
 
-        // The problem has two languages in this point
+        // The problem has two languages at this point
         $problem_languages = ProblemsLanguagesDAO::search([
             'problem_id' => $problemData['problem']->problem_id,
         ]);

--- a/frontend/www/js/common.navbar.grader_status.js
+++ b/frontend/www/js/common.navbar.grader_status.js
@@ -8,7 +8,9 @@
         'grader-error grader-ok grader-warning grader-unknown');
     graderCount.html("<img src='/media/waitcircle.gif' />");
     var html = '<li><a href="/arena/admin/">' +
-               omegaup.T.wordsLatestSubmissions + '</a></li>';
+               omegaup.T.wordsLatestSubmissions + '</a></li>' +
+               '<li><a href="/api/problem/setLanguage">' +
+               'Llenar tabla de Problems_Languages</a></li>';
     omegaup.API.Grader.status()
         .then(function(stats) {
           var graderInfo = stats.grader;

--- a/frontend/www/js/common.navbar.grader_status.js
+++ b/frontend/www/js/common.navbar.grader_status.js
@@ -8,9 +8,7 @@
         'grader-error grader-ok grader-warning grader-unknown');
     graderCount.html("<img src='/media/waitcircle.gif' />");
     var html = '<li><a href="/arena/admin/">' +
-               omegaup.T.wordsLatestSubmissions + '</a></li>' +
-               '<li><a href="/api/problem/setLanguage">' +
-               'Llenar tabla de Problems_Languages</a></li>';
+               omegaup.T.wordsLatestSubmissions + '</a></li>';
     omegaup.API.Grader.status()
         .then(function(stats) {
           var graderInfo = stats.grader;


### PR DESCRIPTION
Se crea un API para extraer la información de file system en los problemas y poder almacenar en la base de datos el idioma en el que se dio de alta. Este funciona tanto para hacer la primer barrida de todos los problemas ya existentes, cómo para los que se den de alta en adelante.

Fixes #1463 