### PR TITLE
Center figures in statements.

### DIFF
--- a/frontend/www/ux/arena.css
+++ b/frontend/www/ux/arena.css
@@ -267,6 +267,11 @@ body#only-problem #problems .main {
 	text-align: justify;
 }
 
+#problem .statement figure {
+	text-align: center;
+	page-break-inside: avoid;
+}
+
 #problem .statement table td {
 	border: 1px solid #000;
 	padding: 10px;


### PR DESCRIPTION
# Descripción

Se centran correctamente las figuras en los statements.

Antes:

![image](https://user-images.githubusercontent.com/468211/54872857-c0653b80-4d90-11e9-80d3-587028be2b65.png)

Después:

![image](https://user-images.githubusercontent.com/468211/54872855-b3e0e300-4d90-11e9-9cfe-67d5fe3d049e.png)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.