### PR TITLE
Agregando filtro para separar datos capturados después del cambio de preguntas

### DIFF
--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -138,9 +138,11 @@ class Utils {
 
             // Tables with special entries.
             $conn->Execute('DELETE FROM `Groups` WHERE `alias` NOT LIKE "%:%";');
+
+            // The format of the question changed from this id
+            $conn->Execute('ALTER TABLE QualityNominations auto_increment = 18664');
         } catch (Exception $e) {
             echo 'Cleanup DB error. Tests will continue anyways:';
-            var_dump($sql);
             var_dump($e->getMessage());
         } finally {
             // Enabling them again

--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -32,7 +32,9 @@ def get_global_quality_and_difficulty_average(dbconn):
     with dbconn.cursor() as cur:
         cur.execute("""SELECT qn.`contents`
                        FROM `QualityNominations` as qn
-                       WHERE `nomination` = 'suggestion';""")
+                       WHERE `nomination` = 'suggestion'
+                          AND qn.`qualitynomination_id` > 18663;""")
+        # The format of the question changed from this id
         quality_sum = 0
         quality_n = 0
         difficulty_sum = 0
@@ -70,8 +72,10 @@ def get_problem_aggregates(dbconn, problem_id):
         cur.execute("""SELECT qn.`contents`
                        FROM `QualityNominations` as qn
                        WHERE qn.`nomination` = 'suggestion'
+                         AND qn.`qualitynomination_id` > 18663
                          AND qn.`problem_id` = %s;""",
                     (problem_id,))
+        # The format of the question changed from this id
         quality_sum = 0
         quality_n = 0
         difficulty_sum = 0
@@ -171,7 +175,9 @@ def aggregate_feedback(dbconn):
     with dbconn.cursor() as cur:
         cur.execute("""SELECT DISTINCT qn.`problem_id`
                        FROM `QualityNominations` as qn
-                       WHERE qn.`nomination` = 'suggestion';""")
+                       WHERE qn.`nomination` = 'suggestion'
+                         AND qn.`qualitynomination_id` > 18663;""")
+        # The format of the question changed from this id
         for row in cur:
             problem_id = row[0]
             logging.debug('Aggregating feedback for problem %d', problem_id)

--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -22,7 +22,7 @@ PROBLEM_TAG_VOTE_MIN_PROPORTION = 0.25
 MAX_NUM_TOPICS = 5
 
 # Before this id the questions were different
-QUALITY_ID_AFTER_QUESTIONS_CHANGE = 18663
+QUALITYNOMINATION_QUESTION_CHANGE_ID = 18663
 
 
 def get_global_quality_and_difficulty_average(dbconn):
@@ -37,7 +37,7 @@ def get_global_quality_and_difficulty_average(dbconn):
                        FROM `QualityNominations` as qn
                        WHERE `nomination` = 'suggestion'
                         AND qn.`qualitynomination_id` > %s;""",
-                    (QUALITY_ID_AFTER_QUESTIONS_CHANGE,))
+                    (QUALITYNOMINATION_QUESTION_CHANGE_ID,))
         quality_sum = 0
         quality_n = 0
         difficulty_sum = 0
@@ -77,7 +77,7 @@ def get_problem_aggregates(dbconn, problem_id):
                        WHERE qn.`nomination` = 'suggestion'
                          AND qn.`qualitynomination_id` > %s
                          AND qn.`problem_id` = %s;""",
-                    (QUALITY_ID_AFTER_QUESTIONS_CHANGE, problem_id,))
+                    (QUALITYNOMINATION_QUESTION_CHANGE_ID, problem_id,))
         quality_sum = 0
         quality_n = 0
         difficulty_sum = 0
