### PR TITLE
Hotfix para el cache

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1049,7 +1049,7 @@ class ProblemController extends Controller {
         $problemStatement = null;
         Cache::getFromCacheOrSet(
             Cache::PROBLEM_STATEMENT,
-            "${problemAlias}-{$language}-markdown",
+            "{$problemAlias}-{$language}-markdown",
             [$problemAlias, $language],
             'ProblemController::getProblemStatementImpl',
             $problemStatement,


### PR DESCRIPTION
Resulta que debido a un typo, el cache seguía sin estarse invalidando.