### PR TITLE
Haciendo idempotente la creación de usuarios

### DIFF
--- a/frontend/server/controllers/InterviewController.php
+++ b/frontend/server/controllers/InterviewController.php
@@ -129,7 +129,6 @@ class InterviewController extends Controller {
             $newUserRequest['email'] = $r['usernameOrEmail'];
             $newUserRequest['username'] = UserController::makeUsernameFromEmail($r['usernameOrEmail']);
             $newUserRequest['password'] = SecurityTools::randomString(8);
-            $newUserRequest['skip_verification_email'] = 1;
 
             UserController::apiCreate($newUserRequest);
 

--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -422,7 +422,7 @@ class SessionController extends Controller {
             return false;
         }
 
-        self::$log->info('Identity ' . $r['usernameOrEmail'] . ' has loged in natively.');
+        self::$log->info('Identity ' . $r['usernameOrEmail'] . ' has logged in natively.');
 
         UserController::checkEmailVerification($r);
 

--- a/frontend/tests/controllers/UserCreateTest.php
+++ b/frontend/tests/controllers/UserCreateTest.php
@@ -35,6 +35,37 @@ class CreateUserTest extends OmegaupTestCase {
     }
 
     /**
+     * Creates an omegaup user then tries to create it again.
+     */
+    public function testCreateUserIdempotent() {
+        // Inflate request
+        UserController::$permissionKey = uniqid();
+        $r = new Request([
+            'username' => Utils::CreateRandomString(),
+            'password' => Utils::CreateRandomString(),
+            'email' => Utils::CreateRandomString().'@'.Utils::CreateRandomString().'.com',
+            'permission_key' => UserController::$permissionKey
+        ]);
+
+        // Call API twice.
+        $response = UserController::apiCreate($r);
+        $this->assertEquals('ok', $response['status']);
+        $this->assertEquals($r['username'], $response['username']);
+
+        $response = UserController::apiCreate($r);
+        $this->assertEquals('ok', $response['status']);
+        $this->assertEquals($r['username'], $response['username']);
+
+        $r['password'] = 'a wrong password';
+        try {
+            UserController::apiCreate($r);
+            $this->fail('User creation should have failed');
+        } catch (DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals('mailInUse', $e->getMessage());
+        }
+    }
+
+    /**
      * Try to create 2 users with same username, should fail.
      *
      * @expectedException DuplicatedEntryInDatabaseException


### PR DESCRIPTION
Este cambio hace que si intentas registrar un usuario dos veces con los
mismos parámetros, la petición es exitosa en vez de rechazarte.

También de paso se mejora la atomicidad de la creación de los objetos en
la base de datos para evitar más casos donde la creación de un usuario
falle.

Parte de #2352.