@@ -179,7 +179,7 @@ def aggregate_feedback(dbconn):
                        FROM `QualityNominations` as qn
                        WHERE qn.`nomination` = 'suggestion'
                          AND qn.`qualitynomination_id` > %s;""",
-                    (QUALITY_ID_AFTER_QUESTIONS_CHANGE,))
+                    (QUALITYNOMINATION_QUESTION_CHANGE_ID,))
         for row in cur:
             problem_id = row[0]
             logging.debug('Aggregating feedback for problem %d', problem_id)

--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -21,6 +21,9 @@ MIN_NUM_VOTES = 5
 PROBLEM_TAG_VOTE_MIN_PROPORTION = 0.25
 MAX_NUM_TOPICS = 5
 
+# Berfore this id the questions were distinct
+QUALITY_ID_AFTER_QUESTIONS_CHANGE = 18663
+
 
 def get_global_quality_and_difficulty_average(dbconn):
     '''Gets the global quality and difficulty average based on user feedback.
@@ -33,7 +36,8 @@ def get_global_quality_and_difficulty_average(dbconn):
         cur.execute("""SELECT qn.`contents`
                        FROM `QualityNominations` as qn
                        WHERE `nomination` = 'suggestion'
-                          AND qn.`qualitynomination_id` > 18663;""")
+                        AND qn.`qualitynomination_id` > %s;""",
+                    (QUALITY_ID_AFTER_QUESTIONS_CHANGE,))
         # The format of the question changed from this id
         quality_sum = 0
         quality_n = 0
@@ -72,9 +76,9 @@ def get_problem_aggregates(dbconn, problem_id):
         cur.execute("""SELECT qn.`contents`
                        FROM `QualityNominations` as qn
                        WHERE qn.`nomination` = 'suggestion'
-                         AND qn.`qualitynomination_id` > 18663
+                         AND qn.`qualitynomination_id` > %s
                          AND qn.`problem_id` = %s;""",
-                    (problem_id,))
+                    (QUALITY_ID_AFTER_QUESTIONS_CHANGE, problem_id,))
         # The format of the question changed from this id
         quality_sum = 0
         quality_n = 0
@@ -176,7 +180,8 @@ def aggregate_feedback(dbconn):
         cur.execute("""SELECT DISTINCT qn.`problem_id`
                        FROM `QualityNominations` as qn
                        WHERE qn.`nomination` = 'suggestion'
-                         AND qn.`qualitynomination_id` > 18663;""")
+                         AND qn.`qualitynomination_id` > %s;""",
+                    (QUALITY_ID_AFTER_QUESTIONS_CHANGE,))
         # The format of the question changed from this id
         for row in cur:
             problem_id = row[0]

--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -21,7 +21,7 @@ MIN_NUM_VOTES = 5
 PROBLEM_TAG_VOTE_MIN_PROPORTION = 0.25
 MAX_NUM_TOPICS = 5
 
-# Berfore this id the questions were distinct
+# Before this id the questions were different
 QUALITY_ID_AFTER_QUESTIONS_CHANGE = 18663
 
 
@@ -38,7 +38,6 @@ def get_global_quality_and_difficulty_average(dbconn):
                        WHERE `nomination` = 'suggestion'
                         AND qn.`qualitynomination_id` > %s;""",
                     (QUALITY_ID_AFTER_QUESTIONS_CHANGE,))
-        # The format of the question changed from this id
         quality_sum = 0
         quality_n = 0
         difficulty_sum = 0
@@ -79,7 +78,6 @@ def get_problem_aggregates(dbconn, problem_id):
                          AND qn.`qualitynomination_id` > %s
                          AND qn.`problem_id` = %s;""",
                     (QUALITY_ID_AFTER_QUESTIONS_CHANGE, problem_id,))
-        # The format of the question changed from this id
         quality_sum = 0
         quality_n = 0
         difficulty_sum = 0
@@ -182,7 +180,6 @@ def aggregate_feedback(dbconn):
                        WHERE qn.`nomination` = 'suggestion'
                          AND qn.`qualitynomination_id` > %s;""",
                     (QUALITY_ID_AFTER_QUESTIONS_CHANGE,))
-        # The format of the question changed from this id
         for row in cur:
             problem_id = row[0]
             logging.debug('Aggregating feedback for problem %d', problem_id)


### PR DESCRIPTION
Se agrega un filtro en las consultas para separar los datos  que se capturaron después del cambio de preguntas en el cronjob.

Fixes #1540 