### PR TITLE
Arreglando el label de "sólo salida" en la arena

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1167,7 +1167,7 @@ export class Arena {
       {language: 'lua', name: 'Lua'},
       {language: 'kp', name: 'Karel (Pascal)'},
       {language: 'kj', name: 'Karel (Java)'},
-      {language: 'cat', name: T.wordJustOutput},
+      {language: 'cat', name: T.wordsJustOutput},
     ];
 
     let self = this;


### PR DESCRIPTION
Este cambio arregla un error cosmético, pero que está confundiendo a la
gente.