### PR TITLE
Arreglando el estilo de las listas en redaccion.php

### DIFF
--- a/frontend/www/css/style.css
+++ b/frontend/www/css/style.css
@@ -526,6 +526,7 @@ padding-right: 5px;
 #problem .statement p { text-align: justify; }
 #problem .statement li { text-align: justify; }
 #problem .statement h1 { font-weight: bold; }
+#problem .statement ul { list-style: initial; }
 
 #problem-form .languages {
 	padding: 0;


### PR DESCRIPTION
Se arregla un estilo que no estaba funcionando correctamente en el template de redaccion.php, ahora en las listas ya se muestra el bullet que antes no se veía.

Fixes #1548 