### PR TITLE
Arreglando las unidades de MemoryLimit

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1969,7 +1969,7 @@ class ProblemController extends Controller {
         $problemSettings = [
             'Limits' => [
                 'ExtraWallTime' => (int)$problem->extra_wall_time . 'ms',
-                'MemoryLimit' => (int)$problem->memory_limit,
+                'MemoryLimit' => (int)$problem->memory_limit * 1024,
                 'OutputLimit' => (int)$problem->output_limit,
                 'OverallWallTimeLimit' => (
                     (int)$problem->overall_wall_time_limit . 'ms'

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -62,7 +62,7 @@ class CreateProblemTest extends OmegaupTestCase {
         $this->assertEquals(5000, $r['time_limit']);
         $this->assertEquals('5s', $problemSettings->Limits->TimeLimit);
         $this->assertEquals(
-            $r['memory_limit'],
+            $r['memory_limit'] * 1024,
             $problemSettings->Limits->MemoryLimit
         );
 


### PR DESCRIPTION
Estábamos guardando MemoryLimit en KibiBytes en vez de bytes en la base
de datos. ugh.