### PR TITLE
Agregando manera de sincronizar archivos de ejemplo con la redacción

### DIFF
--- a/frontend/www/js/contest.print.js
+++ b/frontend/www/js/contest.print.js
@@ -8,7 +8,7 @@
     var payload = JSON.parse(problem.querySelector('script.payload').innerText);
 
     output.innerHTML = markdownConverter.makeHtmlWithImages(
-        payload.statement.markdown, payload.statement.images);
+        payload.statement.markdown, payload.statement.images, payload.settings);
     MathJax.Hub.Queue(['Typeset', MathJax.Hub, output]);
   }
 })();

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1485,7 +1485,7 @@ export class Arena {
     self.currentProblem = problem;
     let statement = document.querySelector('#problem div.statement');
     statement.innerHTML = self.markdownConverter.makeHtmlWithImages(
-        problem.statement.markdown, problem.statement.images);
+        problem.statement.markdown, problem.statement.images, problem.settings);
     const creationDate =
         document.querySelector('#problem .problem-creation-date');
     if (problem.problemsetter && creationDate) {

--- a/frontend/www/js/problem.print.js
+++ b/frontend/www/js/problem.print.js
@@ -4,6 +4,6 @@
 
   var statement = document.querySelector('div.statement');
   statement.innerHTML = markdownConverter.makeHtmlWithImages(
-      payload.statement.markdown, payload.statement.images);
+      payload.statement.markdown, payload.statement.images, payload.settings);
   MathJax.Hub.Queue(['Typeset', MathJax.Hub, statement]);
 })();


### PR DESCRIPTION
Este cambio hace posible tener los casos de ejemplo en archivos en la
carpeta `examples/` y referirse a ellos desde la redacción usando la
sintaxis:

    ||examplefile
    nombredelcaso
    ||end

y eso desplegaría un renglón con los contenidos de los archivos
`examples/nombredelcaso.in` y `examples/nombredelcaso.out`.

Fixes: #2509 