### PR TITLE
Usando libinteractive en las pruebas de Travis

### DIFF
--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -595,9 +595,6 @@ class CreateProblemTest extends OmegaupTestCase {
      * Test that we are able to submit a problem with an interactive/ directory.
      */
     public function testValidProblemInteractive() {
-        if (!file_exists('/usr/share/java/libinteractive.jar')) {
-            $this->markTestSkipped('libinteractive not available');
-        }
         // Get the problem data
         $problemData = ProblemsFactory::getRequest(new ProblemParams([
             'zipName' => OMEGAUP_RESOURCES_ROOT . 'triangulos_interactive.zip'

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -44,6 +44,11 @@ install_omegaup_update_problem() {
 	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
 	sudo xz --decompress "${TARGET}"
 	sudo chmod +x "${TARGET%.xz}"
+
+	# omegaup-update-problem depends on libinteractive.
+	DOWNLOAD_URL='https://github.com/omegaup/libinteractive/releases/download/v2.0.23/libinteractive.jar'
+	TARGET='/usr/share/java/libinteractive.jar'
+	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
 }
 
 setup_phpenv() {


### PR DESCRIPTION
Ahora que las pruebas de Travis ya pueden usar `sudo` de nuevo,
es posible instalar libinteractive en el lugar correcto. Esto quita un poco
de complejidad y agrega coverage.