### PR TITLE
Actualizando checkbox de `public` en clarificaciones

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -892,7 +892,7 @@ export class Arena {
         contest: clarification.contest_alias,
         problem: clarification.problem_alias,
         message: clarification.message,
-        answer: clarification.answer,
+        answer: clarification.answer, public: clarification.public,
         anchor: '#' + anchor,
         modificationTime: clarification.time.getTime()
       });
@@ -917,6 +917,8 @@ export class Arena {
           if (clarification.public == 1) {
             $('#create-response-is-public', responseFormNode)
                 .attr('checked', 'checked');
+            $('#create-response-is-public', responseFormNode)
+                .prop('checked', true);
           }
           responseFormNode.on('submit', function() {
             let responseText = null;
@@ -972,7 +974,7 @@ export class Arena {
         contest: clarification.contest_alias,
         problem: clarification.problem_alias,
         message: clarification.message,
-        answer: clarification.answer,
+        answer: clarification.answer, public: clarification.public,
         anchor: '#' + anchor,
         modificationTime: clarification.time.getTime()
       });
@@ -990,6 +992,9 @@ export class Arena {
     } else {
       $('.answer pre', r).show();
       $(r).addClass('resolved');
+    }
+    if (clarification.public == 1) {
+      $('#create-response-is-public', r).prop('checked', true);
     }
   }
 


### PR DESCRIPTION
# Descripción

Se arregla bug donde no se actualizaba el checkbox de `public` en la vista de Clarificaciones cuando alguien más realizaba una respuesta pública.

Fixes: #766 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.