### PR TITLE
Fix/edit-profile-sorting-states-list

### DIFF
--- a/frontend/www/js/user.edit.js
+++ b/frontend/www/js/user.edit.js
@@ -26,12 +26,10 @@ omegaup.OmegaUp.on('ready', function() {
         
         var states = {};
         Object.keys(country.sub).sort().forEach(function(key){
-          console.log(key);
           states[key] = country.sub[key];
         });
 
         for (var key in states) {
-          console.log(key);
           if (!states.hasOwnProperty(key)) continue;
           var id = key.split('-')[1];
           $('#state_id')

--- a/frontend/www/js/user.edit.js
+++ b/frontend/www/js/user.edit.js
@@ -23,14 +23,21 @@ omegaup.OmegaUp.on('ready', function() {
           return;
         }
         $('#state_id').prop('disabled', false);
+        
+        var states = {};
+        Object.keys(country.sub).sort().forEach(function(key){
+          console.log(key);
+          states[key] = country.sub[key];
+        });
 
-        for (var key in country.sub) {
-          if (!country.sub.hasOwnProperty(key)) continue;
+        for (var key in states) {
+          console.log(key);
+          if (!states.hasOwnProperty(key)) continue;
           var id = key.split('-')[1];
           $('#state_id')
               .append($('<option></option')
                           .attr('value', id)
-                          .text(country.sub[key].name));
+                          .text(states[key].name));
         }
       });
 


### PR DESCRIPTION
# Descripción

Se añade el cambio para mostrar la lista de estados ordenada en [profile/edit/](url)

Fixes: #2313 

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
