### PR TITLE
Actualizando Runs::current_run_id antes de invocar al Grader

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -320,6 +320,8 @@ class RunController extends Controller {
             SubmissionsDAO::create($submission);
             $run->submission_id = $submission->submission_id;
             RunsDAO::create($run);
+            $submission->current_run_id = $run->run_id;
+            SubmissionsDAO::update($submission);
 
             // Call Grader
             try {
@@ -333,9 +335,6 @@ class RunController extends Controller {
                 self::$log->error("Call to Grader::grade() failed: $e");
                 throw $e;
             }
-
-            $submission->current_run_id = $run->run_id;
-            SubmissionsDAO::update($submission);
 
             SubmissionLogDAO::create(new SubmissionLog([
                 'user_id' => $r['current_user_id'],


### PR DESCRIPTION
Este cambio hace que el Grader pueda usar current_run_id para hacer la
correlación entre envíos y ejecuciones y evitar comparaciones caras de
hashes SHA-1.