### PR TITLE
Arreglar un error al habilitar fechas

### DIFF
--- a/frontend/www/js/omegaup/components/DatePicker.vue
+++ b/frontend/www/js/omegaup/components/DatePicker.vue
@@ -2,7 +2,7 @@
   <input class="form-control"
         size="16"
         type="text"
-        v-bind:disabled="enabled">
+        v-bind:disabled="!enabled">
 </template>
 
 <script>

--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
@@ -30,7 +30,7 @@
                   data-placement="top"
                   data-toggle="tooltip"
                   v-bind:title="T.courseAssignmentNewFormStartDateDesc"></span>
-                  <omegaup-datetimepicker v-bind:enabled="update"
+                  <omegaup-datetimepicker v-bind:enabled="!update"
                                     v-model="startTime"></omegaup-datetimepicker></label>
           </div>
           <div class="form-group col-md-4">

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -31,7 +31,7 @@
                   class="glyphicon glyphicon-info-sign"
                   data-placement="top"
                   data-toggle="tooltip"
-                  v-bind:title="T.courseNewFormEndDateDesc"></span>
+                  v-bind:title="T.courseNewFormStartDateDesc"></span>
                   <omegaup-datepicker v-bind:enabled="!update"
                                 v-model="startTime"></omegaup-datepicker></label>
           </div>

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -32,7 +32,7 @@
                   data-placement="top"
                   data-toggle="tooltip"
                   v-bind:title="T.courseNewFormEndDateDesc"></span>
-                  <omegaup-datepicker v-bind:enabled="update"
+                  <omegaup-datepicker v-bind:enabled="!update"
                                 v-model="startTime"></omegaup-datepicker></label>
           </div>
           <div class="form-group col-md-4">


### PR DESCRIPTION
Resulta que en una actualizacion de #2213 se quedo un bool invertido `disabled=enabled` y luego se corrigio invirtiendo los updates en `Details` y `AssignmentDetails`. Este cambio corrige eso.

Fixes: #2240

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
