### PR TITLE
Hotfix para el API de actualizar problemas en concurso

### DIFF
--- a/frontend/server/libs/dao/Problemset_Problems.dao.php
+++ b/frontend/server/libs/dao/Problemset_Problems.dao.php
@@ -378,8 +378,10 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
     }
 
     public static function updateProblemsetProblemSubmissions(
-        ProblemsetProblem $problemsetProblem
+        ProblemsetProblems $problemsetProblem
     ) : void {
+        global $conn;
+
         $sql = '
             INSERT IGNORE INTO
                 Runs (
@@ -390,7 +392,7 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
             FROM
                 Submissions s
             WHERE
-                s.problemset_id = ?
+                s.problemset_id = ? AND
                 s.problem_id = ?
             ORDER BY
                 s.submission_id;

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -1026,6 +1026,9 @@ class UpdateProblemTest extends OmegaupTestCase {
             return [
                 'pastRunData' => $pastRunData,
                 'presentRunData' => $presentRunData,
+                'problemData' => $problemData,
+                'pastContestData' => $pastContestData,
+                'presentContestData' => $presentContestData,
             ];
         } finally {
             Time::setTimeForTesting($originalTime);
@@ -1150,6 +1153,22 @@ class UpdateProblemTest extends OmegaupTestCase {
             'WA',
             RunsDAO::getByPK(
                 SubmissionsDAO::getByGuid($result['presentRunData']['response']['guid'])->current_run_id
+            )->verdict
+        );
+
+        // Now explicitly change the version of the problemset.
+        $login = self::login($result['problemData']['author']);
+        ContestController::apiAddProblem(new Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $result['problemData']['problem']->alias,
+            'contest_alias' => $result['pastContestData']['contest']->alias,
+            'points' => 100,
+            'order_in_contest' => 1,
+        ]));
+        $this->assertEquals(
+            'WA',
+            RunsDAO::getByPK(
+                SubmissionsDAO::getByGuid($result['pastRunData']['response']['guid'])->current_run_id
             )->verdict
         );
     }


### PR DESCRIPTION
Resulta que por hacer las cosas a la carrera, no se hizo bien este
cambio :/ Así que ahora sí debe ser correcto.