### PR TITLE
Mejorando la invocación de omegaup/hook_tools

### DIFF
--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -56,4 +56,7 @@ fi
 
 /usr/bin/python3 $OMEGAUP_ROOT/stuff/database_schema.py validate $ARGS
 /usr/bin/python3 $OMEGAUP_ROOT/stuff/policy-tool.py validate
-/usr/bin/docker run --rm -v "$OMEGAUP_ROOT:/src" -v "$OMEGAUP_ROOT:/opt/omegaup" omegaup/hook_tools -j4 validate $ARGS < /dev/null
+exec /usr/bin/docker run --interactive --tty --rm \
+	--volume "$OMEGAUP_ROOT:/src" \
+	--volume "$OMEGAUP_ROOT:$OMEGAUP_ROOT" \
+	omegaup/hook_tools -j4 validate $ARGS


### PR DESCRIPTION
Este cambio hace que la invocación de Docker para omegaup/hook_tools
ahora use un TTY interactivo. Esto hace que se puedan auto-ejecutar los
fixes automáticos.