### PR TITLE
Haciendo que el API retorne los datos de los histogramas.

### DIFF
--- a/frontend/server/libs/dao/Problems.dao.php
+++ b/frontend/server/libs/dao/Problems.dao.php
@@ -243,7 +243,7 @@ class ProblemsDAO extends ProblemsDAOBase {
         $result = $conn->Execute("$select $sql", $args);
 
         // Only these fields (plus score, points and ratio) will be returned.
-        $filters = ['title','quality', 'difficulty', 'alias', 'visibility'];
+        $filters = ['title','quality', 'difficulty', 'alias', 'visibility', 'quality_histogram', 'difficulty_histogram'];
         $problems = [];
         $hiddenTags = $identity_type !== IDENTITY_ANONYMOUS ? UsersDao::getHideTags($identity_id) : false;
         if (!is_null($result)) {

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -53,8 +53,8 @@ class ProblemList extends OmegaupTestCase {
                 break;
             }
             // Check if quality_histogram and difficulty_histogram fields are being returned also
-            $this -> assertTrue(array_key_exists('quality_histogram', $problemResponse));
-            $this -> assertTrue(array_key_exists('difficulty_histogram', $problemResponse));
+            $this->assertTrue(array_key_exists('quality_histogram', $problemResponse));
+            $this->assertTrue(array_key_exists('difficulty_histogram', $problemResponse));
         }
 
         if ($exists) {

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -52,6 +52,9 @@ class ProblemList extends OmegaupTestCase {
                 $exists = true;
                 break;
             }
+            // Check if quality_histogram and difficulty_histogram fields are being returned also
+            $this -> assertTrue(array_key_exists('quality_histogram', $problemResponse));
+            $this -> assertTrue(array_key_exists('difficulty_histogram', $problemResponse));
         }
 
         if ($exists) {


### PR DESCRIPTION
# Descripción

Se agregan los campos campos `quality_histogram` y `difficulty_histogram` dentro en el DAO de Problemas para que sean retornados por el Controlador cuando retorne los datos de los problemas.

Fixes: #2028 
