### PR TITLE
Allow hardcoded URLs on <img> tags

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -459,7 +459,7 @@ let UI = {
 
     let converter = Markdown.getSanitizingConverter();
     let whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|code|i|table|tbody|thead|tr|th|td|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
-    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
+    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+.?]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
 
     converter.hooks.chain('isValidTag', function(tag) {
       return tag.match(whitelist) || tag.match(imageWhitelist);

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -459,7 +459,7 @@ let UI = {
 
     let converter = Markdown.getSanitizingConverter();
     let whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|code|i|table|tbody|thead|tr|th|td|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
-    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+.:?&]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
+    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+.:?&%]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
 
     converter.hooks.chain('isValidTag', function(tag) {
       return tag.match(whitelist) || tag.match(imageWhitelist);

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -459,7 +459,7 @@ let UI = {
 
     let converter = Markdown.getSanitizingConverter();
     let whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|code|i|table|tbody|thead|tr|th|td|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
-    let imageWhitelist = new RegExp('^<img\\ssrc="data:image\/[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
+    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
 
     converter.hooks.chain('isValidTag', function(tag) {
       return tag.match(whitelist) || tag.match(imageWhitelist);

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -459,7 +459,7 @@ let UI = {
 
     let converter = Markdown.getSanitizingConverter();
     let whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|code|i|table|tbody|thead|tr|th|td|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
-    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+.?]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
+    let imageWhitelist = new RegExp('^<img\\ssrc="(data:image\/)?[a-zA-Z0-9/;,=+.:?&]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$', 'i');
 
     converter.hooks.chain('isValidTag', function(tag) {
       return tag.match(whitelist) || tag.match(imageWhitelist);


### PR DESCRIPTION
# Descripción

El whitelist de markdown actual solo deja pasar imágenes que traen encodeados los datos en base64. Las imágenes directamente en en formato markdown (e.g. `![](xyz.png)`) sí dejan este tipo de URLs.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
