### PR TITLE
Agregando una fecha fija en el servidor para todas las pruebas

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -74,6 +74,7 @@ require_once('libs/third_party/Mailchimp/Mailchimp.php');
 require_once('libs/third_party/ZipStream.php');
 require_once('libs/third_party/phpmailer/class.phpmailer.php');
 require_once('libs/third_party/phpmailer/class.smtp.php');
+require_once(OMEGAUP_ROOT . '/tests/common/Utils.php');
 
 /*
  * Configurar log4php

--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -67,6 +67,7 @@ require_once('libs/Request.php');
 require_once('libs/Scoreboard.php');
 require_once('libs/SecurityTools.php');
 require_once('libs/SessionManager.php');
+require_once('libs/Time.php');
 require_once('libs/UITools.php');
 require_once('libs/UrlHelper.php');
 require_once('libs/Validators.php');
@@ -74,7 +75,6 @@ require_once('libs/third_party/Mailchimp/Mailchimp.php');
 require_once('libs/third_party/ZipStream.php');
 require_once('libs/third_party/phpmailer/class.phpmailer.php');
 require_once('libs/third_party/phpmailer/class.smtp.php');
-require_once(OMEGAUP_ROOT . '/tests/common/Utils.php');
 
 /*
  * Configurar log4php

--- a/frontend/server/controllers/ClarificationController.php
+++ b/frontend/server/controllers/ClarificationController.php
@@ -68,7 +68,7 @@ class ClarificationController extends Controller {
 
         $response = [];
 
-        $time = Utils::GetPhpUnixTimestamp();
+        $time = Time::get();
         $r['clarification'] = new Clarifications([
             'author_id' => $r['current_user_id'],
             'problemset_id' => $r['contest']->problemset_id,
@@ -199,7 +199,7 @@ class ClarificationController extends Controller {
         $r['clarification'] = $clarification;
 
         // Let DB handle time update
-        $time = Utils::GetPhpUnixTimestamp();
+        $time = Time::get();
         $clarification->time = gmdate('Y-m-d H:i:s', $time);
 
         // Save the clarification

--- a/frontend/server/controllers/ClarificationController.php
+++ b/frontend/server/controllers/ClarificationController.php
@@ -68,7 +68,7 @@ class ClarificationController extends Controller {
 
         $response = [];
 
-        $time = time();
+        $time = Utils::GetPhpUnixTimestamp();
         $r['clarification'] = new Clarifications([
             'author_id' => $r['current_user_id'],
             'problemset_id' => $r['contest']->problemset_id,
@@ -199,7 +199,7 @@ class ClarificationController extends Controller {
         $r['clarification'] = $clarification;
 
         // Let DB handle time update
-        $time = time();
+        $time = Utils::GetPhpUnixTimestamp();
         $clarification->time = gmdate('Y-m-d H:i:s', $time);
 
         // Save the clarification

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -544,7 +544,7 @@ class CourseController extends Controller {
             'status' => 'ok',
             'assignments' => [],
         ];
-        $time = Utils::GetPhpUnixTimestamp();
+        $time = Time::get();
         foreach ($assignments as $a) {
             $a->toUnixTime();
             if (!$isAdmin && $v['start_time'] > $time) {
@@ -1236,7 +1236,7 @@ class CourseController extends Controller {
             return;
         }
 
-        if ($r['assignment']->start_time > Utils::GetPhpUnixTimestamp() ||
+        if ($r['assignment']->start_time > Time::get() ||
             !GroupRolesDAO::isContestant($r['current_user_id'], $r['assignment']->acl_id)
         ) {
             throw new ForbiddenAccessException();

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -544,7 +544,7 @@ class CourseController extends Controller {
             'status' => 'ok',
             'assignments' => [],
         ];
-        $time = time();
+        $time = Utils::GetPhpUnixTimestamp();
         foreach ($assignments as $a) {
             $a->toUnixTime();
             if (!$isAdmin && $v['start_time'] > $time) {
@@ -1236,7 +1236,7 @@ class CourseController extends Controller {
             return;
         }
 
-        if ($r['assignment']->start_time > time() ||
+        if ($r['assignment']->start_time > Utils::GetPhpUnixTimestamp() ||
             !GroupRolesDAO::isContestant($r['current_user_id'], $r['assignment']->acl_id)
         ) {
             throw new ForbiddenAccessException();

--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -287,7 +287,7 @@ class GroupController extends Controller {
                 'name' => $r['name'],
                 'description' =>$r['description'],
                 'alias' => $r['alias'],
-                'create_time' => gmdate('Y-m-d H:i:s', time())
+                'create_time' => gmdate('Y-m-d H:i:s', Utils::GetPhpUnixTimestamp())
             ]);
 
             GroupsScoreboardsDAO::save($groupScoreboard);

--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -287,7 +287,7 @@ class GroupController extends Controller {
                 'name' => $r['name'],
                 'description' =>$r['description'],
                 'alias' => $r['alias'],
-                'create_time' => gmdate('Y-m-d H:i:s', Utils::GetPhpUnixTimestamp())
+                'create_time' => gmdate('Y-m-d H:i:s', Time::get())
             ]);
 
             GroupsScoreboardsDAO::save($groupScoreboard);

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1253,7 +1253,7 @@ class ProblemController extends Controller {
                     ProblemsetProblemOpenedDAO::save(new ProblemsetProblemOpened([
                         'problemset_id' => $problemset_id,
                         'problem_id' => $r['problem']->problem_id,
-                        'open_time' => gmdate('Y-m-d H:i:s', Utils::GetPhpUnixTimestamp()),
+                        'open_time' => gmdate('Y-m-d H:i:s', Time::get()),
                         'user_id' => $r['current_user_id']
                     ]));
                 } catch (Exception $e) {

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1253,6 +1253,7 @@ class ProblemController extends Controller {
                     ProblemsetProblemOpenedDAO::save(new ProblemsetProblemOpened([
                         'problemset_id' => $problemset_id,
                         'problem_id' => $r['problem']->problem_id,
+                        'open_time' => gmdate('Y-m-d H:i:s', Utils::GetPhpUnixTimestamp()),
                         'user_id' => $r['current_user_id']
                     ]));
                 } catch (Exception $e) {

--- a/frontend/server/controllers/ResetController.php
+++ b/frontend/server/controllers/ResetController.php
@@ -91,7 +91,7 @@ class ResetController extends Controller {
             throw new InvalidParameterException('unverifiedUser');
         }
 
-        $seconds = time() - strtotime($user->reset_sent_at);
+        $seconds = Utils::GetPhpUnixTimestamp() - strtotime($user->reset_sent_at);
         if ($seconds < PASSWORD_RESET_MIN_WAIT) {
             throw new InvalidParameterException('passwordResetMinWait');
         }
@@ -119,7 +119,7 @@ class ResetController extends Controller {
 
         SecurityTools::testStrongPassword($password);
 
-        $seconds = time() - strtotime($user->reset_sent_at);
+        $seconds = Utils::GetPhpUnixTimestamp() - strtotime($user->reset_sent_at);
         if ($seconds > PASSWORD_RESET_TIMEOUT) {
             throw new InvalidParameterException('passwordResetResetExpired');
         }

--- a/frontend/server/controllers/ResetController.php
+++ b/frontend/server/controllers/ResetController.php
@@ -91,7 +91,7 @@ class ResetController extends Controller {
             throw new InvalidParameterException('unverifiedUser');
         }
 
-        $seconds = Utils::GetPhpUnixTimestamp() - strtotime($user->reset_sent_at);
+        $seconds = Time::get() - strtotime($user->reset_sent_at);
         if ($seconds < PASSWORD_RESET_MIN_WAIT) {
             throw new InvalidParameterException('passwordResetMinWait');
         }
@@ -119,7 +119,7 @@ class ResetController extends Controller {
 
         SecurityTools::testStrongPassword($password);
 
-        $seconds = Utils::GetPhpUnixTimestamp() - strtotime($user->reset_sent_at);
+        $seconds = Time::get() - strtotime($user->reset_sent_at);
         if ($seconds > PASSWORD_RESET_TIMEOUT) {
             throw new InvalidParameterException('passwordResetResetExpired');
         }

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -119,7 +119,7 @@ class RunController extends Controller {
                 // in this scenario.
                 if (ProblemsDAO::isVisible($r['problem']) ||
                       Authorization::isProblemAdmin($r['current_user_id'], $r['problem']) ||
-                      time() > ProblemsDAO::getPracticeDeadline($r['problem']->problem_id)) {
+                      Utils::GetPhpUnixTimestamp() > ProblemsDAO::getPracticeDeadline($r['problem']->problem_id)) {
                     if (!RunsDAO::IsRunInsideSubmissionGap(
                         null,
                         null,
@@ -276,7 +276,7 @@ class RunController extends Controller {
 
             if (!is_null($start)) {
                 //ok, what time is it now?
-                $c_time = time();
+                $c_time = Utils::GetPhpUnixTimestamp();
                 $start = strtotime($start);
 
                 //asuming submit_delay is in minutes
@@ -301,6 +301,7 @@ class RunController extends Controller {
                     'memory' => 0,
                     'score' => 0,
                     'contest_score' => $problemset_id != null ? 0 : null,
+                    'time' => gmdate('Y-m-d H:i:s', Utils::GetPhpUnixTimestamp()),
                     'submit_delay' => $submit_delay, /* based on penalty_type */
                     'guid' => md5(uniqid(rand(), true)),
                     'verdict' => 'JE',

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -119,7 +119,7 @@ class RunController extends Controller {
                 // in this scenario.
                 if (ProblemsDAO::isVisible($r['problem']) ||
                       Authorization::isProblemAdmin($r['current_user_id'], $r['problem']) ||
-                      Utils::GetPhpUnixTimestamp() > ProblemsDAO::getPracticeDeadline($r['problem']->problem_id)) {
+                      Time::get() > ProblemsDAO::getPracticeDeadline($r['problem']->problem_id)) {
                     if (!RunsDAO::IsRunInsideSubmissionGap(
                         null,
                         null,
@@ -276,7 +276,7 @@ class RunController extends Controller {
 
             if (!is_null($start)) {
                 //ok, what time is it now?
-                $c_time = Utils::GetPhpUnixTimestamp();
+                $c_time = Time::get();
                 $start = strtotime($start);
 
                 //asuming submit_delay is in minutes
@@ -301,7 +301,7 @@ class RunController extends Controller {
                     'memory' => 0,
                     'score' => 0,
                     'contest_score' => $problemset_id != null ? 0 : null,
-                    'time' => gmdate('Y-m-d H:i:s', Utils::GetPhpUnixTimestamp()),
+                    'time' => gmdate('Y-m-d H:i:s', Time::get()),
                     'submit_delay' => $submit_delay, /* based on penalty_type */
                     'guid' => md5(uniqid(rand(), true)),
                     'verdict' => 'JE',

--- a/frontend/server/controllers/SchoolController.php
+++ b/frontend/server/controllers/SchoolController.php
@@ -124,7 +124,7 @@ class SchoolController extends Controller {
         $canUseCache = is_null($r['start_time']) && is_null($r['finish_time']);
 
         if (is_null($r['start_time'])) {
-            $r['start_time'] = date('Y-m-01');
+            $r['start_time'] = date('Y-m-01', Utils::GetPhpUnixTimestamp());
         } else {
             $r['start_time'] = gmdate('Y-m-d', $r['start_time']);
         }

--- a/frontend/server/controllers/SchoolController.php
+++ b/frontend/server/controllers/SchoolController.php
@@ -124,7 +124,7 @@ class SchoolController extends Controller {
         $canUseCache = is_null($r['start_time']) && is_null($r['finish_time']);
 
         if (is_null($r['start_time'])) {
-            $r['start_time'] = date('Y-m-01', Utils::GetPhpUnixTimestamp());
+            $r['start_time'] = date('Y-m-01', Time::get());
         } else {
             $r['start_time'] = gmdate('Y-m-d', $r['start_time']);
         }

--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -68,7 +68,7 @@ class SessionController extends Controller {
             return [
                 'status' => 'ok',
                 'session' => self::$current_session,
-                'time' => Utils::GetPhpUnixTimestamp(),
+                'time' => Time::get(),
             ];
         }
         if (is_null($r)) {
@@ -96,7 +96,7 @@ class SessionController extends Controller {
         return [
             'status' => 'ok',
             'session' => self::$current_session,
-            'time' => Utils::GetPhpUnixTimestamp(),
+            'time' => Time::get(),
         ];
     }
 

--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -68,7 +68,7 @@ class SessionController extends Controller {
             return [
                 'status' => 'ok',
                 'session' => self::$current_session,
-                'time' => time(),
+                'time' => Utils::GetPhpUnixTimestamp(),
             ];
         }
         if (is_null($r)) {
@@ -96,7 +96,7 @@ class SessionController extends Controller {
         return [
             'status' => 'ok',
             'session' => self::$current_session,
-            'time' => time(),
+            'time' => Utils::GetPhpUnixTimestamp(),
         ];
     }
 

--- a/frontend/server/controllers/TimeController.php
+++ b/frontend/server/controllers/TimeController.php
@@ -16,7 +16,7 @@ class TimeController extends Controller {
      */
     public static function apiGet(Request $r = null) {
         $response = [];
-        $response['time'] = time();
+        $response['time'] = Utils::GetPhpUnixTimestamp();
         $response['status'] = 'ok';
 
         return $response;

--- a/frontend/server/controllers/TimeController.php
+++ b/frontend/server/controllers/TimeController.php
@@ -16,7 +16,7 @@ class TimeController extends Controller {
      */
     public static function apiGet(Request $r = null) {
         $response = [];
-        $response['time'] = Utils::GetPhpUnixTimestamp();
+        $response['time'] = Time::get();
         $response['status'] = 'ok';
 
         return $response;

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1571,7 +1571,7 @@ class UserController extends Controller {
                 $r['birth_date'] = strtotime($r['birth_date']);
             }
 
-            if ($r['birth_date'] >= strtotime('-5 year', time())) {
+            if ($r['birth_date'] >= strtotime('-5 year', Utils::GetPhpUnixTimestamp())) {
                 throw new InvalidParameterException('birthdayInTheFuture', 'birth_date');
             }
         }
@@ -1845,7 +1845,7 @@ class UserController extends Controller {
         $newUsername = substr($email, 0, strpos($email, '@'));
         $newUsername = str_replace('-', '_', $newUsername);
         $newUsername = str_replace('.', '_', $newUsername);
-        return $newUsername . time();
+        return $newUsername . Utils::GetPhpUnixTimestamp();
     }
 
     /**

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1571,7 +1571,7 @@ class UserController extends Controller {
                 $r['birth_date'] = strtotime($r['birth_date']);
             }
 
-            if ($r['birth_date'] >= strtotime('-5 year', Utils::GetPhpUnixTimestamp())) {
+            if ($r['birth_date'] >= strtotime('-5 year', Time::get())) {
                 throw new InvalidParameterException('birthdayInTheFuture', 'birth_date');
             }
         }
@@ -1845,7 +1845,7 @@ class UserController extends Controller {
         $newUsername = substr($email, 0, strpos($email, '@'));
         $newUsername = str_replace('-', '_', $newUsername);
         $newUsername = str_replace('.', '_', $newUsername);
-        return $newUsername . Utils::GetPhpUnixTimestamp();
+        return $newUsername . Time::get();
     }
 
     /**

--- a/frontend/server/libs/Scoreboard.php
+++ b/frontend/server/libs/Scoreboard.php
@@ -199,7 +199,7 @@ class Scoreboard {
             $this->params['auth_token']
         );
 
-        $timeout = max(0, $this->params['finish_time'] - Utils::GetPhpUnixTimestamp());
+        $timeout = max(0, $this->params['finish_time'] - Time::get());
         if ($can_use_contestant_cache) {
             $contestantScoreboardCache->set($result, $timeout);
         } elseif ($can_use_admin_cache) {
@@ -270,7 +270,7 @@ class Scoreboard {
             $problem_mapping
         );
 
-        $timeout = max(0, $this->params['finish_time'] - Utils::GetPhpUnixTimestamp());
+        $timeout = max(0, $this->params['finish_time'] - Time::get());
         if ($can_use_contestant_cache) {
             $contestantEventsCache->set($result, $timeout);
         } elseif ($can_use_admin_cache) {
@@ -338,7 +338,7 @@ class Scoreboard {
 
         // Cache scoreboard until the contest ends (or forever if it has already ended).
         // Contestant cache
-        $timeout = max(0, $params['finish_time'] - Utils::GetPhpUnixTimestamp());
+        $timeout = max(0, $params['finish_time'] - Time::get());
         $contestantScoreboardCache = new Cache(Cache::CONTESTANT_SCOREBOARD_PREFIX, $params['problemset_id']);
         $contestantScoreboard = Scoreboard::getScoreboardFromRuns(
             $contest_runs,
@@ -437,7 +437,7 @@ class Scoreboard {
     private static function getScoreboardTimeLimitUnixTimestamp(
         ScoreboardParams $params
     ) {
-        if ($params['show_all_runs'] || ((Utils::GetPhpUnixTimestamp() >= $params['finish_time']) && $params['show_scoreboard_after'])) {
+        if ($params['show_all_runs'] || ((Time::get() >= $params['finish_time']) && $params['show_scoreboard_after'])) {
             // Show full scoreboard to admin users
             // or if the contest finished and the creator wants to show it at the end
             return null;
@@ -604,7 +604,7 @@ class Scoreboard {
             'start_time' => $contest_start_time,
             'finish_time' => $contest_finish_time,
             'title' => $contest_title,
-            'time' => Utils::GetPhpUnixTimestamp() * 1000
+            'time' => Time::get() * 1000
         ];
     }
 

--- a/frontend/server/libs/Scoreboard.php
+++ b/frontend/server/libs/Scoreboard.php
@@ -199,7 +199,7 @@ class Scoreboard {
             $this->params['auth_token']
         );
 
-        $timeout = max(0, $this->params['finish_time'] - time());
+        $timeout = max(0, $this->params['finish_time'] - Utils::GetPhpUnixTimestamp());
         if ($can_use_contestant_cache) {
             $contestantScoreboardCache->set($result, $timeout);
         } elseif ($can_use_admin_cache) {
@@ -270,7 +270,7 @@ class Scoreboard {
             $problem_mapping
         );
 
-        $timeout = max(0, $this->params['finish_time'] - time());
+        $timeout = max(0, $this->params['finish_time'] - Utils::GetPhpUnixTimestamp());
         if ($can_use_contestant_cache) {
             $contestantEventsCache->set($result, $timeout);
         } elseif ($can_use_admin_cache) {
@@ -338,7 +338,7 @@ class Scoreboard {
 
         // Cache scoreboard until the contest ends (or forever if it has already ended).
         // Contestant cache
-        $timeout = max(0, $params['finish_time'] - time());
+        $timeout = max(0, $params['finish_time'] - Utils::GetPhpUnixTimestamp());
         $contestantScoreboardCache = new Cache(Cache::CONTESTANT_SCOREBOARD_PREFIX, $params['problemset_id']);
         $contestantScoreboard = Scoreboard::getScoreboardFromRuns(
             $contest_runs,
@@ -437,7 +437,7 @@ class Scoreboard {
     private static function getScoreboardTimeLimitUnixTimestamp(
         ScoreboardParams $params
     ) {
-        if ($params['show_all_runs'] || ((time() >= $params['finish_time']) && $params['show_scoreboard_after'])) {
+        if ($params['show_all_runs'] || ((Utils::GetPhpUnixTimestamp() >= $params['finish_time']) && $params['show_scoreboard_after'])) {
             // Show full scoreboard to admin users
             // or if the contest finished and the creator wants to show it at the end
             return null;
@@ -604,7 +604,7 @@ class Scoreboard {
             'start_time' => $contest_start_time,
             'finish_time' => $contest_finish_time,
             'title' => $contest_title,
-            'time' => time() * 1000
+            'time' => Utils::GetPhpUnixTimestamp() * 1000
         ];
     }
 

--- a/frontend/server/libs/SessionManager.php
+++ b/frontend/server/libs/SessionManager.php
@@ -7,8 +7,8 @@ class SessionManager {
             foreach ($cookies as $cookie) {
                 $parts = explode('=', $cookie);
                 $old_name = trim($parts[0]);
-                setcookie($old_name, '', Utils::GetPhpUnixTimestamp() - 1000);
-                setcookie($old_name, '', Utils::GetPhpUnixTimestamp() - 1000, '/');
+                setcookie($old_name, '', Time::get() - 1000);
+                setcookie($old_name, '', Time::get() - 1000, '/');
             }
         }
 

--- a/frontend/server/libs/SessionManager.php
+++ b/frontend/server/libs/SessionManager.php
@@ -7,8 +7,8 @@ class SessionManager {
             foreach ($cookies as $cookie) {
                 $parts = explode('=', $cookie);
                 $old_name = trim($parts[0]);
-                setcookie($old_name, '', time()-1000);
-                setcookie($old_name, '', time()-1000, '/');
+                setcookie($old_name, '', Utils::GetPhpUnixTimestamp() - 1000);
+                setcookie($old_name, '', Utils::GetPhpUnixTimestamp() - 1000, '/');
             }
         }
 

--- a/frontend/server/libs/Time.php
+++ b/frontend/server/libs/Time.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ *
+ * @author juan.pablo
+ */
+class Time {
+    private static $time = null;
+
+    public static function get() {
+        if (self::$time != null) {
+            return self::$time;
+        }
+        return time();
+    }
+
+    public static function setTimeForTesting($time) {
+        self::$time = $time;
+    }
+}

--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -162,11 +162,11 @@ class ContestsDAO extends ContestsDAOBase {
     }
 
     public static function hasStarted(Contests $contest) {
-        return Utils::GetPhpUnixTimestamp() >= strtotime($contest->start_time);
+        return Time::get() >= strtotime($contest->start_time);
     }
 
     public static function hasFinished(Contests $contest) {
-        return Utils::GetPhpUnixTimestamp() >= strtotime($contest->finish_time);
+        return Time::get() >= strtotime($contest->finish_time);
     }
 
     public static function getContestsParticipated($user_id) {

--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -162,11 +162,11 @@ class ContestsDAO extends ContestsDAOBase {
     }
 
     public static function hasStarted(Contests $contest) {
-        return time() >= strtotime($contest->start_time);
+        return Utils::GetPhpUnixTimestamp() >= strtotime($contest->start_time);
     }
 
     public static function hasFinished(Contests $contest) {
-        return time() >= strtotime($contest->finish_time);
+        return Utils::GetPhpUnixTimestamp() >= strtotime($contest->finish_time);
     }
 
     public static function getContestsParticipated($user_id) {

--- a/frontend/server/libs/dao/Problemsets.dao.php
+++ b/frontend/server/libs/dao/Problemsets.dao.php
@@ -41,13 +41,13 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
      */
     public static function isLateSubmission($container) {
         return isset($container->finish_time) &&
-               (time() > strtotime($container->finish_time));
+               (Utils::GetPhpUnixTimestamp() > strtotime($container->finish_time));
     }
 
     public static function insideSubmissionWindow($container, $user_id) {
         if (isset($container->finish_time)) {
-            if (time() > strtotime($container->finish_time) ||
-                time() < strtotime($container->start_time)) {
+            if (Utils::GetPhpUnixTimestamp() > strtotime($container->finish_time) ||
+                Utils::GetPhpUnixTimestamp() < strtotime($container->start_time)) {
                 return false;
             }
         }
@@ -62,6 +62,6 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
         );
         $first_access_time = $problemset_user->access_time;
 
-        return time() <= strtotime($first_access_time) + $container->window_length * 60;
+        return Utils::GetPhpUnixTimestamp() <= strtotime($first_access_time) + $container->window_length * 60;
     }
 }

--- a/frontend/server/libs/dao/Problemsets.dao.php
+++ b/frontend/server/libs/dao/Problemsets.dao.php
@@ -41,13 +41,13 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
      */
     public static function isLateSubmission($container) {
         return isset($container->finish_time) &&
-               (Utils::GetPhpUnixTimestamp() > strtotime($container->finish_time));
+               (Time::get() > strtotime($container->finish_time));
     }
 
     public static function insideSubmissionWindow($container, $user_id) {
         if (isset($container->finish_time)) {
-            if (Utils::GetPhpUnixTimestamp() > strtotime($container->finish_time) ||
-                Utils::GetPhpUnixTimestamp() < strtotime($container->start_time)) {
+            if (Time::get() > strtotime($container->finish_time) ||
+                Time::get() < strtotime($container->start_time)) {
                 return false;
             }
         }
@@ -62,6 +62,6 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
         );
         $first_access_time = $problemset_user->access_time;
 
-        return Utils::GetPhpUnixTimestamp() <= strtotime($first_access_time) + $container->window_length * 60;
+        return Time::get() <= strtotime($first_access_time) + $container->window_length * 60;
     }
 }

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -326,7 +326,7 @@ class RunsDAO extends RunsDAOBase {
         }
 
         $run = new Runs($rs);
-        return [$run, Utils::GetPhpUnixTimestamp() - strtotime($run->time)];
+        return [$run, Time::get() - strtotime($run->time)];
     }
 
     /*
@@ -562,7 +562,7 @@ class RunsDAO extends RunsDAOBase {
             );
         }
 
-        return Utils::GetPhpUnixTimestamp() >= (strtotime($lastrun->time) + $submission_gap);
+        return Time::get() >= (strtotime($lastrun->time) + $submission_gap);
     }
 
     public static function GetRunCountsToDate($date) {

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -326,7 +326,7 @@ class RunsDAO extends RunsDAOBase {
         }
 
         $run = new Runs($rs);
-        return [$run, time() - strtotime($run->time)];
+        return [$run, Utils::GetPhpUnixTimestamp() - strtotime($run->time)];
     }
 
     /*
@@ -562,7 +562,7 @@ class RunsDAO extends RunsDAOBase {
             );
         }
 
-        return time() >= (strtotime($lastrun->time) + $submission_gap);
+        return Utils::GetPhpUnixTimestamp() >= (strtotime($lastrun->time) + $submission_gap);
     }
 
     public static function GetRunCountsToDate($date) {

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -33,6 +33,8 @@ require_once(OMEGAUP_ROOT . '/tests/factories/RunsFactory.php');
 require_once(OMEGAUP_ROOT . '/tests/factories/GroupsFactory.php');
 require_once(OMEGAUP_ROOT . '/tests/factories/SchoolsFactory.php');
 
+require_once(OMEGAUP_ROOT . '/server/libs/Time.php');
+
 // Clean previous log
 Utils::CleanLog();
 
@@ -73,5 +75,5 @@ UserController::$sendEmailOnVerify = true;
 RunController::$defaultSubmissionGap = 0;
 
 $current_time = time();
-define('TEST_TIMESTAMP', $current_time);
+Time::setTimeForTesting($current_time);
 $conn->EXECUTE('SET TIMESTAMP = ' . $current_time);

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -74,6 +74,7 @@ UserController::$sendEmailOnVerify = true;
 // Globally disable run wait gap.
 RunController::$defaultSubmissionGap = 0;
 
+// Mock time
 $current_time = time();
 Time::setTimeForTesting($current_time);
 $conn->EXECUTE('SET TIMESTAMP = ' . $current_time);

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -71,3 +71,7 @@ UserController::$sendEmailOnVerify = true;
 
 // Globally disable run wait gap.
 RunController::$defaultSubmissionGap = 0;
+
+$current_time = time();
+define('TEST_TIMESTAMP', $current_time);
+$conn->EXECUTE('SET TIMESTAMP = ' . $current_time);

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -38,10 +38,7 @@ class Utils {
 
     public static function GetPhpUnixTimestamp($time = null) {
         if (is_null($time)) {
-            if (!defined('IS_TEST') || IS_TEST !== true) {
-                return time();
-            }
-            return TEST_TIMESTAMP;
+            return Time::get();
         } else {
             return strtotime($time);
         }

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -38,7 +38,10 @@ class Utils {
 
     public static function GetPhpUnixTimestamp($time = null) {
         if (is_null($time)) {
-            return time();
+            if (!defined('IS_TEST') || IS_TEST !== true) {
+                return time();
+            }
+            return TEST_TIMESTAMP;
         } else {
             return strtotime($time);
         }

--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -44,6 +44,7 @@ class ContestListTest extends OmegaupTestCase {
         $login = self::login($contestant);
         $r = new Request([
             'auth_token' => $login->auth_token,
+            'page_size' => 50
         ]);
         $response = ContestController::apiList($r);
 
@@ -60,12 +61,10 @@ class ContestListTest extends OmegaupTestCase {
      * Basic test. Check that most recent contest is at the top of the list
      */
     public function testLatestPublicContestNotLoggedIn() {
-        $r = new Request();
-
         // Create new PUBLIC contest
         $contestData = ContestsFactory::createContest();
 
-        $response = ContestController::apiList($r);
+        $response = ContestController::apiList(new Request(['page_size' => 50]));
 
         $this->assertArrayContainsInKeyExactlyOnce(
             $response['results'],
@@ -139,6 +138,7 @@ class ContestListTest extends OmegaupTestCase {
         $login = self::login(UserFactory::createAdminUser());
         $r = new Request([
             'auth_token' => $login->auth_token,
+            'page_size' => 50
         ]);
         $response = ContestController::apiList($r);
 

--- a/frontend/tests/controllers/DbConfigTest.php
+++ b/frontend/tests/controllers/DbConfigTest.php
@@ -3,7 +3,7 @@
 class DbConfigTest extends PHPUnit_Framework_TestCase {
     public function testTimeSync() {
         $db_time = Utils::GetDbDatetime();
-        $php_time = date('Y-m-d H:i:s');
+        $php_time = date('Y-m-d H:i:s', TEST_TIMESTAMP);
 
         $this->assertEquals($php_time, $db_time);
     }

--- a/frontend/tests/controllers/DbConfigTest.php
+++ b/frontend/tests/controllers/DbConfigTest.php
@@ -3,7 +3,7 @@
 class DbConfigTest extends PHPUnit_Framework_TestCase {
     public function testTimeSync() {
         $db_time = Utils::GetDbDatetime();
-        $php_time = date('Y-m-d H:i:s', TEST_TIMESTAMP);
+        $php_time = date('Y-m-d H:i:s', Time::get());
 
         $this->assertEquals($php_time, $db_time);
     }

--- a/frontend/tests/controllers/ResetCreateTest.php
+++ b/frontend/tests/controllers/ResetCreateTest.php
@@ -38,7 +38,7 @@ class ResetCreateTest extends OmegaupTestCase {
         $this->assertEquals('passwordResetMinWait', $message);
 
         // time travel
-        $reset_sent_at = ApiUtils::GetStringTime(time() - PASSWORD_RESET_MIN_WAIT - 1);
+        $reset_sent_at = ApiUtils::GetStringTime(Utils::GetPhpUnixTimestamp() - PASSWORD_RESET_MIN_WAIT - 1);
         $user = UsersDAO::FindByEmail($user_data['email']);
         $user->reset_sent_at = $reset_sent_at;
         UsersDAO::save($user);

--- a/frontend/tests/controllers/ResetUpdateTest.php
+++ b/frontend/tests/controllers/ResetUpdateTest.php
@@ -74,7 +74,7 @@ class ResetUpdateTest extends OmegaupTestCase {
         $user_data['reset_token'] = $response['token'];
 
         // Time travel
-        $reset_sent_at = ApiUtils::GetStringTime(time() - PASSWORD_RESET_TIMEOUT - 1);
+        $reset_sent_at = ApiUtils::GetStringTime(Utils::GetPhpUnixTimestamp() - PASSWORD_RESET_TIMEOUT - 1);
         $user = UsersDAO::FindByEmail($user_data['email']);
         $user->reset_sent_at = $reset_sent_at;
         UsersDAO::save($user);

--- a/frontend/tests/controllers/TimeTest.php
+++ b/frontend/tests/controllers/TimeTest.php
@@ -11,7 +11,7 @@ class TimeTest extends OmegaupTestCase {
         $response = TimeController::apiGet();
 
         // Validate result
-        $time = time();
+        $time = Utils::GetPhpUnixTimestamp();
         $this->assertLessThanOrEqual($time, $response['time']);
     }
 }

--- a/frontend/tests/controllers/UserRegistrationTest.php
+++ b/frontend/tests/controllers/UserRegistrationTest.php
@@ -15,7 +15,7 @@ class UserRegistrationTest extends OmegaupTestCase {
 	 *			email=A@gmail.com
 	 */
     public function testUserNameCollision() {
-        $salt = time();
+        $salt = Utils::GetPhpUnixTimestamp();
 
         // Test users should not exist
         $this->assertNull(UsersDAO::FindByUsername('A'.$salt));


### PR DESCRIPTION
Se crea una constante con la fecha fija en el servidor para que las pruebas sean mas consistentes y no fallen eventualmente por variaciones en las comparaciones de timestamps.

Fixes #1475 