### PR TITLE
Mejorar la manera en agregar problemas a un curso #2459

### DIFF
--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -535,7 +535,7 @@ class CourseController extends Controller {
         Problemsets $problemSet,
         Problems $problem,
         $points
-    ) {        
+    ) {
         if (!is_numeric($points)) {
             $points = 100;
         }
@@ -592,12 +592,13 @@ class CourseController extends Controller {
         }
 
         self::addProblemToAssignmentProblemset(
-            $r['current_identity_id'], 
-            $r['assignment_alias'], 
-            $r['course'], 
-            $problemSet, 
-            $problem, 
-            $r['points']);
+            $r['current_identity_id'],
+            $r['assignment_alias'],
+            $r['course'],
+            $problemSet,
+            $problem,
+            $r['points']
+        );
         return ['status' => 'ok'];
     }
 

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -102,8 +102,8 @@ class CourseController extends Controller {
                     throw new NotFoundException('problemNotFound');
                 }
 
-                if (!Validators::isNumber($problemData->points, 'points')) {
-                    throw new InvalidParameterException('parameterEmpty', 'problems');
+                if (isset($problemData->points) && !is_numeric($problemData->points)) {
+                    throw new InvalidParameterException('parameterNotANumber', 'points');
                 }
             }
         }
@@ -415,7 +415,7 @@ class CourseController extends Controller {
                         $r['course'],
                         $problemset,
                         $problem,
-                        $problemData->points
+                        isset($problemData->points) ? $problemData->points : null
                     );
                 }
             }
