### PR TITLE
Haciendo un refactor de la matriz de Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ branches:
 php:
   - 7.0.7
 
-env:
-  - TEST_SUITE=phpunit
-  - TEST_SUITE=lint
-  - TEST_SUITE=selenium
-
 addons:
   apt:
     sources:
@@ -25,17 +20,31 @@ addons:
       - llvm-toolchain-precise-3.7
       - deadsnakes
     packages:
-      - clang-format-3.7
       - libmysqlclient-dev
-      - nginx
       - python-pip
       - python3.5
       - python3-pip
       - realpath
-  sauce_connect:
-    username: lhchavez
-  jwt:
-    secure: PjNJHqneJ7qPBxbZEmgBemJT6tFE+sHKmVGQ2GwzaXSHT+3cthzTjMGe/k/fi+XiiuMTfHXs09uF6bEzJAMPW6PeCjkOYR+9H5btMmEEQJvdJBafNTbL26xSr4bBNLYBlryudDCx4hKDXOGoIPCJ+mhKHTtwApbfdx5ec8r1kD4=
+
+matrix:
+  include:
+    - env: TEST_SUITE=phpunit
+    - env: TEST_SUITE=lint
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-format-3.7
+    - env: TEST_SUITE=selenium
+      addons:
+        apt:
+          packages:
+            - nginx
+        sauce_connect:
+          username: lhchavez
+        jwt:
+          secure: PjNJHqneJ7qPBxbZEmgBemJT6tFE+sHKmVGQ2GwzaXSHT+3cthzTjMGe/k/fi+XiiuMTfHXs09uF6bEzJAMPW6PeCjkOYR+9H5btMmEEQJvdJBafNTbL26xSr4bBNLYBlryudDCx4hKDXOGoIPCJ+mhKHTtwApbfdx5ec8r1kD4=
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,16 @@ branches:
 php:
   - 7.0.7
 
+# Common sources and packages. If a matrix entry needs these, it should
+# explicitly add both of the sources and package YAML references in its addons
+# section.
 addons:
   apt:
-    sources:
+    sources: &common_sources
       - ubuntu-toolchain-r-test
       - llvm-toolchain-precise-3.7
       - deadsnakes
-    packages:
+    packages: &common_packages
       - libmysqlclient-dev
       - python-pip
       - python3.5
@@ -33,14 +36,19 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-precise-3.7
+            - *common_sources
+            - [llvm-toolchain-precise-3.7]
           packages:
-            - clang-format-3.7
+            - *common_packages
+            - [clang-format-3.7]
     - env: TEST_SUITE=selenium
       addons:
         apt:
+          sources:
+            - *common_sources
           packages:
-            - nginx
+            - *common_packages
+            - [nginx]
         sauce_connect:
           username: lhchavez
         jwt:


### PR DESCRIPTION
Este cambio hace que la matriz de pruebas de Travis ahora permita la
instalación condicional de algunos paquetes y correr sauce_connect.