### PR TITLE
Arreglando las pruebas de Firefox en Selenium

### DIFF
--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -393,6 +393,10 @@ def driver(request, browser_name):
 
     browser = _get_browser(request, browser_name)
     browser.implicitly_wait(_DEFAULT_TIMEOUT)
+    if browser_name != 'firefox':
+        # Ensure that getting browser logs is supported in non-Firefox
+        # browsers.
+        assert isinstance(browser.get_log('browser'), list)
     wait = WebDriverWait(browser, _DEFAULT_TIMEOUT,
                          poll_frequency=0.1)
 

--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -10,6 +10,7 @@ import re
 import functools
 
 from urllib.parse import urlparse
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -74,7 +75,12 @@ def get_console_logs(driver, path_whitelist, message_whitelist):
     '''Checks whether there is an error or warning in javascript console'''
 
     log = []
-    for entry in driver.browser.get_log('browser'):
+    try:
+        browser_logs = driver.browser.get_log('browser')
+    except WebDriverException:
+        # Firefox does not support getting console logs.
+        browser_logs = []
+    for entry in browser_logs:
         if entry['level'] != 'SEVERE':
             continue
         if is_path_whitelisted(entry['message'], path_whitelist):


### PR DESCRIPTION
Este cambio hace que se puedan volver a correr las pruebas de Firefox en
Selenium.