### PR TITLE
[Color Hierarchy] make apiProfile() return user's color #1771

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1240,6 +1240,8 @@ class UserController extends Controller {
             ];
             $response['userinfo']['is_private'] = true;
         }
+        $classname=UsersDAO::cd($response['userinfo']['username']);
+        $response['userinfo']['classname']=$classname; //update the userinfo
         $response['status'] = 'ok';
         return $response;
     }

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1240,7 +1240,7 @@ class UserController extends Controller {
             ];
             $response['userinfo']['is_private'] = true;
         }
-        $response['userinfo']['classname'] = UsersDAO::cd($response['userinfo']['user_id']);
+        $response['userinfo']['classname'] = UsersDAO::getRankingClassName($r['user']->user_id);
         $response['status'] = 'ok';
         return $response;
     }

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1240,8 +1240,7 @@ class UserController extends Controller {
             ];
             $response['userinfo']['is_private'] = true;
         }
-        $classname=UsersDAO::cd($response['userinfo']['username']);
-        $response['userinfo']['classname']=$classname; //update the userinfo
+        $response['userinfo']['classname'] = UsersDAO::cd($response['userinfo']['user_id']);
         $response['status'] = 'ok';
         return $response;
     }

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -148,4 +148,28 @@ class UsersDAO extends UsersDAOBase {
         global $conn;
         return $conn->GetOne($sql, $params);
     }
+    public static function FindClassName($username){
+        global $conn;
+        $sql = 'select User_Rank.score 
+                from Users
+                inner join User_Rank on User_Rank.user_id=Users.user_id
+                where username = ?';
+        $params = [$username];
+        $rs = $conn->GetRow($sql, $params);
+        if (count($rs)==0){
+            return null;
+        }else{
+            $score = $rs[0];
+            $sql = 'select score, classname from User_Rank_Cutoffs order by score desc';
+            $rs = getAll($sql);
+            $classname = '';
+            foreach ($rs as $rule){
+                if ($score >= $rule[0]){
+                    $classname = $rule[1];
+                    break;
+                }
+            }
+            return $classname;
+        }
+    }
 }

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -167,7 +167,7 @@ class UsersDAO extends UsersDAOBase {
                 ORDER BY
                     `urc`.`percentile` ASC
                 LIMIT
-                    1;';
+                    1';
         $params = [$user_id];
         global $conn;
         return $conn->GetOne($sql, $params) ?? 'user-rank-unranked';

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -148,7 +148,8 @@ class UsersDAO extends UsersDAOBase {
         global $conn;
         return $conn->GetOne($sql, $params);
     }
-    public static function FindClassName($user_id){
+    
+    public static function getRankingClassName($user_id){
         $sql = 'SELECT
                     `urc`.`classname`,
                     `urc`.`score`,
@@ -170,7 +171,6 @@ class UsersDAO extends UsersDAOBase {
                     1';
         $params = [$user_id];
         global $conn;
-        return $conn->GetOne($sql, $params) ?? 'user-rank-unranked';
-        
+        return $conn->GetOne($sql, $params) ?? 'user-rank-unranked';     
     }
 }

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -148,28 +148,29 @@ class UsersDAO extends UsersDAOBase {
         global $conn;
         return $conn->GetOne($sql, $params);
     }
-    public static function FindClassName($username){
+    public static function FindClassName($user_id){
+        $sql = 'SELECT
+                    `urc`.`classname`,
+                    `urc`.`score`,
+                    `urc`.`percentile`
+                FROM
+                    `User_Rank_Cutoffs` `urc`
+                WHERE
+                    `urc`.score` =< (
+                        SELECT
+                            `ur`.`score`
+                        FROM
+                            `User_Rank` `ur`
+                        WHERE
+                            `ur`.user_id` = ?
+                    )
+                ORDER BY
+                    `urc`.`percentile` ASC
+                LIMIT
+                    1;';
+        $params = [$user_id];
         global $conn;
-        $sql = 'select User_Rank.score 
-                from Users
-                inner join User_Rank on User_Rank.user_id=Users.user_id
-                where username = ?';
-        $params = [$username];
-        $rs = $conn->GetRow($sql, $params);
-        if (count($rs)==0){
-            return null;
-        }else{
-            $score = $rs[0];
-            $sql = 'select score, classname from User_Rank_Cutoffs order by score desc';
-            $rs = getAll($sql);
-            $classname = '';
-            foreach ($rs as $rule){
-                if ($score >= $rule[0]){
-                    $classname = $rule[1];
-                    break;
-                }
-            }
-            return $classname;
-        }
+        return $conn->GetOne($sql, $params) ?? 'user-rank-unranked';
+        
     }
 }

--- a/frontend/tests/controllers/UserRankTest.php
+++ b/frontend/tests/controllers/UserRankTest.php
@@ -110,6 +110,23 @@ class UserRankTest extends OmegaupTestCase {
         $this->assertEquals($response['problems_solved'], 1);
     }
 
+    public function testUserRankingClassName() {
+        // Create a user and sumbit a run with him
+        $contestant = UserFactory::createUser();
+        $problemData = ProblemsFactory::createProblem();
+        $runData = RunsFactory::createRunToProblem($problemData, $contestant);
+        RunsFactory::gradeRun($runData);
+
+        // Refresh Rank
+        $this->refreshUserRank();
+
+        // Call API
+        $response = UserController::apiProfile(new Request([
+            'username' => $contestant->username
+        ]));
+
+        $this->assertNotEquals($response['userinfo']['classname'], 'user-rank-unranked');
+    }
     /**
      * Tests apiRankByProblemsSolved for a specific user with no runs
      */


### PR DESCRIPTION
Modified `apiProfile()` to return the CSS class name with userinfo. 
In oder to do that I declared a new function in `Users.dao.php` to compute appropriate class name when user name is given. And call it from `aprProfile()` and update userinfo.