### PR TITLE
Arregla el link de descarga de los problemas interactivos en un concurso

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1342,6 +1342,7 @@ class ProblemController extends Controller {
 
         // Get the expected commit version.
         $commit = $problem['problem']->commit;
+        $version = $problem['problem']->current_version;
         if (!empty($problem['problemset'])) {
             $problemsetProblem = ProblemsetProblemsDAO::getByPK(
                 $problem['problemset']->problemset_id,
@@ -1354,6 +1355,7 @@ class ProblemController extends Controller {
                 ];
             }
             $commit = $problemsetProblem->commit;
+            $version = $problemsetProblem->version;
         }
 
         $response['statement'] = ProblemController::getProblemStatement(
@@ -1386,11 +1388,12 @@ class ProblemController extends Controller {
 
         // Add the problem the response
         $response = array_merge($response, $problem['problem']->asFilteredArray([
-            'title', 'alias', 'commit', 'current_version', 'input_limit',
-            'visits', 'submissions', 'accepted', 'difficulty', 'creation_date',
-            'source', 'order', 'points', 'visibility', 'languages',
-            'email_clarifications',
+            'title', 'alias', 'input_limit', 'visits', 'submissions',
+            'accepted', 'difficulty', 'creation_date', 'source', 'order',
+            'points', 'visibility', 'languages', 'email_clarifications',
         ]));
+        $response['version'] = $version;
+        $response['commit'] = $commit;
 
         // If the problem is public or if the user has admin privileges, show the
         // problem source and alias of owner.

--- a/frontend/server/libs/dao/Problemset_Problems.dao.php
+++ b/frontend/server/libs/dao/Problemset_Problems.dao.php
@@ -161,6 +161,7 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
                     p.order,
                     p.languages,
                     pp.points,
+                    pp.commit,
                     pp.version
                 FROM
                     Problems p

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -72,6 +72,8 @@ class ContestDetailsTest extends OmegaupTestCase {
             // Get points of problem from Contest-Problem relationship
             $problemInContest = ProblemsetProblemsDAO::getByPK($contest->problemset_id, $problem->problem_id);
             $this->assertEquals($problemInContest->points, $problem_array['points']);
+            $this->assertEquals($problemInContest->commit, $problem_array['commit']);
+            $this->assertEquals($problemInContest->version, $problem_array['version']);
 
             $i++;
         }

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -137,6 +137,8 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ]));
 
         $this->assertEquals($response['alias'], $problemData['request']['problem_alias']);
+        $this->assertEquals($response['commit'], $problemData['problem']->commit);
+        $this->assertEquals($response['version'], $problemData['problem']->current_version);
     }
 
     /**


### PR DESCRIPTION
Este cambio hace que cuando se abre un problema en un concurso, los
enlaces de descarga de interactivo funcionen de nuevo.