### PR TITLE
Arreglando varios problemas en el scoreboard de cursos

### DIFF
--- a/frontend/server/libs/dao/Runs.dao.php
+++ b/frontend/server/libs/dao/Runs.dao.php
@@ -417,13 +417,18 @@ class RunsDAO extends RunsDAOBase {
                 s.identity_id, s.type, UNIX_TIMESTAMP(s.time) AS time,
                 s.submit_delay, s.guid
             FROM
+                Problemset_Problems pp
+            INNER JOIN
                 Submissions s
+            ON
+                s.problemset_id = pp.problemset_id AND
+                s.problem_id = pp.problem_id
             INNER JOIN
                 Runs r
             ON
                 s.current_run_id = r.run_id
             WHERE
-                s.problemset_id = ? AND
+                pp.problemset_id = ? AND
                 r.status = \'ready\' AND
                 s.type = \'normal\' AND ' .
                 ($onlyAC ?

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -73,35 +73,40 @@ class ContestScoreboardTest extends OmegaupTestCase {
      */
     public function testBasicScoreboard() {
         $runMap = [
-            ['problem_idx' => 0,
-             'contestant_idx' => 0,
-             'points' => 0,
-             'verdict' => 'CE',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 0,
+                'verdict' => 'CE',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 0,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 1,
-             'points' => .9,
-             'verdict' => 'PA',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 1,
+                'points' => .9,
+                'verdict' => 'PA',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 2,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 200
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 2,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 200,
             ],
-            ['problem_idx' => 1,
-             'contestant_idx' => 0,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 200
+            [
+                'problem_idx' => 1,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 200,
             ],
         ];
         $testData = $this->prepareContestScoreboardData(3, $runMap);
@@ -510,41 +515,47 @@ class ContestScoreboardTest extends OmegaupTestCase {
      */
     public function testBasicScoreboardEventsPositive() {
         $runMap = [
-            ['problem_idx' => 0,
-             'contestant_idx' => 0,
-             'points' => 0,
-             'verdict' => 'CE',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 0,
+                'verdict' => 'CE',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 0,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 1,
-             'points' => .9,
-             'verdict' => 'PA',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 1,
+                'points' => .9,
+                'verdict' => 'PA',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 2,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 200
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 2,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 200,
             ],
-            ['problem_idx' => 1,
-             'contestant_idx' => 0,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 200
+            [
+                'problem_idx' => 1,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 200,
             ],
-            ['problem_idx' => 1,
-             'contestant_idx' => 2,
-             'points' => 0,
-             'verdict' => 'CE',
-             'submit_delay' => 200
+            [
+                'problem_idx' => 1,
+                'contestant_idx' => 2,
+                'points' => 0,
+                'verdict' => 'CE',
+                'submit_delay' => 200,
             ],
         ];
 
@@ -635,18 +646,20 @@ class ContestScoreboardTest extends OmegaupTestCase {
         $scoreboardTestRun = new ScopedScoreboardTestRun();
 
         $runMap = [
-            ['problem_idx' => 0,
-             'contestant_idx' => 0,
-             'points' => 0,
-             'verdict' => 'CE',
-             'submit_delay' => 60
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 0,
+                'verdict' => 'CE',
+                'submit_delay' => 60,
             ],
-            ['problem_idx' => 0,
-             'contestant_idx' => 0,
-             'points' => 1,
-             'verdict' => 'AC',
-             'submit_delay' => 60
-            ]
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 60,
+            ],
         ];
 
         $testData = $this->prepareContestScoreboardData(2, $runMap);
@@ -675,5 +688,51 @@ class ContestScoreboardTest extends OmegaupTestCase {
         $response4 = ProblemsetController::$testApi($r);
         $this->assertEquals(true, Scoreboard::getIsLastRunFromCacheForTesting());
         $this->assertEquals($response3, $response4);
+    }
+
+    /**
+     * Test for Scoreboard with an added and removed problem from the problemset.
+     */
+    public function testScoreboardWithRemovedProblem() {
+        $runMap = [
+            [
+                'problem_idx' => 0,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 60,
+            ],
+            [
+                'problem_idx' => 1,
+                'contestant_idx' => 0,
+                'points' => 1,
+                'verdict' => 'AC',
+                'submit_delay' => 60,
+            ],
+        ];
+
+        $testData = $this->prepareContestScoreboardData(2, $runMap);
+
+        // Only system admins can remove problems from a problemset where at
+        // least one run has been added.
+        UserFactory::addSystemRole(
+            $testData['contestData']['director'],
+            Authorization::ADMIN_ROLE
+        );
+        $login = self::login($testData['contestData']['director']);
+        ContestController::apiRemoveProblem(new Request([
+            'auth_token' => $login->auth_token,
+            'contest_alias' => $testData['contestData']['contest']->alias,
+            'problem_alias' => $testData['problemData'][1]['problem']->alias,
+        ]));
+
+        // Now the scoreboard should be available with a single problem.
+        $response = ProblemsetController::apiScoreboard(new Request([
+            'auth_token' => $login->auth_token,
+            'problemset_id' => $testData['contestData']['contest']->problemset_id,
+        ]));
+        $this->assertEquals(1, count($response['ranking']));
+        $this->assertEquals(1, count($response['problems']));
+        $this->assertEquals(1, count($response['ranking'][0]['problems']));
     }
 }


### PR DESCRIPTION
Este cambio:

* No permite que se eliminen problemas de un curso si ya se hicieron
  envíos, lo cual lo hace consistente con los concursos.
* Aún si ya hay un curso donde se eliminó un problema, el scoreboard ya
  muestra la información correcta.

Fixes: #2481