### PR TITLE
Arreglando el visor del evaluador efímero para envíos programáticos

### DIFF
--- a/frontend/www/js/omegaup/grader/CaseSelectorComponent.vue
+++ b/frontend/www/js/omegaup/grader/CaseSelectorComponent.vue
@@ -19,7 +19,7 @@
                    v-bind:title="verdictTooltip(groupResult(group.name))">{{
                    verdictLabel(groupResult(group.name)) }}<span class="score">{{
                    score(groupResult(group.name)) }}</span></span> <span v-bind:title=
-                   "item.name">{{ group.name }}</span>
+                   "group.name">{{ group.name }}</span>
             </div>
           </div><button class=
           "list-group-item list-group-item-action d-flex justify-content-between align-items-center"

--- a/frontend/www/js/omegaup/grader/ephemeral.js
+++ b/frontend/www/js/omegaup/grader/ephemeral.js
@@ -1297,6 +1297,16 @@ function onHashChanged() {
             Util.parseDuration(request.input.limits.OverallWallTimeLimit);
         request.input.limits.TimeLimit =
             Util.parseDuration(request.input.limits.TimeLimit);
+        if (!request.input.cases.sample) {
+          // When the run was made programatically, it does not always contain
+          // a sample case. In order to display those runs without crashing,
+          // just create a fake entry with no weight.
+          request.input.cases.sample = {
+            'in': '',
+            out: '',
+            weight: 0,
+          };
+        }
         store.commit('request', request);
         fetch(`run/${token}/details.json`)
             .then(response => {


### PR DESCRIPTION
Cuando se hace un envío programático, no siempre se incluye un
`sample.in`, aunque la interfaz te obliga a tenerlo. Para evitar que
aparezcan errores que impidan que continúe la evaluación, este cambio
agrega un `sample.in` vacío sin peso.