### PR TITLE
Arreglando el enlace entre envíos y ejecuciones

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -320,6 +320,8 @@ class RunController extends Controller {
             SubmissionsDAO::create($submission);
             $run->submission_id = $submission->submission_id;
             RunsDAO::create($run);
+            $submission->current_run_id = $run->run_id;
+            SubmissionsDAO::update($submission);
 
             // Call Grader
             try {
@@ -338,11 +340,6 @@ class RunController extends Controller {
                 self::$log->error("Call to Grader::grade() failed: $e");
                 throw $e;
             }
-
-            // Now that the Grader has ACKed the submission, we can set the
-            // link between the submission and the run.
-            $submission->current_run_id = $run->run_id;
-            SubmissionsDAO::update($submission);
 
             SubmissionLogDAO::create(new SubmissionLog([
                 'user_id' => $r['current_user_id'],


### PR DESCRIPTION
Resulta ser que debido a un problema al hacer un merge en un commit
pasado, no se movieron unas líneas que debioeron haberse movido.

Ahora sí debería soportarse bien la separación de envíos y ejecuciones
en el grader.