### PR TITLE
Solucionando el error de que todos los problemas salgan con dificultad Muy Fácil y calidad Baja

### DIFF
--- a/frontend/www/problemlist.php
+++ b/frontend/www/problemlist.php
@@ -47,8 +47,8 @@ $pager_items = Pager::paginate(
 );
 
 foreach ($response['results'] as $key => $problem) {
-    $response['results'][$key]['difficulty'] = floatval($problem['difficulty']);
-    $response['results'][$key]['quality'] = floatval($problem['quality']);
+    $response['results'][$key]['difficulty'] = $response['results'][$key]['difficulty'] ? floatval($problem['difficulty']) : NULL;
+    $response['results'][$key]['quality'] = $response['results'][$key]['quality'] ? floatval($problem['quality']) : NULL;
     $response['results'][$key]['points'] = floatval($problem['points']);
     $response['results'][$key]['ratio'] = floatval($problem['ratio']);
     $response['results'][$key]['score'] = floatval($problem['score']);

--- a/frontend/www/problemlist.php
+++ b/frontend/www/problemlist.php
@@ -47,8 +47,8 @@ $pager_items = Pager::paginate(
 );
 
 foreach ($response['results'] as $key => $problem) {
-    $response['results'][$key]['difficulty'] = $response['results'][$key]['difficulty'] ? floatval($problem['difficulty']) : NULL;
-    $response['results'][$key]['quality'] = $response['results'][$key]['quality'] ? floatval($problem['quality']) : NULL;
+    $response['results'][$key]['difficulty'] = $response['results'][$key]['difficulty'] ? floatval($problem['difficulty']) : null;
+    $response['results'][$key]['quality'] = $response['results'][$key]['quality'] ? floatval($problem['quality']) : null;
     $response['results'][$key]['points'] = floatval($problem['points']);
     $response['results'][$key]['ratio'] = floatval($problem['ratio']);
     $response['results'][$key]['score'] = floatval($problem['score']);


### PR DESCRIPTION
# Descripción

Había un problema que surgió luego de hacer un casting a los valores null convirtiéndolos a flotantes.
Esto ocasionó que todos los problemas en la lista salgan con una dificultad y calidad establecidas.
![1](https://user-images.githubusercontent.com/20785082/41264638-5c381168-6db3-11e8-940b-5e446e022436.png)
