### PR TITLE
Agregando redirección de un problema al ser seleccionado

### DIFF
--- a/frontend/www/js/problem_search_bar.js
+++ b/frontend/www/js/problem_search_bar.js
@@ -1,3 +1,6 @@
 omegaup.OmegaUp.on('ready', function() {
-  omegaup.UI.problemTypeahead($('#problem-search-box'));
+  omegaup.UI.problemTypeahead($('#problem-search-box'), function(event, item) {
+    window.location.href =
+        window.location.origin + '/arena/problem/' + item.alias;
+  });
 });


### PR DESCRIPTION
# Descripción

Al seleccionar un problema en  https://omegaup.com/problem/ se redirecciona directamente a https://omegaup.com/arena/problem/{problema-seleccionado}, para evitar dar demasiados clicks. 

Esto funciona para los dos métodos existentes:
- Auto completado: Cuando se selecciona un elemento del listado de coincidencias, es decir, navegas con las teclas y una vez que tienes el problema indicado presionas la tecla **_Tab_**.
- Click: Al elegir directamente con un click alguna de las coincidencias.

Fixes: #2408 

# Comentarios

Si no se selecciona ningún elemento de la lista, y se presiona la tecla _**Enter**_ o el botón de buscar, se muestra la página con todos los problemas que coinciden con el patrón de búsqueda, tal cual como funcionaba antes.

![2408](https://user-images.githubusercontent.com/3230352/56869066-f06fb200-69c0-11e9-9df7-1f9e7c689211.gif)


# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
