### PR TITLE
Fix typo in error message label

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -272,7 +272,7 @@ class UserController extends Controller {
         }
 
         if (is_null($user_id) && is_null($email) && is_null($username)) {
-            throw new ApiException('mustProvideUSerIdEmailOrUsername');
+            throw new ApiException('mustProvideUserIdEmailOrUsername');
         }
 
         $vo_UserToTest = null;


### PR DESCRIPTION
mustProvideUSerIdEmailOrUsername has an upper case S that should be lower case

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
