### PR TITLE
Changes for new assignment button

### DIFF
--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -28,7 +28,7 @@ OmegaUp.on('ready', function() {
         window.location.hash = tabName;
         if (tabName.split('#')[1] !== 'assignments') {
           assignmentDetails.show = false;
-          manageNewAssignmentButton(true);
+          updateNewAssignmentButtonVisibility(true);
         }
         $(this).tab('show');
       });
@@ -41,11 +41,12 @@ OmegaUp.on('ready', function() {
   var defaultStartTime = Date.create(defaultDate);
   defaultDate.setHours(defaultDate.getHours() + 5);
   var defaultFinishTime = Date.create(defaultDate);
-  function manageNewAssignmentButton(status) {
-    let newStatus = (status ? 'block' : 'none');
-    let buttonNewAssignment = document.querySelector('form.new');
-    buttonNewAssignment.setAttribute('style', 'display:' + newStatus + ';');
+
+  function updateNewAssignmentButtonVisibility(visible) {
+    document.querySelector('form.new').style.display =
+        (visible ? 'initial' : 'none');
   }
+
   function onNewAssignment(assignmentType) {
     assignmentDetails.show = true;
     assignmentDetails.update = false;
@@ -54,7 +55,7 @@ OmegaUp.on('ready', function() {
       finish_time: defaultFinishTime,
       assignment_type: assignmentType,
     };
-    manageNewAssignmentButton(false);
+    updateNewAssignmentButtonVisibility(false);
 
     // Vue lazily updates the DOM, so any interactions with `$el` need to
     // wait until the update is done.
@@ -166,7 +167,7 @@ OmegaUp.on('ready', function() {
             assignmentDetails.update = true;
             assignmentDetails.assignment = assignment;
             assignmentDetails.$el.scrollIntoView();
-            manageNewAssignmentButton(true);
+            updateNewAssignmentButtonVisibility(true);
           },
           'delete': function(assignment) {
             if (!window.confirm(
@@ -262,7 +263,7 @@ OmegaUp.on('ready', function() {
                                 })
                   .then(function(data) {
                     omegaup.UI.success(omegaup.T.courseAssignmentAdded);
-                    manageNewAssignmentButton(true);
+                    updateNewAssignmentButtonVisibility(true);
                     refreshAssignmentsList();
                   })
                   .fail(function(error) {
@@ -274,7 +275,7 @@ OmegaUp.on('ready', function() {
           },
           cancel: function() {
             assignmentDetails.show = false;
-            manageNewAssignmentButton(true);
+            updateNewAssignmentButtonVisibility(true);
           },
         },
       });

--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -24,7 +24,7 @@ OmegaUp.on('ready', function() {
       .on('click', 'a', function(e) {
         e.preventDefault();
         // add this line
-        let tabName = $(this).attr('href');
+        var tabName = $(this).attr('href');
         window.location.hash = tabName;
         if (tabName.split('#')[1] !== 'assignments') {
           assignmentDetails.show = false;

--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -24,7 +24,12 @@ OmegaUp.on('ready', function() {
       .on('click', 'a', function(e) {
         e.preventDefault();
         // add this line
-        window.location.hash = $(this).attr('href');
+        let tabName = $(this).attr('href');
+        window.location.hash = tabName;
+        if (tabName.split('#')[1] !== 'assignments') {
+          assignmentDetails.show = false;
+          manageNewAssignmentButton(true);
+        }
         $(this).tab('show');
       });
 
@@ -36,7 +41,11 @@ OmegaUp.on('ready', function() {
   var defaultStartTime = Date.create(defaultDate);
   defaultDate.setHours(defaultDate.getHours() + 5);
   var defaultFinishTime = Date.create(defaultDate);
-
+  function manageNewAssignmentButton(status) {
+    let newStatus = (status ? 'block' : 'none');
+    let buttonNewAssignment = document.querySelector('form.new');
+    buttonNewAssignment.setAttribute('style', 'display:' + newStatus + ';');
+  }
   function onNewAssignment(assignmentType) {
     assignmentDetails.show = true;
     assignmentDetails.update = false;
@@ -45,6 +54,8 @@ OmegaUp.on('ready', function() {
       finish_time: defaultFinishTime,
       assignment_type: assignmentType,
     };
+    manageNewAssignmentButton(false);
+
     // Vue lazily updates the DOM, so any interactions with `$el` need to
     // wait until the update is done.
     Vue.nextTick(function() { assignmentDetails.$el.scrollIntoView(); });
@@ -155,6 +166,7 @@ OmegaUp.on('ready', function() {
             assignmentDetails.update = true;
             assignmentDetails.assignment = assignment;
             assignmentDetails.$el.scrollIntoView();
+            manageNewAssignmentButton(true);
           },
           'delete': function(assignment) {
             if (!window.confirm(
@@ -250,6 +262,7 @@ OmegaUp.on('ready', function() {
                                 })
                   .then(function(data) {
                     omegaup.UI.success(omegaup.T.courseAssignmentAdded);
+                    manageNewAssignmentButton(true);
                     refreshAssignmentsList();
                   })
                   .fail(function(error) {
@@ -259,7 +272,10 @@ OmegaUp.on('ready', function() {
             }
             assignmentDetails.show = false;
           },
-          cancel: function() { assignmentDetails.show = false; },
+          cancel: function() {
+            assignmentDetails.show = false;
+            manageNewAssignmentButton(true);
+          },
         },
       });
     },


### PR DESCRIPTION
# Descripción
Se arregla el comportamiento del botón que agrega nueva tarea/examen en los cursos de omegaUp para escuelas, y que el formulario aparezca según corresponda. También se consideró el caso cuando se está actualizando una tarea.

Al hacer click
**Antes**
![image](https://user-images.githubusercontent.com/12377916/56086551-d1005300-5e1e-11e9-9257-53352178eb06.png)

**Después**
![image](https://user-images.githubusercontent.com/12377916/56086558-fdb46a80-5e1e-11e9-9ccf-6f2c2fd44fe7.png)

Fixes: #2331 

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
