### PR TITLE
Agregando un archivo con polyfills

### DIFF
--- a/frontend/www/js/omegaup/polyfills.js
+++ b/frontend/www/js/omegaup/polyfills.js
@@ -1,0 +1,14 @@
+// This file contains miscellaneous polyfills to increase
+// backwards-compatibility with older browsers.
+
+'use strict';
+
+// From https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+if (window.NodeList && !window.NodeList.prototype.forEach) {
+  window.NodeList.prototype.forEach = function(callback, thisArg) {
+    thisArg = thisArg || window;
+    for (var i = 0; i < this.length; i++) {
+      callback.call(thisArg, this[i], i, this);
+    }
+  };
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,11 @@ var webpack = require('webpack')
 
 module.exports = {
   entry: {
-    omegaup: ['babel-polyfill', './frontend/www/js/omegaup/omegaup.js'],
+    omegaup: [
+      'babel-polyfill',
+      './frontend/www/js/omegaup/polyfills.js',
+      './frontend/www/js/omegaup/omegaup.js'
+    ],
     activity_feed: './frontend/www/js/omegaup/activity/feed.js',
     admin_support: './frontend/www/js/omegaup/admin/support.js',
     admin_user: './frontend/www/js/omegaup/admin/user.js',


### PR DESCRIPTION
Este cambio agrega polyfills para NodeList.prototype.forEach, para hacer
que Firefox 46-51 esté soportado.

Mejora para issue #2079