### PR TITLE
Agregando más funcionalidad a los APIs para cambiar versiones de los problemas

### DIFF
--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -17,8 +17,13 @@ class ProblemDeployer {
     public $publishedCommit = null;
     private $updatedStatementLanguages = [];
     private $acceptsSubmissions = true;
+    private $updatePublished = true;
 
-    public function __construct($alias, $acceptsSubmissions = true) {
+    public function __construct(
+        string $alias,
+        bool $acceptsSubmissions = true,
+        bool $updatePublished = true
+    ) {
         $this->log = Logger::getLogger('ProblemDeployer');
         $this->alias = $alias;
 
@@ -31,12 +36,18 @@ class ProblemDeployer {
         }
 
         $this->acceptsSubmissions = $acceptsSubmissions;
+        $this->updatePublished = $updatePublished;
     }
 
     public function __destruct() {
     }
 
-    public function commit(string $message, Users $user, int $operation, array $problemSettings) {
+    public function commit(
+        string $message,
+        Users $user,
+        int $operation,
+        array $problemSettings
+    ) : void {
         $mergeStrategy = 'ours';
 
         switch ($operation) {
@@ -61,7 +72,8 @@ class ProblemDeployer {
             null,
             $mergeStrategy,
             $operation == ProblemDeployer::CREATE,
-            $this->acceptsSubmissions
+            $this->acceptsSubmissions,
+            $this->updatePublished
         );
         $this->processResult($result);
     }
@@ -207,7 +219,8 @@ class ProblemDeployer {
                 $blobUpdate,
                 'recursive-theirs',
                 false,
-                $this->acceptsSubmissions
+                $this->acceptsSubmissions,
+                $this->updatePublished
             );
             $this->processResult($result);
         } finally {
@@ -277,7 +290,8 @@ class ProblemDeployer {
         $blobUpdate,
         string $mergeStrategy,
         bool $create,
-        bool $acceptsSubmissions
+        bool $acceptsSubmissions,
+        bool $updatePublished
     ) {
         $curl = curl_init();
         $zipFile = fopen($zipPath, 'r');
@@ -286,6 +300,7 @@ class ProblemDeployer {
             $queryParams = [
                 'message' => $commitMessage,
                 'acceptsSubmissions' => $acceptsSubmissions ? 'true' : 'false',
+                'updatePublished' => $updatePublished ? 'true' : 'false',
                 'mergeStrategy' => $mergeStrategy,
             ];
             if ($create) {

--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -757,11 +757,14 @@ class RunsDAO extends RunsDAOBase {
     }
 
     /**
-     * Update the version of the runs of a problem to the current version.
+     * Creates any necessary runs for submissions against a problem, given a
+     * problem version.
      *
      * @param Problems $problem the problem.
      */
-    final public static function updateVersionToCurrent(Problems $problem) : void {
+    final public static function createRunsForVersion(
+        Problems $problem
+    ) : void {
         global $conn;
 
         $sql = '
@@ -779,6 +782,16 @@ class RunsDAO extends RunsDAOBase {
                 s.submission_id;
         ';
         $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
+    }
+
+    /**
+     * Update the version of the non-problemset runs of a problem to the
+     * current version.
+     *
+     * @param Problems $problem the problem.
+     */
+    final public static function updateVersionToCurrent(Problems $problem) : void {
+        global $conn;
 
         $sql = '
             UPDATE

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,7 +42,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.9/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.10/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.


### PR DESCRIPTION
Agregando más funcionalidad a los APIs para cambiar versiones de los problemas

Este cambio hace que sea posible:

a) elegir si cuando se actualiza un problema también se actualizan todos
   sus envíos se van a reevaluar, incluyendo los envíos a tareas /
   concursos que aún están corriendo y que el autor del problema tiene
   privilegios de edición.
b) Mostrar más información en el API de versiones para hacerlo más útil.