### PR TITLE
Fix getRankingClassname logic error

### DIFF
--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -159,7 +159,7 @@ class UsersDAO extends UsersDAOBase {
                 FROM
                     `User_Rank_Cutoffs` `urc`
                 WHERE
-                    `urc`.score >= (
+                    `urc`.score <= (
                         SELECT
                             `ur`.`score`
                         FROM


### PR DESCRIPTION
Fix #1945 

There are 2 error caused by this logic failure
1. Top contestants ranking class name become unrated for unknown reason
2. Non top contestant (precisely all contestants below percentile 0.01) become International master

This was caused because
1. 1st case
Top contestants have score higher 0.01 than percentile. `getRankingClassname` will return no array.
2. 2st case
getRankingClassName will return International master. `getRankingClassname` will return international master