### PR TITLE
Arreglando el link de Hangouts

### DIFF
--- a/frontend/www/hangout/index.php
+++ b/frontend/www/hangout/index.php
@@ -1,2 +1,2 @@
 <?php
-header('Location: https://plus.google.com/hangouts/_/event/cigk2mbe6r61ef0da7aivmqa7ko');
+header('Location: https://hangouts.google.com/hangouts/_/omegaup.com/omegaup-hangout');


### PR DESCRIPTION
Como el servicio de Hangouts cambió, el URL anterior ya no está
funcionando bien.