### PR TITLE
Agregando pruebas para validar las revisiones

### DIFF
--- a/stuff/db-migrate.py
+++ b/stuff/db-migrate.py
@@ -120,6 +120,21 @@ def migrate(args, auth, update_metadata=True):
                     (revision, comment), dbname='_omegaup_metadata', auth=auth)
 
 
+def validate(args, auth):  # pylint: disable=unused-argument
+    '''Validates that the versioning is has no repeated or missing entries.'''
+
+    expected_revision = 0
+    valid = True
+    for revision, _, path in _scripts():
+        expected_revision += 1
+        if expected_revision != revision:
+            print('Expected revision %d for path %s' % (expected_revision,
+                                                        path))
+            valid = False
+    if not valid:
+        sys.exit(1)
+
+
 def ensure(args, auth):  # pylint: disable=unused-argument
     '''Creates both the metadata database and table, if they don't exist yet.
     '''
@@ -230,6 +245,10 @@ def main():
     parser_migrate.set_defaults(func=migrate)
 
     # Commands for development.
+    parser_validate = subparsers.add_parser(
+        'validate', help='Validates that the versioning is sane')
+    parser_validate.set_defaults(func=validate)
+
     parser_ensure = subparsers.add_parser(
         'ensure', help='Ensures that the migration table exists')
     parser_ensure.set_defaults(func=ensure)

--- a/stuff/runtests.sh
+++ b/stuff/runtests.sh
@@ -19,6 +19,8 @@ else
 	$OMEGAUP_ROOT/stuff/git-hooks/pre-push $REF
 fi
 
+/usr/bin/python3 $OMEGAUP_ROOT/stuff/db-migrate.py validate
+
 /usr/bin/phpunit \
 	--bootstrap $OMEGAUP_ROOT/frontend/tests/bootstrap.php \
 	--configuration $OMEGAUP_ROOT/frontend/tests/phpunit.xml \

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -28,5 +28,6 @@ stage_script() {
 	yarn test
 
 	python3 stuff/i18n.py --validate < /dev/null
+	python3 stuff/db-migrate.py validate
 	python3.5 stuff/hook_tools/lint.py -j4 validate --all < /dev/null
 }


### PR DESCRIPTION
Si en dos commits se agregan scripts de migración con el mismo ordinal,
o se hace commit de dos scripts de migración en el orden incorrecto, el
deployment puede que falle o se salte uno de los scripts.

Este cambio agrega una prueba en Travis para evitar que ocurra eso.