### PR TITLE
Usando Xenial para Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ matrix:
           username: lhchavez
         jwt:
           secure: PjNJHqneJ7qPBxbZEmgBemJT6tFE+sHKmVGQ2GwzaXSHT+3cthzTjMGe/k/fi+XiiuMTfHXs09uF6bEzJAMPW6PeCjkOYR+9H5btMmEEQJvdJBafNTbL26xSr4bBNLYBlryudDCx4hKDXOGoIPCJ+mhKHTtwApbfdx5ec8r1kD4=
+      services:
+        - mysql
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ addons:
 matrix:
   include:
     - env: TEST_SUITE=phpunit
+      services:
+        - mysql
     - env: TEST_SUITE=lint
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: php
 
-dist: trusty
-
-group: edge
-
-sudo: false
+dist: xenial
 
 branches:
   only:

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -40,11 +40,10 @@ install_yarn() {
 
 install_omegaup_update_problem() {
 	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.2.0/omegaup-update-problem.xz'
-	TARGET="${HOME}/bin/omegaup-update-problem.xz"
-	mkdir -p $(dirname "${TARGET}")
-	curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
-	unxz "${TARGET}"
-	chmod +x "${TARGET%.xz}"
+	TARGET="/usr/bin/omegaup-update-problem.xz"
+	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
+	sudo xz --decompress "${TARGET}"
+	sudo chmod +x "${TARGET%.xz}"
 }
 
 setup_phpenv() {

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -39,9 +39,7 @@ install_yarn() {
 }
 
 install_omegaup_update_problem() {
-	DOWNLOAD_URL=$(\
-		curl --location https://api.github.com/repos/omegaup/gitserver/releases/latest |\
-		gawk 'match($0, /browser_download_url.*(https:\/\/.*omegaup-update-problem.xz)/, line) { print line[1] }')
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.2.0/omegaup-update-problem.xz'
 	TARGET="${HOME}/bin/omegaup-update-problem.xz"
 	mkdir -p $(dirname "${TARGET}")
 	curl --location "${DOWNLOAD_URL}" -o "${TARGET}"

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -12,11 +12,14 @@ stage_before_install() {
 	pip install --user six
 	pip install --user https://github.com/google/closure-linter/zipball/master
 	python3 -m pip install --user --upgrade pip
+	python3 -m pip install --user setuptools
+	python3 -m pip install --user wheel
 	python3 -m pip install --user pylint
 	python3 -m pip install --user pep8
 	python3 -m pip install --user awscli
 	python3.5 -m pip install --user --upgrade pip
 	python3.5 -m pip install --user setuptools
+	python3.5 -m pip install --user wheel
 	python3.5 -m pip install --user pylint
 	python3.5 -m pip install --user pep8
 

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -16,6 +16,7 @@ stage_before_install() {
 	python3 -m pip install --user pep8
 	python3 -m pip install --user awscli
 	python3.5 -m pip install --user --upgrade pip
+	python3.5 -m pip install --user setuptools
 	python3.5 -m pip install --user pylint
 	python3.5 -m pip install --user pep8
 

--- a/stuff/travis/nginx/config.php.tpl
+++ b/stuff/travis/nginx/config.php.tpl
@@ -13,7 +13,6 @@ define('OMEGAUP_DB_USER', 'travis');
 define('OMEGAUP_ENVIRONMENT', 'production');
 define('OMEGAUP_GRADER_FAKE', true);
 define('OMEGAUP_LOG_FILE', '/tmp/omegaup.log');
-define('OMEGAUP_UPDATE_PROBLEM', '/home/travis/bin/omegaup-update-problem');
 define('PROBLEMS_GIT_PATH', '/tmp/omegaup/problems.git');
 define('RUNS_PATH', '/tmp/omegaup/submissions');
 define('SMARTY_CACHE_DIR', '/tmp');

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -7,7 +7,9 @@ stage_before_install() {
 }
 
 stage_install() {
+	pip3 install --user --upgrade pip
 	pip3 install --user setuptools
+	pip3 install --user wheel
 	pip3 install --user mysqlclient
 
 	install_omegaup_update_problem

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -13,14 +13,10 @@ stage_install() {
 	pip3 install --user mysqlclient
 
 	# We should really try upgrading to PHP 7.1 soon.
-	curl -sSfL -o ~/.phpenv/versions/7.0.7/bin/phpunit \
+	curl -sSfL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit \
 		https://phar.phpunit.de/phpunit-5.3.4.phar
 
 	install_omegaup_update_problem
-	cat > frontend/tests/test_config.php <<EOF
-<?php
-define('OMEGAUP_UPDATE_PROBLEM', '/home/travis/bin/omegaup-update-problem');
-EOF
 }
 
 stage_before_script() {

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -7,6 +7,7 @@ stage_before_install() {
 }
 
 stage_install() {
+	pip3 install --user setuptools
 	pip3 install --user mysqlclient
 
 	install_omegaup_update_problem

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -12,6 +12,10 @@ stage_install() {
 	pip3 install --user wheel
 	pip3 install --user mysqlclient
 
+	# We should really try upgrading to PHP 7.1 soon.
+	curl -sSfL -o ~/.phpenv/versions/7.0.7/bin/phpunit \
+		https://phar.phpunit.de/phpunit-5.3.4.phar
+
 	install_omegaup_update_problem
 	cat > frontend/tests/test_config.php <<EOF
 <?php


### PR DESCRIPTION
Llevamos años usando Xenial en la VM y en prod. Travis acaba de empezar
a soportar Xenial, así que es momento de migrarlo también.