### PR TITLE
Callando los errores de git

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -969,7 +969,7 @@ class ProblemController extends Controller {
         $problemArtifacts = new ProblemArtifacts($r['problem']->alias);
 
         try {
-            $file_content = $problemArtifacts->get('examples/sample.in');
+            $file_content = $problemArtifacts->get('examples/sample.in', true /* quiet */);
         } catch (Exception $e) {
             // Most problems won't have a sample input.
             $file_content = '';

--- a/frontend/server/libs/Git.php
+++ b/frontend/server/libs/Git.php
@@ -9,7 +9,7 @@ class Git {
         $this->log = Logger::getLogger('Git');
     }
 
-    private function execute($args, $pipe_stdout, $cwd_override = null) {
+    private function execute($args, $pipe_stdout, $cwd_override, $quiet) {
         $descriptorspec = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
@@ -46,20 +46,22 @@ class Git {
 
         $retval = proc_close($proc);
         if ($retval != 0) {
-            $this->log->error("$cmd failed: $retval $output $err");
+            if (!$quiet) {
+                $this->log->error("$cmd failed: $retval $output $err");
+            }
             throw new Exception($err);
         }
 
         return $output;
     }
 
-    public function get($args, $cwd_override = null) {
+    public function get($args, $cwd_override = null, $quiet = false) {
         $args = array_merge(['/usr/bin/git'], $args);
-        return $this->execute($args, true, $cwd_override);
+        return $this->execute($args, true, $cwd_override, $quiet);
     }
 
-    public function exec($args, $cwd_override = null) {
+    public function exec($args, $cwd_override = null, $quiet = false) {
         $args = array_merge(['/usr/bin/git'], $args);
-        $this->execute($args, false, $cwd_override);
+        $this->execute($args, false, $cwd_override, $quiet);
     }
 }

--- a/frontend/server/libs/ProblemArtifacts.php
+++ b/frontend/server/libs/ProblemArtifacts.php
@@ -11,13 +11,21 @@ class ProblemArtifacts {
         $this->git = new Git(PROBLEMS_GIT_PATH . DIRECTORY_SEPARATOR . $alias);
     }
 
-    public function get($path) {
-        return $this->git->get(['cat-file', 'blob', 'HEAD:' . $path]);
+    public function get($path, $quiet = false) {
+        return $this->git->get(
+            ['cat-file', 'blob', 'HEAD:' . $path],
+            null /* $cwd_override */,
+            $quiet
+        );
     }
 
     public function exists($path) {
         try {
-            $this->git->get(['cat-file', '-e', 'HEAD:' . $path]);
+            $this->git->get(
+                ['cat-file', '-e', 'HEAD:' . $path],
+                null /* cwd_override */,
+                true /* quiet */
+            );
             return true;
         } catch (Exception $e) {
             // This is expected to fail quite often.
@@ -38,7 +46,7 @@ class WorkingDirProblemArtifacts extends ProblemArtifacts {
         $this->path = $path;
     }
 
-    public function get($path) {
+    public function get($path, $quiet = false) {
         return file_get_contents("{$this->path}/$path");
     }
 


### PR DESCRIPTION
Este cambio evita andar loggueando errores de git que esperamos que
ocurran bastante seguido.