### PR TITLE
Agregando soporte para cambiar versiones en los problemas

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -479,12 +479,7 @@ class RunController extends Controller {
         self::$log->info('Run being rejudged!!');
 
         // Reset fields.
-        $r['run']->verdict = 'JE';
         $r['run']->status = 'new';
-        $r['run']->runtime = 0;
-        $r['run']->memory = 0;
-        $r['run']->score = 0;
-        $r['run']->contest_score = 0;
         RunsDAO::save($r['run']);
 
         try {

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -757,19 +757,69 @@ class RunsDAO extends RunsDAOBase {
      * @param Problems $problem the problem.
      */
     final public static function updateVersionToCurrent(Problems $problem) : void {
+        global $conn;
+
+        $sql = '
+            INSERT IGNORE INTO
+                Runs (
+                    submission_id, version, verdict
+                )
+            SELECT
+                s.submission_id, ?, "JE"
+            FROM
+                Submissions s
+            WHERE
+                s.problem_id = ?
+            ORDER BY
+                s.submission_id;
+        ';
+        $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
+
         $sql = '
             UPDATE
+                Submissions s
+            INNER JOIN
+                Runs r
+            ON
+                r.submission_id = s.submission_id
+            SET
+                s.current_run_id = r.run_id
+            WHERE
+                s.problemset_id IS NULL AND
+                r.version = ? AND
+                s.problem_id = ?;
+        ';
+        $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
+    }
+
+    /**
+     * Gets the runs that were inserted due to a version change.
+     *
+     * @param Problems $problem the problem.
+     */
+    final public static function getNewRunsForVersion(Problems $problem) : array {
+        global $conn;
+
+        $sql = '
+            SELECT
+                r.run_id
+            FROM
                 Runs r
             INNER JOIN
                 Submissions s
             ON
                 s.submission_id = r.submission_id
-            SET
-                r.version = ?
             WHERE
+                r.status = "new" AND
+                r.version = ? AND
                 s.problem_id = ?;
         ';
-        global $conn;
-        $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
+        $params = [$problem->current_version, $problem->problem_id];
+
+        $result = [];
+        foreach ($conn->Execute($sql, $params) as $row) {
+            $result[] = new Runs($row);
+        }
+        return $result;
     }
 }

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,7 +42,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.7/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.9/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.


### PR DESCRIPTION
Este cambio por fin permite a los autores de los problemas regresar a
versiones anteriores del problema, o hacer commit a un cambio sin forzar
el rejueceo.

El rejueceo no-destructivo ha llegado!