### PR TITLE
Bonitificando aún más la impresión

### DIFF
--- a/frontend/templates/contest.print.tpl
+++ b/frontend/templates/contest.print.tpl
@@ -2,7 +2,7 @@
 <html lang="{#locale#}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title>omegaUp &mdash; {$contestName}</title>
+    <title>omegaUp &mdash; {$contestName|htmlspecialchars}</title>
     <script type="text/javascript" src="{version_hash src="/js/mathjax-config.js"}"></script>
     <script type="text/javascript" src="/third_party/js/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script type="text/javascript" src="{version_hash src="/third_party/js/jquery-3.2.1.min.js"}"></script>
@@ -22,7 +22,7 @@
     <div class="problem">
       <script type="text/json" class="payload">{$problem.payload|json_encode}</script>
       <div class="title">
-        <h1 class="problem-title">{$problem.letter}. {$problem.title|htmlspecialchars}</h2>
+        <h1 class="problem-title">{$contestName|htmlspecialchars} &mdash; {$problem.letter}. {$problem.title|htmlspecialchars}</h2>
         <table class="data">
           <tr>
             <td>{#wordsPoints#}</td>
@@ -39,8 +39,6 @@
         </table>
       </div>
       <div class="statement"></div>
-      <hr />
-      <div class="page-break"></div>
     </div>
 {/foreach}
   <script type="text/javascript" src="{version_hash src="/js/contest.print.js"}"></script>

--- a/frontend/www/css/report.css
+++ b/frontend/www/css/report.css
@@ -1,56 +1,100 @@
 @media all {
-	.page-break	   { display: none; }
 	body {
 		font-size: 10pt;
 		font-family: "Arial Narrow", sans-serif;
+		margin: 0;
+		padding: 0;
 	}
-	tr:nth-child(even) { background-color: #eee; }
-	td.numeric         { text-align: right; }
-	table td {
-		border: 1px solid #000;
-		padding: 0.2em;
+
+	div.problem {
+		page-break-before: always;
+	}
+
+	.title h1.problem-title {
+		text-align: center;
 	}
 	.title .data {
 		margin: 0 auto 1em auto;
 	}
-	.title .data tr:nth-child(even) { background-color: transparent; }
+	.title .data tr:nth-child(even) {
+		background-color: transparent;
+	}
+
+	h1, h2, h3, h4, h5, h6 {
+		page-break-after: avoid;
+		page-break-inside: avoid;
+	}
+	h1 {
+		font-size: 1.5em;
+	}
+	h2 {
+		font-size: 1.3em;
+	}
+	h3 {
+		font-size: 1.15em;
+	}
+
+	table {
+		page-break-inside: avoid;
+	}
+	table td {
+		border: 1px solid #000;
+		padding: 0.2em;
+	}
+	tr:nth-child(even) {
+		background-color: #eee;
+	}
+	td.numeric {
+		text-align: right;
+	}
+
 	.statement p, .statement li {
+		hyphens: auto;
 		line-height: 150%;
 		text-align: justify;
+		orphans: 2;
+		widows: 2;
+		page-break-inside: avoid;
 	}
 	.statement p {
-		hyphens: auto;
 		margin-bottom: 1.5em;
-	}
-	#report > .title {
-		text-align: center;
 	}
 	.statement ul {
 		list-style: disc;
 	}
-
 	.statement ol {
 		list-style: decimal;
 	}
-
 	.statement li {
 		margin-left: 2em;
+	}
+
+	.statement img {
+		max-width: 50%;
+		page-break-inside: avoid;
+	}
+
+	.statement pre {
+		line-height: 125%;
 	}
 
 	.statement table.sample_io {
 		border: 1px solid #000;
 		background: #eee;
-		margin: 5px;
-		padding : 5px;
+		margin: 0.75ex;
+		padding : 0.75ex;
 	}
-	.statement .sample_io td {
+	.statement table.sample_io th {
+		padding: 0.75ex;
+	}
+	.statement table.sample_io td {
 		font-size: 10pt;
 		background: #eee;
 		vertical-align: top;
-		padding: 10px;
+		padding: 1.25ex;
 		border: 1px solid #000;
 	}
-	.statement .sample_io pre {
+	.statement table.sample_io pre {
 		white-space: pre;
 		word-break: keep-all;
 		word-wrap: normal;
@@ -59,40 +103,20 @@
 		padding: 0px;
 		margin: inherit;
 	}
-	p, li {
-		font-family: "Arial Narrow", sans-serif;
-	}
 	figure {
 		text-align: center;
+		page-break-inside: avoid;
 	}
-	li {
-		line-height: 100% !important;
-	}
-	hr { display: none; }
-	h1, h2, h3 {
-		page-break-after: avoid;
-		break-after: avoid;
-		-webkit-region-break-after: avoid;
+	hr {
+		display: none;
 	}
 	div.libinteractive-download {
 		display: none;
 	}
-	.statement img {
-		max-width: 50%;
-	}
 }
 
 @media print {
-	@page { margin: 1in; }
-	.page-break	{
-		display: block;
-		page-break-before: always;
-		break-before: always;
-		-webkit-region-break-before: always;
-	}
-	table {
-		page-break-inside: avoid;
-		break-inside: avoid;
-		-webkit-region-break-inside: avoid;
+	@page {
+		margin: 1in;
 	}
 }


### PR DESCRIPTION
Este cambio:

* Reordena el CSS para que tenga más sentido.
* Agrega el nombre del concurso en el título y lo centra.
* Agrega interlineado en las listas.
* Previene separación de un montón de elementos.
* Agrega espaciado en las tablas.
* Establece tamaños explícitos para los headers.

Otro cambio de #1975.