### PR TITLE
Arreglando el tipo de penalty `problem_open`

### DIFF
--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -872,7 +872,7 @@ class RunsDAO extends RunsDAOBase {
                         ON (ppo.problemset_id = r.problemset_id
                             AND r.problem_id = ppo.problem_id)
                     INNER JOIN
-                        `Identities`
+                        `Identities` i
                         ON (i.identity_id = ppo.identity_id AND r.identity_id = i.identity_id)
                     INNER JOIN `Contests` c ON (c.problemset_id = r.problemset_id)
                     SET


### PR DESCRIPTION
Este cambio arregla el error que ocurre al intentar cambiar el tipo de
penalty a `problem_open`.

Fixes: #2329