### PR TITLE
Arreglando la descarga de .zip con salida de los envíos

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -668,7 +668,7 @@ class RunController extends Controller {
         self::authenticateRequest($r);
 
         Validators::isStringNonEmpty($r['run_alias'], 'run_alias');
-        if (!downloadSubmission($r['run_alias'], $r['current_identity_id'], /*passthru=*/true)) {
+        if (!RunController::downloadSubmission($r['run_alias'], $r['current_identity_id'], /*passthru=*/true)) {
             http_response_code(404);
         }
         exit;


### PR DESCRIPTION
Este cambio hace que de nuevo se puedan descargar los .zip con salidas.