### PR TITLE
Arreglando un par de errores con la vista de envíos

### DIFF
--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -34,13 +34,11 @@ def test_create_contest(driver):
 
     with driver.login(user1, password):
         create_run_user(driver, contest_alias, problem, 'Main.cpp11',
-                        verdict='AC', score=1,
-                        source_contents='cout<<a+b<<endl')
+                        verdict='AC', score=1)
 
     with driver.login(user2, password):
         create_run_user(driver, contest_alias, problem, 'Main_wrong.cpp11',
-                        verdict='WA', score=0,
-                        source_contents='cout<<a-b<<endl')
+                        verdict='WA', score=0)
 
     update_scoreboard_for_contest(driver, contest_alias)
 

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -34,11 +34,13 @@ def test_create_contest(driver):
 
     with driver.login(user1, password):
         create_run_user(driver, contest_alias, problem, 'Main.cpp11',
-                        verdict='AC', score=1)
+                        verdict='AC', score=1,
+                        source_contents='cout<<a+b<<endl')
 
     with driver.login(user2, password):
         create_run_user(driver, contest_alias, problem, 'Main_wrong.cpp11',
-                        verdict='WA', score=0)
+                        verdict='WA', score=0,
+                        source_contents='cout<<a-b<<endl')
 
     update_scoreboard_for_contest(driver, contest_alias)
 
@@ -213,9 +215,9 @@ def create_run_user(driver, contest_alias, problem, filename,
     assert (('show-run:') in
             driver.browser.current_url), driver.browser.current_url
     source_element = driver.wait.until(
-        EC.visibility_of_element_located(
+        EC.element_to_be_clickable(
             (By.XPATH, (
-                '//form[@class = "run-details-view"]'
+                '//div[@id = "overlay"]'
                 '//pre[@class = "source"]'))))
     if source_contents:
         assert source_contents in source_element.text

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -34,17 +34,16 @@ def test_create_contest(driver):
 
     with driver.login(user1, password):
         create_run_user(driver, contest_alias, problem, 'Main.cpp11',
-                        verdict='AC', score=1,
-                        source_contents='cout<<a+b<<endl')
+                        verdict='AC', score=1)
 
     with driver.login(user2, password):
         create_run_user(driver, contest_alias, problem, 'Main_wrong.cpp11',
-                        verdict='WA', score=0,
-                        source_contents='cout<<a-b<<endl')
+                        verdict='WA', score=0)
 
     update_scoreboard_for_contest(driver, contest_alias)
 
     with driver.login_admin():
+
         driver.wait.until(
             EC.element_to_be_clickable(
                 (By.ID, 'nav-contests'))).click()
@@ -92,13 +91,11 @@ def test_user_ranking_contest(driver):
 
     with driver.login(user1, password):
         create_run_user(driver, contest_alias, problem, 'Main.cpp11',
-                        verdict='AC', score=1,
-                        source_contents='cout<<a+b<<endl')
+                        verdict='AC', score=1)
 
     with driver.login(user2, password):
         create_run_user(driver, contest_alias, problem, 'Main_wrong.cpp11',
-                        verdict='WA', score=0,
-                        source_contents='cout<<a-b<<endl')
+                        verdict='WA', score=0)
 
     update_scoreboard_for_contest(driver, contest_alias)
 
@@ -177,8 +174,7 @@ def update_scoreboard_for_contest(driver, contest_alias):
     assert '{"status":"ok"}' in driver.browser.page_source
 
 
-def create_run_user(driver, contest_alias, problem, filename,
-                    source_contents=None, **kwargs):
+def create_run_user(driver, contest_alias, problem, filename, **kwargs):
     '''Makes the user join a course and then creates a run.'''
 
     enter_contest(driver, contest_alias)
@@ -214,13 +210,6 @@ def create_run_user(driver, contest_alias, problem, filename,
 
     assert (('show-run:') in
             driver.browser.current_url), driver.browser.current_url
-    source_element = driver.wait.until(
-        EC.element_to_be_clickable(
-            (By.XPATH, (
-                '//div[@id = "overlay"]'
-                '//pre[@class = "source"]'))))
-    if source_contents:
-        assert source_contents in source_element.text
 
 
 def create_contest(driver, contest_alias):

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -34,16 +34,17 @@ def test_create_contest(driver):
 
     with driver.login(user1, password):
         create_run_user(driver, contest_alias, problem, 'Main.cpp11',
-                        verdict='AC', score=1)
+                        verdict='AC', score=1,
+                        source_contents='cout<<a+b<<endl')
 
     with driver.login(user2, password):
         create_run_user(driver, contest_alias, problem, 'Main_wrong.cpp11',
-                        verdict='WA', score=0)
+                        verdict='WA', score=0,
+                        source_contents='cout<<a-b<<endl')
 
     update_scoreboard_for_contest(driver, contest_alias)
 
     with driver.login_admin():
-
         driver.wait.until(
             EC.element_to_be_clickable(
                 (By.ID, 'nav-contests'))).click()
@@ -91,11 +92,13 @@ def test_user_ranking_contest(driver):
 
     with driver.login(user1, password):
         create_run_user(driver, contest_alias, problem, 'Main.cpp11',
-                        verdict='AC', score=1)
+                        verdict='AC', score=1,
+                        source_contents='cout<<a+b<<endl')
 
     with driver.login(user2, password):
         create_run_user(driver, contest_alias, problem, 'Main_wrong.cpp11',
-                        verdict='WA', score=0)
+                        verdict='WA', score=0,
+                        source_contents='cout<<a-b<<endl')
 
     update_scoreboard_for_contest(driver, contest_alias)
 
@@ -174,7 +177,8 @@ def update_scoreboard_for_contest(driver, contest_alias):
     assert '{"status":"ok"}' in driver.browser.page_source
 
 
-def create_run_user(driver, contest_alias, problem, filename, **kwargs):
+def create_run_user(driver, contest_alias, problem, filename,
+                    source_contents=None, **kwargs):
     '''Makes the user join a course and then creates a run.'''
 
     enter_contest(driver, contest_alias)
@@ -210,6 +214,13 @@ def create_run_user(driver, contest_alias, problem, filename, **kwargs):
 
     assert (('show-run:') in
             driver.browser.current_url), driver.browser.current_url
+    source_element = driver.wait.until(
+        EC.visibility_of_element_located(
+            (By.XPATH, (
+                '//form[@class = "run-details-view"]'
+                '//pre[@class = "source"]'))))
+    if source_contents:
+        assert source_contents in source_element.text
 
 
 def create_contest(driver, contest_alias):

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1526,7 +1526,7 @@ export class Arena {
         return (x[key].length - i) - (y[key].length - j);
       };
     }
-    let detailsGroups = data.details.groups;
+    let detailsGroups = data.details && data.details.groups;
     let groups = null;
     if (detailsGroups && detailsGroups.length) {
       detailsGroups.sort(numericSort('group'));

--- a/frontend/www/js/omegaup/components/arena/RunDetails.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.vue
@@ -55,7 +55,7 @@
       </pre>
       <pre class="source"
            v-else=""
-           v-html="data.source"></pre>
+           v-text="data.source"></pre>
       <div class="compile_error"
            v-if="data.compile_error">
         <h3>{{ T.wordsCompilerOutput }}</h3>


### PR DESCRIPTION
Este cambio:

* Evita un acceso a `null` si no se envían los grupos.
* Evita XSS al desplegar la fuente de un envío.
* Agrega pruebas de Selenium para evitar regresiones.

Fixes: #1895