### PR TITLE
Reporte de errores de JavaScript

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -96,6 +96,10 @@ Logger::configure([
                 'appenders' => ['csp'],
                 'additivity' => false,
             ],
+            'jserror' => [
+                'appenders' => ['jserror'],
+                'additivity' => false,
+            ],
         ],
         'appenders' => [
             'default' => [
@@ -121,6 +125,19 @@ Logger::configure([
                 ],
                 'params' => [
                     'file' => OMEGAUP_CSP_LOG_FILE,
+                    'append' => true,
+                ],
+            ],
+            'jserror' => [
+                'class' => 'LoggerAppenderFile',
+                'layout' => [
+                    'class' => 'LoggerLayoutPattern',
+                    'params' => [
+                        'conversionPattern' => '%date: %message %newline',
+                    ],
+                ],
+                'params' => [
+                    'file' => OMEGAUP_JSERROR_LOG_FILE,
                     'append' => true,
                 ],
             ]

--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -47,6 +47,7 @@ try_define('OMEGAUP_LOG_DB_QUERYS', false);
 try_define('OMEGAUP_LOG_LEVEL', 'info');
 try_define('OMEGAUP_LOG_FILE', '/var/log/omegaup/omegaup.log');
 try_define('OMEGAUP_CSP_LOG_FILE', '/var/log/omegaup/csp.log');
+try_define('OMEGAUP_JSERROR_LOG_FILE', '/var/log/omegaup/jserror.log');
 
 # ####################################
 # GRADER CONFIG

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -8,6 +8,7 @@
 {else}
 		<meta name="google-signin-client_id" content="{$GOOGLECLIENTID}">
 {/if}
+		<script type="text/javascript" src="{version_hash src="/js/error_handler.js"}"></script>
 		<title>{if isset($htmlTitle)}{$htmlTitle} &ndash; {/if}omegaUp</title>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/jquery-1.10.2.min.js"}"></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/highstock.js"}"></script>

--- a/frontend/www/js/error_handler.js
+++ b/frontend/www/js/error_handler.js
@@ -1,0 +1,62 @@
+// This should not use jQuery (or any other non-vanilla JS) and should work
+// with as many old browsers (IE9+) as possible.
+function sendError(message, filename, lineno, colno, error) {
+  'use strict';
+  // Try to get a stack.
+  try {
+    if (!error) {
+      error = new Error('force-added error');
+    }
+    if (!error.stack) {
+      error.stack = new Error('force-added stack').stack;
+      if (error.stack) {
+        error.stack = error.stack.toString();
+      } else {
+        try {
+          throw new Error('force-thrown stack');
+        } catch (e) {
+          error.stack = e.stack;
+        }
+      }
+    }
+  } catch (e) {
+    // That was a best-effort attempt to grab a stack. Older browsers will
+    // still fail, but at the very least the filename and line number should be
+    // correctly reported.
+  }
+
+  // Try to send the error.
+  try {
+    var httpRequest = new XMLHttpRequest();
+    httpRequest.onreadystatechange = function() {
+      if (httpRequest.readyState !== XMLHttpRequest.DONE) return;
+      if (httpRequest.status === 200) return;
+
+      // The submission failed.
+      console.error('Failed to upload the error', httpRequest.status);
+    };
+    httpRequest.open('POST', '/jserrorreport.php');
+    httpRequest.setRequestHeader('Content-Type', 'application/jserror-report');
+    var report = {
+      userAgent: navigator.userAgent,
+    };
+    if (error.stack) report.stack = error.stack;
+    if (typeof message !== 'undefined') report.message = message;
+    if (typeof filename !== 'undefined') report.filename = filename;
+    if (typeof lineno !== 'undefined') report.lineno = lineno;
+    if (typeof colno !== 'undefined') report.colno = colno;
+    httpRequest.send(JSON.stringify(report));
+  } catch (e) {
+    console.error('Failed to upload the error', e);
+  }
+}
+if (window.addEventListener) {
+  // Way too old browsers (IE8) don't even support window.addEventListener.
+  // Let's stop making it worse for them and just silently degrade.
+  window.addEventListener('error', function(event) {
+    'use strict';
+    sendError(event.message, event.filename, event.lineno, event.colno,
+              event.error);
+    return true;
+  });
+}

--- a/frontend/www/jserrorreport.php
+++ b/frontend/www/jserrorreport.php
@@ -1,0 +1,11 @@
+<?php
+require_once('../server/bootstrap.php');
+
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    header('HTTP/1.1 400 Bad Request');
+    die();
+}
+
+$log = Logger::getLogger('jserror');
+$log->error(file_get_contents('php://input'));
+die();


### PR DESCRIPTION
New Relic no nos permite tener un agregado de errores de JavaScript con
el plan que tenemos, así que hagamos uno propio. Este cambio reporta
todos los errores no-atrapados en JavaScript a un log, igual que los
errores de CSP.

Fixes: #1646