### PR TITLE
Evitando un error con el pseudo-locale

### DIFF
--- a/frontend/www/js/head.sugar_locale.js
+++ b/frontend/www/js/head.sugar_locale.js
@@ -1,1 +1,7 @@
-Date.setLocale($('head').attr('data-locale'));
+(function() {
+  var locale = $('head').attr('data-locale');
+  if (locale == 'pseudo') {
+    locale = 'en';
+  }
+  Date.setLocale(locale);
+})();


### PR DESCRIPTION
Este cambio evita que sugar arroje una excepción cuando se utiliza el
pseudolocale.