### PR TITLE
Cambiando fecha en una prueba para que sea el último día del mes

### DIFF
--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -192,9 +192,9 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         }
 
         // Changing date with valid range
-        $runCreationDate = date('Y-m-t', Time::get()); // Last day of the month is valid date to select a coder
+        $runCreationDate = date('Y-m-d', Time::get()); // Last day of the month is valid date to select a coder
         $runCreationDate = strtotime('-1 month', strtotime($runCreationDate));
-        $runCreationDate = date('Y-m-d', $runCreationDate);
+        $runCreationDate = date('Y-m-t', $runCreationDate);
         Time::setTimeForTesting(strtotime($runCreationDate));
 
         // Call api again.


### PR DESCRIPTION
# Descripción

Se encontró otra falla en las pruebas para elegir al Coder del mes, esto ocurrió por cambio de mes, ahora fue por el inicio de uno nuevo. 

También habrá que monitorear cuando sea cambio de año que ninguna prueba se rompa.

Parte de : #2265 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
