### PR TITLE
Recalculando el score de los envios cuando se modifica el problema

### DIFF
--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -40,12 +40,12 @@ class ProblemsetController extends Controller {
      * the contest_score for all the problemset and problem runs
      */
     public static function updateProblemsetProblem(ProblemsetProblems $updatedProblemsetProblem) {
-        $newProblemset = ProblemsetProblemsDAOBase::save($updatedProblemsetProblem);
         $problem = ProblemsetProblemsDAOBase::getByPK(
             $updatedProblemsetProblem->problemset_id,
             $updatedProblemsetProblem->problem_id
         );
-        if (is_null($problem) && $problem->points == $updatedProblemsetProblem->points) {
+        $newProblemset = ProblemsetProblemsDAOBase::save($updatedProblemsetProblem);
+        if (is_null($problem) || $problem->points == $updatedProblemsetProblem->points) {
             return;
         }
         RunsDAO::recalculateScore(

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -44,7 +44,7 @@ class ProblemsetController extends Controller {
             $updatedProblemsetProblem->problemset_id,
             $updatedProblemsetProblem->problem_id
         );
-        $newProblemset = ProblemsetProblemsDAOBase::save($updatedProblemsetProblem);
+        ProblemsetProblemsDAOBase::save($updatedProblemsetProblem);
         if (is_null($problem) || $problem->points == $updatedProblemsetProblem->points) {
             return;
         }

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -24,7 +24,7 @@ class ProblemsetController extends Controller {
         );
 
         try {
-            self::saveProblem(new ProblemsetProblems([
+            self::updateProblemsetProblem(new ProblemsetProblems([
                 'problemset_id' => $problemset_id,
                 'problem_id' => $problem->problem_id,
                 'points' => $points,
@@ -39,21 +39,20 @@ class ProblemsetController extends Controller {
      * When problem is already in the problemset, it must recalculate
      * the contest_score for all the problemset and problem runs
      */
-    public static function saveProblem(ProblemsetProblems $Problemset_Problems) {
+    public static function updateProblemsetProblem(ProblemsetProblems $updatedProblemsetProblem) {
+        $newProblemset = ProblemsetProblemsDAOBase::save($updatedProblemsetProblem);
         $problem = ProblemsetProblemsDAOBase::getByPK(
-            $Problemset_Problems->problemset_id,
-            $Problemset_Problems->problem_id
+            $updatedProblemsetProblem->problemset_id,
+            $updatedProblemsetProblem->problem_id
         );
-        if (!is_null($problem)) {
-            if ($problem->points != $Problemset_Problems->points) {
-                RunsDAO::recalculateScore(
-                    $Problemset_Problems->problemset_id,
-                    $Problemset_Problems->problem_id,
-                    $Problemset_Problems->points,
-                    $problem->points
-                );
-            }
+        if (is_null($problem) && $problem->points == $updatedProblemsetProblem->points) {
+            return;
         }
-        ProblemsetProblemsDAOBase::save($Problemset_Problems);
+        RunsDAO::recalculateScore(
+            $updatedProblemsetProblem->problemset_id,
+            $updatedProblemsetProblem->problem_id,
+            $updatedProblemsetProblem->points,
+            $problem->points
+        );
     }
 }

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -46,31 +46,14 @@ class ProblemsetController extends Controller {
         );
         if (!is_null($problem)) {
             if ($problem->points != $Problemset_Problems->points) {
-                self::recalculateScore($Problemset_Problems, $problem->points);
+                RunsDAO::recalculateScore(
+                    $Problemset_Problems->problemset_id,
+                    $Problemset_Problems->problem_id,
+                    $Problemset_Problems->points,
+                    $problem->points
+                );
             }
         }
         ProblemsetProblemsDAOBase::save($Problemset_Problems);
-    }
-
-    /**
-     * Recalculate the contest_score of all problemset and problem Runs
-     */
-    private static function recalculateScore(ProblemsetProblems $Problemset_Problems, $original_points) {
-        $runs = RunsDAO::GetAllRuns(
-            $Problemset_Problems->problemset_id,
-            null,
-            null,
-            $Problemset_Problems->problem_id,
-            null,
-            null,
-            null,
-            null
-        );
-        foreach ($runs as $run) {
-            $exsistingRun = RunsDAOBase::getByPK($run['run_id']);
-            $exsistingRun->contest_score = round((
-                (int)$run['contest_score'] / (int)$original_points) * (int)$Problemset_Problems->points);
-            RunsDAOBase::save($exsistingRun);
-        }
     }
 }

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -723,4 +723,28 @@ class RunsDAO extends RunsDAOBase {
         }
         return $ar;
     }
+
+    /**
+     * Recalculate the contest_score of all problemset and problem Runs
+     */
+    public static function recalculateScore($problemset_id, $problem_id, $current_points, $original_points) {
+        $sql = 'UPDATE
+                  `Runs`
+                SET
+                  `contest_score` = ROUND((`contest_score` / ?) * ?)
+                WHERE
+                  `problemset_id` = ?
+                  AND `problem_id` = ?;';
+
+        $params = [
+            $original_points,
+            $current_points,
+            $problemset_id,
+            $problem_id
+        ];
+
+        global $conn;
+        $conn->Execute($sql, $params);
+        return $conn->Affected_Rows();
+    }
 }

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -731,13 +731,12 @@ class RunsDAO extends RunsDAOBase {
         $sql = 'UPDATE
                   `Runs`
                 SET
-                  `contest_score` = ROUND((`contest_score` / ?) * ?)
+                  `contest_score` = `score` * ?
                 WHERE
                   `problemset_id` = ?
                   AND `problem_id` = ?;';
 
         $params = [
-            $original_points,
             $current_points,
             $problemset_id,
             $problem_id


### PR DESCRIPTION
Se agrega función para recalcular el puntaje obtenido por cada envío que pertenezca a un concurso donde se modifica el score a las preguntas

Fixes #849 