### PR TITLE
Se elimina markdown.php en la página de redaccion.php

### DIFF
--- a/frontend/www/redaccion.php
+++ b/frontend/www/redaccion.php
@@ -1,6 +1,5 @@
 <?php
     require_once('../server/bootstrap.php');
-    require_once('../server/libs/third_party/Markdown/markdown.php');
 
     $smarty->assign('LOAD_MATHJAX', true);
 


### PR DESCRIPTION
Se elimina `markdown.php` en la página de `redaccion.php`

Fixes: #2165 
