### PR TITLE
Arreglando el evaluador efímero

### DIFF
--- a/frontend/www/js/omegaup/grader/ZipViewerComponent.vue
+++ b/frontend/www/js/omegaup/grader/ZipViewerComponent.vue
@@ -35,7 +35,7 @@ export default {
       this.active = item.name;
       item.async('string')
           .then(value => { this.contents = value; })
-          .fail(Util.asyncError);
+          .catch(Util.asyncError);
     },
   },
 };

--- a/frontend/www/js/omegaup/grader/ephemeral.js
+++ b/frontend/www/js/omegaup/grader/ephemeral.js
@@ -3,6 +3,7 @@
 import JSZip from 'jszip';
 import Vue from 'vue';
 import Vuex from 'vuex';
+import pako from 'pako';
 
 import * as Util from './util';
 import CaseSelectorComponent from './CaseSelectorComponent.vue';
@@ -713,7 +714,7 @@ function onFilesZipReady(blob) {
                 }
                 store.commit('compilerOutput', '');
               })
-              .fail(Util.asyncError);
+              .catch(Util.asyncError);
           for (let filename in zip.files) {
             if (filename.indexOf('/') !== -1) continue;
             zip.file(filename)
@@ -724,10 +725,10 @@ function onFilesZipReady(blob) {
                     contents: contents,
                   });
                 })
-                .fail(Util.asyncError);
+                .catch(Util.asyncError);
           }
         })
-        .fail(Util.asyncError);
+        .catch(Util.asyncError);
   });
   reader.readAsArrayBuffer(blob);
 }
@@ -778,14 +779,14 @@ document.getElementById('upload').addEventListener('change', e => {
                     store.commit('currentCase', caseName);
                     store.commit('inputIn', value);
                   })
-                  .fail(Util.asyncError);
+                  .catch(Util.asyncError);
               zip.file(caseOutFileName)
                   .async('string')
                   .then(value => {
                     store.commit('currentCase', caseName);
                     store.commit('inputOut', value);
                   })
-                  .fail(Util.asyncError);
+                  .catch(Util.asyncError);
             } else if (fileName.startsWith('validator.')) {
               let extension = fileName.substring('validator.'.length);
               if (!Util.languageExtensionMapping.hasOwnProperty(extension))
@@ -799,7 +800,7 @@ document.getElementById('upload').addEventListener('change', e => {
                         'request.input.validator.custom_validator.source',
                         value);
                   })
-                  .fail(Util.asyncError);
+                  .catch(Util.asyncError);
             } else if (fileName.startsWith('interactive/') &&
                        fileName.endsWith('.idl')) {
               let moduleName = fileName.substring(
@@ -811,7 +812,7 @@ document.getElementById('upload').addEventListener('change', e => {
                     store.commit('InteractiveModuleName', moduleName);
                     store.commit('request.input.interactive.idl', value);
                   })
-                  .fail(Util.asyncError);
+                  .catch(Util.asyncError);
             } else if (fileName.startsWith('interactive/Main.')) {
               let extension = fileName.substring('interactive/Main.'.length);
               if (!Util.languageExtensionMapping.hasOwnProperty(extension))
@@ -824,7 +825,7 @@ document.getElementById('upload').addEventListener('change', e => {
                     store.commit('request.input.interactive.main_source',
                                  value);
                   })
-                  .fail(Util.asyncError);
+                  .catch(Util.asyncError);
             }
           }
 
@@ -844,7 +845,7 @@ document.getElementById('upload').addEventListener('change', e => {
                     });
                   }
                 })
-                .fail(Util.asyncError);
+                .catch(Util.asyncError);
           }
           if (zip.files.hasOwnProperty('settings.json')) {
             zip.file('settings.json')
@@ -869,10 +870,10 @@ document.getElementById('upload').addEventListener('change', e => {
                     }
                   }
                 })
-                .fail(Util.asyncError);
+                .catch(Util.asyncError);
           }
         })
-        .fail(Util.asyncError);
+        .catch(Util.asyncError);
   });
   reader.readAsArrayBuffer(files[0]);
 });
@@ -946,7 +947,7 @@ document.getElementById('download')
             downloadElement.download = 'omegaup.zip';
             downloadElement.href = window.URL.createObjectURL(blob);
           })
-          .fail(Util.asyncError);
+          .catch(Util.asyncError);
     });
 
 document.getElementsByTagName('form')[0].addEventListener('submit', e => {
@@ -1006,7 +1007,7 @@ document.getElementsByTagName('form')[0].addEventListener('submit', e => {
 
         onFilesZipReady(formData.get('files.zip'));
       })
-      .fail(Util.asyncError);
+      .catch(Util.asyncError);
 });
 
 function onHashChanged() {
@@ -1045,23 +1046,23 @@ function onHashChanged() {
               return response.json();
             })
             .then(onDetailsJsonReady)
-            .fail(Util.asyncError);
+            .catch(Util.asyncError);
         fetch(`run/${token}/files.zip`)
             .then(response => {
               if (!response.ok) return null;
               return response.blob();
             })
             .then(onFilesZipReady)
-            .fail(Util.asyncError);
+            .catch(Util.asyncError);
         fetch(`run/${token}/logs.txt`)
             .then(response => {
               if (!response.ok) return '';
               return response.text();
             })
             .then(text => store.commit('logs', text))
-            .fail(Util.asyncError);
+            .catch(Util.asyncError);
       })
-      .fail(Util.asyncError);
+      .catch(Util.asyncError);
 }
 window.addEventListener('hashchange', onHashChanged, false);
 onHashChanged();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "codemirror": "^5.38.0",
     "jszip": "^3.1.5",
+    "pako": "^1.0.7",
     "vue": "^2.5.16",
     "vue-async-computed": "^3.3.1"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,6 +119,7 @@ module.exports = [{
       'vue$': 'vue/dist/vue.common.js',
       'vue-async-computed': 'vue-async-computed/dist/vue-async-computed.js',
       jszip: 'jszip/dist/jszip.js',
+      pako: 'pako/dist/pako.min.js',
     }
   },
   devServer: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,9 +3820,10 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
-pako@~1.0.2, pako@~1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
+pako@^1.0.7, pako@~1.0.2, pako@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
+  integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
 
 parse-asn1@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
Este cambio hace que el evaluador efímero vuelva a funcionar. El linter
"arregló" un montón de promesas de JS convirtiéndolas a las
incompatibles pseudopromesas `$.Deferred`. También importa correctamente
el módulo pako.