### PR TITLE
Arreglando un bug que mostraba textos de si o no sin contexto

### DIFF
--- a/frontend/www/js/omegaup/components/course/Intro.vue
+++ b/frontend/www/js/omegaup/components/course/Intro.vue
@@ -12,11 +12,14 @@
          v-if="requestsUserInformation == 'optional'"></p>
       <template v-if="requestsUserInformation == 'required'">
         <p v-html="T.courseUserInformationRequired"></p>
-      </template><label><input type="radio"
-             v-bind:value="1"
-             v-model="shareUserInformation"> {{ T.wordsYes }}</label> <label><input type="radio"
-             v-bind:value="0"
-             v-model="shareUserInformation"> {{ T.wordsNo }}</label>
+      </template>
+      <template v-if="requestsUserInformation != 'no'">
+        <label><input type="radio"
+               v-bind:value="1"
+               v-model="shareUserInformation"> {{ T.wordsYes }}</label> <label><input type="radio"
+               v-bind:value="0"
+               v-model="shareUserInformation"> {{ T.wordsNo }}</label>
+      </template>
       <div class="text-center">
         <form v-on:submit.prevent="">
           <button class="btn btn-primary btn-lg"


### PR DESCRIPTION
# Descripción

Se arregla bug donde mostraban unos radios con los textos `Si` y `No` sin ningún contexto

Fixes: #1941 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.