### PR TITLE
Arreglando un error de traducción

### DIFF
--- a/frontend/server/libs/ApiException.php
+++ b/frontend/server/libs/ApiException.php
@@ -84,13 +84,16 @@ abstract class ApiException extends Exception {
     }
 
     protected function getErrorMessage() {
+        if (is_null($this->message)) {
+            self::$log->error('null error message');
+            return '{untranslated:(null)}';
+        }
         $localizedText = Translations::getInstance()->get($this->message);
         if (empty($localizedText)) {
             self::$log->error("Untranslated error message: {$this->message}");
             return "{untranslated:{$this->message}}";
-        } else {
-            return $localizedText;
         }
+        return $localizedText;
     }
 }
 


### PR DESCRIPTION
Este cambio hace que si se intenta regresar un error con mensaje nulo,
en vez de arrojar una segunda excepción, se procese la petición por
completo.