### PR TITLE
Evitando propagar un error de login como error interno

### DIFF
--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -292,8 +292,7 @@ class SessionController extends Controller {
         try {
             $loginTicket = $client->verifyIdToken($r['storeToken']);
         } catch (Google_Auth_Exception $ge) {
-            self::$log->error($ge->getMessage());
-            throw new InternalServerErrorException($ge);
+            throw new UnauthorizedException('loginRequired', $ge);
         }
 
         $payload = $loginTicket->getAttributes()['payload'];


### PR DESCRIPTION
Este cambio hace que si no se puede hacer login usando OAuth de Google,
no se reporte como error interno del servidor y sea un error de
autenticación normal.