### PR TITLE
Hotfix del regex del testplan

### DIFF
--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -489,7 +489,7 @@ class ProblemDeployer {
         $testplan_array = [];
 
         // LOL RegEx magic to get test case names from testplan
-        preg_match_all('/^\\s*([^#]+?)\\s+(\\d+)\\s*$/m', $testplan, $testplan_array);
+        preg_match_all('/^\\s*([^# \\t]+)\\s+([0-9.]+)\\s*$/m', $testplan, $testplan_array);
 
         if (count($testplan_array[1]) == 0) {
                 throw new InvalidParameterException('problemDeployerTestplanEmpty', null);


### PR DESCRIPTION
Este cambio utiliza un regex más decente para parsear el testplan.

Fixes: #1718