### PR TITLE
Agregando el URL al reporte de error de JS

### DIFF
--- a/frontend/www/js/error_handler.js
+++ b/frontend/www/js/error_handler.js
@@ -39,6 +39,7 @@ function sendError(message, filename, lineno, colno, error) {
     httpRequest.setRequestHeader('Content-Type', 'application/jserror-report');
     var report = {
       userAgent: navigator.userAgent,
+      location: window.location.href,
     };
     if (error.stack) report.stack = error.stack;
     if (typeof message !== 'undefined') report.message = message;


### PR DESCRIPTION
Este cambio agrega el URL actual al reporte para hacer más fácil la
reproducción de errores.