### PR TITLE
Mejorando el procesamiento de los errores

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -2488,9 +2488,11 @@ class ContestController extends Controller {
             }
 
             $sizeOfBucket = $totalPoints / 100;
-            $scoreboardResponse = self::apiScoreboard($r);
-            foreach ($scoreboardResponse['ranking'] as $results) {
-                $distribution[(int)($results['total']['points'] / $sizeOfBucket)]++;
+            if ($sizeOfBucket > 0) {
+                $scoreboardResponse = self::apiScoreboard($r);
+                foreach ($scoreboardResponse['ranking'] as $results) {
+                    $distribution[(int)($results['total']['points'] / $sizeOfBucket)]++;
+                }
             }
         } catch (Exception $e) {
             // Operation failed in the data layer

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -356,23 +356,17 @@ class UserController extends Controller {
      * @param Request $r
      */
     public static function apiLogin(Request $r) {
-        // Create a SessionController to perform login
         $sessionController = new SessionController();
 
-        // Require the auth_token back
         $r['returnAuthToken'] = true;
-
-        // Get auth_token
         $auth_token = $sessionController->NativeLogin($r);
-
-        // If user was correctly logged in
-        if ($auth_token !== false) {
-            return [
-                'status' => 'ok',
-                'auth_token' => $auth_token];
-        } else {
+        if ($auth_token === false) {
             throw new InvalidCredentialsException();
         }
+        return [
+            'status' => 'ok',
+            'auth_token' => $auth_token,
+        ];
     }
 
     /**

--- a/frontend/server/libs/ApiException.php
+++ b/frontend/server/libs/ApiException.php
@@ -35,7 +35,7 @@ abstract class ApiException extends Exception {
      *
      * @return string
      */
-    public function getHeader() {
+    final public function getHeader() : string {
         return $this->header;
     }
 
@@ -45,7 +45,7 @@ abstract class ApiException extends Exception {
      * @param string $key
      * @param type $value
      */
-    public function addCustomMessageToArray($key, $value) {
+    final public function addCustomMessageToArray($key, $value) : void {
         $this->customMessage[$key] = $value;
     }
 
@@ -53,17 +53,18 @@ abstract class ApiException extends Exception {
      *
      * @return array
      */
-    public function asArray() {
-        $arrayToReturn =  [
-            'status' => 'error',
-            'error' => $this->getErrorMessage(),
-            'errorcode' => $this->code,
-            'header' => $this->header,
-            'cause' => !is_null($this->getPrevious()) ? $this->getPrevious()->getMessage() : null,
-            'trace' => $this->getTraceAsString(),
-        ];
-
-        return array_merge($arrayToReturn, $this->customMessage);
+    final public function asArray() : array {
+        return array_merge(
+            [
+                'status' => 'error',
+                'error' => $this->getErrorMessage(),
+                'errorcode' => $this->code,
+                'header' => $this->header,
+                'cause' => !is_null($this->getPrevious()) ? $this->getPrevious()->getMessage() : null,
+                'trace' => $this->getTraceAsString(),
+            ],
+            $this->customMessage
+        );
     }
 
     /**
@@ -71,16 +72,17 @@ abstract class ApiException extends Exception {
      *
      * @return array
      */
-    public function asResponseArray() {
-        $arrayToReturn =  [
-            'status' => 'error',
-            'error' => $this->getErrorMessage(),
-            'errorname' => $this->message,
-            'errorcode' => $this->code,
-            'header' => $this->header
-        ];
-
-        return array_merge($arrayToReturn, $this->customMessage);
+    final public function asResponseArray() : array {
+        return array_merge(
+            [
+                'status' => 'error',
+                'error' => $this->getErrorMessage(),
+                'errorname' => $this->message,
+                'errorcode' => $this->code,
+                'header' => $this->header,
+            ],
+            $this->customMessage
+        );
     }
 
     protected function getErrorMessage() : string {

--- a/frontend/server/libs/Request.php
+++ b/frontend/server/libs/Request.php
@@ -18,13 +18,6 @@ class Request extends ArrayObject {
     private $parent = null;
 
     /**
-     * The format in which the request will be rendered.
-     */
-    const JSON_FORMAT = 0;
-    const HTML_FORMAT = 1;
-    public $renderFormat = Request::JSON_FORMAT;
-
-    /**
      * The object of the user currently logged in.
      */
     public $user = null;
@@ -66,7 +59,6 @@ class Request extends ArrayObject {
         $req = new Request($contents);
         $req->parent = $this;
         $req->user = $this->user;
-        $req->renderFormat = $this->renderFormat;
         return $req;
     }
 

--- a/frontend/server/libs/UITools.php
+++ b/frontend/server/libs/UITools.php
@@ -39,9 +39,9 @@ class UITools {
      */
     public static function setProfile(Smarty $smarty) {
         $profileRequest = new Request([
-                    'username' => array_key_exists('username', $_REQUEST) ? $_REQUEST['username'] : null,
-                    'auth_token' => $smarty->getTemplateVars('CURRENT_USER_AUTH_TOKEN')
-                ]);
+            'username' => array_key_exists('username', $_REQUEST) ? $_REQUEST['username'] : null,
+            'auth_token' => $smarty->getTemplateVars('CURRENT_USER_AUTH_TOKEN'),
+        ]);
         $profileRequest->method = 'UserController::apiProfile';
         $response = ApiCaller::call($profileRequest);
 

--- a/frontend/tests/controllers/ApiCallerMock.php
+++ b/frontend/tests/controllers/ApiCallerMock.php
@@ -7,16 +7,6 @@
  */
 class ApiCallerMock extends ApiCaller {
     /**
-     * Returns the string instad of echoing it
-     *
-     * @param sring $string
-     * @return string
-     */
-    public static function printResult($string) {
-        return $string;
-    }
-
-    /**
      * headers() is not phpunit-safe. This is a no-op for test
      *
      * @param array $response

--- a/frontend/www/api/ApiCaller.php
+++ b/frontend/www/api/ApiCaller.php
@@ -11,15 +11,6 @@ class ApiCaller {
     public static $log;
 
     /**
-     * Initializes the Request before calling API
-     *
-     * @return Request
-     */
-    private static function init() {
-        return self::parseUrl();
-    }
-
-    /**
      * Execute the request and return the response as associative
      * array.
      *
@@ -29,9 +20,6 @@ class ApiCaller {
     public static function call(Request $request) {
         try {
             $response = $request->execute();
-        } catch (InvalidCredentialsException $e) {
-            // No log because the code that threw it already logged.
-            $response = $e->asResponseArray();
         } catch (ApiException $e) {
             self::$log->error($e);
             $response = $e->asResponseArray();
@@ -70,29 +58,33 @@ class ApiCaller {
     }
 
     /**
-     *Handles main API workflow. All HTTP API calls start here.
-     *
+     * Handles main API workflow. All HTTP API calls start here.
      */
-    public static function httpEntryPoint() {
+    public static function httpEntryPoint() : string {
         $r = null;
+        $apiException = null;
         try {
-            $r = self::init();
             if (self::isCSRFAttempt()) {
                 throw new CSRFException();
             }
-            $response = self::call($r);
-        } catch (ApiException $apiException) {
-            self::$log->error($apiException);
-            $response = $apiException->asResponseArray();
+            $r = self::createRequest();
+            $response = $r->execute();
+            if (is_null($response) || !is_array($response)) {
+                $apiException = new InternalServerErrorException(
+                    new Exception('API did not return an array.')
+                );
+            }
+        } catch (ApiException $e) {
+            $apiException = $e;
         } catch (Exception $e) {
-            self::$log->error($e);
             $apiException = new InternalServerErrorException($e);
-            $response = $apiException->asResponseArray();
         }
 
-        if (is_null($response) || !is_array($response)) {
-            $apiException = new InternalServerErrorException(new Exception('Api did not return an array.'));
+        if (!is_null($apiException)) {
             self::$log->error($apiException);
+            if (extension_loaded('newrelic') && $apiException->getCode() == 500) {
+                newrelic_notice_error($apiException);
+            }
             $response = $apiException->asResponseArray();
         }
 
@@ -120,20 +112,12 @@ class ApiCaller {
     }
 
     /**
-     * Renders the response properly and, in the case of HTTP API,
-     * sets the header
+     * Renders the response properly and sets the HTTP header.
      *
      * @param array $response
      * @param Request $r
      */
-    private static function render(array $response, Request $r = null) {
-        if (!is_null($r) && $r->renderFormat == Request::HTML_FORMAT) {
-            $smarty->assign('EXPLORER_RESPONSE', $response);
-            $smarty->display('../templates/explorer.tpl');
-
-            return;
-        }
-
+    private static function render(array $response, ?Request $r = null) : string {
         // Only add the request ID if the response is an associative array. This
         // allows the APIs that return a flat array to return the right type.
         if (self::isAssociativeArray($response)) {
@@ -142,7 +126,7 @@ class ApiCaller {
         $jsonEncodeFlags = 0;
         // If this request is being explicitly made from the browser,
         // pretty-print the response.
-        if ($r['prettyprint'] == 'true') {
+        if (!is_null($r) && $r['prettyprint'] == 'true') {
             $jsonEncodeFlags = JSON_PRETTY_PRINT;
         }
         static::setHttpHeaders($response);
@@ -162,34 +146,24 @@ class ApiCaller {
             }
             if ($jsonResult === false) {
                 $apiException = new InternalServerErrorException();
+                self::$log->error($apiException);
+                if (extension_loaded('newrelic')) {
+                    newrelic_notice_error($apiException);
+                }
                 $jsonResult = json_encode($apiException->asResponseArray());
             }
         }
-
-        // Print the result using late static binding semantics
-        // Return needed for testability purposes, for production it
-        // returns void.
-        return static::printResult($jsonResult);
-    }
-
-    /**
-     * In production, prints the result.
-     * Decoupled for testability purposes
-     *
-     * @param string $string
-     */
-    private static function printResult($string) {
-        echo $string;
+        return $jsonResult;
     }
 
     /**
      * Parses the URI from $_SERVER and determines which controller and
-     * function to call.
+     * function to call in order to build a Request object.
      *
      * @return Request
      * @throws NotFoundException
      */
-    private static function parseUrl() {
+    private static function createRequest() {
         $apiAsUrl = $_SERVER['REQUEST_URI'];
         // Spliting only by '/' results in URIs with parameters like this:
         //      /api/problem/list/?page=1

--- a/frontend/www/api/ApiEntryPoint.php
+++ b/frontend/www/api/ApiEntryPoint.php
@@ -2,4 +2,4 @@
 
 require_once('ApiCaller.php');
 
-ApiCaller::httpEntryPoint();
+echo ApiCaller::httpEntryPoint();


### PR DESCRIPTION
Este cambio simplifica el código que maneja las excepciones para que
tenga menos rutas posibles. También hace que en caso de errores 500
(léase: inesperados), reportemos el error a New Relic.