@@ -535,7 +535,11 @@ class CourseController extends Controller {
         Problemsets $problemSet,
         Problems $problem,
         $points
-    ) {
+    ) {        
+        if (!is_numeric($points)) {
+            $points = 100;
+        }
+
         ProblemsetController::addProblem(
             $problemSet->problemset_id,
             $problem,
@@ -587,12 +591,13 @@ class CourseController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        $points = 100;
-        if (is_numeric($r['points'])) {
-            $points = (int)$r['points'];
-        }
-
-        self::addProblemToAssignmentProblemset($r['current_identity_id'], $r['assignment_alias'], $r['course'], $problemSet, $problem, $points);
+        self::addProblemToAssignmentProblemset(
+            $r['current_identity_id'], 
+            $r['assignment_alias'], 
+            $r['course'], 
+            $problemSet, 
+            $problem, 
+            $r['points']);
         return ['status' => 'ok'];
     }
 

--- a/frontend/templates/course.edit.tpl
+++ b/frontend/templates/course.edit.tpl
@@ -11,7 +11,6 @@
 	<ul class="nav nav-tabs" id="sections">
 		<li class="active"><a href="#edit" data-toggle="tab">{#courseEdit#}</a></li>
 		<li><a href="#assignments" data-toggle="tab">{#wordsAssignments#}</a></li>
-		<li><a href="#problems" data-toggle="tab">{#wordsProblems#}</a></li>
 		<li><a href="#students" data-toggle="tab">{#courseEditStudents#}</a></li>
 		<li><a href="#admins" data-toggle="tab">{#courseEditAdmins#}</a></li>
 		<li><a href="#clone" data-toggle="tab">{#courseEditClone#}</a></li>

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -163,18 +163,18 @@ class CourseCreateTest extends OmegaupTestCase {
         // Create 3 problems
         $nProblems = 3;
         $pointsTotal = 0;
-        $problemsData = array();
+        $problemsData = [];
         for ($i = 1; $i <= $nProblems; $i++) {
             $problem = ProblemsFactory::createProblem(new ProblemParams([
                 'visibility' => 1,
                 'user' => $user
-            ]), $login); 
+            ]), $login);
 
             $problemsData[$i]['alias'] = $problem['request']['problem_alias'];
             $problemsData[$i]['points'] = $i;
             $pointsTotal += $i;
         }
-        
+
         // Create the assignment
         $login = self::login($user);
         $assignmentAlias = Utils::CreateRandomString();
@@ -195,7 +195,7 @@ class CourseCreateTest extends OmegaupTestCase {
         $course = CoursesDAO::getByAlias($courseAlias);
         $assignment = AssignmentsDAO::getByAliasAndCourse($assignmentAlias, $course->course_id);
         $this->assertNotNull($assignment);
-        
+
         // Check problems were added to the underlying problemset
         $problems = ProblemsetProblemsDAO::getByProblemset($assignment->problemset_id);
         $this->assertEquals($nProblems, count($problems));

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -171,7 +171,7 @@ class CourseCreateTest extends OmegaupTestCase {
             ]), $login);
 
             $problemsData[$i]['alias'] = $problem['request']['problem_alias'];
-                
+
             if ($usePoints) {
                 $problemsData[$i]['points'] = $i;
                 $pointsTotal += $i;
@@ -209,8 +209,8 @@ class CourseCreateTest extends OmegaupTestCase {
 
     public function testCreateSchoolAssignmentWithProblemsNoPoints() {
         $this->createSchoolAssignmentWithProblems(false /* usePoints */);
-    } 
-    
+    }
+
     public function testCreateSchoolAssignmentWithProblems() {
         $this->createSchoolAssignmentWithProblems();
     }

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -142,7 +142,7 @@ class CourseCreateTest extends OmegaupTestCase {
         $this->assertEquals($points, $problems[0]->points);
     }
 
-    public function testCreateSchoolAssignmentWithProblems() {
+    private function createSchoolAssignmentWithProblems($usePoints = true) {
         // Create a test course
         $user = UserFactory::createUser();
         $courseAlias = Utils::CreateRandomString();
@@ -171,8 +171,13 @@ class CourseCreateTest extends OmegaupTestCase {
             ]), $login);
 
             $problemsData[$i]['alias'] = $problem['request']['problem_alias'];
-            $problemsData[$i]['points'] = $i;
-            $pointsTotal += $i;
+                
+            if ($usePoints) {
+                $problemsData[$i]['points'] = $i;
+                $pointsTotal += $i;
+            } else {
+                $pointsTotal += 100;
+            }
         }
 
         // Create the assignment
@@ -200,6 +205,14 @@ class CourseCreateTest extends OmegaupTestCase {
         $problems = ProblemsetProblemsDAO::getByProblemset($assignment->problemset_id);
         $this->assertEquals($nProblems, count($problems));
         $this->assertEquals($pointsTotal, $assignment->max_points);
+    }
+
+    public function testCreateSchoolAssignmentWithProblemsNoPoints() {
+        $this->createSchoolAssignmentWithProblems(false /* usePoints */);
+    } 
+    
+    public function testCreateSchoolAssignmentWithProblems() {
+        $this->createSchoolAssignmentWithProblems();
     }
 
     /**


### PR DESCRIPTION
# Descripción

Reduciendo el número de clicks que se requieren para agregar un problema a un assignment integrando el formulario de agregar problemas dentro de la edición del assignment. El cambio también desaparece la pestaña de edición de problemas para evitar mayor confusión:

![image](https://user-images.githubusercontent.com/207097/56871874-772f8980-69d7-11e9-82c1-27fd590f0632.png)

Fixes: #2459 

# Comentarios
Hay ciertas cosas controversiales en este cambio:
* Integrar componentes en vez de reusar el componente existente: Para facilitar la UX y la implementación preferí que se integrara la edición de problemas en el mismo componente del assignment, con miras a eliminar el componente de agregar problemas si no se va a usar en otro lado. Estoy abierto a sugerencias.

* Como consecuencia, removí la selección de problemas por temas que estaba vacía, para evitar confusión a los usuarios (tenemos un plan para llenar la lista btw? :) )

* La API que crea assignments también asigna los problemas - para evitar llamar 2+ APIs.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron. (selenium aún falla, investigando)...
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz. (El cambio está en el borderline, pero puedo partirlo)..
- [ ] Eliminar los componentes de problemList y sus rastros.
- [ ] Agregar títulos en las subsecciones del formulario de creación/edición de assignments, para separar visualmente las secciones. 
