### PR TITLE
Relajando condiciones para ver detalles de envíos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ yarn-error.log
 frontend/server/api/tests/problems/
 frontend/server/api/tests/submissions/
 frontend/tests/controllers/img/
+frontend/tests/controllers/grade/
 frontend/tests/ui/results/
 omegaup_test.log
 

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -617,11 +617,13 @@ class RunController extends Controller {
         // Get the source
         $response['source'] = file_get_contents(RunController::getSubmissionPath($r['run']));
         $response['admin'] = Authorization::isProblemAdmin($r['current_identity_id'], $r['problem']);
+        $showDetails = $response['admin'] ||
+            ProblemsDAO::isProblemSolved($r['problem'], $r['current_identity_id']);
 
-        // Get the error
+        // Get the details and/or compile error.
         $grade_dir = RunController::getGradePath($r['run']);
         $details = null;
-        if (($response['admin'] || $r['run']->verdict == 'CE') &&
+        if (($showDetails || $r['run']->verdict == 'CE') &&
             file_exists("$grade_dir/details.json")) {
             $details = json_decode(file_get_contents("$grade_dir/details.json"), true);
         }
@@ -630,17 +632,17 @@ class RunController extends Controller {
         } elseif (file_exists("$grade_dir/compile_error.log")) {
             $response['compile_error'] = file_get_contents("$grade_dir/compile_error.log");
         }
+        if ($showDetails && !is_null($details)) {
+            if (count(array_filter(array_keys($details), 'is_string')) > 0) {
+                $response['details'] = $details;
+            } else {
+                // TODO(lhchavez): Remove this backwards-compatibility shim
+                // with backendv1.
+                $response['groups'] = $details;
+            }
+        }
 
         if ($response['admin']) {
-            if (!is_null($details)) {
-                if (count(array_filter(array_keys($details), 'is_string')) > 0) {
-                    $response['details'] = $details;
-                } else {
-                    // TODO(lhchavez): Remove this backwards-compatibility shim
-                    // with backendv1.
-                    $response['groups'] = $details;
-                }
-            }
             if (file_exists("$grade_dir/logs.txt.gz")) {
                 $response['logs'] = file_get_contents("compress.zlib://$grade_dir/logs.txt.gz");
             } elseif (file_exists("$grade_dir/run.log")) {

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -810,4 +810,62 @@ class RunCreateTest extends OmegaupTestCase {
              'source'   => "#include <stdio.h>\nint main() {printf(\"3\"); return 0; }",
         ]));
     }
+
+    /**
+     * User can send runs and view details of it after they have solved it.
+     */
+    public function testRunDetailsAfterSolving() {
+        // Create public problem
+        $problemData = ProblemsFactory::createProblem();
+
+        // Create contestant
+        $contestant = UserFactory::createUser();
+
+        $login = self::login($contestant);
+        $waRunData = RunsFactory::createRunToProblem($problemData, $contestant, $login);
+        RunsFactory::gradeRun($waRunData, 0, 'WA', 60);
+
+        // Contestant should be able to view run (but not the run details).
+        $this->assertFalse(Authorization::isProblemAdmin(
+            $contestant->main_identity_id,
+            $problemData['problem']
+        ));
+        $response = RunController::apiDetails(new Request([
+            'run_alias' => $waRunData['response']['guid'],
+            'auth_token' => $login->auth_token,
+        ]));
+        $this->assertFalse(array_key_exists('details', $response));
+
+        $acRunData = RunsFactory::createRunToProblem($problemData, $contestant, $login);
+        RunsFactory::gradeRun($acRunData, 1, 'AC', 65);
+
+        // Contestant should be able to view run and details after solving it.
+        $response = RunController::apiDetails(new Request([
+            'run_alias' => $acRunData['response']['guid'],
+            'auth_token' => $login->auth_token,
+        ]));
+        $this->assertTrue(array_key_exists('details', $response));
+        $response = RunController::apiDetails(new Request([
+            'run_alias' => $waRunData['response']['guid'],
+            'auth_token' => $login->auth_token,
+        ]));
+        $this->assertTrue(array_key_exists('details', $response));
+
+        // But having solved a problem does not grant permission to view
+        // details to runs that the user would otherwise not had permission to
+        // view.
+        $contestant2 = UserFactory::createUser();
+        $login2 = self::login($contestant2);
+        $runData = RunsFactory::createRunToProblem($problemData, $contestant2, $login2);
+        RunsFactory::gradeRun($runData, 1, 'AC', 30);
+        try {
+            RunController::apiDetails(new Request([
+                'run_alias' => $runData['response']['guid'],
+                'auth_token' => $login->auth_token,
+            ]));
+            $this->fail('User should not have been able to view another users\' run details');
+        } catch (ForbiddenAccessException $e) {
+            // OK
+        }
+    }
 }

--- a/frontend/tests/factories/RunsFactory.php
+++ b/frontend/tests/factories/RunsFactory.php
@@ -132,5 +132,14 @@ class RunsFactory {
         }
 
         RunsDAO::save($run);
+
+        $gradeDir = RunController::getGradePath($run);
+        mkdir($gradeDir, 0755, true);
+        file_put_contents("$gradeDir/details.json", json_encode([
+            'verdict' => $verdict,
+            'contest_score' => $points,
+            'score' => $points,
+            'judged_by' => 'RunsFactory.php',
+        ]));
     }
 }


### PR DESCRIPTION
Este cambio relaja las condiciones para que un usuario pueda ver los
detalles de sus envíos. La nueva regla es que se permite si:

*   Es un usuario que tiene permisos de ver el código fuente del envío ya
    sea:
    *   Porque es el usuario que hizo el envío.
    *   Porque es administrador del problema.
    *   Porque es administrador del curso/concurso al que se hizo el
        envío.
*   Y además es administrador del problema O ya ha resuelto el problema.

Esta nueva condición permite el reuso de problemas en concursos sin
necesidad de clonar los problemas, y la restricción de que el usuario
debe haber resuelto el problema anteriormente es razonable en el
contexto de cursos (se espera que el profesor del curso sea capaz de
resolver los problemas que pone a sus alumnos, por si los alumnos tienen
dudas de cómo resolverlo).

Fixes: #1868 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.