### PR TITLE
Fix #2198

### DIFF
--- a/frontend/www/schools/index.php
+++ b/frontend/www/schools/index.php
@@ -2,9 +2,15 @@
 
 require_once('../../server/bootstrap.php');
 $r = new Request($_REQUEST);
-$course = CourseController::apiListCourses($r);
+try {
+    $course = CourseController::apiListCourses($r);
+} catch (UnauthorizedException $e) {
+    // No login, so we default to show the intro screen
+    // for Schools.
+}
 
-if (count($course['student']) != 0 || count($course['admin']) != 0) {
+if (isset($course)
+    && (count($course['student']) != 0 || count($course['admin']) != 0)) {
     die(header('Location: /course'));
 } else {
     $smarty->display('../templates/schools.intro.tpl');


### PR DESCRIPTION
Verificar que el usuario tenga un login para poder llamar a `apiListCourses` al decidir si mostrar la pantalla introductoria de Schools