### PR TITLE
 Tercer intento de arreglar los des-envíos en caso de errores

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -320,8 +320,6 @@ class RunController extends Controller {
             SubmissionsDAO::create($submission);
             $run->submission_id = $submission->submission_id;
             RunsDAO::create($run);
-            $submission->current_run_id = $run->run_id;
-            SubmissionsDAO::update($submission);
 
             // Call Grader
             try {
@@ -335,6 +333,11 @@ class RunController extends Controller {
                 self::$log->error("Call to Grader::grade() failed: $e");
                 throw $e;
             }
+
+            // Now that the Grader has ACKed the submission, we can set the
+            // link between the submission and the run.
+            $submission->current_run_id = $run->run_id;
+            SubmissionsDAO::update($submission);
 
             SubmissionLogDAO::create(new SubmissionLog([
                 'user_id' => $r['current_user_id'],


### PR DESCRIPTION
Resulta que diferir el enlace entre envío y evaluación hasta después de
que el Grader acepte el envío no fue tan buena idea porque luego es
bastante más complicado encontrar el envío si se le proporciona el GUID.
Mejor des-hagamos el enlace antes de eliminar las filas.