### PR TITLE
Fix/link practice no sirve

### DIFF
--- a/frontend/www/arena/practice.php
+++ b/frontend/www/arena/practice.php
@@ -15,6 +15,24 @@ try {
 }
 
 if ($show_intro['shouldShowIntro']) {
+    $session = SessionController::apiCurrentSession($r)['session'];
+    $smarty->assign(
+        'needsBasicInformation',
+        $show_intro['needs_basic_information'] && !is_null($session['user']) && (
+            !$session['user']->country_id || !$session['user']->state_id || !$session['user']->school_id
+        )
+    );
+    $smarty->assign(
+        'requestsUserInformation',
+        $show_intro['requests_user_information']
+    );
+    if (isset($show_intro['privacy_statement_markdown'])) {
+        $smarty->assign('privacyStatement', [
+            'markdown' => $show_intro['privacy_statement_markdown'],
+            'gitObjectId' => $show_intro['git_object_id'],
+            'statementType' => $show_intro['statement_type'],
+        ]);
+    }
     $smarty->display('../../templates/arena.contest.intro.tpl');
 } else {
     $smarty->display('../../templates/arena.contest.practice.tpl');


### PR DESCRIPTION
# Descripción

Se realizó el fix para que usuarios puedan acceder al modo práctica de un concurso en el cual no participaron.


Fixes: #2259 
# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
