### PR TITLE
Aceptar .bmp como formato válido de imágenes

### DIFF
--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -404,7 +404,7 @@ class ProblemDeployer {
         }
 
         // Also extract any images in the statements directory.
-        $images = preg_grep('/^statements\/.*\.(gif|jpg|jpeg|png)$/', $zipFilesArray);
+        $images = preg_grep('/^statements\/.*\.(gif|jpg|jpeg|png|bmp)$/', $zipFilesArray);
 
         // Add images to the files to be unzipped.
         foreach ($images as $file) {


### PR DESCRIPTION
Los problemas viejos muy viejos también usan formatos de imágenes viejos muy viejos :c

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
