### PR TITLE
Creando el workflow de deployment desde Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ sudo: false
 branches:
   only:
     - master
+    - release
 
 php:
   - 7.0.7

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -41,8 +41,15 @@ stage_script() {
 stage_after_success() {
 	if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
 		mkdir -p build/webpack-artifacts
+
+		# Upload a tarball with the build artifacts.
 		local tarball="build/webpack-artifacts/${TRAVIS_COMMIT}.tar.xz"
 		tar --xz --create --file "${tarball}" -C frontend/www/js/dist .
 		aws s3 cp "${tarball}" "s3://omegaup-build-artifacts/webpack-artifacts/${TRAVIS_COMMIT}.tar.xz"
+
+		# Start a deployment now that the build artifacts are done.
+		curl -H "${GITHUB_OAUTH_TOKEN}" \
+			https://api.github.com/repos/omegaup/omegaup/deployments \
+			--data "{\"ref\":\"${TRAVIS_BRANCH}\",\"required_contexts\":[]}"
 	fi
 }


### PR DESCRIPTION
Este cambio hace que Travis inicie un deployment de GitHub. Esto evita
que los ambientes de producción y el canario tengan que compilar los
artefactos.