### PR TITLE
Separando los envíos de las evaluaciones, parte 1

### DIFF
--- a/frontend/database/85_submissions_create.sql
+++ b/frontend/database/85_submissions_create.sql
@@ -1,0 +1,65 @@
+-- Submissions
+CREATE TABLE `Submissions` (
+  `submission_id` int(11) NOT NULL AUTO_INCREMENT,
+  `current_run_id` int(11) NULL COMMENT 'La evaluación actual del envío',
+  `identity_id` int(11) NOT NULL COMMENT 'Identidad del usuario',
+  `problem_id` int(11) NOT NULL,
+  `problemset_id` int(11) DEFAULT NULL,
+  `guid` char(32) NOT NULL,
+  `language` enum('c','cpp','java','py','rb','pl','cs','pas','kp','kj','cat','hs','cpp11','lua') NOT NULL,
+  `penalty` int(11) NOT NULL DEFAULT '0',
+  `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `submit_delay` int(11) NOT NULL DEFAULT '0',
+  `type` enum('normal','test','disqualified') DEFAULT 'normal',
+  PRIMARY KEY (`submission_id`),
+  UNIQUE KEY `submissions_guid` (`guid`),
+  KEY `problem_id` (`problem_id`),
+  KEY `problemset_id` (`problemset_id`),
+  KEY `identity_id` (`identity_id`),
+  CONSTRAINT `fk_s_current_run_id` FOREIGN KEY (`current_run_id`) REFERENCES `Runs` (`run_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fk_s_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fk_s_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fk_s_problemset_id` FOREIGN KEY (`problemset_id`) REFERENCES `Problemsets` (`problemset_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Envíos';
+
+INSERT IGNORE INTO `Submissions`
+	(
+		`submission_id`, `current_run_id`, `identity_id`, `problem_id`, `problemset_id`,
+		`guid`, `language`, `time`, `submit_delay`, `type`
+	)
+SELECT
+	`run_id` AS `submission_id`, `run_id` AS `current_run_id`, `identity_id`,
+	`problem_id`, `problemset_id`, `guid`, `language`, `time`, `submit_delay`,
+	`type`
+FROM
+	`Runs`;
+
+-- Problems
+ALTER TABLE `Problems`
+	ADD COLUMN `current_version` char(40) NULL COMMENT 'La versión actual del problema.' AFTER `alias`;
+
+-- Problemset_Problems
+ALTER TABLE `Problemset_Problems`
+	ADD COLUMN `version` char(40) NULL COMMENT 'La versión del problema.' AFTER `problem_id`;
+
+-- Runs
+ALTER TABLE `Runs`
+	ADD COLUMN `submission_id` int(11) NOT NULL COMMENT 'El envío' AFTER `run_id`,
+	ADD COLUMN `version` char(40) NULL COMMENT 'La versión del problema.' AFTER `submission_id`;
+
+ALTER TABLE `Runs`
+	DROP KEY `runs_alias`;
+
+UPDATE `Runs` SET `submission_id` = `run_id`;
+
+ALTER TABLE `Runs`
+	ADD CONSTRAINT `fk_r_submission_id` FOREIGN KEY (`submission_id`) REFERENCES `Submissions` (`submission_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+	ADD CONSTRAINT UNIQUE KEY `runs_versions` (`submission_id`, `version`);
+
+-- Submission_Log
+ALTER TABLE `Submission_Log`
+	DROP FOREIGN KEY `fk_slr_run_id`;
+
+ALTER TABLE `Submission_Log`
+	CHANGE COLUMN `run_id` `submission_id` int(11) NOT NULL,
+  ADD CONSTRAINT `fk_slr_submission_id` FOREIGN KEY (`submission_id`) REFERENCES `Submissions` (`submission_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -2266,29 +2266,6 @@ class ContestController extends Controller {
             $problemset->requests_user_information = $r['requests_user_information'] ?? 'no';
             ProblemsetsDAO::save($problemset);
 
-            if (!is_null($r['problems'])) {
-                // Get current problems
-                $currentProblemIds = ProblemsetProblemsDAO::getIdByProblemset($r['contest']->problemset_id);
-                // Check who needs to be deleted and who needs to be added
-                $to_delete = array_diff($currentProblemIds, self::$problems_id);
-                $to_add = array_diff(self::$problems_id, $currentProblemIds);
-
-                foreach ($to_add as $problem) {
-                    ProblemsetProblemsDAO::save(new ProblemsetProblems([
-                        'problemset_id' => $r['contest']->problemset_id,
-                        'problem_id' => $problem,
-                        'points' => $r['problems'][$problem]['points']
-                    ]));
-                }
-
-                foreach ($to_delete as $problem) {
-                    ProblemsetProblemsDAO::delete(new ProblemsetProblems([
-                        'problemset_id' => $r['contest']->problemset_id,
-                        'problem_id' => $problem,
-                    ]));
-                }
-            }
-
             // End transaction
             DAO::transEnd();
         } catch (Exception $e) {

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -152,27 +152,28 @@ class ProblemController extends Controller {
         self::validateCreateOrUpdate($r);
 
         // Populate a new Problem object
-        $problem = new Problems();
-        $problem->visibility = $r['visibility']; /* private by default */
-        $problem->title = $r['title'];
-        $problem->validator = $r['validator'];
-        $problem->time_limit = $r['time_limit'];
-        $problem->validator_time_limit = $r['validator_time_limit'];
-        $problem->overall_wall_time_limit = $r['overall_wall_time_limit'];
-        $problem->extra_wall_time = $r['extra_wall_time'];
-        $problem->memory_limit = $r['memory_limit'];
-        $problem->output_limit = $r['output_limit'];
-        $problem->input_limit = $r['input_limit'];
-        $problem->visits = 0;
-        $problem->submissions = 0;
-        $problem->accepted = 0;
-        $problem->difficulty = 0;
-        $problem->source = $r['source'];
-        $problem->order = 'normal'; /* defaulting to normal */
-        $problem->alias = $r['problem_alias'];
-        $problem->languages = $r['languages'];
-        $problem->email_clarifications = $r['email_clarifications'];
-        $problem->tolerance = 1e-9;
+        $problem = new Problems([
+            'visibility' => $r['visibility'], /* private by default */
+            'title' => $r['title'],
+            'validator' => $r['validator'],
+            'time_limit' => $r['time_limit'],
+            'validator_time_limit' => $r['validator_time_limit'],
+            'overall_wall_time_limit' => $r['overall_wall_time_limit'],
+            'extra_wall_time' => $r['extra_wall_time'],
+            'memory_limit' => $r['memory_limit'],
+            'output_limit' => $r['output_limit'],
+            'input_limit' => $r['input_limit'],
+            'visits' => 0,
+            'submissions' => 0,
+            'accepted' => 0,
+            'difficulty' => 0,
+            'source' => $r['source'],
+            'order' => 'normal', /* defaulting to normal */
+            'alias' => $r['problem_alias'],
+            'languages' => $r['languages'],
+            'email_clarifications' => $r['email_clarifications'],
+            'tolerance' => 1e-9,
+        ]);
 
         $problemSettings = self::getProblemSettings($problem);
         $acceptsSubmissions = $r['languages'] !== '';
@@ -195,11 +196,12 @@ class ProblemController extends Controller {
                 ProblemDeployer::CREATE,
                 $problemSettings
             );
+            $problem->current_version = $problemDeployer->privateTreeHash;
 
             // Save the contest object with data sent by user to the database
-            ACLsDAO::save($acl);
+            ACLsDAO::create($acl);
             $problem->acl_id = $acl->acl_id;
-            ProblemsDAO::save($problem);
+            ProblemsDAO::create($problem);
 
             // Add tags
             if (!empty($r['selected_tags'])) {
@@ -673,6 +675,7 @@ class ProblemController extends Controller {
             foreach ($runs as $run) {
                 $guids[] = $run->guid;
                 $run->status = 'new';
+                $run->version = $r['problem']->current_version;
                 $run->verdict = 'JE';
                 $run->score = 0;
                 $run->contest_score = 0;
@@ -762,14 +765,19 @@ class ProblemController extends Controller {
                 $problemSettings
             );
             $response['rejudged'] = $problemDeployer->requiresRejudge;
+            if ($problemDeployer->requiresRejudge) {
+                $problem->current_version = $problemDeployer->privateTreeHash;
+                // TODO(lhchavez): Stop updating the problemsets and runs.
+                ProblemsetProblemsDAO::updateVersionToCurrent($problem);
+                RunsDAO::updateVersionToCurrent($problem);
+            }
             $updatedStatementLanguages = $problemDeployer->getUpdatedStatementLanguages();
 
             // Save the contest object with data sent by user to the database
-            ProblemsDAO::save($problem);
+            ProblemsDAO::update($problem);
 
             ProblemController::setRestrictedTags($problem);
 
-            //End transaction
             DAO::transEnd();
         } catch (ApiException $e) {
             // Operation failed in the data layer, rollback transaction

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -37,6 +37,7 @@ class ProblemsetController extends Controller {
             self::updateProblemsetProblem(new ProblemsetProblems([
                 'problemset_id' => $problemset_id,
                 'problem_id' => $problem->problem_id,
+                'version' => $problem->current_version,
                 'points' => $points,
                 'order' => $order_in_contest,
             ]));

--- a/frontend/server/controllers/SubmissionController.php
+++ b/frontend/server/controllers/SubmissionController.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * SubmissionController
+ */
+class SubmissionController extends Controller {
+    public static function getSource(Submissions $submission) {
+        return Grader::GetInstance()->getSource($submission->guid);
+    }
+}

--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -17,6 +17,7 @@ class ProblemDeployer {
     private $alias;
     private $zipPath = null;
     public $requiresRejudge = false;
+    public $privateTreeHash = null;
     private $updatedStatementLanguages = [];
     private $acceptsSubmissions = true;
 
@@ -85,6 +86,7 @@ class ProblemDeployer {
             foreach ($result['updated_refs'] as $ref) {
                 if ($ref['name'] == 'refs/heads/private') {
                     $this->requiresRejudge = true;
+                    $this->privateTreeHash = $ref['to_tree'];
                 }
             }
         }

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -180,20 +180,6 @@ class RunsDAO extends RunsDAOBase {
         return $ar;
     }
 
-    final public static function getByAlias($alias) {
-        $sql = 'SELECT * FROM Runs WHERE (guid = ? ) LIMIT 1;';
-        $params = [$alias];
-
-        global $conn;
-        $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
-            return null;
-        }
-
-        $contest = new Runs($rs);
-        return $contest;
-    }
-
     /*
      * Gets the count of total runs sent to a given problemset
      */
@@ -885,6 +871,24 @@ class RunsDAO extends RunsDAOBase {
         $params = [$contest->problemset_id];
         global $conn;
         $conn->Execute($sql, $params);
+        return $conn->Affected_Rows();
+    }
+
+    /**
+     * Update the version of the runs of a problem to the current version.
+     *
+     * @param Problems $problem the problem.
+     * @return integer the number of affected rows.
+     */
+    final public static function updateVersionToCurrent(Problems $problem) {
+        $sql = 'UPDATE
+                    Runs
+                SET
+                    version = ?
+                WHERE
+                    problem_id = ?;';
+        global $conn;
+        $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
         return $conn->Affected_Rows();
     }
 }

--- a/frontend/server/libs/dao/Submission_Log.dao.php
+++ b/frontend/server/libs/dao/Submission_Log.dao.php
@@ -38,13 +38,13 @@ class SubmissionLogDAO extends SubmissionLogDAOBase {
                 ON
                     i.identity_id = sl.identity_id
                 INNER JOIN
-                    Runs r
+                    Submissions s
                 ON
-                    r.run_id = sl.run_id
+                    s.submission_id = sl.submission_id
                 INNER JOIN
                     Problems p
                 ON
-                    p.problem_id = r.problem_id
+                    p.problem_id = s.problem_id
                 WHERE
                     sl.problemset_id = ?
                 ORDER BY
@@ -68,13 +68,13 @@ class SubmissionLogDAO extends SubmissionLogDAOBase {
                 ON
                     i.identity_id = sl.identity_id
                 INNER JOIN
-                    Runs r
+                    Submissions s
                 ON
-                    r.run_id = sl.run_id
+                    s.submission_id = sl.submission_id
                 INNER JOIN
                     Problems p
                 ON
-                    p.problem_id = r.problem_id
+                    p.problem_id = s.problem_id
                 INNER JOIN
                     Assignments a
                 ON

--- a/frontend/server/libs/dao/Submissions.dao.php
+++ b/frontend/server/libs/dao/Submissions.dao.php
@@ -1,0 +1,25 @@
+<?php
+
+include_once('base/Submissions.dao.base.php');
+include_once('base/Submissions.vo.base.php');
+/** Submissions Data Access Object (DAO).
+  *
+  * Esta clase contiene toda la manipulacion de bases de datos que se necesita para
+  * almacenar de forma permanente y recuperar instancias de objetos {@link Submissions }.
+  * @access public
+  *
+  */
+class SubmissionsDAO extends SubmissionsDAOBase {
+    final public static function getByGuid($guid) {
+        $sql = 'SELECT * FROM Submissions WHERE (guid = ?) LIMIT 1;';
+        $params = [$guid];
+
+        global $conn;
+        $rs = $conn->GetRow($sql, $params);
+        if (count($rs) == 0) {
+            return null;
+        }
+
+        return new Submissions($rs);
+    }
+}

--- a/frontend/server/libs/dao/base/Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems.dao.base.php
@@ -48,12 +48,13 @@ abstract class ProblemsDAOBase {
      * @param Problems [$Problems] El objeto de tipo Problems a actualizar.
      */
     final public static function update(Problems $Problems) {
-        $sql = 'UPDATE `Problems` SET `acl_id` = ?, `visibility` = ?, `title` = ?, `alias` = ?, `validator` = ?, `languages` = ?, `server` = ?, `remote_id` = ?, `time_limit` = ?, `validator_time_limit` = ?, `overall_wall_time_limit` = ?, `extra_wall_time` = ?, `memory_limit` = ?, `output_limit` = ?, `input_limit` = ?, `visits` = ?, `submissions` = ?, `accepted` = ?, `difficulty` = ?, `creation_date` = ?, `source` = ?, `order` = ?, `tolerance` = ?, `slow` = ?, `deprecated` = ?, `email_clarifications` = ?, `quality` = ?, `quality_histogram` = ?, `difficulty_histogram` = ? WHERE `problem_id` = ?;';
+        $sql = 'UPDATE `Problems` SET `acl_id` = ?, `visibility` = ?, `title` = ?, `alias` = ?, `current_version` = ?, `validator` = ?, `languages` = ?, `server` = ?, `remote_id` = ?, `time_limit` = ?, `validator_time_limit` = ?, `overall_wall_time_limit` = ?, `extra_wall_time` = ?, `memory_limit` = ?, `output_limit` = ?, `input_limit` = ?, `visits` = ?, `submissions` = ?, `accepted` = ?, `difficulty` = ?, `creation_date` = ?, `source` = ?, `order` = ?, `tolerance` = ?, `slow` = ?, `deprecated` = ?, `email_clarifications` = ?, `quality` = ?, `quality_histogram` = ?, `difficulty_histogram` = ? WHERE `problem_id` = ?;';
         $params = [
             $Problems->acl_id,
             $Problems->visibility,
             $Problems->title,
             $Problems->alias,
+            $Problems->current_version,
             $Problems->validator,
             $Problems->languages,
             $Problems->server,
@@ -99,7 +100,7 @@ abstract class ProblemsDAOBase {
         if (is_null($problem_id)) {
             return null;
         }
-        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`validator`, `Problems`.`languages`, `Problems`.`server`, `Problems`.`remote_id`, `Problems`.`time_limit`, `Problems`.`validator_time_limit`, `Problems`.`overall_wall_time_limit`, `Problems`.`extra_wall_time`, `Problems`.`memory_limit`, `Problems`.`output_limit`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`tolerance`, `Problems`.`slow`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` FROM Problems WHERE (problem_id = ?) LIMIT 1;';
+        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`current_version`, `Problems`.`validator`, `Problems`.`languages`, `Problems`.`server`, `Problems`.`remote_id`, `Problems`.`time_limit`, `Problems`.`validator_time_limit`, `Problems`.`overall_wall_time_limit`, `Problems`.`extra_wall_time`, `Problems`.`memory_limit`, `Problems`.`output_limit`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`tolerance`, `Problems`.`slow`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` FROM Problems WHERE (problem_id = ?) LIMIT 1;';
         $params = [$problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
@@ -154,7 +155,7 @@ abstract class ProblemsDAOBase {
      * @return Array Un arreglo que contiene objetos del tipo {@link Problems}.
      */
     final public static function getAll($pagina = null, $filasPorPagina = null, $orden = null, $tipoDeOrden = 'ASC') {
-        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`validator`, `Problems`.`languages`, `Problems`.`server`, `Problems`.`remote_id`, `Problems`.`time_limit`, `Problems`.`validator_time_limit`, `Problems`.`overall_wall_time_limit`, `Problems`.`extra_wall_time`, `Problems`.`memory_limit`, `Problems`.`output_limit`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`tolerance`, `Problems`.`slow`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` from Problems';
+        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`current_version`, `Problems`.`validator`, `Problems`.`languages`, `Problems`.`server`, `Problems`.`remote_id`, `Problems`.`time_limit`, `Problems`.`validator_time_limit`, `Problems`.`overall_wall_time_limit`, `Problems`.`extra_wall_time`, `Problems`.`memory_limit`, `Problems`.`output_limit`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`tolerance`, `Problems`.`slow`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` from Problems';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
@@ -238,12 +239,13 @@ abstract class ProblemsDAOBase {
         if (is_null($Problems->email_clarifications)) {
             $Problems->email_clarifications = '0';
         }
-        $sql = 'INSERT INTO Problems (`acl_id`, `visibility`, `title`, `alias`, `validator`, `languages`, `server`, `remote_id`, `time_limit`, `validator_time_limit`, `overall_wall_time_limit`, `extra_wall_time`, `memory_limit`, `output_limit`, `input_limit`, `visits`, `submissions`, `accepted`, `difficulty`, `creation_date`, `source`, `order`, `tolerance`, `slow`, `deprecated`, `email_clarifications`, `quality`, `quality_histogram`, `difficulty_histogram`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problems (`acl_id`, `visibility`, `title`, `alias`, `current_version`, `validator`, `languages`, `server`, `remote_id`, `time_limit`, `validator_time_limit`, `overall_wall_time_limit`, `extra_wall_time`, `memory_limit`, `output_limit`, `input_limit`, `visits`, `submissions`, `accepted`, `difficulty`, `creation_date`, `source`, `order`, `tolerance`, `slow`, `deprecated`, `email_clarifications`, `quality`, `quality_histogram`, `difficulty_histogram`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
             $Problems->acl_id,
             $Problems->visibility,
             $Problems->title,
             $Problems->alias,
+            $Problems->current_version,
             $Problems->validator,
             $Problems->languages,
             $Problems->server,

--- a/frontend/server/libs/dao/base/Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems.vo.base.php
@@ -41,6 +41,9 @@ class Problems extends VO {
         if (isset($data['alias'])) {
             $this->alias = $data['alias'];
         }
+        if (isset($data['current_version'])) {
+            $this->current_version = $data['current_version'];
+        }
         if (isset($data['validator'])) {
             $this->validator = $data['validator'];
         }
@@ -165,6 +168,13 @@ class Problems extends VO {
       * @var varchar(32)
       */
     public $alias;
+
+    /**
+      * La versión actual del problema.
+      * @access public
+      * @var char(40)
+      */
+    public $current_version;
 
     /**
       *  [Campo no documentado]

--- a/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
@@ -32,6 +32,9 @@ class ProblemsetProblems extends VO {
         if (isset($data['problem_id'])) {
             $this->problem_id = $data['problem_id'];
         }
+        if (isset($data['version'])) {
+            $this->version = $data['version'];
+        }
         if (isset($data['points'])) {
             $this->points = $data['points'];
         }
@@ -66,6 +69,13 @@ class ProblemsetProblems extends VO {
       * @var int(11)
       */
     public $problem_id;
+
+    /**
+      * La versión del problema.
+      * @access public
+      * @var char(40)
+      */
+    public $version;
 
     /**
       *  [Campo no documentado]

--- a/frontend/server/libs/dao/base/Runs.dao.base.php
+++ b/frontend/server/libs/dao/base/Runs.dao.base.php
@@ -48,8 +48,10 @@ abstract class RunsDAOBase {
      * @param Runs [$Runs] El objeto de tipo Runs a actualizar.
      */
     final public static function update(Runs $Runs) {
-        $sql = 'UPDATE `Runs` SET `identity_id` = ?, `problem_id` = ?, `problemset_id` = ?, `guid` = ?, `language` = ?, `status` = ?, `verdict` = ?, `runtime` = ?, `penalty` = ?, `memory` = ?, `score` = ?, `contest_score` = ?, `time` = ?, `submit_delay` = ?, `judged_by` = ?, `type` = ? WHERE `run_id` = ?;';
+        $sql = 'UPDATE `Runs` SET `submission_id` = ?, `version` = ?, `identity_id` = ?, `problem_id` = ?, `problemset_id` = ?, `guid` = ?, `language` = ?, `status` = ?, `verdict` = ?, `runtime` = ?, `penalty` = ?, `memory` = ?, `score` = ?, `contest_score` = ?, `time` = ?, `submit_delay` = ?, `judged_by` = ?, `type` = ? WHERE `run_id` = ?;';
         $params = [
+            $Runs->submission_id,
+            $Runs->version,
             $Runs->identity_id,
             $Runs->problem_id,
             $Runs->problemset_id,
@@ -86,7 +88,7 @@ abstract class RunsDAOBase {
         if (is_null($run_id)) {
             return null;
         }
-        $sql = 'SELECT `Runs`.`run_id`, `Runs`.`identity_id`, `Runs`.`problem_id`, `Runs`.`problemset_id`, `Runs`.`guid`, `Runs`.`language`, `Runs`.`status`, `Runs`.`verdict`, `Runs`.`runtime`, `Runs`.`penalty`, `Runs`.`memory`, `Runs`.`score`, `Runs`.`contest_score`, `Runs`.`time`, `Runs`.`submit_delay`, `Runs`.`judged_by`, `Runs`.`type` FROM Runs WHERE (run_id = ?) LIMIT 1;';
+        $sql = 'SELECT `Runs`.`run_id`, `Runs`.`submission_id`, `Runs`.`version`, `Runs`.`identity_id`, `Runs`.`problem_id`, `Runs`.`problemset_id`, `Runs`.`guid`, `Runs`.`language`, `Runs`.`status`, `Runs`.`verdict`, `Runs`.`runtime`, `Runs`.`penalty`, `Runs`.`memory`, `Runs`.`score`, `Runs`.`contest_score`, `Runs`.`time`, `Runs`.`submit_delay`, `Runs`.`judged_by`, `Runs`.`type` FROM Runs WHERE (run_id = ?) LIMIT 1;';
         $params = [$run_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
@@ -141,7 +143,7 @@ abstract class RunsDAOBase {
      * @return Array Un arreglo que contiene objetos del tipo {@link Runs}.
      */
     final public static function getAll($pagina = null, $filasPorPagina = null, $orden = null, $tipoDeOrden = 'ASC') {
-        $sql = 'SELECT `Runs`.`run_id`, `Runs`.`identity_id`, `Runs`.`problem_id`, `Runs`.`problemset_id`, `Runs`.`guid`, `Runs`.`language`, `Runs`.`status`, `Runs`.`verdict`, `Runs`.`runtime`, `Runs`.`penalty`, `Runs`.`memory`, `Runs`.`score`, `Runs`.`contest_score`, `Runs`.`time`, `Runs`.`submit_delay`, `Runs`.`judged_by`, `Runs`.`type` from Runs';
+        $sql = 'SELECT `Runs`.`run_id`, `Runs`.`submission_id`, `Runs`.`version`, `Runs`.`identity_id`, `Runs`.`problem_id`, `Runs`.`problemset_id`, `Runs`.`guid`, `Runs`.`language`, `Runs`.`status`, `Runs`.`verdict`, `Runs`.`runtime`, `Runs`.`penalty`, `Runs`.`memory`, `Runs`.`score`, `Runs`.`contest_score`, `Runs`.`time`, `Runs`.`submit_delay`, `Runs`.`judged_by`, `Runs`.`type` from Runs';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
@@ -192,8 +194,10 @@ abstract class RunsDAOBase {
         if (is_null($Runs->type)) {
             $Runs->type = 'normal';
         }
-        $sql = 'INSERT INTO Runs (`identity_id`, `problem_id`, `problemset_id`, `guid`, `language`, `status`, `verdict`, `runtime`, `penalty`, `memory`, `score`, `contest_score`, `time`, `submit_delay`, `judged_by`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Runs (`submission_id`, `version`, `identity_id`, `problem_id`, `problemset_id`, `guid`, `language`, `status`, `verdict`, `runtime`, `penalty`, `memory`, `score`, `contest_score`, `time`, `submit_delay`, `judged_by`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
+            $Runs->submission_id,
+            $Runs->version,
             $Runs->identity_id,
             $Runs->problem_id,
             $Runs->problemset_id,

--- a/frontend/server/libs/dao/base/Submission_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Submission_Log.dao.base.php
@@ -34,7 +34,7 @@ abstract class SubmissionLogDAOBase {
      * @return Un entero mayor o igual a cero identificando el número de filas afectadas.
      */
     final public static function save(SubmissionLog $Submission_Log) {
-        if (is_null(self::getByPK($Submission_Log->run_id))) {
+        if (is_null(self::getByPK($Submission_Log->submission_id))) {
             return SubmissionLogDAOBase::create($Submission_Log);
         }
         return SubmissionLogDAOBase::update($Submission_Log);
@@ -48,14 +48,14 @@ abstract class SubmissionLogDAOBase {
      * @param SubmissionLog [$Submission_Log] El objeto de tipo SubmissionLog a actualizar.
      */
     final public static function update(SubmissionLog $Submission_Log) {
-        $sql = 'UPDATE `Submission_Log` SET `problemset_id` = ?, `user_id` = ?, `identity_id` = ?, `ip` = ?, `time` = ? WHERE `run_id` = ?;';
+        $sql = 'UPDATE `Submission_Log` SET `problemset_id` = ?, `user_id` = ?, `identity_id` = ?, `ip` = ?, `time` = ? WHERE `submission_id` = ?;';
         $params = [
             $Submission_Log->problemset_id,
             $Submission_Log->user_id,
             $Submission_Log->identity_id,
             $Submission_Log->ip,
             $Submission_Log->time,
-            $Submission_Log->run_id,
+            $Submission_Log->submission_id,
         ];
         global $conn;
         $conn->Execute($sql, $params);
@@ -71,12 +71,12 @@ abstract class SubmissionLogDAOBase {
      * @static
      * @return @link SubmissionLog Un objeto del tipo {@link SubmissionLog}. NULL si no hay tal registro.
      */
-    final public static function getByPK($run_id) {
-        if (is_null($run_id)) {
+    final public static function getByPK($submission_id) {
+        if (is_null($submission_id)) {
             return null;
         }
-        $sql = 'SELECT `Submission_Log`.`problemset_id`, `Submission_Log`.`run_id`, `Submission_Log`.`user_id`, `Submission_Log`.`identity_id`, `Submission_Log`.`ip`, `Submission_Log`.`time` FROM Submission_Log WHERE (run_id = ?) LIMIT 1;';
-        $params = [$run_id];
+        $sql = 'SELECT `Submission_Log`.`problemset_id`, `Submission_Log`.`submission_id`, `Submission_Log`.`user_id`, `Submission_Log`.`identity_id`, `Submission_Log`.`ip`, `Submission_Log`.`time` FROM Submission_Log WHERE (submission_id = ?) LIMIT 1;';
+        $params = [$submission_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
         if (count($rs) == 0) {
@@ -102,8 +102,8 @@ abstract class SubmissionLogDAOBase {
      * @param SubmissionLog [$Submission_Log] El objeto de tipo SubmissionLog a eliminar
      */
     final public static function delete(SubmissionLog $Submission_Log) {
-        $sql = 'DELETE FROM `Submission_Log` WHERE run_id = ?;';
-        $params = [$Submission_Log->run_id];
+        $sql = 'DELETE FROM `Submission_Log` WHERE submission_id = ?;';
+        $params = [$Submission_Log->submission_id];
         global $conn;
 
         $conn->Execute($sql, $params);
@@ -130,7 +130,7 @@ abstract class SubmissionLogDAOBase {
      * @return Array Un arreglo que contiene objetos del tipo {@link SubmissionLog}.
      */
     final public static function getAll($pagina = null, $filasPorPagina = null, $orden = null, $tipoDeOrden = 'ASC') {
-        $sql = 'SELECT `Submission_Log`.`problemset_id`, `Submission_Log`.`run_id`, `Submission_Log`.`user_id`, `Submission_Log`.`identity_id`, `Submission_Log`.`ip`, `Submission_Log`.`time` from Submission_Log';
+        $sql = 'SELECT `Submission_Log`.`problemset_id`, `Submission_Log`.`submission_id`, `Submission_Log`.`user_id`, `Submission_Log`.`identity_id`, `Submission_Log`.`ip`, `Submission_Log`.`time` from Submission_Log';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
@@ -160,10 +160,10 @@ abstract class SubmissionLogDAOBase {
         if (is_null($Submission_Log->time)) {
             $Submission_Log->time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Submission_Log (`problemset_id`, `run_id`, `user_id`, `identity_id`, `ip`, `time`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Submission_Log (`problemset_id`, `submission_id`, `user_id`, `identity_id`, `ip`, `time`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
             $Submission_Log->problemset_id,
-            $Submission_Log->run_id,
+            $Submission_Log->submission_id,
             $Submission_Log->user_id,
             $Submission_Log->identity_id,
             $Submission_Log->ip,

--- a/frontend/server/libs/dao/base/Submission_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Submission_Log.vo.base.php
@@ -29,8 +29,8 @@ class SubmissionLog extends VO {
         if (isset($data['problemset_id'])) {
             $this->problemset_id = $data['problemset_id'];
         }
-        if (isset($data['run_id'])) {
-            $this->run_id = $data['run_id'];
+        if (isset($data['submission_id'])) {
+            $this->submission_id = $data['submission_id'];
         }
         if (isset($data['user_id'])) {
             $this->user_id = $data['user_id'];
@@ -70,7 +70,7 @@ class SubmissionLog extends VO {
       * @access public
       * @var int(11)
       */
-    public $run_id;
+    public $submission_id;
 
     /**
       *  [Campo no documentado]

--- a/frontend/server/libs/dao/base/Submissions.dao.base.php
+++ b/frontend/server/libs/dao/base/Submissions.dao.base.php
@@ -8,20 +8,20 @@
   *                                                                                 *
   * ******************************************************************************* */
 
-/** ProblemsetProblems Data Access Object (DAO) Base.
+/** Submissions Data Access Object (DAO) Base.
  *
  * Esta clase contiene toda la manipulacion de bases de datos que se necesita
  * para almacenar de forma permanente y recuperar instancias de objetos
- * {@link ProblemsetProblems}.
+ * {@link Submissions}.
  * @access public
  * @abstract
  *
  */
-abstract class ProblemsetProblemsDAOBase {
+abstract class SubmissionsDAOBase {
     /**
      * Guardar registros.
      *
-     * Este metodo guarda el estado actual del objeto {@link ProblemsetProblems}
+     * Este metodo guarda el estado actual del objeto {@link Submissions}
      * pasado en la base de datos. La llave primaria indicará qué instancia va
      * a ser actualizada en base de datos. Si la llave primara o combinación de
      * llaves primarias que describen una fila que no se encuentra en la base de
@@ -30,14 +30,14 @@ abstract class ProblemsetProblemsDAOBase {
      *
      * @static
      * @throws Exception si la operacion fallo.
-     * @param ProblemsetProblems [$Problemset_Problems] El objeto de tipo ProblemsetProblems
+     * @param Submissions [$Submissions] El objeto de tipo Submissions
      * @return Un entero mayor o igual a cero identificando el número de filas afectadas.
      */
-    final public static function save(ProblemsetProblems $Problemset_Problems) {
-        if (is_null(self::getByPK($Problemset_Problems->problemset_id, $Problemset_Problems->problem_id))) {
-            return ProblemsetProblemsDAOBase::create($Problemset_Problems);
+    final public static function save(Submissions $Submissions) {
+        if (is_null(self::getByPK($Submissions->submission_id))) {
+            return SubmissionsDAOBase::create($Submissions);
         }
-        return ProblemsetProblemsDAOBase::update($Problemset_Problems);
+        return SubmissionsDAOBase::update($Submissions);
     }
 
     /**
@@ -45,16 +45,22 @@ abstract class ProblemsetProblemsDAOBase {
      *
      * @static
      * @return Filas afectadas
-     * @param ProblemsetProblems [$Problemset_Problems] El objeto de tipo ProblemsetProblems a actualizar.
+     * @param Submissions [$Submissions] El objeto de tipo Submissions a actualizar.
      */
-    final public static function update(ProblemsetProblems $Problemset_Problems) {
-        $sql = 'UPDATE `Problemset_Problems` SET `version` = ?, `points` = ?, `order` = ? WHERE `problemset_id` = ? AND `problem_id` = ?;';
+    final public static function update(Submissions $Submissions) {
+        $sql = 'UPDATE `Submissions` SET `current_run_id` = ?, `identity_id` = ?, `problem_id` = ?, `problemset_id` = ?, `guid` = ?, `language` = ?, `penalty` = ?, `time` = ?, `submit_delay` = ?, `type` = ? WHERE `submission_id` = ?;';
         $params = [
-            $Problemset_Problems->version,
-            $Problemset_Problems->points,
-            $Problemset_Problems->order,
-            $Problemset_Problems->problemset_id,
-            $Problemset_Problems->problem_id,
+            $Submissions->current_run_id,
+            $Submissions->identity_id,
+            $Submissions->problem_id,
+            $Submissions->problemset_id,
+            $Submissions->guid,
+            $Submissions->language,
+            $Submissions->penalty,
+            $Submissions->time,
+            $Submissions->submit_delay,
+            $Submissions->type,
+            $Submissions->submission_id,
         ];
         global $conn;
         $conn->Execute($sql, $params);
@@ -62,33 +68,33 @@ abstract class ProblemsetProblemsDAOBase {
     }
 
     /**
-     * Obtener {@link ProblemsetProblems} por llave primaria.
+     * Obtener {@link Submissions} por llave primaria.
      *
-     * Este metodo cargará un objeto {@link ProblemsetProblems} de la base
+     * Este metodo cargará un objeto {@link Submissions} de la base
      * de datos usando sus llaves primarias.
      *
      * @static
-     * @return @link ProblemsetProblems Un objeto del tipo {@link ProblemsetProblems}. NULL si no hay tal registro.
+     * @return @link Submissions Un objeto del tipo {@link Submissions}. NULL si no hay tal registro.
      */
-    final public static function getByPK($problemset_id, $problem_id) {
-        if (is_null($problemset_id) || is_null($problem_id)) {
+    final public static function getByPK($submission_id) {
+        if (is_null($submission_id)) {
             return null;
         }
-        $sql = 'SELECT `Problemset_Problems`.`problemset_id`, `Problemset_Problems`.`problem_id`, `Problemset_Problems`.`version`, `Problemset_Problems`.`points`, `Problemset_Problems`.`order` FROM Problemset_Problems WHERE (problemset_id = ? AND problem_id = ?) LIMIT 1;';
-        $params = [$problemset_id, $problem_id];
+        $sql = 'SELECT `Submissions`.`submission_id`, `Submissions`.`current_run_id`, `Submissions`.`identity_id`, `Submissions`.`problem_id`, `Submissions`.`problemset_id`, `Submissions`.`guid`, `Submissions`.`language`, `Submissions`.`penalty`, `Submissions`.`time`, `Submissions`.`submit_delay`, `Submissions`.`type` FROM Submissions WHERE (submission_id = ?) LIMIT 1;';
+        $params = [$submission_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
         if (count($rs) == 0) {
             return null;
         }
-        return new ProblemsetProblems($rs);
+        return new Submissions($rs);
     }
 
     /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en
-     * el objeto ProblemsetProblems suministrado. Una vez que se ha
+     * el objeto Submissions suministrado. Una vez que se ha
      * eliminado un objeto, este no puede ser restaurado llamando a
      * {@link save()}, ya que este último creará un nuevo registro con una
      * llave primaria distinta a la que estaba en el objeto eliminado.
@@ -98,11 +104,11 @@ abstract class ProblemsetProblemsDAOBase {
      *
      * @static
      * @throws Exception Se arroja cuando no se encuentra el objeto a eliminar en la base de datos.
-     * @param ProblemsetProblems [$Problemset_Problems] El objeto de tipo ProblemsetProblems a eliminar
+     * @param Submissions [$Submissions] El objeto de tipo Submissions a eliminar
      */
-    final public static function delete(ProblemsetProblems $Problemset_Problems) {
-        $sql = 'DELETE FROM `Problemset_Problems` WHERE problemset_id = ? AND problem_id = ?;';
-        $params = [$Problemset_Problems->problemset_id, $Problemset_Problems->problem_id];
+    final public static function delete(Submissions $Submissions) {
+        $sql = 'DELETE FROM `Submissions` WHERE submission_id = ?;';
+        $params = [$Submissions->submission_id];
         global $conn;
 
         $conn->Execute($sql, $params);
@@ -115,7 +121,7 @@ abstract class ProblemsetProblemsDAOBase {
      * Obtener todas las filas.
      *
      * Esta funcion leerá todos los contenidos de la tabla en la base de datos
-     * y construirá un arreglo que contiene objetos de tipo {@link ProblemsetProblems}.
+     * y construirá un arreglo que contiene objetos de tipo {@link Submissions}.
      * Este método consume una cantidad de memoria proporcional al número de
      * registros regresados, así que sólo debe usarse cuando la tabla en
      * cuestión es pequeña o se proporcionan parámetros para obtener un menor
@@ -126,10 +132,10 @@ abstract class ProblemsetProblemsDAOBase {
      * @param $filasPorPagina Filas por página.
      * @param $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
-     * @return Array Un arreglo que contiene objetos del tipo {@link ProblemsetProblems}.
+     * @return Array Un arreglo que contiene objetos del tipo {@link Submissions}.
      */
     final public static function getAll($pagina = null, $filasPorPagina = null, $orden = null, $tipoDeOrden = 'ASC') {
-        $sql = 'SELECT `Problemset_Problems`.`problemset_id`, `Problemset_Problems`.`problem_id`, `Problemset_Problems`.`version`, `Problemset_Problems`.`points`, `Problemset_Problems`.`order` from Problemset_Problems';
+        $sql = 'SELECT `Submissions`.`submission_id`, `Submissions`.`current_run_id`, `Submissions`.`identity_id`, `Submissions`.`problem_id`, `Submissions`.`problemset_id`, `Submissions`.`guid`, `Submissions`.`language`, `Submissions`.`penalty`, `Submissions`.`time`, `Submissions`.`submit_delay`, `Submissions`.`type` from Submissions';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
@@ -140,7 +146,7 @@ abstract class ProblemsetProblemsDAOBase {
         $rs = $conn->Execute($sql);
         $allData = [];
         foreach ($rs as $row) {
-            $allData[] = new ProblemsetProblems($row);
+            $allData[] = new Submissions($row);
         }
         return $allData;
     }
@@ -149,26 +155,37 @@ abstract class ProblemsetProblemsDAOBase {
      * Crear registros.
      *
      * Este metodo creará una nueva fila en la base de datos de acuerdo con los
-     * contenidos del objeto ProblemsetProblems suministrado.
+     * contenidos del objeto Submissions suministrado.
      *
      * @static
      * @return Un entero mayor o igual a cero identificando el número de filas afectadas.
-     * @param ProblemsetProblems [$Problemset_Problems] El objeto de tipo ProblemsetProblems a crear.
+     * @param Submissions [$Submissions] El objeto de tipo Submissions a crear.
      */
-    final public static function create(ProblemsetProblems $Problemset_Problems) {
-        if (is_null($Problemset_Problems->points)) {
-            $Problemset_Problems->points = '1';
+    final public static function create(Submissions $Submissions) {
+        if (is_null($Submissions->penalty)) {
+            $Submissions->penalty = '0';
         }
-        if (is_null($Problemset_Problems->order)) {
-            $Problemset_Problems->order = '1';
+        if (is_null($Submissions->time)) {
+            $Submissions->time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Problemset_Problems (`problemset_id`, `problem_id`, `version`, `points`, `order`) VALUES (?, ?, ?, ?, ?);';
+        if (is_null($Submissions->submit_delay)) {
+            $Submissions->submit_delay = '0';
+        }
+        if (is_null($Submissions->type)) {
+            $Submissions->type = 'normal';
+        }
+        $sql = 'INSERT INTO Submissions (`current_run_id`, `identity_id`, `problem_id`, `problemset_id`, `guid`, `language`, `penalty`, `time`, `submit_delay`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Problemset_Problems->problemset_id,
-            $Problemset_Problems->problem_id,
-            $Problemset_Problems->version,
-            $Problemset_Problems->points,
-            $Problemset_Problems->order,
+            $Submissions->current_run_id,
+            $Submissions->identity_id,
+            $Submissions->problem_id,
+            $Submissions->problemset_id,
+            $Submissions->guid,
+            $Submissions->language,
+            $Submissions->penalty,
+            $Submissions->time,
+            $Submissions->submit_delay,
+            $Submissions->type,
         ];
         global $conn;
         $conn->Execute($sql, $params);
@@ -176,6 +193,7 @@ abstract class ProblemsetProblemsDAOBase {
         if ($ar == 0) {
             return 0;
         }
+        $Submissions->submission_id = $conn->Insert_ID();
 
         return $ar;
     }

--- a/frontend/server/libs/dao/base/Submissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Submissions.vo.base.php
@@ -9,16 +9,16 @@
   * ******************************************************************************* */
 
 /**
- * Value Object file for table Runs.
+ * Value Object file for table Submissions.
  *
  * VO does not have any behaviour.
  * @access public
  */
-class Runs extends VO {
+class Submissions extends VO {
     /**
-     * Constructor de Runs
+     * Constructor de Submissions
      *
-     * Para construir un objeto de tipo Runs debera llamarse a el constructor
+     * Para construir un objeto de tipo Submissions debera llamarse a el constructor
      * sin parametros. Es posible, construir un objeto pasando como parametro un arreglo asociativo
      * cuyos campos son iguales a las variables que constituyen a este objeto.
      */
@@ -26,14 +26,11 @@ class Runs extends VO {
         if (is_null($data)) {
             return;
         }
-        if (isset($data['run_id'])) {
-            $this->run_id = $data['run_id'];
-        }
         if (isset($data['submission_id'])) {
             $this->submission_id = $data['submission_id'];
         }
-        if (isset($data['version'])) {
-            $this->version = $data['version'];
+        if (isset($data['current_run_id'])) {
+            $this->current_run_id = $data['current_run_id'];
         }
         if (isset($data['identity_id'])) {
             $this->identity_id = $data['identity_id'];
@@ -50,35 +47,14 @@ class Runs extends VO {
         if (isset($data['language'])) {
             $this->language = $data['language'];
         }
-        if (isset($data['status'])) {
-            $this->status = $data['status'];
-        }
-        if (isset($data['verdict'])) {
-            $this->verdict = $data['verdict'];
-        }
-        if (isset($data['runtime'])) {
-            $this->runtime = $data['runtime'];
-        }
         if (isset($data['penalty'])) {
             $this->penalty = $data['penalty'];
-        }
-        if (isset($data['memory'])) {
-            $this->memory = $data['memory'];
-        }
-        if (isset($data['score'])) {
-            $this->score = $data['score'];
-        }
-        if (isset($data['contest_score'])) {
-            $this->contest_score = $data['contest_score'];
         }
         if (isset($data['time'])) {
             $this->time = $data['time'];
         }
         if (isset($data['submit_delay'])) {
             $this->submit_delay = $data['submit_delay'];
-        }
-        if (isset($data['judged_by'])) {
-            $this->judged_by = $data['judged_by'];
         }
         if (isset($data['type'])) {
             $this->type = $data['type'];
@@ -103,21 +79,14 @@ class Runs extends VO {
       * @access public
       * @var int(11)
       */
-    public $run_id;
-
-    /**
-      * El envío
-      * @access public
-      * @var int(11)
-      */
     public $submission_id;
 
     /**
-      * La versión del problema.
+      * La evaluación actual del envío
       * @access public
-      * @var char(40)
+      * @var int(11)
       */
-    public $version;
+    public $current_run_id;
 
     /**
       * Identidad del usuario
@@ -157,51 +126,9 @@ class Runs extends VO {
     /**
       *  [Campo no documentado]
       * @access public
-      * @var enum('new','waiting','compiling','running','ready')
-      */
-    public $status;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var enum('ac','pa','pe','wa','tle','ole','mle','rte','rfe','ce','je')
-      */
-    public $verdict;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var int(11)
-      */
-    public $runtime;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
       * @var int(11)
       */
     public $penalty;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var int(11)
-      */
-    public $memory;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var double
-      */
-    public $score;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var double
-      */
-    public $contest_score;
 
     /**
       *  [Campo no documentado]
@@ -216,13 +143,6 @@ class Runs extends VO {
       * @var int(11)
       */
     public $submit_delay;
-
-    /**
-      *  [Campo no documentado]
-      * @access public
-      * @var char(32)
-      */
-    public $judged_by;
 
     /**
       *  [Campo no documentado]

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -126,6 +126,7 @@ class Utils {
             'QualityNominations',
             'Runs',
             'Schools',
+            'Submissions',
             'Submission_Log',
             'Tags',
             'User_Roles',

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -87,10 +87,13 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
             //sumbmission gap between runs must be 60 seconds
             Time::setTimeForTesting(Time::get() + 60);
 
-            // Force the run to be in any date
-            $run = RunsDAO::getByAlias($runData['response']['guid']);
+            // Force the submission to be in any date
+            $submission = SubmissionsDAO::getByGuid($runData['response']['guid']);
+            $submission->time = $runCreationDate;
+            SubmissionsDAO::update($submission);
+            $run = RunsDAO::getByPK($submission->current_run_id);
             $run->time = $runCreationDate;
-            RunsDAO::save($run);
+            RunsDAO::update($run);
         }
     }
 

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -1387,7 +1387,9 @@ class QualityNominationTest extends OmegaupTestCase {
     private static function deleteAllPreviousRuns() {
         global $conn;
         $conn->Execute('DELETE FROM `Submission_Log`;');
+        $conn->Execute('UPDATE `Submissions` SET `current_run_id` = NULL;');
         $conn->Execute('DELETE FROM `Runs`;');
+        $conn->Execute('DELETE FROM `Submissions`;');
     }
 
     private static function deleteAllProblemsOfTheWeek() {

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -109,22 +109,23 @@ class RunCreateTest extends OmegaupTestCase {
         $this->assertEquals('ok', $response['status']);
         $this->assertArrayHasKey('guid', $response);
 
-        // Get run from DB
-        $run = RunsDAO::getByAlias($response['guid']);
-        $this->assertNotNull($run);
+        // Get submissionn from DB
+        $submission = SubmissionsDAO::getByGuid($response['guid']);
+        $this->assertNotNull($submission);
 
         // Get contest from DB to check times with respect to contest start
         $contest = ContestsDAO::getByAlias($r['contest_alias']);
 
         // Validate data
-        $this->assertEquals($r['language'], $run->language);
-        $this->assertNotNull($run->guid);
+        $this->assertEquals($r['language'], $submission->language);
+        $this->assertNotNull($submission->guid);
 
         // Validate file created
-        $fileContent = RunController::getRunSource($run);
+        $fileContent = SubmissionController::getSource($submission);
         $this->assertEquals($r['source'], $fileContent);
 
         // Validate defaults
+        $run = RunsDAO::getByPK($submission->current_run_id);
         $this->assertEquals('new', $run->status);
         $this->assertEquals(0, $run->runtime);
         $this->assertEquals(0, $run->memory);
@@ -135,13 +136,13 @@ class RunCreateTest extends OmegaupTestCase {
         $submission_gap = isset($contest->submissions_gap) ? $contest->submissions_gap : RunController::$defaultSubmissionGap;
         $this->assertEquals(Utils::GetPhpUnixTimestamp() + $submission_gap, $response['nextSubmissionTimestamp']);
 
-        $log = SubmissionLogDAO::getByPK($run->run_id);
+        $log = SubmissionLogDAO::getByPK($submission->submission_id);
 
         $this->assertNotNull($log);
         $this->assertEquals(ip2long('127.0.0.1'), $log->ip);
 
         if (!is_null($contest)) {
-            $this->assertEquals((Utils::GetPhpUnixTimestamp() - intval(strtotime($contest->start_time))) / 60, $run->penalty, '', 0.5);
+            $this->assertEquals((Utils::GetPhpUnixTimestamp() - intval(strtotime($contest->start_time))) / 60, $submission->penalty, '', 0.5);
         }
 
         $this->assertEquals('JE', $run->verdict);

--- a/frontend/tests/controllers/RunsTotalsTest.php
+++ b/frontend/tests/controllers/RunsTotalsTest.php
@@ -24,9 +24,12 @@ class RunsTotalsTest extends OmegaupTestCase {
         Time::setTimeForTesting(Time::get() + 60);
         $runDataOld = RunsFactory::createRun($problemData, $contestData, $contestant);
 
-        $run = RunsDAO::getByAlias($runDataOld['response']['guid']);
+        $submission = SubmissionsDAO::getByGuid($runDataOld['response']['guid']);
+        $submission->time = date('Y-m-d H:i:s', strtotime('-72 hours'));
+        SubmissionsDAO::update($submission);
+        $run = RunsDAO::getByPK($submission->current_run_id);
         $run->time = date('Y-m-d H:i:s', strtotime('-72 hours'));
-        RunsDAO::save($run);
+        RunsDAO::update($run);
 
         $response = RunController::apiCounts(new Request());
 

--- a/frontend/tests/factories/RunsFactory.php
+++ b/frontend/tests/factories/RunsFactory.php
@@ -170,7 +170,8 @@ class RunsFactory {
      * @param string $verdict
      */
     public static function gradeRun($runData, $points = 1, $verdict = 'AC', $submitDelay = null, $runGuid = null) {
-        $run = RunsDAO::getByAlias($runGuid === null ? $runData['response']['guid'] : $runGuid);
+        $submission = SubmissionsDAO::getByGuid($runGuid === null ? $runData['response']['guid'] : $runGuid);
+        $run = RunsDAO::getByPK($submission->current_run_id);
 
         $run->verdict = $verdict;
         $run->score = $points;

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,11 +42,8 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.2/omegaup-gitserver.xz'
-	TARGET="/usr/bin/omegaup-gitserver.xz"
-	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
-	sudo xz --decompress "${TARGET}"
-	sudo chmod +x "${TARGET%.xz}"
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.7/omegaup-gitserver.tar.xz'
+	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.
 	DOWNLOAD_URL='https://github.com/omegaup/libinteractive/releases/download/v2.0.23/libinteractive.jar'


### PR DESCRIPTION
Este cambio es el primero en una serie de cambios para habilitar la
evaluación no-destructiva. Lo que hace es separar los envíos
(Submissions) de las evaluaciones (Runs). Para hacer la migración más
sencilla, primero los Submissions y Runs van a tener campos duplicados y
poco a poco se irán de-duplicando.