### PR TITLE
Fix readOnly prop on CodeMirror component

### DIFF
--- a/frontend/www/js/omegaup/components/arena/CodeView.vue
+++ b/frontend/www/js/omegaup/components/arena/CodeView.vue
@@ -36,7 +36,7 @@ for (const mode of modeList) {
 export default {
   props: {
     language: String,
-    readOnly: Boolean,
+    readonly: Boolean,
     value: String,
   },
   data: function() {
@@ -45,7 +45,7 @@ export default {
   computed: {
     editorOptions: function() {
       return {
-        tabSize: 2, lineNumbers: true, mode: this.mode, readOnly: this.readOnly
+        tabSize: 2, lineNumbers: true, mode: this.mode, readOnly: this.readonly
       }
     }
   },

--- a/frontend/www/js/omegaup/components/arena/RunDetails.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.vue
@@ -51,7 +51,7 @@
            v-bind:href="data.source"
            v-if="data.source_link">{{ T.wordsDownload }}</a>
            <omegaup-arena-code-view v-bind:language="data.language"
-           v-bind:readOnly="true"
+           v-bind:readonly="true"
            v-bind:value="data.source"
            v-else></omegaup-arena-code-view>
       <div class="compile_error"

--- a/frontend/www/js/omegaup/components/arena/RunDetails.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.vue
@@ -51,7 +51,7 @@
            v-bind:href="data.source"
            v-if="data.source_link">{{ T.wordsDownload }}</a>
            <omegaup-arena-code-view v-bind:language="data.language"
-           v-bind:readonly="true"
+           v-bind:readOnly="true"
            v-bind:value="data.source"
            v-else></omegaup-arena-code-view>
       <div class="compile_error"


### PR DESCRIPTION
# Descripción

Se arregla typo en la propiedad `readOnly` del componente de codemirror.

Fixes: #1974 

# Comentarios

El lint cambio la propiedad `readOnly` por `readonly`.


