### PR TITLE
Otro uprev de hook-tools

### DIFF
--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -36,13 +36,15 @@ if [ $GIT_PUSH -eq 1 ]; then
 	# Fetch the remote in case we don't know the remote ref (e.g. when rebasing
 	# from the UI).
 	if [ "${REMOTE_HASH}" == "${EMPTY_HASH}" ]; then
-		ARGS="--all-files HEAD"
-		echo 'New branch. Running validations across all files...'
+		MERGE_BASE="$(git fetch upstream master && git merge-base HEAD upstream/master)"
+		ARGS="${MERGE_BASE}"
+		echo "New branch. Running validations across all changed files since ${MERGE_BASE}..."
 	elif ! git cat-file -e "${REMOTE_HASH}"; then
 		echo $'\e[31mUnknown remote hash ' "\"${REMOTE_HASH}\"" $'.\e[0m You may have missed to run `git pull`.'
 		confirm 'Do you still want to push? [y/N]'
-		ARGS="--all-files HEAD"
-		echo 'Running validations across all files...'
+		MERGE_BASE="$(git fetch upstream master && git merge-base HEAD upstream/master)"
+		ARGS="${MERGE_BASE}"
+		echo "Running validations across all files since ${MERGE_BASE}..."
 	fi
 	if [ "$(/usr/bin/git status --porcelain | grep '^ M' | wc -l)" != "0" ]; then
 		confirm $'\e[31mYou have unstaged files.\e[0m Do you still want to push? [y/N]'


### PR DESCRIPTION
Se me olvidó que había otro bug arreglable. Ahora también el push tool
ya no va a intentar correr las validaciones contra _todos_ los archivos
en ramas nuevas o push forzados, sino únicamente contra todos los
archivos que han cambiado desde el merge base.