### PR TITLE
Fix issue to get current timestamp on previous contests

### DIFF
--- a/frontend/www/js/omegaup/user/profile.js
+++ b/frontend/www/js/omegaup/user/profile.js
@@ -25,7 +25,8 @@ OmegaUp.on('ready', function() {
             let contests = [];
             for (var contest_alias in data['contests']) {
               var now = new Date();
-              var currentTimestamp = data['contests'][contest_alias]['finish_time'] * 1000;
+              var currentTimestamp =
+                  data['contests'][contest_alias]['finish_time'] * 1000;
               var end = OmegaUp.remoteTime(currentTimestamp);
               if (data['contests'][contest_alias]['place'] != null &&
                   now > end) {

--- a/frontend/www/js/omegaup/user/profile.js
+++ b/frontend/www/js/omegaup/user/profile.js
@@ -25,9 +25,8 @@ OmegaUp.on('ready', function() {
             let contests = [];
             for (var contest_alias in data['contests']) {
               var now = new Date();
-              var end = OmegaUp.remoteTime(
-                  data['contests'][contest_alias]['data']['finish_time'] *
-                  1000);
+              var currentTimestamp = data['contests'][contest_alias]['finish_time'] * 1000;
+              var end = OmegaUp.remoteTime(currentTimestamp);
               if (data['contests'][contest_alias]['place'] != null &&
                   now > end) {
                 contests.push(data['contests'][contest_alias]);

--- a/frontend/www/js/profile.js
+++ b/frontend/www/js/profile.js
@@ -6,7 +6,8 @@ omegaup.API.User.contestStats({username: username})
       t = 0;
       for (var contest_alias in data['contests']) {
         var now = new Date();
-        var currentTimestamp = data['contests'][contest_alias]['finish_time'] * 1000;
+        var currentTimestamp =
+            data['contests'][contest_alias]['finish_time'] * 1000;
         var end = omegaup.OmegaUp.remoteTime(currentTimestamp);
 
         if (data['contests'][contest_alias]['place'] != null && now > end) {

--- a/frontend/www/js/profile.js
+++ b/frontend/www/js/profile.js
@@ -6,8 +6,8 @@ omegaup.API.User.contestStats({username: username})
       t = 0;
       for (var contest_alias in data['contests']) {
         var now = new Date();
-        var end = omegaup.OmegaUp.remoteTime(
-            data['contests'][contest_alias]['data']['finish_time'] * 1000);
+        var currentTimestamp = data['contests'][contest_alias]['finish_time'] * 1000;
+        var end = omegaup.OmegaUp.remoteTime(currentTimestamp);
 
         if (data['contests'][contest_alias]['place'] != null && now > end) {
           var title = data['contests'][contest_alias]['data']['title'];


### PR DESCRIPTION
# Descripción

Este PR repara un detalle al obtener las fechas de inicio y fin de un contest para mostrarlo en la sección de concursos pasados en la pantalla de perfil de usuario.

Fixes: #2195 

# Checklist:

- [* ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Crear pruebas.
