### PR TITLE
Simplificar manejo de cache de user ranks

### DIFF
--- a/frontend/server/libs/Cache.php
+++ b/frontend/server/libs/Cache.php
@@ -120,7 +120,6 @@ class Cache {
     const RUN_COUNTS = 'run-counts-';
     const USER_PROFILE = 'profile-';
     const PROBLEMS_SOLVED_RANK = 'problems-solved-rank-';
-    const PROBLEMS_SOLVED_RANK_LIST = 'problems-solved-rank-list';
     const CONTESTS_LIST_PUBLIC = 'contest-list-public';
     const CONTESTS_LIST_SYSTEM_ADMIN = 'contest-list-sys-admin';
     const CONTESTS_LIST_USER_ID = 'contest-list-user-id';


### PR DESCRIPTION
Creo que la solucion original de mantener una entrada en el cache con una lista de entradas en el cache para borrarlas eficientemente es de antes de que usaramos el sistema de versionamiento del cache. Con versiones, "borrar todo eficientemente" se vuelve mucho mas sencillo.