### PR TITLE
Creando compatibilidad para obtener recursos de S3 mediante run_id

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1598,7 +1598,7 @@ class ProblemController extends Controller {
 
                 // Try to open the details file. It's okay if the file is missing.
                 $details = Grader::getInstance()->getGraderResource(
-                    $run->guid,
+                    $run,
                     'details.json',
                     /*passthru=*/false,
                     /*missingOk=*/true

--- a/frontend/server/libs/Grader.php
+++ b/frontend/server/libs/Grader.php
@@ -135,7 +135,7 @@ class Grader {
     }
 
     public function getGraderResource(
-        string $guid,
+        Runs $run,
         string $filename,
         bool $passthru = false,
         bool $missingOk = false
@@ -147,7 +147,7 @@ class Grader {
             OMEGAUP_GRADER_URL . '/run/resource/',
             $passthru ? self::REQUEST_MODE_PASSTHRU : self::REQUEST_MODE_RAW,
             [
-                'id' => $guid,
+                'id' => $run->guid,
                 'filename' => $filename,
             ],
             $missingOk
@@ -210,14 +210,14 @@ class Grader {
 
             // Execute call
             $response = curl_exec($curl);
+            $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-            if ($response === false || curl_getinfo($curl, CURLINFO_HTTP_CODE) != 200) {
-                if (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 404 && $missingOk) {
+            if ($response === false || $httpStatus != 200) {
+                if ($httpStatus == 404 && $missingOk) {
                     return null;
                 }
                 $message = 'curl_exec failed: ' . curl_error($curl) . ' ' .
-                    curl_errno($curl) . ' HTTP ' .
-                    curl_getinfo($curl, CURLINFO_HTTP_CODE);
+                    curl_errno($curl) . " HTTP {$httpStatus}";
                 throw new Exception($message);
             }
 

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -471,7 +471,7 @@ class NoOpGrader extends Grader {
     }
 
     public function getGraderResource(
-        string $guid,
+        Runs $run,
         string $filename,
         bool $passthru = false,
         bool $missingOk = false
@@ -479,7 +479,7 @@ class NoOpGrader extends Grader {
         if ($passthru) {
             throw new UnimplementedException();
         }
-        $path = "{$guid}/{$filename}";
+        $path = "{$run->guid}/{$filename}";
         if (!array_key_exists($path, $this->resources)) {
             if (!$missingOk) {
                 throw new Exception("Resource {$path} not found");


### PR DESCRIPTION
Este cambio permite que se puedan obtener los recursos de S3 mediante ya
sea guid o run_id en lo que terminamos la migración.