### PR TITLE
Asignar lenguaje usando el attributo html.lang

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:fb="http://www.facebook.com/2008/fbml" lang="{#locale#}">
 	<head data-locale="{#locale#}">
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 {if isset($inArena) && $inArena}


### PR DESCRIPTION
Creo que deberia ayudar a buscadores a descubrir que cambiar el header `Accept-Language` hace que cambie nuestra respuesta, y por tanto, deberia aparecer el contenido correcto en busquedas dependiendo el lenguage, en lugar de ofrecer traducirlo:
![image](https://user-images.githubusercontent.com/189223/38776615-9f969f52-404e-11e8-81dd-38bffce7fd5e.png)

