### PR TITLE
Eliminando código duplicado

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -157,10 +157,6 @@ class ProblemController extends Controller {
         $problem->stack_limit = $r['stack_limit'];
         $problem->email_clarifications = $r['email_clarifications'];
 
-        if (file_exists(PROBLEMS_PATH . DIRECTORY_SEPARATOR . $r['alias'])) {
-            throw new DuplicatedEntryInDatabaseException('problemExists');
-        }
-
         $problemDeployer = new ProblemDeployer($r['alias'], ProblemDeployer::CREATE);
 
         $acl = new ACLs();


### PR DESCRIPTION
ProblemDeployer tenía una función para acceder a `git`, al igual que la
clase Git. Este cambio elimina la copia de ProblemDeployer en favor de
la clase Git.