### PR TITLE
Refactor de cron scripts para compartir funcionalidad

### DIFF
--- a/stuff/cron/lib/db.py
+++ b/stuff/cron/lib/db.py
@@ -7,14 +7,16 @@ Using this library consists of two parts:
 - Getting a DB connection using arguments from the command line.
 '''
 
+import argparse
 import configparser
 import getpass
 import os
 
 import MySQLdb
+import MySQLdb.connections
 
 
-def configure_parser(parser):
+def configure_parser(parser: argparse.ArgumentParser):
     '''Add DB-related arguments to `parser`'''
     db_args = parser.add_argument_group('DB Access')
     db_args.add_argument('--mysql-config-file',
@@ -29,7 +31,7 @@ def configure_parser(parser):
                          default='omegaup')
 
 
-def connect(args):
+def connect(args: argparse.Namespace) -> MySQLdb.connections.Connection:
     '''Connects to MySQL with the arguments provided.
 
     Returns a MySQLdb connection.

--- a/stuff/cron/lib/db.py
+++ b/stuff/cron/lib/db.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+'''Library of common database code shared across cron scripts.
+
+Using this library consists of two parts:
+- Configuring a command line parser with configure_parser.
+- Getting a DB connection using arguments from the command line.
+'''
+
+import configparser
+import getpass
+import os
+
+import MySQLdb
+
+
+def configure_parser(parser):
+    '''Add DB-related arguments to `parser`'''
+    db_args = parser.add_argument_group('DB Access')
+    db_args.add_argument('--mysql-config-file',
+                         default=os.path.join(os.getenv('HOME') or '.',
+                                              '.my.cnf'),
+                         help='.my.cnf file that stores credentials')
+    db_args.add_argument('--host', type=str, help='MySQL host',
+                         default='localhost')
+    db_args.add_argument('--user', type=str, help='MySQL username')
+    db_args.add_argument('--password', type=str, help='MySQL password')
+    db_args.add_argument('--database', type=str, help='MySQL database',
+                         default='omegaup')
+
+
+def connect(args):
+    '''Connects to MySQL with the arguments provided.
+
+    Returns a MySQLdb connection.
+    '''
+    host = args.host
+    user = args.user
+    password = args.password
+    if user is None and os.path.isfile(args.mysql_config_file):
+        config = configparser.ConfigParser()
+        config.read(args.mysql_config_file)
+        # Puppet quotes some configuration entries.
+        host = config['client']['host'].strip("'")
+        user = config['client']['user'].strip("'")
+        password = config['client']['password'].strip("'")
+    if password is None:
+        password = getpass.getpass()
+
+    assert user is not None, 'Missing --user parameter'
+    assert host is not None, 'Missing --host parameter'
+    assert password is not None, 'Missing --password parameter'
+
+    return MySQLdb.connect(
+        host=host,
+        user=user,
+        passwd=password,
+        db=args.database
+    )
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/stuff/cron/lib/logs.py
+++ b/stuff/cron/lib/logs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+'''Library of common database code shared across cron scripts.
+
+Using this library consists of two parts:
+- Configuring a command line parser with configure_parser.
+- Getting a DB connection using arguments from the command line.
+'''
+
+import logging
+
+
+def configure_parser(parser):
+    '''Add Logging-related arguments to `parser`'''
+    logging_args = parser.add_argument_group('Logging')
+    logging_args.add_argument('--quiet', '-q', action='store_true',
+                              help='Disables logging')
+    logging_args.add_argument('--verbose', '-v', action='store_true',
+                              help='Enables verbose logging')
+    logging_args.add_argument('--logfile', type=str, default=None,
+                              help='Enables logging to a file')
+
+
+def init(program, args):
+    '''Initializes the logging module using arguments from the command line
+
+    Args:
+       program (str): The name of the program for logging purposes.
+       args (argparse.Namespace): Arguments resulting from parsing the command
+                                  line with a parser configured with
+                                  `configure_parser`.
+    '''
+    logging.basicConfig(filename=args.logfile,
+                        format='%%(asctime)s:%s:%%(message)s' % program,
+                        level=(logging.DEBUG if args.verbose else
+                               logging.INFO if not args.quiet else
+                               logging.ERROR))
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/stuff/cron/lib/logs.py
+++ b/stuff/cron/lib/logs.py
@@ -7,10 +7,11 @@ Using this library consists of two parts:
 - Getting a DB connection using arguments from the command line.
 '''
 
+import argparse
 import logging
 
 
-def configure_parser(parser):
+def configure_parser(parser: argparse.ArgumentParser):
     '''Add Logging-related arguments to `parser`'''
     logging_args = parser.add_argument_group('Logging')
     logging_args.add_argument('--quiet', '-q', action='store_true',
@@ -21,7 +22,7 @@ def configure_parser(parser):
                               help='Enables logging to a file')
 
 
-def init(program, args):
+def init(program: str, args: argparse.Namespace):
     '''Initializes the logging module using arguments from the command line
 
     Args:


### PR DESCRIPTION
# Descripción

Refactor de los cron scripts para mover funcionalidad compartida a un par de bibliotecas. A petición de @lhchavez en el review de #2516.
'
Pendiente: agregar typing... ya que entienda como se usa.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
