### PR TITLE
Se agrega la funcionalidad de administrar identidades para un grupo

### DIFF
--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -261,7 +261,7 @@ class GroupController extends Controller {
         $response = [];
 
         try {
-            $response['identities'] = GroupsIdentitiesDAO::GetMemberUsernames($r['group']);
+            $response['identities'] = GroupsIdentitiesDAO::GetMemberIdentities($r['group']);
         } catch (Exception $ex) {
             throw new InvalidDatabaseOperationException($ex);
         }

--- a/frontend/server/libs/dao/Groups_Identities.dao.php
+++ b/frontend/server/libs/dao/Groups_Identities.dao.php
@@ -10,15 +10,31 @@ include_once('base/Groups_Identities.vo.base.php');
   *
   */
 class GroupsIdentitiesDAO extends GroupsIdentitiesDAOBase {
-    public static function GetMemberUsernames(Groups $group) {
+    public static function GetMemberIdentities(Groups $group) {
         global  $conn;
         $sql = '
             SELECT
-                i.username
+                i.username,
+                IF(LOCATE(\':\', i.username) > 0, i.name, NULL) as name,
+                IF(LOCATE(\':\', i.username) > 0, c.name, NULL) as country,
+                IF(LOCATE(\':\', i.username) > 0, c.country_id, NULL) as country_id,
+                IF(LOCATE(\':\', i.username) > 0, s.name, NULL) as state,
+                IF(LOCATE(\':\', i.username) > 0, s.state_id, NULL) as state_id,
+                IF(LOCATE(\':\', i.username) > 0, sc.name, NULL) as school,
+                IF(LOCATE(\':\', i.username) > 0, sc.school_id, NULL) as school_id,
+                IF(LOCATE(\':\', i.username) > 0, u.username, NULL) as user_username
             FROM
                 Groups_Identities gi
             INNER JOIN
                 Identities i ON i.identity_id = gi.identity_id
+            LEFT JOIN
+                States s ON s.state_id = i.state_id AND s.country_id = i.country_id
+            LEFT JOIN
+                Countries c ON c.country_id = s.country_id
+            LEFT JOIN
+                Schools sc ON sc.school_id = i.school_id
+            LEFT JOIN
+                Users u ON u.user_id = i.user_id
             WHERE
                 gi.group_id = ?;';
         $params = [$group->group_id];

--- a/frontend/templates/group.edit.members.tpl
+++ b/frontend/templates/group.edit.members.tpl
@@ -1,22 +1,3 @@
-<div class="panel panel-primary">
-	<div class="panel-body">
-		<form class="form" id="add-member-form">
-			<div class="form-group">
-				<label for="member-username">{#wordsMember#}</label>
-				<input id="member-username" name="username" value="" type="text" size="20" class="form-control" autocomplete="off" />
-			</div>
-
-			<input id="member-user" name="user" value="" type="hidden">
-
-			<button class="btn btn-primary" type='submit'>{#wordsAddMember#}</button>
-		</form>
-	</div>
-
-	<table class="table table-striped">
-		<thead>
-			<th>{#wordsUser#}</th>
-			<th>{#contestEditRegisteredAdminDelete#}</th>
-		</thead>
-		<tbody id="group-members"></tbody>
-	</table>
-</div>
+<div id="group_members"></div>
+<script type="text/json" id="payload">{$PAYLOAD|json_encode}</script>
+<script src="{version_hash src="/js/dist/group_members.js"}" type="text/javascript"></script>

--- a/frontend/templates/group.edit.tpl
+++ b/frontend/templates/group.edit.tpl
@@ -14,6 +14,6 @@
 		{include file='group.edit.members.tpl'}
 	</div>
 	<div class="tab-pane" id="scoreboards">
-		{include file='group.edit.scoreboards.tpl'}
+		{include file='group.edit.scoreboards.tpl' payload=$PAYLOAD}
 	</div>
 </div>

--- a/frontend/www/groupedit.php
+++ b/frontend/www/groupedit.php
@@ -3,4 +3,7 @@
 require_once('../server/bootstrap.php');
 
 $smarty->assign('IS_UPDATE', 1);
+$smarty->assign('PAYLOAD', [
+    'countries' => CountriesDAO::getAll(null, null, 'name'),
+]);
 $smarty->display('../templates/group.edit.tpl');

--- a/frontend/www/js/groups.js
+++ b/frontend/www/js/groups.js
@@ -40,74 +40,6 @@ $(function() {
           $(this).tab('show');
         });
 
-    // Typehead
-    refreshGroupMembers();
-    omegaup.UI.userTypeahead($('#member-username'));
-
-    $('#add-member-form')
-        .on('submit', function() {
-          var username = $('#member-username').val();
-
-          omegaup.API.Group.addUser({
-                             group_alias: groupAlias,
-                             usernameOrEmail: username,
-                           })
-              .then(function(response) {
-                omegaup.UI.success('Member successfully added!');
-                $('div.post.footer').show();
-
-                refreshGroupMembers();
-              })
-              .fail(omegaup.UI.apiError);
-
-          return false;  // Prevent refresh
-        });
-
-    function refreshGroupMembers() {
-      omegaup.API.Group.members({group_alias: groupAlias})
-          .then(function(group) {
-            $('#group-members').empty();
-
-            for (var i = 0; i < group.identities.length; i++) {
-              var identity = group.identities[i];
-              $('#group-members')
-                  .append(
-                      $('<tr></tr>')
-                          .append(
-                              $('<td></td>')
-                                  .append($('<a></a>')
-                                              .attr('href',
-                                                    '/profile/' +
-                                                        identity.username + '/')
-                                              .text(omegaup.UI.escape(
-                                                  identity.username))))
-                          .append(
-                              $('<td><button type="button" class="close">' +
-                                '&times;</button></td>')
-                                  .on('click', (function(username) {
-                                        return function(e) {
-                                          omegaup.API.Group.removeUser({
-                                                             group_alias:
-                                                                 groupAlias,
-                                                             usernameOrEmail:
-                                                                 username,
-                                                           })
-                                              .then(function(response) {
-                                                omegaup.UI.success(
-                                                    'Member successfully removed!');
-                                                $('div.post.footer').show();
-                                                var tr = e.target.parentElement
-                                                             .parentElement;
-                                                $(tr).remove();
-                                              })
-                                              .fail(omegaup.UI.apiError);
-                                        };
-                                      })(identity.username))));
-            }
-          })
-          .fail(omegaup.UI.apiError);
-    }
-
     $('#add-scoreboard-form')
         .on('submit', function() {
           omegaup.API.Group.createScoreboard({
@@ -117,7 +49,7 @@ $(function() {
                              description: $('#description').val(),
                            })
               .then(function(response) {
-                omegaup.UI.success('Scoreboard successfully added!');
+                omegaup.UI.success(omegaup.T.groupEditScoreboardsAdded);
                 $('div.post.footer').show();
                 refreshGroupScoreboards();
               })

--- a/frontend/www/js/groups.scoreboards.js
+++ b/frontend/www/js/groups.scoreboards.js
@@ -30,7 +30,7 @@ $(function() {
                                        weight: $('#weight').val(),
                                      })
               .then(function(data) {
-                omegaup.UI.success('Contest successfully added!');
+                omegaup.UI.success(omegaup.T.groupEditScoreboardsContestsAdded);
                 refreshScoreboardContests();
               })
               .fail(omegaup.UI.apiError);
@@ -66,8 +66,8 @@ $(function() {
                                                   omegaup.T.wordsNo))
                           .append($('<td></td>').append(contest.weight))
                           .append(
-                              $('<td><button type="button" class="close">' +
-                                '&times;</button></td>')
+                              $('<td><a href="#" class="glyphicon glyphicon-remove">' +
+                                '</a></td>')
                                   .on('click', (function(contestAlias) {
                                         return function(e) {
                                           omegaup.API.GroupScoreboard
@@ -79,8 +79,8 @@ $(function() {
                                               })
                                               .then(function(response) {
                                                 omegaup.UI.success(
-                                                    'Contest successfully ' +
-                                                    'removed!');
+                                                    omegaup.T
+                                                        .groupEditScoreboardsContestsRemoved);
 
                                                 var tr = e.target.parentElement
                                                              .parentElement;

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="panel panel-primary">
+    <div class="panel-body">
+      <form class="form"
+            v-on:submit.prevent="onAddMember">
+        <div class="form-group">
+          <label>{{ T.wordsMember }} <input autocomplete="off"
+                 class="form-control typeahead"
+                 name="username"
+                 size="20"
+                 type="text"></label>
+        </div><button class="btn btn-primary"
+              type="submit">{{ T.wordsAddMember }}</button>
+      </form>
+    </div>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>{{ T.wordsUser }}</th>
+          <th>{{ T.contestEditRegisteredAdminDelete }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="identity in identities">
+          <td>
+            <a v-bind:href="memberProfileUrl(identity.username)">{{ identity.username }}</a>
+          </td>
+          <td>
+            <a class="glyphicon glyphicon-remove"
+                href="#"
+                v-on:click="onRemove(identity.username)"></a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>{{ T.wordsIdentity }}</th>
+          <th>{{ T.wordsName }}</th>
+          <th>{{ T.profileCountry }}</th>
+          <th>{{ T.profileState }}</th>
+          <th>{{ T.profileSchool }}</th>
+          <th>{{ T.wordsActions }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="identity in identitiesCsv">
+          <td>
+            <a v-bind:href="memberProfileUrl(identity.username)">{{ identity.username }}</a>
+          </td>
+          <td>{{ identity.name }}</td>
+          <td>{{ identity.country }}</td>
+          <td>{{ identity.state }}</td>
+          <td>{{ identity.school }}</td>
+          <td>
+            <a class="glyphicon glyphicon-edit"
+                href="#"
+                v-bind:title="T.groupEditMembersEdit"
+                v-on:click="onEdit(identity)"></a> <a class="glyphicon glyphicon-lock"
+                href="#"
+                v-bind:title="T.groupEditMembersChangePassword"
+                v-on:click="onChangePass(identity.username)"></a> <a class=
+                "glyphicon glyphicon-user"
+                href="#"
+                v-bind:title="T.groupEditMembersAssignUser"
+                v-on:click="onAssignUser(identity.username, identity.user_username)"></a> <a class=
+                "glyphicon glyphicon-remove"
+                href="#"
+                v-bind:title="T.groupEditMembersRemove"
+                v-on:click="onRemove(identity.username)"></a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import {T, UI} from '../../omegaup.js';
+
+export default {
+  props: {
+    identities: Array,
+    identitiesCsv: Array,
+    countries: Array,
+  },
+  data: function() {
+    return {
+      T: T,
+      memberUsername: '',
+      username: '',
+      name: '',
+      country: '',
+      country_id: '',
+      state: '',
+      state_id: '',
+      school: '',
+      school_id: '',
+      user_username: ''
+    };
+  },
+  mounted: function() {
+    let self = this;
+    UI.userTypeahead($('input.typeahead', self.$el), function(event, item) {
+      self.memberUsername = item.value;
+    });
+  },
+  methods: {
+    onAddMember: function() {
+      let hintElem = $('input.typeahead.tt-hint', this.$el);
+      let hint = hintElem.val();
+      if (hint) {
+        // There is a hint currently visible in the UI, the user likely
+        // expects that hint to be used when trying to add someone, instead
+        // of what they've actually typed so far.
+        this.memberUsername = hint;
+      } else {
+        this.memberUsername = $('input.typeahead.tt-input', this.$el).val();
+      }
+      this.$emit('add-member', this.memberUsername);
+    },
+    onEdit: function(identity) {
+      this.username = identity.username;
+      this.name = identity.name;
+      this.country = identity.country;
+      this.country_id = identity.country_id;
+      this.state = identity.state;
+      this.state_id = identity.state_id;
+      this.school = identity.school;
+      this.school_id = identity.school_id;
+      $('.modal-edit').modal();
+    },
+    onChangePass: function(username) {
+      this.username = username;
+      $('.modal-change-password').modal();
+    },
+    onAssignUser: function(username, user_username) {
+      this.username = username;
+      this.user_username = user_username;
+      $('.modal-assign-user').modal();
+    },
+    onRemove: function(username) { this.$emit('remove', username);},
+    reset: function() {
+      this.memberUsername = '';
+
+      let inputElem = $('input.typeahead', this.$el);
+      inputElem.typeahead('close');
+      inputElem.val('');
+    },
+    memberProfileUrl: function(member) { return '/profile/' + member + '/';},
+  },
+};
+</script>
+
+<style>
+label {
+  display: inline;
+}
+</style>

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -61,10 +61,6 @@
                 href="#"
                 v-bind:title="T.groupEditMembersChangePassword"
                 v-on:click="onChangePass(identity.username)"></a> <a class=
-                "glyphicon glyphicon-user"
-                href="#"
-                v-bind:title="T.groupEditMembersAssignUser"
-                v-on:click="onAssignUser(identity.username, identity.user_username)"></a> <a class=
                 "glyphicon glyphicon-remove"
                 href="#"
                 v-bind:title="T.groupEditMembersRemove"
@@ -134,11 +130,6 @@ export default {
     onChangePass: function(username) {
       this.username = username;
       $('.modal-change-password').modal();
-    },
-    onAssignUser: function(username, user_username) {
-      this.username = username;
-      this.user_username = user_username;
-      $('.modal-assign-user').modal();
     },
     onRemove: function(username) { this.$emit('remove', username);},
     reset: function() {

--- a/frontend/www/js/omegaup/group/members.js
+++ b/frontend/www/js/omegaup/group/members.js
@@ -1,0 +1,70 @@
+import group_Members from '../components/group/Members.vue';
+import {OmegaUp, UI, T, API} from '../omegaup.js';
+import Vue from 'vue';
+
+OmegaUp.on('ready', function() {
+  const formData = document.querySelector('#form-data');
+  const groupAlias = formData.getAttribute('data-alias');
+  const payload = JSON.parse(document.getElementById('payload').innerText);
+  let groupMembers = new Vue({
+    el: '#group_members',
+    render: function(createElement) {
+      return createElement('omegaup-group-members', {
+        props: {
+          identities: this.identities,
+          identitiesCsv: this.identitiesCsv,
+          countries: this.countries,
+        },
+        on: {
+          'add-member': function(username) {
+            API.Group.addUser({
+                       group_alias: groupAlias,
+                       usernameOrEmail: username,
+                     })
+                .then(function(data) {
+                  refreshMemberList();
+                  UI.success(T.groupEditMemberAdded);
+                  groupMembers.$children[0].reset();
+                })
+                .fail(UI.apiError);
+          },
+          remove: function(username) {
+            API.Group.removeUser(
+                         {group_alias: groupAlias, usernameOrEmail: username})
+                .then(function(data) {
+                  refreshMemberList();
+                  UI.success(T.groupEditMemberRemoved);
+                })
+                .fail(UI.apiError);
+          },
+        },
+      });
+    },
+    data: {
+      identities: [],
+      identitiesCsv: [],
+      countries: payload.countries,
+    },
+    components: {
+      'omegaup-group-members': group_Members,
+    },
+  });
+
+  function refreshMemberList() {
+    API.Group.members({group_alias: groupAlias})
+        .then(function(data) {
+          groupMembers.identities = [];
+          groupMembers.identitiesCsv = [];
+          for (let identity of data.identities) {
+            if (identity.username.split(':').length == 1) {
+              groupMembers.identities.push(identity);
+            } else {
+              groupMembers.identitiesCsv.push(identity);
+            }
+          }
+        })
+        .fail(UI.apiError);
+  }
+
+  refreshMemberList();
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = [{
     course_student: './frontend/www/js/omegaup/course/student.js',
     course_students: './frontend/www/js/omegaup/course/students.js',
     group_list: './frontend/www/js/omegaup/group/list.js',
+    group_members: './frontend/www/js/omegaup/group/members.js',
     problem_feedback: './frontend/www/js/omegaup/problem/feedback.js',
     problem_list: './frontend/www/js/omegaup/problem/list.js',
     schools_intro: './frontend/www/js/omegaup/schools/intro.js',


### PR DESCRIPTION
# Descripción

El PR incluye los cambios en la interfaz que corresponden a lo siguiente:

- Listado de Identidades agregadas al grupo.
- Botón de editar identidad.
- Botón de cambiar contraseña de identidad.
- Botón de remover identidad de un grupo.

Además de que se creó el componente en Vue para esta vista.

Fixes: #1912 Parte 1

# Comentarios

El PR no incluye las traducciones de los textos, ni el código de los
modals, para que no quedara tan grande el cambio. Dichos cambios se
realizarán en otro PR.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
