### PR TITLE
Compatibilidad con bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
     - release
 
 php:
-  - 7.0.7
+  - 7.0.33
 
 # Common sources and packages. If a matrix entry needs these, it should
 # explicitly add both of the sources and package YAML references in its addons

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -1,14 +1,5 @@
 <?php
 
-// Older (~Xenial) PHP Unit compatibility hack.
-// We should be able to remove this once we upgrade PHPUnit and/or PHP.
-namespace PHPUnit\Framework {
-    if (!class_exists('\\PHPUnit\\Framework\\TestCase')) {
-        class TestCase extends \PHPUnit_Framework_TestCase {
-        }
-    }
-}
-
 namespace {
     define('IS_TEST', true);
 
@@ -54,6 +45,7 @@ namespace {
     Utils::CleanPath(IMAGES_PATH);
     Utils::CleanPath(RUNS_PATH);
     Utils::CleanPath(TEMPLATES_PATH);
+    Utils::CleanPath(PROBLEMS_GIT_PATH);
 
     for ($i = 0; $i < 256; $i++) {
         mkdir(RUNS_PATH . sprintf('/%02x', $i), 0775, true);

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -49,7 +49,7 @@ try_define('OMEGAUP_SSLCERT_URL', OMEGAUP_ROOT . '/omegaup.pem');
 // We need to have this directory be NOT within the /opt/omegaup directory
 // since we intend to share it through VirtualBox, and that does not support
 // mmapping files, which is needed for libgit2.
-try_define('PROBLEMS_GIT_PATH', '/tmp/problems.git');
+try_define('PROBLEMS_GIT_PATH', '/tmp/omegaup/problems.git');
 try_define('RUNS_PATH', OMEGAUP_TEST_ROOT . 'submissions');
 try_define('TEMPLATES_PATH', OMEGAUP_TEST_ROOT . '/templates/');
 

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -170,10 +170,11 @@ def test_user_ranking_contest_when_scoreboard_show_time_finished(driver):
                     (By.XPATH,
                      '//a[starts-with(@href, "%s")]' % contest_url))).click()
 
-        # User checks the score, it should be 0 because broadcaster is turned
+        # User checks the score, it might be be 0 because broadcaster is turned
         # off in Travis, and the only way to get updated results while we are
         # on the same page is going back to the page.
-        check_ranking(driver, problem, driver.user_username, score='0')
+        check_ranking(driver, problem, driver.user_username,
+                      scores=['0', '100'])
 
         # User enters to problem in contest, the ranking for this problem
         # should update.
@@ -188,11 +189,11 @@ def test_user_ranking_contest_when_scoreboard_show_time_finished(driver):
             '//a[contains(@href, "problems/%s")]' % problem).click()
 
         # Now, user checks the score again, ranking should be 100
-        check_ranking(driver, problem, driver.user_username, score='100')
+        check_ranking(driver, problem, driver.user_username, scores=['100'])
 
 
 @util.annotate
-def check_ranking(driver, problem, user, *, score):
+def check_ranking(driver, problem, user, *, scores):
     ''' Check ranking for a contest'''
 
     driver.wait.until(
@@ -206,7 +207,7 @@ def check_ranking(driver, problem, user, *, score):
         '//tr[@class = "%s"]/td[contains(@class, "%s")]/div[@class = "points"]'
         % (user, problem))
 
-    assert ranking_problem.text == score, ranking_problem
+    assert ranking_problem.text in scores, ranking_problem
 
 
 @util.annotate

--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -56,4 +56,4 @@ fi
 
 /usr/bin/python3 $OMEGAUP_ROOT/stuff/database_schema.py validate $ARGS
 /usr/bin/python3 $OMEGAUP_ROOT/stuff/policy-tool.py validate
-/usr/bin/python3 $OMEGAUP_ROOT/stuff/hook_tools/lint.py validate $ARGS
+/usr/bin/docker run --rm -v "$OMEGAUP_ROOT:/src" -v "$OMEGAUP_ROOT:/opt/omegaup" omegaup/hook_tools -j4 validate $ARGS < /dev/null

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -20,11 +20,6 @@ stage_before_install() {
 }
 
 stage_before_script() {
-	DOWNLOAD_URL='https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.4.0/phpcbf.phar'
-	TARGET="/usr/bin/phpcbf"
-	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
-	sudo chmod +x "${TARGET}"
-
 	setup_phpenv
 }
 

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -12,9 +12,8 @@ stage_install() {
 	pip3 install --user wheel
 	pip3 install --user mysqlclient
 
-	# We should really try upgrading to PHP 7.1 soon.
 	curl -sSfL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit \
-		https://phar.phpunit.de/phpunit-5.7.phar
+		https://phar.phpunit.de/phpunit-6.5.9.phar
 
 	install_omegaup_gitserver
 }


### PR DESCRIPTION
Este cambio hace que omegaUp sea compatible con Ubuntu bionic. En
particular, actualiza a phpunit 6.5.9, que tampoco está soportado, pero
al menos es _un poco_ más nuevo que lo que estábamos usando.