### PR TITLE
Arreglando una condición de carrera en Arena

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -385,6 +385,8 @@ export class Arena {
 
     self.startTime = start;
     self.finishTime = finish;
+    // Once the clock is ready, we can now connect to the socket.
+    self.connectSocket();
     if (self.options.isPractice) {
       self.elements.clock.html('&infin;');
       return;

--- a/frontend/www/ux/admin.js
+++ b/frontend/www/ux/admin.js
@@ -21,7 +21,6 @@ omegaup.OmegaUp.on('ready', function() {
     $('#loading').fadeOut('slow');
     $('#root').fadeIn('slow');
   } else {
-    arena.connectSocket();
     omegaup.API.Contest.details({contest_alias: arena.options.contestAlias})
         .then(function(contest) {
           if (!contest.admin) {

--- a/frontend/www/ux/contest.js
+++ b/frontend/www/ux/contest.js
@@ -117,7 +117,6 @@ omegaup.OmegaUp.on('ready', function() {
     onlyProblemLoaded(JSON.parse(
         document.getElementById('problem-json').firstChild.nodeValue));
   } else {
-    arena.connectSocket();
     omegaup.API.Contest.details({contest_alias: arena.options.contestAlias})
         .then(arena.contestLoaded.bind(arena))
         .fail(omegaup.UI.ignoreError);

--- a/frontend/www/ux/scoreboard.js
+++ b/frontend/www/ux/scoreboard.js
@@ -10,7 +10,6 @@ omegaup.OmegaUp.on('ready', function() {
   var arena = new omegaup.arena.Arena(options);
   var getRankingByTokenRefresh = 5 * 60 * 1000;  // 5 minutes
 
-  arena.connectSocket();
   omegaup.API.Contest.details({
                        contest_alias: arena.options.contestAlias,
                        token: arena.options.scoreboardToken,


### PR DESCRIPTION
Si el WebSocket carga antes que la información del concurso, hay un
montón de cosas que fallan por una excepción no-manejada al intentar
acceder el tiempo de inicio del concurso al intentar dibujar la gráfica
de ranking.