### PR TITLE
Agregando la administración de identidades como experimento

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -2476,6 +2476,8 @@ class UserController extends Controller {
      * @throws InvalidDatabaseOperationException
      */
     public static function apiAssociateIdentity(Request $r) {
+        global $experiments;
+        $experiments->ensureEnabled(Experiments::IDENTITIES);
         self::authenticateRequest($r);
 
         Validators::isStringNonEmpty($r['username'], 'username');
@@ -2512,6 +2514,8 @@ class UserController extends Controller {
      * @throws InvalidDatabaseOperationException
      */
     public static function apiListAssociatedIdentities(Request $r) {
+        global $experiments;
+        $experiments->ensureEnabled(Experiments::IDENTITIES);
         self::authenticateRequest($r);
 
         try {

--- a/frontend/server/libs/Experiments.php
+++ b/frontend/server/libs/Experiments.php
@@ -41,10 +41,16 @@ class Experiments {
     const VIRTUAL = 'virtual';
 
     /**
+     * Constant for manage identities experiment.
+     */
+    const IDENTITIES = 'identities';
+
+    /**
      * An array with all the known experiments.
      */
     private static $kKnownExperiments = [
-        self::VIRTUAL
+        self::VIRTUAL,
+        self::IDENTITIES,
     ];
 
     /**

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -11,6 +11,7 @@ if (!function_exists('try_define')) {
 # EXPERIMENTS
 # ####################################
 try_define('EXPERIMENT_VIRTUAL', true);
+try_define('EXPERIMENT_IDENTITIES', true);
 
 # ####################################
 # DATABASE CONFIG

--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -14,6 +14,9 @@ export class Experiments {
       self.enabledExperiments[experiment] = true;
   }
 
+  // Current frontend-available experiments:
+  static get IDENTITIES() { return 'identities'; }
+
   // The list of all enabled experiments for a particular request should have
   // been injected into the DOM by Smarty.
   static loadGlobal() {


### PR DESCRIPTION
# Descripción

Se agrega la funcionalidad de administración de identidades como experimental hasta que todos los PRs relacionados sean aprobados.

Parte de #2089 

# Comentarios

No sé si me faltó realizar algún cambio para también esconder la parte gráfica.

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
