### PR TITLE
Arreglando la lógica para desplegar un concurso como virtual

### DIFF
--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -284,6 +284,7 @@ class ContestsDAO extends ContestsDAOBase {
                 UNIX_TIMESTAMP (c.start_time) as start_time,
                 UNIX_TIMESTAMP (c.finish_time) as finish_time,
                 c.admission_mode,
+                c.rerun_id,
                 ps.scoreboard_url,
                 ps.scoreboard_url_admin
             FROM
@@ -343,6 +344,7 @@ class ContestsDAO extends ContestsDAOBase {
                 UNIX_TIMESTAMP (c.start_time) as start_time,
                 UNIX_TIMESTAMP (c.finish_time) as finish_time,
                 c.admission_mode,
+                c.rerun_id,
                 ps.scoreboard_url,
                 ps.scoreboard_url_admin
             FROM

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -47,7 +47,7 @@ let UI = {
     return clock;
   },
 
-  isVirtual: function(contest) { return contest.rerun_id != 0; },
+  isVirtual: function(contest) { return contest.rerun_id > 0; },
 
   contestTitle: function(contest) {
     if (UI.isVirtual(contest)) {


### PR DESCRIPTION
Este cambio

a) Envía el campo que se usa en el frontend para determinar si el
   concurso es virtual.
b) Cambia la condición usada para hacer esa prueba más robusta.

Fixes: #2493