### PR TITLE
Arreglando una prueba que estaba mandando mal un timestamp

### DIFF
--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -238,6 +238,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         // Testing with an intermediate day of the month
         $timestampTest = Time::get();
         $dateTest = date('Y-m-15', $timestampTest);
+        $timestampTest = strtotime($dateTest);
         $canChooseCoder = Authorization::canChooseCoder($timestampTest);
         $this->assertFalse($canChooseCoder);
 


### PR DESCRIPTION
# Descripción

Se arregla un bug donde un test de PHPUnit marcaba error por un timestamp que no se enviaba correctamente

Fixes: #2265 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
