### PR TITLE
Eliminando configuraciones viejas

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -61,8 +61,6 @@ try_define('OMEGAUP_GITSERVER_SECRET_TOKEN', '');
 try_define('OMEGAUP_GRADER_SECRET', 'secret');
 try_define('OMEGAUP_SSLCERT_URL', OMEGAUP_ROOT . '/omegaup.pem');
 try_define('OMEGAUP_CACERT_URL', OMEGAUP_ROOT . '/omegaup.pem');
-try_define('GRADE_PATH', '/var/lib/omegaup/grade');
-try_define('PROBLEMS_GIT_PATH', '/var/lib/omegaup/problems.git');
 try_define('BIN_PATH', OMEGAUP_ROOT . '/../bin');
 try_define('IMAGES_PATH', OMEGAUP_ROOT . '/www/img/');
 try_define('IMAGES_URL_PATH', '/img/');
@@ -70,7 +68,6 @@ try_define('TEMPLATES_PATH', OMEGAUP_ROOT . '/www/templates/');
 try_define('TEMPLATES_URL_PATH', '/templates/');
 try_define('OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE', true);
 try_define('OMEGAUP_GRADER_FAKE', false);
-try_define('OMEGAUP_UPDATE_PROBLEM', '/usr/bin/omegaup-update-problem');
 
 # ####################################
 # FACEBOOK LOGIN CONFIG
@@ -160,6 +157,5 @@ try_define('PASSWORD_RESET_MIN_WAIT', 5 * 60);
 # ########################
 # S3 CONFIG
 # ########################
-try_define('AWS_CLI_BINARY', '/usr/local/bin/aws');
 try_define('AWS_CLI_ACCESS_KEY_ID', null);
 try_define('AWS_CLI_SECRET_ACCESS_KEY', null);

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -51,15 +51,12 @@ namespace {
     Utils::CleanLog();
 
     // Clean problems and runs path
-    Utils::CleanPath(GRADE_PATH);
     Utils::CleanPath(IMAGES_PATH);
-    Utils::CleanPath(PROBLEMS_GIT_PATH);
     Utils::CleanPath(RUNS_PATH);
     Utils::CleanPath(TEMPLATES_PATH);
 
     for ($i = 0; $i < 256; $i++) {
         mkdir(RUNS_PATH . sprintf('/%02x', $i), 0775, true);
-        mkdir(GRADE_PATH . sprintf('/%02x', $i), 0775, true);
     }
 
     // Clean DB

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -16,7 +16,7 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
         parent::setUpBeforeClass();
 
         $scriptFilename = __DIR__ . '/gitserver-start.sh ' .
-            OMEGAUP_GITSERVER_PORT . ' ' . PROBLEMS_GIT_PATH;
+            OMEGAUP_GITSERVER_PORT . ' /tmp/omegaup/problems.git';
         exec($scriptFilename, $output, $returnVar);
         if ($returnVar != 0) {
             throw new Exception(

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -39,7 +39,6 @@ try_define('OMEGAUP_LOG_LEVEL', 'debug');
 # GRADER CONFIG
 # ####################################
 try_define('BIN_PATH', OMEGAUP_ROOT . '/../bin');
-try_define('GRADE_PATH', OMEGAUP_TEST_ROOT . 'grade');
 try_define('IMAGES_PATH', OMEGAUP_TEST_ROOT . 'img/');
 try_define('IMAGES_URL_PATH', '/img/');
 try_define('OMEGAUP_CACERT_URL', OMEGAUP_ROOT . '/omegaup.pem');

--- a/stuff/travis/nginx/config.php.tpl
+++ b/stuff/travis/nginx/config.php.tpl
@@ -1,7 +1,6 @@
 <?php
 define('OMEGAUP_ROOT', '${OMEGAUP_ROOT}/frontend');
 
-define('GRADE_PATH', '/tmp/omegaup/grade');
 define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', true);
 define('OMEGAUP_CSP_LOG_FILE', '/tmp/csp.log');
 define('OMEGAUP_DB_HOST', 'localhost');
@@ -13,5 +12,4 @@ define('OMEGAUP_DB_USER', 'travis');
 define('OMEGAUP_ENVIRONMENT', 'production');
 define('OMEGAUP_GRADER_FAKE', true);
 define('OMEGAUP_LOG_FILE', '/tmp/omegaup.log');
-define('PROBLEMS_GIT_PATH', '/tmp/omegaup/problems.git');
 define('SMARTY_CACHE_DIR', '/tmp');


### PR DESCRIPTION
Este cambio se deshace de alguas configuraciones que ya no se usan desde
que se separaron el frontend y el grader. Con esto se puede fácilmente
demostrar que ya no se comunican ambos mediante el sistema de archivos.