### PR TITLE
Permitir a los Problemsets apuntar a un commit distinto

### DIFF
--- a/frontend/database/88_problem_commit.sql
+++ b/frontend/database/88_problem_commit.sql
@@ -1,0 +1,7 @@
+-- Problems
+ALTER TABLE `Problems`
+	ADD COLUMN `commit` char(40) NOT NULL DEFAULT 'published' COMMENT 'El hash SHA1 del commit en la rama master del problema.' AFTER `alias`;
+
+-- Problemset_Problems
+ALTER TABLE `Problemset_Problems`
+	ADD COLUMN `commit` char(40) NOT NULL DEFAULT 'published' COMMENT 'El hash SHA1 del commit en la rama master del problema.' AFTER `problem_id`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -450,6 +450,7 @@ CREATE TABLE `Problems` (
   `visibility` tinyint(1) NOT NULL DEFAULT '1' COMMENT '-1 banned, 0 private, 1 public, 2 recommended',
   `title` varchar(256) NOT NULL,
   `alias` varchar(32) NOT NULL,
+  `commit` char(40) NOT NULL DEFAULT 'published' COMMENT 'El hash SHA1 del commit en la rama master del problema.',
   `current_version` char(40) NOT NULL COMMENT 'El hash SHA1 del árbol de la rama private.',
   `languages` set('c','cpp','java','py','rb','pl','cs','pas','kp','kj','cat','hs','cpp11','lua') NOT NULL DEFAULT 'c,cpp,java,py,rb,pl,cs,pas,hs,cpp11,lua',
   `input_limit` int(11) NOT NULL DEFAULT '10240',
@@ -596,6 +597,7 @@ CREATE TABLE `Problemset_Problem_Opened` (
 CREATE TABLE `Problemset_Problems` (
   `problemset_id` int(11) NOT NULL,
   `problem_id` int(11) NOT NULL,
+  `commit` char(40) NOT NULL DEFAULT 'published' COMMENT 'El hash SHA1 del commit en la rama master del problema.',
   `version` char(40) NOT NULL COMMENT 'El hash SHA1 del árbol de la rama private.',
   `points` double NOT NULL DEFAULT '1',
   `order` int(11) NOT NULL DEFAULT '1' COMMENT 'Define el orden de aparición de los problemas en una lista de problemas',

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -521,9 +521,16 @@ class CourseController extends Controller {
             $points = (int)$r['points'];
         }
 
+        [$masterCommit, $currentVersion] = ProblemController::resolveCommit(
+            $problem,
+            $r['commit']
+        );
+
         ProblemsetController::addProblem(
             $problemSet->problemset_id,
             $problem,
+            $masterCommit,
+            $currentVersion,
             $r['current_identity_id'],
             $points
         );

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -23,6 +23,8 @@ class ProblemsetController extends Controller {
     public static function addProblem(
         $problemset_id,
         Problems $problem,
+        string $commit,
+        string $currentVersion,
         $current_identity_id,
         $points,
         $order_in_contest = 1
@@ -37,7 +39,8 @@ class ProblemsetController extends Controller {
             self::updateProblemsetProblem(new ProblemsetProblems([
                 'problemset_id' => $problemset_id,
                 'problem_id' => $problem->problem_id,
-                'version' => $problem->current_version,
+                'commit' => $commit,
+                'version' => $currentVersion,
                 'points' => $points,
                 'order' => $order_in_contest,
             ]));

--- a/frontend/server/controllers/QualityNominationController.php
+++ b/frontend/server/controllers/QualityNominationController.php
@@ -530,7 +530,8 @@ class QualityNominationController extends Controller {
             // Pull original problem statements in every language the nominator is trying to override.
             foreach ($response['contents']['statements'] as $language => $_) {
                 $response['original_contents']['statements'][$language] = ProblemController::getProblemStatement(
-                    $problem->alias,
+                    $problem,
+                    'published',
                     $language
                 );
             }

--- a/frontend/server/libs/dao/Problemset_Problems.dao.php
+++ b/frontend/server/libs/dao/Problemset_Problems.dao.php
@@ -205,7 +205,9 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
      *
      * @param Problems $problem the problem.
      */
-    final public static function updateVersionToCurrent(Problems $problem) : void {
+    final public static function updateVersionToCurrent(
+        Problems $problem
+    ) : void {
         global $conn;
 
         $sql = '
@@ -216,11 +218,11 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
             ON
                 p.problemset_id = pp.problemset_id
             SET
-                pp.version = ?
+                pp.commit = ?, pp.version = ?
             WHERE
                 pp.problem_id = ?;
         ';
-        $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
+        $conn->Execute($sql, [$problem->commit, $problem->current_version, $problem->problem_id]);
 
         $sql = '
             UPDATE
@@ -242,5 +244,33 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
                 s.problem_id = ?;
         ';
         $conn->Execute($sql, [$problem->current_version, $problem->problem_id]);
+    }
+
+    /**
+     * Update the commit of the problem across all problemsets to the current
+     * version.
+     *
+     * @param Problems $problem the problem.
+     * @param string   $commit  the SHA1 hash of the current commit.
+     */
+    final public static function updateCommit(
+        Problems $problem,
+        string $commit
+    ) : void {
+        global $conn;
+
+        $sql = '
+            UPDATE
+                Problemset_Problems pp
+            INNER JOIN
+                Problemsets p
+            ON
+                p.problemset_id = pp.problemset_id
+            SET
+                pp.commit = ?
+            WHERE
+                pp.problem_id = ?;
+        ';
+        $conn->Execute($sql, [$commit, $problem->problem_id]);
     }
 }

--- a/frontend/server/libs/dao/base/Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems.dao.base.php
@@ -48,12 +48,13 @@ abstract class ProblemsDAOBase {
      * @param Problems [$Problems] El objeto de tipo Problems a actualizar.
      */
     final public static function update(Problems $Problems) {
-        $sql = 'UPDATE `Problems` SET `acl_id` = ?, `visibility` = ?, `title` = ?, `alias` = ?, `current_version` = ?, `languages` = ?, `input_limit` = ?, `visits` = ?, `submissions` = ?, `accepted` = ?, `difficulty` = ?, `creation_date` = ?, `source` = ?, `order` = ?, `deprecated` = ?, `email_clarifications` = ?, `quality` = ?, `quality_histogram` = ?, `difficulty_histogram` = ? WHERE `problem_id` = ?;';
+        $sql = 'UPDATE `Problems` SET `acl_id` = ?, `visibility` = ?, `title` = ?, `alias` = ?, `commit` = ?, `current_version` = ?, `languages` = ?, `input_limit` = ?, `visits` = ?, `submissions` = ?, `accepted` = ?, `difficulty` = ?, `creation_date` = ?, `source` = ?, `order` = ?, `deprecated` = ?, `email_clarifications` = ?, `quality` = ?, `quality_histogram` = ?, `difficulty_histogram` = ? WHERE `problem_id` = ?;';
         $params = [
             $Problems->acl_id,
             $Problems->visibility,
             $Problems->title,
             $Problems->alias,
+            $Problems->commit,
             $Problems->current_version,
             $Problems->languages,
             $Problems->input_limit,
@@ -89,7 +90,7 @@ abstract class ProblemsDAOBase {
         if (is_null($problem_id)) {
             return null;
         }
-        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`current_version`, `Problems`.`languages`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` FROM Problems WHERE (problem_id = ?) LIMIT 1;';
+        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`commit`, `Problems`.`current_version`, `Problems`.`languages`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` FROM Problems WHERE (problem_id = ?) LIMIT 1;';
         $params = [$problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
@@ -144,7 +145,7 @@ abstract class ProblemsDAOBase {
      * @return Array Un arreglo que contiene objetos del tipo {@link Problems}.
      */
     final public static function getAll($pagina = null, $filasPorPagina = null, $orden = null, $tipoDeOrden = 'ASC') {
-        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`current_version`, `Problems`.`languages`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` from Problems';
+        $sql = 'SELECT `Problems`.`problem_id`, `Problems`.`acl_id`, `Problems`.`visibility`, `Problems`.`title`, `Problems`.`alias`, `Problems`.`commit`, `Problems`.`current_version`, `Problems`.`languages`, `Problems`.`input_limit`, `Problems`.`visits`, `Problems`.`submissions`, `Problems`.`accepted`, `Problems`.`difficulty`, `Problems`.`creation_date`, `Problems`.`source`, `Problems`.`order`, `Problems`.`deprecated`, `Problems`.`email_clarifications`, `Problems`.`quality`, `Problems`.`quality_histogram`, `Problems`.`difficulty_histogram` from Problems';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
@@ -174,6 +175,9 @@ abstract class ProblemsDAOBase {
         if (is_null($Problems->visibility)) {
             $Problems->visibility = '1';
         }
+        if (is_null($Problems->commit)) {
+            $Problems->commit = 'published';
+        }
         if (is_null($Problems->languages)) {
             $Problems->languages = 'c,cpp,java,py,rb,pl,cs,pas,hs,cpp11,lua';
         }
@@ -201,12 +205,13 @@ abstract class ProblemsDAOBase {
         if (is_null($Problems->email_clarifications)) {
             $Problems->email_clarifications = '0';
         }
-        $sql = 'INSERT INTO Problems (`acl_id`, `visibility`, `title`, `alias`, `current_version`, `languages`, `input_limit`, `visits`, `submissions`, `accepted`, `difficulty`, `creation_date`, `source`, `order`, `deprecated`, `email_clarifications`, `quality`, `quality_histogram`, `difficulty_histogram`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problems (`acl_id`, `visibility`, `title`, `alias`, `commit`, `current_version`, `languages`, `input_limit`, `visits`, `submissions`, `accepted`, `difficulty`, `creation_date`, `source`, `order`, `deprecated`, `email_clarifications`, `quality`, `quality_histogram`, `difficulty_histogram`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [
             $Problems->acl_id,
             $Problems->visibility,
             $Problems->title,
             $Problems->alias,
+            $Problems->commit,
             $Problems->current_version,
             $Problems->languages,
             $Problems->input_limit,

--- a/frontend/server/libs/dao/base/Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems.vo.base.php
@@ -41,6 +41,9 @@ class Problems extends VO {
         if (isset($data['alias'])) {
             $this->alias = $data['alias'];
         }
+        if (isset($data['commit'])) {
+            $this->commit = $data['commit'];
+        }
         if (isset($data['current_version'])) {
             $this->current_version = $data['current_version'];
         }
@@ -135,6 +138,13 @@ class Problems extends VO {
       * @var varchar(32)
       */
     public $alias;
+
+    /**
+      * El hash SHA1 del commit en la rama master del problema.
+      * @access public
+      * @var char(40)
+      */
+    public $commit;
 
     /**
       * El hash SHA1 del árbol de la rama private.

--- a/frontend/server/libs/dao/base/Problemset_Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problems.dao.base.php
@@ -48,8 +48,9 @@ abstract class ProblemsetProblemsDAOBase {
      * @param ProblemsetProblems [$Problemset_Problems] El objeto de tipo ProblemsetProblems a actualizar.
      */
     final public static function update(ProblemsetProblems $Problemset_Problems) {
-        $sql = 'UPDATE `Problemset_Problems` SET `version` = ?, `points` = ?, `order` = ? WHERE `problemset_id` = ? AND `problem_id` = ?;';
+        $sql = 'UPDATE `Problemset_Problems` SET `commit` = ?, `version` = ?, `points` = ?, `order` = ? WHERE `problemset_id` = ? AND `problem_id` = ?;';
         $params = [
+            $Problemset_Problems->commit,
             $Problemset_Problems->version,
             $Problemset_Problems->points,
             $Problemset_Problems->order,
@@ -74,7 +75,7 @@ abstract class ProblemsetProblemsDAOBase {
         if (is_null($problemset_id) || is_null($problem_id)) {
             return null;
         }
-        $sql = 'SELECT `Problemset_Problems`.`problemset_id`, `Problemset_Problems`.`problem_id`, `Problemset_Problems`.`version`, `Problemset_Problems`.`points`, `Problemset_Problems`.`order` FROM Problemset_Problems WHERE (problemset_id = ? AND problem_id = ?) LIMIT 1;';
+        $sql = 'SELECT `Problemset_Problems`.`problemset_id`, `Problemset_Problems`.`problem_id`, `Problemset_Problems`.`commit`, `Problemset_Problems`.`version`, `Problemset_Problems`.`points`, `Problemset_Problems`.`order` FROM Problemset_Problems WHERE (problemset_id = ? AND problem_id = ?) LIMIT 1;';
         $params = [$problemset_id, $problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
@@ -129,7 +130,7 @@ abstract class ProblemsetProblemsDAOBase {
      * @return Array Un arreglo que contiene objetos del tipo {@link ProblemsetProblems}.
      */
     final public static function getAll($pagina = null, $filasPorPagina = null, $orden = null, $tipoDeOrden = 'ASC') {
-        $sql = 'SELECT `Problemset_Problems`.`problemset_id`, `Problemset_Problems`.`problem_id`, `Problemset_Problems`.`version`, `Problemset_Problems`.`points`, `Problemset_Problems`.`order` from Problemset_Problems';
+        $sql = 'SELECT `Problemset_Problems`.`problemset_id`, `Problemset_Problems`.`problem_id`, `Problemset_Problems`.`commit`, `Problemset_Problems`.`version`, `Problemset_Problems`.`points`, `Problemset_Problems`.`order` from Problemset_Problems';
         global $conn;
         if (!is_null($orden)) {
             $sql .= ' ORDER BY `' . mysqli_real_escape_string($conn->_connectionID, $orden) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
@@ -156,16 +157,20 @@ abstract class ProblemsetProblemsDAOBase {
      * @param ProblemsetProblems [$Problemset_Problems] El objeto de tipo ProblemsetProblems a crear.
      */
     final public static function create(ProblemsetProblems $Problemset_Problems) {
+        if (is_null($Problemset_Problems->commit)) {
+            $Problemset_Problems->commit = 'published';
+        }
         if (is_null($Problemset_Problems->points)) {
             $Problemset_Problems->points = '1';
         }
         if (is_null($Problemset_Problems->order)) {
             $Problemset_Problems->order = '1';
         }
-        $sql = 'INSERT INTO Problemset_Problems (`problemset_id`, `problem_id`, `version`, `points`, `order`) VALUES (?, ?, ?, ?, ?);';
+        $sql = 'INSERT INTO Problemset_Problems (`problemset_id`, `problem_id`, `commit`, `version`, `points`, `order`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [
             $Problemset_Problems->problemset_id,
             $Problemset_Problems->problem_id,
+            $Problemset_Problems->commit,
             $Problemset_Problems->version,
             $Problemset_Problems->points,
             $Problemset_Problems->order,

--- a/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
@@ -32,6 +32,9 @@ class ProblemsetProblems extends VO {
         if (isset($data['problem_id'])) {
             $this->problem_id = $data['problem_id'];
         }
+        if (isset($data['commit'])) {
+            $this->commit = $data['commit'];
+        }
         if (isset($data['version'])) {
             $this->version = $data['version'];
         }
@@ -69,6 +72,13 @@ class ProblemsetProblems extends VO {
       * @var int(11)
       */
     public $problem_id;
+
+    /**
+      * El hash SHA1 del commit en la rama master del problema.
+      * @access public
+      * @var char(40)
+      */
+    public $commit;
 
     /**
       * El hash SHA1 del árbol de la rama private.

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -672,10 +672,10 @@ class CreateProblemTest extends OmegaupTestCase {
 
         // Verify that the templates were generated.
         $this->assertTrue(
-            file_exists(TEMPLATES_PATH . "/{$problem->alias}/{$problem->alias}_unix_cpp.tar.bz2")
+            file_exists(TEMPLATES_PATH . "/{$problem->alias}/{$problem->commit}/{$problem->alias}_unix_cpp.tar.bz2")
         );
         $this->assertTrue(
-            file_exists(TEMPLATES_PATH . "/{$problem->alias}/{$problem->alias}_windows_cpp.zip")
+            file_exists(TEMPLATES_PATH . "/{$problem->alias}/{$problem->commit}/{$problem->alias}_windows_cpp.zip")
         );
     }
 }

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -353,13 +353,14 @@ export class Arena {
           let form = $(e.target);
           e.preventDefault();
           let alias = self.currentProblem.alias;
+          let commit = self.currentProblem.commit;
           let os = form.find('.download-os').val();
           let lang = form.find('.download-lang').val();
           let extension = (os == 'unix' ? '.tar.bz2' : '.zip');
 
-          UI.navigateTo(window.location.protocol + '//' + window.location.host +
-                        '/templates/' + alias + '/' + alias + '_' + os + '_' +
-                        lang + extension);
+          UI.navigateTo(
+              window.location.protocol + '//' + window.location.host +
+              `/templates/${alias}/${commit}/${alias}_${os}_${lang}${extension}`);
 
           return false;
         });


### PR DESCRIPTION
Este cambio agrega una nueva columna en Problemset_Problems que hace que
se pueda congelar una versión completa del problema (incluyendo imágenes
y redacciones!) en un Problemset.