### PR TITLE
Arreglando una advertencia al crear directorios

### DIFF
--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -144,7 +144,7 @@ class ProblemDeployer {
                     "interactive/Main.distrib.{$distribSettings['interactive']['language']}"
                 )
             );
-            mkdir("{$tmpDir}/examples");
+            @mkdir("{$tmpDir}/examples");
             foreach ($distribSettings['cases'] as $filename => $data) {
                 file_put_contents(
                     "{$tmpDir}/examples/{$filename}.in",
@@ -152,7 +152,7 @@ class ProblemDeployer {
                 );
             }
             $target = TEMPLATES_PATH . "/{$this->alias}";
-            mkdir($target);
+            @mkdir($target);
             $args = ['/usr/bin/java', '-Xmx64M', '-jar',
                 '/usr/share/java/libinteractive.jar', 'generate-all', $idlPath,
                 '--package-directory', $target, '--package-prefix',


### PR DESCRIPTION
Para evitar errores TOCTTOU, mkdir() debería llamarse incondicionalmente
y verificar el valor de retorno para ver si el directorio ya existía (en
vez de verificar si el directorio existe *y luego* crearlo).

En nuestro caso, no nos importa si ya existía, así que sólo se ignoran
los errores para evitar que New Relic se queje.