### PR TITLE
Arreglando ProblemsDAO::addTagFilter

### DIFF
--- a/frontend/server/libs/dao/Problems.dao.php
+++ b/frontend/server/libs/dao/Problems.dao.php
@@ -36,7 +36,7 @@ class ProblemsDAO extends ProblemsDAOBase {
             if ($add_identity_id) {
                 $args[] = $identity_id;
             }
-        } elseif (is_array($tag)) {
+        } elseif (is_array($tag) && !empty($tag)) {
             // Look for problems matching ALL tags or not
             $having_clause = $require_all_tags ? 'HAVING (COUNT(pt.tag_id) = ?)':'';
             $placeholders = array_fill(0, count($tag), '?');


### PR DESCRIPTION
Este cambio hace que si el arreglo de tags está vacío, no se intente
ejecutar un query inválido.