### PR TITLE
Arreglando la lógica de "des-enviar" cuando hay errores

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -329,7 +329,7 @@ class RunController extends Controller {
                 // because the Run row would not be visible from the Grader
                 // process, so we attempt to roll it back by hand.
                 RunsDAO::delete($run);
-                SubmissionsDAO::delete($run);
+                SubmissionsDAO::delete($submission);
                 self::$log->error("Call to Grader::grade() failed: $e");
                 throw $e;
             }


### PR DESCRIPTION
Este cambio hace que se puedan des-enviar envíos cuando el Grader falla
en persistir el envío en su sistema de archivos.