### PR TITLE
Se arreglan las dos fuentes de WARNings más comunes

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1484,6 +1484,9 @@ class ProblemController extends Controller {
                 if (file_exists("$grade_dir/details.json")) {
                     $details = json_decode(file_get_contents("$grade_dir/details.json"));
                     foreach ($details as $group) {
+                        if (!is_object($group) || !isset($group->cases) || !is_array($group->cases)) {
+                            continue;
+                        }
                         foreach ($group->cases as $case) {
                             if (!array_key_exists($case->name, $casesStats['counts'])) {
                                 $casesStats['counts'][$case->name] = 0;

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1484,7 +1484,7 @@ class ProblemController extends Controller {
                 if (file_exists("$grade_dir/details.json")) {
                     $details = json_decode(file_get_contents("$grade_dir/details.json"));
                     foreach ($details as $group) {
-                        if (!is_object($group) || !isset($group->cases) || !is_array($group->cases)) {
+                        if (!isset($group->cases) || !is_array($group->cases)) {
                             continue;
                         }
                         foreach ($group->cases as $case) {

--- a/frontend/www/js/problem.mine.js
+++ b/frontend/www/js/problem.mine.js
@@ -25,7 +25,7 @@
                                        'tag pull-left';
                     tags.append($('<a></a>')
                                     .addClass(tagClass)
-                                    .attr('href', '/problem/?tag=' +
+                                    .attr('href', '/problem/?tag[]=' +
                                                       omegaup.UI.escape(
                                                           problem.tags[j].name))
                                     .text(problem.tags[j].name));

--- a/frontend/www/problemlist.php
+++ b/frontend/www/problemlist.php
@@ -1,12 +1,27 @@
 <?php
 
+function getTagList() {
+    if (!isset($_GET['tag'])) {
+        return null;
+    }
+    $tags = $_GET['tag'];
+    // Still allow strings to be sent to avoid breaking permalinks.
+    if ($tags === '') {
+        $tags = [];
+    }
+    if (!is_array($tags)) {
+        $tags = explode(',', (string)$tags);
+    }
+    return array_unique($tags);
+}
+
 require_once('../server/bootstrap.php');
 $r = new Request();
 $mode = isset($_GET['mode']) ? $_GET['mode'] : 'asc';
 $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
 $order_by = isset($_GET['order_by']) ? $_GET['order_by'] : 'title';
 $language = isset($_GET['language']) ? $_GET['language'] : null;
-$tags = isset($_GET['tag']) ? array_unique($_GET['tag']) : null;
+$tags = getTagList();
 
 $r['page'] = $page;
 $r['language'] = $language;


### PR DESCRIPTION
Este cambio agrega un poco más de validaciones para evitar los warnings
de PHP que causaron las últimas dos alertas en New Relic.