### PR TITLE
Ignorando los tags restringidos al crear problemas

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -206,7 +206,11 @@ class ProblemController extends Controller {
             // Add tags
             if (!empty($r['selected_tags'])) {
                 foreach ($r['selected_tags'] as $tag) {
-                    self::addTag($tag->tagname, $tag->public, $problem);
+                    $tagName = TagController::normalize($tag->tagname);
+                    if (in_array($tagName, self::RESTRICTED_TAG_NAMES)) {
+                        continue;
+                    }
+                    self::addTag($tagName, $tag->public, $problem);
                 }
             }
             ProblemController::setRestrictedTags($problem);
@@ -380,7 +384,12 @@ class ProblemController extends Controller {
         return ['status' => 'ok', 'name' => $r['name']];
     }
 
-    private static function addTag(string $tagName, bool $isPublic, Problems $problem, bool $allowRestricted = false) {
+    private static function addTag(
+        string $tagName,
+        bool $isPublic,
+        Problems $problem,
+        bool $allowRestricted = false
+    ) : void {
         // Normalize name.
         $tagName = TagController::normalize($tagName);
 

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -485,10 +485,18 @@ class CreateProblemTest extends OmegaupTestCase {
         // Login user
         $login = self::login($problemAuthor);
         $r['auth_token'] = $login->auth_token;
-        $r['selected_tags'] = json_encode([
+        $expectedTags = [
             ['tagname' => 'math', 'public' => true],
             ['tagname' => 'geometry', 'public' => false],
-        ]);
+        ];
+
+        $r['selected_tags'] = json_encode(
+            $expectedTags + [
+                // The following tags will be ignored:
+                ['tagname' => 'karel', 'public' => true],
+                ['tagname' => 'solo-salida', 'public' => false],
+            ]
+        );
 
         // Get File Uploader Mock and tell Omegaup API to use it
         FileHandler::SetFileUploader($this->createFileUploaderMock());
@@ -501,9 +509,9 @@ class CreateProblemTest extends OmegaupTestCase {
             'problem_alias' => $problemData['request']['problem_alias'],
         ]))['tags'];
 
-        foreach ($r['selected_tags'] as $selectedTag) {
+        foreach ($expectedTags as $selectedTag) {
             $this->assertArrayContainsWithPredicate($tags, function ($tag) use ($selectedTag) {
-                return $tag['name'] == $selectedTag->tagname;
+                return $tag['name'] == $selectedTag['tagname'];
             });
         }
         $this->assertArrayContainsWithPredicate($tags, function ($tag) use ($selectedTag) {


### PR DESCRIPTION
Este cambio hace que si le pasas tags restringidos a un problema, no
falle su creación.