### PR TITLE
Permitiendo el registro de un usuario que había ingresado con redes sociales

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -42,12 +42,29 @@ class UserController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        if (!is_null($userByEmail)) {
-            throw new DuplicatedEntryInDatabaseException('mailInUse');
-        }
-
         if (!is_null($user)) {
             throw new DuplicatedEntryInDatabaseException('usernameInUse');
+        }
+
+        if (!is_null($userByEmail)) {
+            if (!is_null($userByEmail->password)) {
+                throw new DuplicatedEntryInDatabaseException('mailInUse');
+            } else {
+                $user_data = [
+                    'user_id' => $userByEmail->user_id,
+                    'username' => $r['username'],
+                    'password' => $hashedPassword
+                ];
+
+                $user = new Users($user_data);
+
+                UsersDAO::savePassword($user);
+
+                return [
+                    'status' => 'ok',
+                    'user_id' => $user->user_id
+                ];
+            }
         }
 
         // Prepare DAOs

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -42,29 +42,26 @@ class UserController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        if (!is_null($user)) {
-            throw new DuplicatedEntryInDatabaseException('usernameInUse');
-        }
-
         if (!is_null($userByEmail)) {
             if (!is_null($userByEmail->password)) {
                 throw new DuplicatedEntryInDatabaseException('mailInUse');
-            } else {
-                $user_data = [
-                    'user_id' => $userByEmail->user_id,
-                    'username' => $r['username'],
-                    'password' => $hashedPassword
-                ];
-
-                $user = new Users($user_data);
-
-                UsersDAO::savePassword($user);
-
-                return [
-                    'status' => 'ok',
-                    'user_id' => $user->user_id
-                ];
             }
+
+            $user = new Users([
+                'user_id' => $userByEmail->user_id,
+                'username' => $r['username'],
+                'password' => $hashedPassword
+            ]);
+            UsersDAO::savePassword($user);
+
+            return [
+                'status' => 'ok',
+                'user_id' => $user->user_id
+            ];
+        }
+
+        if (!is_null($user)) {
+            throw new DuplicatedEntryInDatabaseException('usernameInUse');
         }
 
         // Prepare DAOs

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -76,4 +76,23 @@ class UsersDAO extends UsersDAOBase {
             ];
         }
     }
+
+    public static function savePassword(Users $Users) {
+        $sql = '
+            UPDATE
+                `Users`
+            SET
+                `password` = ?,
+                `username` = ?
+            WHERE
+                `user_id` = ?;';
+        $params = [
+            $Users->password,
+            $Users->username,
+            $Users->user_id,
+        ];
+        global $conn;
+        $conn->Execute($sql, $params);
+        return $conn->Affected_Rows();
+    }
 }


### PR DESCRIPTION
Se agrega la funcionalidad de poder combinar una cuenta registrada con redes sociales a una cuenta creada desde la plataforma de omegaUp, esto permite que se pueda cambiar el username.

La forma en la que se valida si un usuario se registró con red social es si no cuenta con contraseña, no sé si sea la forma correcta.

Fixes #398 