### PR TITLE
Arreglando Grader::curlRequest()

### DIFF
--- a/frontend/server/libs/Grader.php
+++ b/frontend/server/libs/Grader.php
@@ -172,6 +172,9 @@ class Grader {
             $response = curl_exec($curl);
 
             if ($response === false || curl_getinfo($curl, CURLINFO_HTTP_CODE) != 200) {
+                if ($missingOk) {
+                    return null;
+                }
                 $message = 'curl_exec failed: ' . curl_error($curl) . ' ' .
                     curl_errno($curl) . ' HTTP ' .
                     curl_getinfo($curl, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Este cambio vuelve a hacerle caso a $missingOk.

Fixes: #2350