### PR TITLE
Arreglando actualizar problemas

### DIFF
--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -25,7 +25,7 @@ class ProblemDeployer {
         $this->alias = $alias;
 
         if (isset($_FILES['problem_contents'])
-            && isset($_FILES['problem_contents']['tmp_name'])
+            && FileHandler::GetFileUploader()->IsUploadedFile($_FILES['problem_contents']['tmp_name'])
         ) {
             $this->zipPath = $_FILES['problem_contents']['tmp_name'];
         } else {


### PR DESCRIPTION
Este cambio hace que se puedan volver a actualizar los problemas.
Resulta que la prueba que se estaba haciendo para distinguir entre el
caso en el que se está subiendo un .zip y el que no estaba mal hecha y
siempre estábamos actuando como si se estuviera subiendo.

Fixes: #2336