### PR TITLE
Forzando el encoding de las redacciones a UTF-8

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -912,7 +912,7 @@ class ProblemController extends Controller {
     public static function getProblemStatementImpl($params) {
         list($problemArtifacts, $sourcePath) = $params;
         try {
-            return $problemArtifacts->get($sourcePath);
+            return mb_convert_encoding($problemArtifacts->get($sourcePath), 'utf-8');
         } catch (Exception $e) {
             throw new InvalidFilesystemOperationException('statementNotFound');
         }


### PR DESCRIPTION
Este cambio hace que las redacciones sean UTF-8. Así si hay algún
caracter inválido, se reemplazarán por '?' (en vez de �, pero bueno,
PHP...).

Fixes: #1727