### PR TITLE
Agregando soporte para inyectar el script de New Relic

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -30,10 +30,53 @@ if (!(defined('IS_TEST') && IS_TEST === true)) {
     }
 }
 
-define('OMEGAUP_LOCKDOWN', isset($_SERVER['HTTP_HOST']) && strpos($_SERVER['HTTP_HOST'], OMEGAUP_LOCKDOWN_DOMAIN) === 0);
+define(
+    'OMEGAUP_LOCKDOWN',
+    isset(
+        $_SERVER['HTTP_HOST']
+    ) && strpos(
+        $_SERVER['HTTP_HOST'],
+        OMEGAUP_LOCKDOWN_DOMAIN
+    ) === 0
+);
 
-$csp_mode = 'Content-Security-Policy';
-header("$csp_mode: script-src 'self' https://www.google.com https://apis.google.com https://www.gstatic.com https://js-agent.newrelic.com https://bam.nr-data.net https://ssl.google-analytics.com https://connect.facebook.net https://platform.twitter.com; frame-src 'self' https://www.facebook.com https://web.facebook.com https://platform.twitter.com https://www.google.com https://apis.google.com https://accounts.google.com https://docs.google.com https://staticxx.facebook.com https://syndication.twitter.com; report-uri /cspreport.php");
+$contentSecurityPolicy = [
+    'script-src' => [
+        '\'self\'',
+        'https://www.google.com',
+        'https://apis.google.com',
+        'https://www.gstatic.com',
+        'https://js-agent.newrelic.com',
+        'https://bam.nr-data.net',
+        'https://ssl.google-analytics.com',
+        'https://connect.facebook.net',
+        'https://platform.twitter.com',
+    ],
+    'frame-src' => [
+        '\'self\'',
+        'https://www.facebook.com',
+        'https://web.facebook.com',
+        'https://platform.twitter.com',
+        'https://www.google.com',
+        'https://apis.google.com',
+        'https://accounts.google.com',
+        'https://docs.google.com',
+        'https://staticxx.facebook.com',
+        'https://syndication.twitter.com',
+    ],
+    'report-uri' => [
+        '/cspreport.php',
+    ],
+];
+if (!is_null(NEW_RELIC_SCRIPT_HASH)) {
+    array_push($contentSecurityPolicy['script-src'], NEW_RELIC_SCRIPT_HASH);
+}
+header('Content-Security-Policy: ' . implode('; ', array_map(
+    function ($k) use ($contentSecurityPolicy) {
+        return "{$k} " . implode(' ', $contentSecurityPolicy[$k]);
+    },
+    array_keys($contentSecurityPolicy)
+)));
 header('X-Frame-Options: DENY');
 
 require_once('libs/third_party/log4php/src/main/php/Logger.php');

--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -160,3 +160,9 @@ try_define('PASSWORD_RESET_MIN_WAIT', 5 * 60);
 try_define('AWS_CLI_ACCESS_KEY_ID', null);
 try_define('AWS_CLI_SECRET_ACCESS_KEY', null);
 try_define('AWS_CLI_BINARY', '/usr/bin/aws');
+
+# ########################
+# NEW RELIC CONFIG
+# ########################
+try_define('NEW_RELIC_SCRIPT', null);
+try_define('NEW_RELIC_SCRIPT_HASH', null);

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -2,6 +2,9 @@
 <html lang="{#locale#}">
 	<head data-locale="{#locale#}">
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+{if !is_null($smarty.const.NEW_RELIC_SCRIPT)}
+		{$smarty.const.NEW_RELIC_SCRIPT}
+{/if}
 {if isset($inArena) && $inArena}
 		{assign var='LOAD_MATHJAX' value='true'}
 		{assign var='navbarSection' value='arena'}


### PR DESCRIPTION
Este cambio hace un pequeño refactor para permitir agregar el hash del
script de New Relic Browser analytics desde el archivo de configuración.