### PR TITLE
Permitiendo que las promesas tengan 'catch'

### DIFF
--- a/stuff/refactor.js
+++ b/stuff/refactor.js
@@ -28,14 +28,15 @@ const promiseVisitor = {
     if (callee.type != 'MemberExpression') {
       return;
     }
-    if (callee.property.name != 'then' && callee.property.name != 'fail') {
+    if (callee.property.name != 'then' && callee.property.name != 'fail' &&
+        callee.property.name != 'catch') {
       return;
     }
     const p = path.getStatementParent();
     if (p.node.type != 'ExpressionStatement') {
       throw new Error('Unexpected statement type: ' + p.node.type);
     }
-    if (callee.property.name == 'fail') {
+    if (callee.property.name == 'fail' || callee.property.name == 'catch') {
       p.hasFail = true;
     } else if (callee.property.name == 'then') {
       if (p.visited) {


### PR DESCRIPTION
Este cambio permite el uso de jQuery.Deferred (que usa 'fail') y las
promesas de ES6 (que usa 'catch'). Por ahora como no tenemos una manera
elegante de obtener el tipo de la expresión, vamos a permitir ambos y
atrapar este tipo de errores en review-time.

Ojalá podamos pasar todo por Babel en algún punto y matar bien muerto a
jQuery.