### PR TITLE
Arreglando la vista de progreso de estudiantes en curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -194,13 +194,8 @@ export default {
 </script>
 
 <style>
-.omegaup-course-viewprogress td, .omegaup-course-viewprogress th {
-  /* max-width 0 makes cell width proportional and allows content to overflow */
-  max-width: 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-.omegaup-course-viewprogress .score {
-  text-align: right;
+.panel-body {
+  overflow: auto;
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
Se agrega un scroll horizontal a la tabla de progreso de estudiantes en los cursos para que el maestro pueda leerlo correctamente.

Fixes #1623 