### PR TITLE
Arreglando /api/contest/${ALIAS}/download/

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -2667,37 +2667,11 @@ class ContestController extends Controller {
 
         self::validateStats($r);
 
-        // Get our runs
-        try {
-            $runs = RunsDAO::getByContest($r['contest']->contest_id);
-        } catch (Exception $e) {
-            // Operation failed in the data layer
-            throw new InvalidDatabaseOperationException($e);
-        }
-
         include_once 'libs/third_party/ZipStream.php';
-        $zip = new ZipStream($r['contest_alias'] . '.zip');
-
-        // Add runs to zip
-        $table = "guid,user,problem,verdict,points\n";
-        foreach ($runs as $run) {
-            $zip->add_file(
-                'runs/' . $run->guid,
-                RunController::getRunSource($run)
-            );
-
-            $columns[0] = 'username';
-            $columns[1] = 'alias';
-            $usernameProblemData = $run->asFilteredArray($columns);
-
-            $table .= $run->guid . ',' . $usernameProblemData['username'] . ',' . $usernameProblemData['alias'] . ',' . $run->verdict . ',' . $run->contest_score;
-            $table .= "\n";
-        }
-
-        $zip->add_file('summary.csv', $table);
-
-        // Return zip
+        $zip = new ZipStream("{$r['contest_alias']}.zip");
+        ProblemsetController::downloadRuns($r['contest']->problemset_id, $zip);
         $zip->finish();
+
         die();
     }
 

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -194,4 +194,29 @@ class ProblemsetController extends Controller {
         }
         return $r;
     }
+
+    /**
+     * Downloads all the runs of the problemset.
+     *
+     * @param $problemsetId integer The problemset ID.
+     * @param $zip ZipStream The object that represents the .zip file.
+     */
+    public static function downloadRuns(int $problemsetId, ZipStream $zip): void {
+        try {
+            $runs = RunsDAO::getByProblemset($problemsetId);
+        } catch (Exception $e) {
+            // Operation failed in the data layer
+            throw new InvalidDatabaseOperationException($e);
+        }
+
+        $table = ['guid,user,problem,verdict,points'];
+        foreach ($runs as $run) {
+            $zip->add_file(
+                "runs/{$run['guid']}.{$run['language']}",
+                RunController::getRunSource($run['guid'])
+            );
+            $table[] = "{$run['guid']},{$run['username']},{$run['alias']},{$run['verdict']},{$run['contest_score']}";
+        }
+        $zip->add_file('summary.csv', implode("\n", $table));
+    }
 }

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -714,15 +714,15 @@ class RunController extends Controller {
         return $response;
     }
 
