### PR TITLE
jQuery uprev

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "file-loader": "^1.1.11",
     "highcharts": "^6.1.0",
     "jasmine": "^3.1.0",
-    "jquery": "3.2.1",
+    "jquery": "^3.4",
     "jsdom": "^11.11.0",
     "node-sass": "^4.9.0",
     "remove-source-webpack-plugin": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,10 +3368,10 @@ jasmine@^3.1.0:
     glob "^7.0.6"
     jasmine-core "~3.3.0"
 
-jquery@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
-  integrity sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=
+jquery@^3.4:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
Este cambio actualiza jQuery para evitar CVE-2019-11358.