### PR TITLE
Activar compresion

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -5,6 +5,9 @@
  *
  * */
 
+// Enable compression.
+ob_start('ob_gzhandler');
+
 // Set default time
 date_default_timezone_set('UTC');
 


### PR DESCRIPTION
Para todas las cosas que corren bajo PHP.
Baja el tamanio de la Arena en un ambiente nuevo de 13KB a 4KB
En prod, segun PageSpeed, la reduccion es consistente en 74%:
https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fomegaup.com%2Farena&tab=desktop