### PR TITLE
Agregando pruebas de login para una identidad

### DIFF
--- a/frontend/tests/controllers/IdentityUpdateTest.php
+++ b/frontend/tests/controllers/IdentityUpdateTest.php
@@ -32,8 +32,6 @@ class IdentityUpdateTest extends OmegaupTestCase {
         ]));
 
         $identity = IdentityController::resolveIdentity($username);
-        $identityLogin = self::login($identity);
-        $this->assertLogin($identity, $identityLogin->auth_token);
 
         $this->assertEquals($username, $identity->username);
         $this->assertEquals($identityName, $identity->name);
@@ -90,7 +88,6 @@ class IdentityUpdateTest extends OmegaupTestCase {
         $identity = IdentityController::resolveIdentity($username);
         $identity->password = $originalPassword;
         $identityLogin = self::login($identity);
-        $this->assertLogin($identity, $identityLogin->auth_token);
 
         // Changing password
         $newPassword = Utils::CreateRandomString();

--- a/frontend/tests/controllers/IdentityUpdateTest.php
+++ b/frontend/tests/controllers/IdentityUpdateTest.php
@@ -32,6 +32,8 @@ class IdentityUpdateTest extends OmegaupTestCase {
         ]));
 
         $identity = IdentityController::resolveIdentity($username);
+        $identityLogin = self::login($identity);
+        $this->assertLogin($identity, $identityLogin->auth_token);
 
         $this->assertEquals($username, $identity->username);
         $this->assertEquals($identityName, $identity->name);
@@ -88,6 +90,7 @@ class IdentityUpdateTest extends OmegaupTestCase {
         $identity = IdentityController::resolveIdentity($username);
         $identity->password = $originalPassword;
         $identityLogin = self::login($identity);
+        $this->assertLogin($identity, $identityLogin->auth_token);
 
         // Changing password
         $newPassword = Utils::CreateRandomString();

--- a/frontend/tests/controllers/LoginTest.php
+++ b/frontend/tests/controllers/LoginTest.php
@@ -28,7 +28,7 @@ class LoginTest extends OmegaupTestCase {
         $response = UserController::apiLogin($r);
 
         $this->assertEquals('ok', $response['status']);
-        $this->assertLogin($user, $response['auth_token']);
+        $this->assertLogin($identity, $response['auth_token']);
 
         // Assert the log is not empty.
         $this->assertEquals(1, count(IdentityLoginLogDAO::getByIdentity($identity->identity_id)));
@@ -41,6 +41,7 @@ class LoginTest extends OmegaupTestCase {
     public function testNativeLoginByEmailPositive() {
         $email = Utils::CreateRandomString() . '@mail.com';
         $user = UserFactory::createUser(new UserParams(['email' => $email]));
+        $identity = IdentitiesDAO::getByPK($user->main_identity_id);
 
         // Inflate request with user data
         $r = new Request([
@@ -51,7 +52,7 @@ class LoginTest extends OmegaupTestCase {
         $response = UserController::apiLogin($r);
 
         $this->assertEquals('ok', $response['status']);
-        $this->assertLogin($user, $response['auth_token']);
+        $this->assertLogin($identity, $response['auth_token']);
     }
 
     /**
@@ -117,6 +118,7 @@ class LoginTest extends OmegaupTestCase {
     public function testNativeLoginPositiveViaHttp() {
         // Create an user
         $user = UserFactory::createUser();
+        $identity = IdentitiesDAO::getByPK($user->main_identity_id);
 
         // Set required context
         $_REQUEST['usernameOrEmail'] = $user->username;
@@ -134,7 +136,7 @@ class LoginTest extends OmegaupTestCase {
 
         // Validate output
         $this->assertEquals('ok', $response['status']);
-        $this->assertLogin($user, $response['auth_token']);
+        $this->assertLogin($identity, $response['auth_token']);
     }
 
     /**
@@ -144,6 +146,7 @@ class LoginTest extends OmegaupTestCase {
     public function test2ConsecutiveLogins() {
         // Create an user in omegaup
         $user = UserFactory::createUser();
+        $identity = IdentitiesDAO::getByPK($user->main_identity_id);
 
         // Inflate request with user data
         $r = new Request([
@@ -154,12 +157,12 @@ class LoginTest extends OmegaupTestCase {
         // Call the API
         $response1 = UserController::apiLogin($r);
         $this->assertEquals('ok', $response1['status']);
-        $this->assertLogin($user, $response1['auth_token']);
+        $this->assertLogin($identity, $response1['auth_token']);
 
         // Call the API for 2nd time
         $response2 = UserController::apiLogin($r);
         $this->assertEquals('ok', $response2['status']);
-        $this->assertLogin($user, $response2['auth_token']);
+        $this->assertLogin($identity, $response2['auth_token']);
 
         $this->assertNotEquals($response1['auth_token'], $response2['auth_token']);
     }

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -57,14 +57,14 @@ class OmegaupTestCase extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Given an User, checks that login let state as supposed
+     * Given an Identity, checks that login let state as supposed
      *
-     * @param Users $user
+     * @param Identities $identity
      * @param type $auth_token
      */
-    public function assertLogin(Users $user, $auth_token = null) {
+    public function assertLogin(Identities $identity, $auth_token = null) {
         // Check auth token
-        $auth_tokens_bd = AuthTokensDAO::getByIdentityId($user->main_identity_id);
+        $auth_tokens_bd = AuthTokensDAO::getByIdentityId($identity->identity_id);
 
         // Validar que el token se guardó en la BDD
         if (!is_null($auth_token)) {
@@ -85,23 +85,23 @@ class OmegaupTestCase extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Logs in a user an returns the auth_token
+     * Logs in a identity an returns the auth_token
      *
-     * @param $user the user to be logged in
+     * @param $identity the identity to be logged in
      *
      * @return string auth_token
      */
-    public static function login($user) {
+    public static function login($identity) {
         UserController::$sendEmailOnVerify = false;
 
         // Deactivate cookie setting
         $oldCookieSetting = SessionController::$setCookieOnRegisterSession;
         SessionController::$setCookieOnRegisterSession = false;
 
-        // Inflate request with user data
+        // Inflate request with identity data
         $r = new Request([
-            'usernameOrEmail' => $user->username,
-            'password' => $user->password,
+            'usernameOrEmail' => $identity->username,
+            'password' => $identity->password,
         ]);
 
         // Call the API


### PR DESCRIPTION
# Descripción

Se agregan las pruebas de login para una identidad que no ha sido asociada a ningún usuario. 
Se ajustan algunas funciones de login en las pruebas que recibían un objeto de tipo `Users`, con esta nueva funcionalidad de que pueden haber identidades no asociadas, ahora se debe recibir un objeto de tipo `Identities`

Fixes: #2085 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
