### PR TITLE
Agregando un polyfill para Node.innerText

### DIFF
--- a/frontend/www/js/omegaup/polyfills.js
+++ b/frontend/www/js/omegaup/polyfills.js
@@ -12,3 +12,10 @@ if (window.NodeList && !window.NodeList.prototype.forEach) {
     }
   };
 }
+
+if (window.Node && !window.Node.prototype.innerText && Object.defineProperty) {
+  Object.defineProperty(window.Node.prototype, 'innerText', {
+    get: function() { return this.textContent; },
+    set: function(value) { this.textContent = value; },
+  });
+}


### PR DESCRIPTION
Este cambio agrega un polyfill para Node.innerText, que hace que seamos
(extraoficialmente) compatibles con Firefox 20-ish (~2013) en adelante.

Mejora para issue #2079