### PR TITLE
Re-activando el descargar problemas

### DIFF
--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,7 +42,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.0/omegaup-gitserver.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.2/omegaup-gitserver.xz'
 	TARGET="/usr/bin/omegaup-gitserver.xz"
 	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
 	sudo xz --decompress "${TARGET}"


### PR DESCRIPTION
Durante un cambio anterior que separaba el grader y el frontend,
accidentalmente se deshabilitó el poder descargar los archivos de un
problema. Este cambio lo arregla.

Fixes: #2340