### PR TITLE
feature/profile-edit-cancel-button

### DIFF
--- a/frontend/templates/user.edit.tpl
+++ b/frontend/templates/user.edit.tpl
@@ -148,11 +148,10 @@
 						</div>
 					</div>
 
-					<div class="form-group">
-						<div class="col-md-offset-3 col-md-7">
-							<button type='submit' class="btn btn-primary">{#wordsSaveChanges#}</button>
-						</div>
-					</div>
+					<div class="col-md-offset-6 col-md-6 col-xs-12">
+						<button type="submit" class="btn btn-primary col-xs-offset-1 col-xs-5">{#wordsSaveChanges#}</button>
+						<a href="/profile" class="btn btn-default col-xs-5 btn-cancel">{#wordsCancel#}</a>
+					</div>	
 				</form>
 			</div>
 		</div>
@@ -186,10 +185,10 @@
 						</div>
 					</div>
 
-					<div class="form-group">
-						<div class="col-md-offset-3 col-md-7">
-							<button type='submit' class="btn btn-primary">{#wordsSaveChanges#}</button>
-						</div>
+					
+					<div class="col-md-offset-6 col-md-6 col-xs-12">
+						<button type="submit" class="btn btn-primary col-xs-offset-1 col-xs-5">{#wordsSaveChanges#}</button>
+						<a href="/profile" class="btn btn-default col-xs-5 btn-cancel">{#wordsCancel#}</a>
 					</div>
 				</form>
 			</div>

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -18,3 +18,6 @@ $header-accent-color: #577DC7;
 $header-font-primary-color: #fff;
 $header-font-secondary-color: #333;
 $header-dropdown-active-item: #f5f5f5;
+
+// BUTTONS
+$btn-cancel-color: #ddd;

--- a/frontend/www/sass/components/_buttons.scss
+++ b/frontend/www/sass/components/_buttons.scss
@@ -1,0 +1,4 @@
+.btn-cancel {
+    margin-left: 5px;
+    background-color: $btn-cancel-color;
+}

--- a/frontend/www/sass/main.scss
+++ b/frontend/www/sass/main.scss
@@ -4,3 +4,4 @@
 
 // COMPONENTS - Re-usable site elements
 @import 'components/_header.scss';
+@import 'components/_buttons.scss';


### PR DESCRIPTION
# Descripción

Se añadió el botón cancelar en la sección **editar perfil**, y al hacer click redirige al usuario a la vista de **profile**

De esta manera se ve en desktop

![image](https://user-images.githubusercontent.com/12377916/51420801-a24a4780-1b63-11e9-85fe-be2f73fdfa0c.png)

**Y mobile**

![image](https://user-images.githubusercontent.com/12377916/51420805-c4dc6080-1b63-11e9-90c5-a3281439ec5f.png)


Fixes: #2312 


# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