-    public static function getRunSource(Runs $run) {
-        return Grader::GetInstance()->getSource($run->guid);
+    public static function getRunSource(string $guid) {
+        return Grader::GetInstance()->getSource($guid);
     }
 
     private static function populateRunDetails(Runs $run, $showDetails, &$response) {
         if (OMEGAUP_LOCKDOWN) {
             $response['source'] = 'lockdownDetailsDisabled';
         } else {
-            $response['source'] = RunController::getRunSource($run);
+            $response['source'] = RunController::getRunSource($run->guid);
         }
         if (!$showDetails && $run->verdict != 'CE') {
             return;

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -537,47 +537,40 @@ class RunsDAO extends RunsDAOBase {
         return $ar;
     }
 
-    final public static function getByContest($contest_id) {
-        $sql = 'SELECT
-                    `run_id`,
-                    `guid`,
-                    `language`,
-                    `status`,
-                    `verdict`,
-                    `runtime`,
-                    `penalty`,
-                    `memory`,
-                    `score`,
-                    `contest_score`,
-                    `time`,
-                    `submit_delay`,
-                    `Identities.username`,
-                    `Problems.alias`
-                FROM
-                    Runs r
-                INNER JOIN
-                    Contests c
-                ON
-                    c.problemset_id = r.problemset_id
-                INNER JOIN
-                    Problems p
-                ON
-                    p.problem_id = r.problem_id
-                INNER JOIN
-                    Identities i
-                ON
-                    i.identity_id = r.identity_id
-                WHERE
-                    c.contest_id = ?
-                ORDER BY
-                    `time` DESC;';
+    final public static function getByProblemset($problemset_id) {
+        $sql = '
+            SELECT
+                guid,
+                language,
+                verdict,
+                contest_score,
+                i.username,
+                p.alias
+            FROM
+                Runs r
+            INNER JOIN
+                Problems p
+            ON
+                p.problem_id = r.problem_id
+            INNER JOIN
+                Problemset_Problems pp
+            ON
+                pp.problemset_id = r.problemset_id AND
+                pp.version = r.version
+            INNER JOIN
+                Identities i
+            ON
+                i.identity_id = r.identity_id
+            WHERE
+                r.problemset_id = ?
+            ORDER BY
+                r.`time` DESC;
+        ';
 
         global $conn;
-        $rs = $conn->Execute($sql, [$contest_id]);
-
         $runs = [];
-        foreach ($rs as $row) {
-            array_push($runs, new Runs($row));
+        foreach ($conn->Execute($sql, [$problemset_id]) as $row) {
+            array_push($runs, $row);
         }
         return $runs;
     }

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -633,4 +633,76 @@ class ContestDetailsTest extends OmegaupTestCase {
             $this->assertEquals('userNotAllowed', $e->getMessage());
         }
     }
+
+    /**
+     * Check that the download functionality works.
+     */
+    public function testDownload() {
+        $contestData = ContestsFactory::createContest();
+        $contestDirector = $contestData['director'];
+
+        // Get a problem
+        $problemData = ProblemsFactory::createProblemWithAuthor($contestDirector);
+
+        // Add the problem to the contest
+        ContestsFactory::addProblemToContest($problemData, $contestData);
+
+        // Create our contestants
+        $contestants = [];
+        array_push($contestants, UserFactory::createUser());
+        array_push($contestants, UserFactory::createUser());
+
+        $detourGrader = new ScopedGraderDetour();
+
+        // Create runs
+        $runsData = [];
+        {
+            $run = RunsFactory::createRun($problemData, $contestData, $contestants[0]);
+            RunsFactory::gradeRun($run, 0, 'CE');
+            $runsData[] = $run;
+        }
+
+        {
+            Time::setTimeForTesting(Time::get() + 60);
+            $run = RunsFactory::createRun($problemData, $contestData, $contestants[0]);
+            RunsFactory::gradeRun($run, 1, 'AC', 60);
+            $runsData[] = $run;
+        }
+
+        {
+            Time::setTimeForTesting(Time::get() + 60);
+            $run = RunsFactory::createRun($problemData, $contestData, $contestants[1]);
+            RunsFactory::gradeRun($run, .9, 'PA');
+            $runsData[] = $run;
+        }
+
+        // Create a mock that stores the file name-contents mapping into an associative array.
+        $files = [];
+        include_once 'libs/third_party/ZipStream.php';
+        $zip = $this->createMock(ZipStream::class);
+        $zip->method('add_file')
+            ->will($this->returnCallback(function (
+                string $path,
+                string $contents,
+                array $opt = []
+            ) use (&$files) {
+                $files[$path] = $contents;
+            }));
+
+        ProblemsetController::downloadRuns($contestData['contest']->problemset_id, $zip);
+
+        // Verify that the data is there.
+        $summary = $files['summary.csv'];
+        $this->assertNotEquals($summary, '');
+        foreach ($runsData as $runData) {
+            $this->assertEquals(
+                $files["runs/{$runData['response']['guid']}.{$runData['request']['language']}"],
+                $runData['request']['source']
+            );
+            $this->assertContains(
+                "{$runData['response']['guid']},{$runData['contestant']->username},{$problemData['problem']->alias}",
+                $summary
+            );
+        }
+    }
 }


### PR DESCRIPTION
Este cambio arregla ese API que lleva roto desde hace meses porque le
estaba pasando los resultados de la consulta SQL al constructor de Runs,
que se deshace de las columnas que no conoce. También agrega una prueba
para evitar que se vuelva a romper sin que nos demos cuenta.
