### PR TITLE
Omitiendo las columans autogeneradas en `*DAO::create`

### DIFF
--- a/frontend/server/libs/dao/base/ACLs.dao.base.php
+++ b/frontend/server/libs/dao/base/ACLs.dao.base.php
@@ -153,9 +153,8 @@ abstract class ACLsDAOBase {
      * @param ACLs [$ACLs] El objeto de tipo ACLs a crear.
      */
     final public static function create(ACLs $ACLs) {
-        $sql = 'INSERT INTO ACLs (`acl_id`, `owner_id`) VALUES (?, ?);';
+        $sql = 'INSERT INTO ACLs (`owner_id`) VALUES (?);';
         $params = [
-            $ACLs->acl_id,
             $ACLs->owner_id,
         ];
         global $conn;

--- a/frontend/server/libs/dao/base/Announcement.dao.base.php
+++ b/frontend/server/libs/dao/base/Announcement.dao.base.php
@@ -158,9 +158,8 @@ abstract class AnnouncementDAOBase {
         if (is_null($Announcement->time)) {
             $Announcement->time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Announcement (`announcement_id`, `user_id`, `time`, `description`) VALUES (?, ?, ?, ?);';
+        $sql = 'INSERT INTO Announcement (`user_id`, `time`, `description`) VALUES (?, ?, ?);';
         $params = [
-            $Announcement->announcement_id,
             $Announcement->user_id,
             $Announcement->time,
             $Announcement->description,

--- a/frontend/server/libs/dao/base/Assignments.dao.base.php
+++ b/frontend/server/libs/dao/base/Assignments.dao.base.php
@@ -176,9 +176,8 @@ abstract class AssignmentsDAOBase {
         if (is_null($Assignments->order)) {
             $Assignments->order = '1';
         }
-        $sql = 'INSERT INTO Assignments (`assignment_id`, `course_id`, `problemset_id`, `acl_id`, `name`, `description`, `alias`, `publish_time_delay`, `assignment_type`, `start_time`, `finish_time`, `max_points`, `order`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Assignments (`course_id`, `problemset_id`, `acl_id`, `name`, `description`, `alias`, `publish_time_delay`, `assignment_type`, `start_time`, `finish_time`, `max_points`, `order`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Assignments->assignment_id,
             $Assignments->course_id,
             $Assignments->problemset_id,
             $Assignments->acl_id,

--- a/frontend/server/libs/dao/base/Badges.dao.base.php
+++ b/frontend/server/libs/dao/base/Badges.dao.base.php
@@ -159,9 +159,8 @@ abstract class BadgesDAOBase {
         if (is_null($Badges->name)) {
             $Badges->name = 'MyBadge';
         }
-        $sql = 'INSERT INTO Badges (`badge_id`, `name`, `image_url`, `description`, `hint`) VALUES (?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Badges (`name`, `image_url`, `description`, `hint`) VALUES (?, ?, ?, ?);';
         $params = [
-            $Badges->badge_id,
             $Badges->name,
             $Badges->image_url,
             $Badges->description,

--- a/frontend/server/libs/dao/base/Clarifications.dao.base.php
+++ b/frontend/server/libs/dao/base/Clarifications.dao.base.php
@@ -166,9 +166,8 @@ abstract class ClarificationsDAOBase {
         if (is_null($Clarifications->public)) {
             $Clarifications->public = '0';
         }
-        $sql = 'INSERT INTO Clarifications (`clarification_id`, `author_id`, `receiver_id`, `message`, `answer`, `time`, `problem_id`, `problemset_id`, `public`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Clarifications (`author_id`, `receiver_id`, `message`, `answer`, `time`, `problem_id`, `problemset_id`, `public`) VALUES (?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Clarifications->clarification_id,
             $Clarifications->author_id,
             $Clarifications->receiver_id,
             $Clarifications->message,

--- a/frontend/server/libs/dao/base/Coder_Of_The_Month.dao.base.php
+++ b/frontend/server/libs/dao/base/Coder_Of_The_Month.dao.base.php
@@ -161,9 +161,8 @@ abstract class CoderOfTheMonthDAOBase {
         if (is_null($Coder_Of_The_Month->time)) {
             $Coder_Of_The_Month->time = '2000-01-01';
         }
-        $sql = 'INSERT INTO Coder_Of_The_Month (`coder_of_the_month_id`, `user_id`, `description`, `time`, `interview_url`, `rank`, `selected_by`) VALUES (?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Coder_Of_The_Month (`user_id`, `description`, `time`, `interview_url`, `rank`, `selected_by`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
-            $Coder_Of_The_Month->coder_of_the_month_id,
             $Coder_Of_The_Month->user_id,
             $Coder_Of_The_Month->description,
             $Coder_Of_The_Month->time,

--- a/frontend/server/libs/dao/base/Contest_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Contest_Log.dao.base.php
@@ -160,9 +160,8 @@ abstract class ContestLogDAOBase {
         if (is_null($Contest_Log->time)) {
             $Contest_Log->time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Contest_Log (`public_contest_id`, `contest_id`, `user_id`, `from_admission_mode`, `to_admission_mode`, `time`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Contest_Log (`contest_id`, `user_id`, `from_admission_mode`, `to_admission_mode`, `time`) VALUES (?, ?, ?, ?, ?);';
         $params = [
-            $Contest_Log->public_contest_id,
             $Contest_Log->contest_id,
             $Contest_Log->user_id,
             $Contest_Log->from_admission_mode,

--- a/frontend/server/libs/dao/base/Contests.dao.base.php
+++ b/frontend/server/libs/dao/base/Contests.dao.base.php
@@ -211,9 +211,8 @@ abstract class ContestsDAOBase {
         if (is_null($Contests->recommended)) {
             $Contests->recommended = '0';
         }
-        $sql = 'INSERT INTO Contests (`contest_id`, `problemset_id`, `acl_id`, `title`, `description`, `start_time`, `finish_time`, `last_updated`, `window_length`, `rerun_id`, `admission_mode`, `alias`, `scoreboard`, `points_decay_factor`, `partial_score`, `submissions_gap`, `feedback`, `penalty`, `penalty_type`, `penalty_calc_policy`, `show_scoreboard_after`, `urgent`, `languages`, `recommended`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Contests (`problemset_id`, `acl_id`, `title`, `description`, `start_time`, `finish_time`, `last_updated`, `window_length`, `rerun_id`, `admission_mode`, `alias`, `scoreboard`, `points_decay_factor`, `partial_score`, `submissions_gap`, `feedback`, `penalty`, `penalty_type`, `penalty_calc_policy`, `show_scoreboard_after`, `urgent`, `languages`, `recommended`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Contests->contest_id,
             $Contests->problemset_id,
             $Contests->acl_id,
             $Contests->title,

--- a/frontend/server/libs/dao/base/Courses.dao.base.php
+++ b/frontend/server/libs/dao/base/Courses.dao.base.php
@@ -182,9 +182,8 @@ abstract class CoursesDAOBase {
         if (is_null($Courses->show_scoreboard)) {
             $Courses->show_scoreboard = '0';
         }
-        $sql = 'INSERT INTO Courses (`course_id`, `name`, `description`, `alias`, `group_id`, `acl_id`, `start_time`, `finish_time`, `public`, `school_id`, `needs_basic_information`, `requests_user_information`, `show_scoreboard`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Courses (`name`, `description`, `alias`, `group_id`, `acl_id`, `start_time`, `finish_time`, `public`, `school_id`, `needs_basic_information`, `requests_user_information`, `show_scoreboard`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Courses->course_id,
             $Courses->name,
             $Courses->description,
             $Courses->alias,

--- a/frontend/server/libs/dao/base/Emails.dao.base.php
+++ b/frontend/server/libs/dao/base/Emails.dao.base.php
@@ -154,9 +154,8 @@ abstract class EmailsDAOBase {
      * @param Emails [$Emails] El objeto de tipo Emails a crear.
      */
     final public static function create(Emails $Emails) {
-        $sql = 'INSERT INTO Emails (`email_id`, `email`, `user_id`) VALUES (?, ?, ?);';
+        $sql = 'INSERT INTO Emails (`email`, `user_id`) VALUES (?, ?);';
         $params = [
-            $Emails->email_id,
             $Emails->email,
             $Emails->user_id,
         ];

--- a/frontend/server/libs/dao/base/Groups.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups.dao.base.php
@@ -160,9 +160,8 @@ abstract class GroupsDAOBase {
         if (is_null($Groups->create_time)) {
             $Groups->create_time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Groups (`group_id`, `acl_id`, `create_time`, `alias`, `name`, `description`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Groups (`acl_id`, `create_time`, `alias`, `name`, `description`) VALUES (?, ?, ?, ?, ?);';
         $params = [
-            $Groups->group_id,
             $Groups->acl_id,
             $Groups->create_time,
             $Groups->alias,

--- a/frontend/server/libs/dao/base/Groups_Scoreboards.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards.dao.base.php
@@ -160,9 +160,8 @@ abstract class GroupsScoreboardsDAOBase {
         if (is_null($Groups_Scoreboards->create_time)) {
             $Groups_Scoreboards->create_time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Groups_Scoreboards (`group_scoreboard_id`, `group_id`, `create_time`, `alias`, `name`, `description`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Groups_Scoreboards (`group_id`, `create_time`, `alias`, `name`, `description`) VALUES (?, ?, ?, ?, ?);';
         $params = [
-            $Groups_Scoreboards->group_scoreboard_id,
             $Groups_Scoreboards->group_id,
             $Groups_Scoreboards->create_time,
             $Groups_Scoreboards->alias,

--- a/frontend/server/libs/dao/base/Identities.dao.base.php
+++ b/frontend/server/libs/dao/base/Identities.dao.base.php
@@ -161,9 +161,8 @@ abstract class IdentitiesDAOBase {
      * @param Identities [$Identities] El objeto de tipo Identities a crear.
      */
     final public static function create(Identities $Identities) {
-        $sql = 'INSERT INTO Identities (`identity_id`, `username`, `password`, `name`, `user_id`, `language_id`, `country_id`, `state_id`, `school_id`, `gender`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Identities (`username`, `password`, `name`, `user_id`, `language_id`, `country_id`, `state_id`, `school_id`, `gender`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Identities->identity_id,
             $Identities->username,
             $Identities->password,
             $Identities->name,

--- a/frontend/server/libs/dao/base/Interviews.dao.base.php
+++ b/frontend/server/libs/dao/base/Interviews.dao.base.php
@@ -158,9 +158,8 @@ abstract class InterviewsDAOBase {
      * @param Interviews [$Interviews] El objeto de tipo Interviews a crear.
      */
     final public static function create(Interviews $Interviews) {
-        $sql = 'INSERT INTO Interviews (`interview_id`, `problemset_id`, `acl_id`, `alias`, `title`, `description`, `window_length`) VALUES (?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Interviews (`problemset_id`, `acl_id`, `alias`, `title`, `description`, `window_length`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
-            $Interviews->interview_id,
             $Interviews->problemset_id,
             $Interviews->acl_id,
             $Interviews->alias,

--- a/frontend/server/libs/dao/base/Languages.dao.base.php
+++ b/frontend/server/libs/dao/base/Languages.dao.base.php
@@ -154,9 +154,8 @@ abstract class LanguagesDAOBase {
      * @param Languages [$Languages] El objeto de tipo Languages a crear.
      */
     final public static function create(Languages $Languages) {
-        $sql = 'INSERT INTO Languages (`language_id`, `name`, `country_id`) VALUES (?, ?, ?);';
+        $sql = 'INSERT INTO Languages (`name`, `country_id`) VALUES (?, ?);';
         $params = [
-            $Languages->language_id,
             $Languages->name,
             $Languages->country_id,
         ];

--- a/frontend/server/libs/dao/base/Messages.dao.base.php
+++ b/frontend/server/libs/dao/base/Messages.dao.base.php
@@ -163,9 +163,8 @@ abstract class MessagesDAOBase {
         if (is_null($Messages->date)) {
             $Messages->date = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Messages (`message_id`, `read`, `sender_id`, `recipient_id`, `message`, `date`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Messages (`read`, `sender_id`, `recipient_id`, `message`, `date`) VALUES (?, ?, ?, ?, ?);';
         $params = [
-            $Messages->message_id,
             $Messages->read,
             $Messages->sender_id,
             $Messages->recipient_id,

--- a/frontend/server/libs/dao/base/Permissions.dao.base.php
+++ b/frontend/server/libs/dao/base/Permissions.dao.base.php
@@ -154,9 +154,8 @@ abstract class PermissionsDAOBase {
      * @param Permissions [$Permissions] El objeto de tipo Permissions a crear.
      */
     final public static function create(Permissions $Permissions) {
-        $sql = 'INSERT INTO Permissions (`permission_id`, `name`, `description`) VALUES (?, ?, ?);';
+        $sql = 'INSERT INTO Permissions (`name`, `description`) VALUES (?, ?);';
         $params = [
-            $Permissions->permission_id,
             $Permissions->name,
             $Permissions->description,
         ];

--- a/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.dao.base.php
@@ -158,9 +158,8 @@ abstract class PrivacyStatementConsentLogDAOBase {
         if (is_null($PrivacyStatement_Consent_Log->timestamp)) {
             $PrivacyStatement_Consent_Log->timestamp = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO PrivacyStatement_Consent_Log (`privacystatement_consent_id`, `identity_id`, `privacystatement_id`, `timestamp`) VALUES (?, ?, ?, ?);';
+        $sql = 'INSERT INTO PrivacyStatement_Consent_Log (`identity_id`, `privacystatement_id`, `timestamp`) VALUES (?, ?, ?);';
         $params = [
-            $PrivacyStatement_Consent_Log->privacystatement_consent_id,
             $PrivacyStatement_Consent_Log->identity_id,
             $PrivacyStatement_Consent_Log->privacystatement_id,
             $PrivacyStatement_Consent_Log->timestamp,

--- a/frontend/server/libs/dao/base/PrivacyStatements.dao.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatements.dao.base.php
@@ -157,9 +157,8 @@ abstract class PrivacyStatementsDAOBase {
         if (is_null($PrivacyStatements->type)) {
             $PrivacyStatements->type = 'privacy_policy';
         }
-        $sql = 'INSERT INTO PrivacyStatements (`privacystatement_id`, `git_object_id`, `type`) VALUES (?, ?, ?);';
+        $sql = 'INSERT INTO PrivacyStatements (`git_object_id`, `type`) VALUES (?, ?);';
         $params = [
-            $PrivacyStatements->privacystatement_id,
             $PrivacyStatements->git_object_id,
             $PrivacyStatements->type,
         ];

--- a/frontend/server/libs/dao/base/Problem_Of_The_Week.dao.base.php
+++ b/frontend/server/libs/dao/base/Problem_Of_The_Week.dao.base.php
@@ -158,9 +158,8 @@ abstract class ProblemOfTheWeekDAOBase {
         if (is_null($Problem_Of_The_Week->time)) {
             $Problem_Of_The_Week->time = '2000-01-01';
         }
-        $sql = 'INSERT INTO Problem_Of_The_Week (`problem_of_the_week_id`, `problem_id`, `time`, `difficulty`) VALUES (?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problem_Of_The_Week (`problem_id`, `time`, `difficulty`) VALUES (?, ?, ?);';
         $params = [
-            $Problem_Of_The_Week->problem_of_the_week_id,
             $Problem_Of_The_Week->problem_id,
             $Problem_Of_The_Week->time,
             $Problem_Of_The_Week->difficulty,

--- a/frontend/server/libs/dao/base/Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems.dao.base.php
@@ -238,9 +238,8 @@ abstract class ProblemsDAOBase {
         if (is_null($Problems->email_clarifications)) {
             $Problems->email_clarifications = '0';
         }
-        $sql = 'INSERT INTO Problems (`problem_id`, `acl_id`, `visibility`, `title`, `alias`, `validator`, `languages`, `server`, `remote_id`, `time_limit`, `validator_time_limit`, `overall_wall_time_limit`, `extra_wall_time`, `memory_limit`, `output_limit`, `input_limit`, `visits`, `submissions`, `accepted`, `difficulty`, `creation_date`, `source`, `order`, `tolerance`, `slow`, `deprecated`, `email_clarifications`, `quality`, `quality_histogram`, `difficulty_histogram`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problems (`acl_id`, `visibility`, `title`, `alias`, `validator`, `languages`, `server`, `remote_id`, `time_limit`, `validator_time_limit`, `overall_wall_time_limit`, `extra_wall_time`, `memory_limit`, `output_limit`, `input_limit`, `visits`, `submissions`, `accepted`, `difficulty`, `creation_date`, `source`, `order`, `tolerance`, `slow`, `deprecated`, `email_clarifications`, `quality`, `quality_histogram`, `difficulty_histogram`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Problems->problem_id,
             $Problems->acl_id,
             $Problems->visibility,
             $Problems->title,

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request_History.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request_History.dao.base.php
@@ -160,9 +160,8 @@ abstract class ProblemsetIdentityRequestHistoryDAOBase {
         if (is_null($Problemset_Identity_Request_History->time)) {
             $Problemset_Identity_Request_History->time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO Problemset_Identity_Request_History (`history_id`, `identity_id`, `problemset_id`, `time`, `accepted`, `admin_id`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problemset_Identity_Request_History (`identity_id`, `problemset_id`, `time`, `accepted`, `admin_id`) VALUES (?, ?, ?, ?, ?);';
         $params = [
-            $Problemset_Identity_Request_History->history_id,
             $Problemset_Identity_Request_History->identity_id,
             $Problemset_Identity_Request_History->problemset_id,
             $Problemset_Identity_Request_History->time,

--- a/frontend/server/libs/dao/base/Problemsets.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemsets.dao.base.php
@@ -175,9 +175,8 @@ abstract class ProblemsetsDAOBase {
         if (is_null($Problemsets->type)) {
             $Problemsets->type = 'Contest';
         }
-        $sql = 'INSERT INTO Problemsets (`problemset_id`, `acl_id`, `access_mode`, `languages`, `needs_basic_information`, `requests_user_information`, `scoreboard_url`, `scoreboard_url_admin`, `type`, `contest_id`, `assignment_id`, `interview_id`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problemsets (`acl_id`, `access_mode`, `languages`, `needs_basic_information`, `requests_user_information`, `scoreboard_url`, `scoreboard_url_admin`, `type`, `contest_id`, `assignment_id`, `interview_id`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Problemsets->problemset_id,
             $Problemsets->acl_id,
             $Problemsets->access_mode,
             $Problemsets->languages,

--- a/frontend/server/libs/dao/base/QualityNomination_Comments.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Comments.dao.base.php
@@ -160,9 +160,8 @@ abstract class QualityNominationCommentsDAOBase {
         if (is_null($QualityNomination_Comments->time)) {
             $QualityNomination_Comments->time = gmdate('Y-m-d H:i:s');
         }
-        $sql = 'INSERT INTO QualityNomination_Comments (`qualitynomination_comment_id`, `qualitynomination_id`, `user_id`, `time`, `vote`, `contents`) VALUES (?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO QualityNomination_Comments (`qualitynomination_id`, `user_id`, `time`, `vote`, `contents`) VALUES (?, ?, ?, ?, ?);';
         $params = [
-            $QualityNomination_Comments->qualitynomination_comment_id,
             $QualityNomination_Comments->qualitynomination_id,
             $QualityNomination_Comments->user_id,
             $QualityNomination_Comments->time,

--- a/frontend/server/libs/dao/base/QualityNomination_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Log.dao.base.php
@@ -167,9 +167,8 @@ abstract class QualityNominationLogDAOBase {
         if (is_null($QualityNomination_Log->to_status)) {
             $QualityNomination_Log->to_status = 'open';
         }
-        $sql = 'INSERT INTO QualityNomination_Log (`qualitynomination_log_id`, `qualitynomination_id`, `time`, `user_id`, `from_status`, `to_status`, `rationale`) VALUES (?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO QualityNomination_Log (`qualitynomination_id`, `time`, `user_id`, `from_status`, `to_status`, `rationale`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
-            $QualityNomination_Log->qualitynomination_log_id,
             $QualityNomination_Log->qualitynomination_id,
             $QualityNomination_Log->time,
             $QualityNomination_Log->user_id,

--- a/frontend/server/libs/dao/base/QualityNominations.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNominations.dao.base.php
@@ -167,9 +167,8 @@ abstract class QualityNominationsDAOBase {
         if (is_null($QualityNominations->status)) {
             $QualityNominations->status = 'open';
         }
-        $sql = 'INSERT INTO QualityNominations (`qualitynomination_id`, `user_id`, `problem_id`, `nomination`, `contents`, `time`, `status`) VALUES (?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO QualityNominations (`user_id`, `problem_id`, `nomination`, `contents`, `time`, `status`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
-            $QualityNominations->qualitynomination_id,
             $QualityNominations->user_id,
             $QualityNominations->problem_id,
             $QualityNominations->nomination,

--- a/frontend/server/libs/dao/base/Roles.dao.base.php
+++ b/frontend/server/libs/dao/base/Roles.dao.base.php
@@ -154,9 +154,8 @@ abstract class RolesDAOBase {
      * @param Roles [$Roles] El objeto de tipo Roles a crear.
      */
     final public static function create(Roles $Roles) {
-        $sql = 'INSERT INTO Roles (`role_id`, `name`, `description`) VALUES (?, ?, ?);';
+        $sql = 'INSERT INTO Roles (`name`, `description`) VALUES (?, ?);';
         $params = [
-            $Roles->role_id,
             $Roles->name,
             $Roles->description,
         ];

--- a/frontend/server/libs/dao/base/Runs.dao.base.php
+++ b/frontend/server/libs/dao/base/Runs.dao.base.php
@@ -192,9 +192,8 @@ abstract class RunsDAOBase {
         if (is_null($Runs->type)) {
             $Runs->type = 'normal';
         }
-        $sql = 'INSERT INTO Runs (`run_id`, `identity_id`, `problem_id`, `problemset_id`, `guid`, `language`, `status`, `verdict`, `runtime`, `penalty`, `memory`, `score`, `contest_score`, `time`, `submit_delay`, `judged_by`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Runs (`identity_id`, `problem_id`, `problemset_id`, `guid`, `language`, `status`, `verdict`, `runtime`, `penalty`, `memory`, `score`, `contest_score`, `time`, `submit_delay`, `judged_by`, `type`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Runs->run_id,
             $Runs->identity_id,
             $Runs->problem_id,
             $Runs->problemset_id,

--- a/frontend/server/libs/dao/base/Schools.dao.base.php
+++ b/frontend/server/libs/dao/base/Schools.dao.base.php
@@ -155,9 +155,8 @@ abstract class SchoolsDAOBase {
      * @param Schools [$Schools] El objeto de tipo Schools a crear.
      */
     final public static function create(Schools $Schools) {
-        $sql = 'INSERT INTO Schools (`school_id`, `country_id`, `state_id`, `name`) VALUES (?, ?, ?, ?);';
+        $sql = 'INSERT INTO Schools (`country_id`, `state_id`, `name`) VALUES (?, ?, ?);';
         $params = [
-            $Schools->school_id,
             $Schools->country_id,
             $Schools->state_id,
             $Schools->name,

--- a/frontend/server/libs/dao/base/Tags.dao.base.php
+++ b/frontend/server/libs/dao/base/Tags.dao.base.php
@@ -153,9 +153,8 @@ abstract class TagsDAOBase {
      * @param Tags [$Tags] El objeto de tipo Tags a crear.
      */
     final public static function create(Tags $Tags) {
-        $sql = 'INSERT INTO Tags (`tag_id`, `name`) VALUES (?, ?);';
+        $sql = 'INSERT INTO Tags (`name`) VALUES (?);';
         $params = [
-            $Tags->tag_id,
             $Tags->name,
         ];
         global $conn;

--- a/frontend/server/libs/dao/base/Users.dao.base.php
+++ b/frontend/server/libs/dao/base/Users.dao.base.php
@@ -183,9 +183,8 @@ abstract class UsersDAOBase {
         if (is_null($Users->is_private)) {
             $Users->is_private = '0';
         }
-        $sql = 'INSERT INTO Users (`user_id`, `username`, `facebook_user_id`, `password`, `main_email_id`, `main_identity_id`, `name`, `country_id`, `state_id`, `school_id`, `scholar_degree`, `language_id`, `graduation_date`, `birth_date`, `gender`, `verified`, `verification_id`, `reset_digest`, `reset_sent_at`, `hide_problem_tags`, `in_mailing_list`, `is_private`, `preferred_language`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Users (`username`, `facebook_user_id`, `password`, `main_email_id`, `main_identity_id`, `name`, `country_id`, `state_id`, `school_id`, `scholar_degree`, `language_id`, `graduation_date`, `birth_date`, `gender`, `verified`, `verification_id`, `reset_digest`, `reset_sent_at`, `hide_problem_tags`, `in_mailing_list`, `is_private`, `preferred_language`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
-            $Users->user_id,
             $Users->username,
             $Users->facebook_user_id,
             $Users->password,

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -173,9 +173,9 @@ abstract class {{ table.class_name }}DAOBase {
 {%- endif %}
         }
 {%- endfor %}
-        $sql = 'INSERT INTO {{ table.name }} ({{ table.columns|listformat('`{.name}`', table=table)|join(', ') }}) VALUES ({{ table.columns|listformat('?', table=table)|join(', ') }});';
+        $sql = 'INSERT INTO {{ table.name }} ({{ table.columns|rejectattr('auto_increment')|listformat('`{.name}`', table=table)|join(', ') }}) VALUES ({{ table.columns|rejectattr('auto_increment')|listformat('?', table=table)|join(', ') }});';
         $params = [
-{%- for column in table.columns %}
+{%- for column in table.columns|rejectattr('auto_increment') %}
             ${{ table.name }}->{{column.name}},
 {%- endfor %}
         ];


### PR DESCRIPTION
Como la intención de los métodos `*DAO::create` en las tablas
autogeneradas es el autopoblar dichas columnas, no tiene sentido agregar
esas columnas en la consulta o en los parámetros.