### PR TITLE
Arreglando bug que no permite agregar participantes a un concurso

### DIFF
--- a/frontend/templates/contest.edit.tpl
+++ b/frontend/templates/contest.edit.tpl
@@ -94,7 +94,7 @@
 						<textarea name="usernames" rows="4" class="form-control"></textarea>
 					</div>
 
-					<button class="btn btn-primary user-add-bulk" type="submit" id="multiple">{#contestAdduserAddUsers#}</button>
+					<button class="btn btn-primary user-add-bulk" type="submit">{#contestAdduserAddUsers#}</button>
 				</form>
 			</div>
 

--- a/frontend/www/js/contest.edit.js
+++ b/frontend/www/js/contest.edit.js
@@ -344,7 +344,8 @@ omegaup.OmegaUp.on('ready', function() {
   $('#add-contestant-form')
       .on('submit', function(evt) {
         evt.preventDefault;
-        isBulk = document.activeElement.id == 'multiple';
+        isBulk =
+            document.activeElement.className.indexOf('user-add-bulk') !== -1;
         if (isBulk) {
           var promises = $('textarea[name="usernames"]')
                              .val()

--- a/frontend/www/js/contest.edit.js
+++ b/frontend/www/js/contest.edit.js
@@ -344,8 +344,7 @@ omegaup.OmegaUp.on('ready', function() {
   $('#add-contestant-form')
       .on('submit', function(evt) {
         evt.preventDefault;
-        isBulk = $($(this).context.attributes[0].ownerDocument.activeElement)
-                     .hasClass('user-add-bulk');
+        isBulk = document.activeElement.id == 'multiple';
         if (isBulk) {
           var promises = $('textarea[name="usernames"]')
                              .val()


### PR DESCRIPTION
Se resuelve el bug que no permitía agregar participantes a un concurso. Se quita el llamado a una propiedad de jQuery que fue removida en la versión 3. 

Fixes #1722 