### PR TITLE
Usando empty($x) en vez de count($x) == 0

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -2658,7 +2658,7 @@ class ContestController extends Controller {
             foreach ($userData['problems'] as $key => $problemData) {
                 // If the user don't have these details then he didn't submit,
                 // we need to fill the report with 0s for completeness
-                if (!isset($problemData['run_details']['cases']) || count($problemData['run_details']['cases']) === 0) {
+                if (!isset($problemData['run_details']['cases']) || empty($problemData['run_details']['cases'])) {
                     for ($i = 0; $i < count($problemStats[$key]['cases_stats']); $i++) {
                         $csvRow[] = '0';
                     }

--- a/frontend/server/controllers/GroupScoreboardController.php
+++ b/frontend/server/controllers/GroupScoreboardController.php
@@ -173,7 +173,7 @@ class GroupScoreboardController extends Controller {
         $response['scoreboard'] = $scoreboard->asArray();
 
         // If we have contests, calculate merged&filtered scoreboard
-        if (count($response['contests']) > 0) {
+        if (!empty($response['contests'])) {
             // Get merged scoreboard
             $r['contest_aliases'] = '';
             foreach ($response['contests'] as $contest) {

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -2015,7 +2015,7 @@ class ProblemController extends Controller {
         }
 
         // Save the last id we saw in case we saw something
-        if (!is_null($runs) && count($runs) > 0) {
+        if (!empty($runs)) {
             $casesStats['last_submission_id'] = $runs[count($runs) - 1]->submission_id;
         }
 

--- a/frontend/server/controllers/SchoolController.php
+++ b/frontend/server/controllers/SchoolController.php
@@ -76,7 +76,7 @@ class SchoolController extends Controller {
         $school_id = 0;
         try {
             $existing = SchoolsDAO::findByName($name);
-            if (count($existing) > 0) {
+            if (!empty($existing)) {
                 return $existing[0]->school_id;
             }
             // Save in db

--- a/frontend/server/libs/Pager.php
+++ b/frontend/server/libs/Pager.php
@@ -42,7 +42,7 @@ class Pager {
         }
 
         $query = '';
-        if (count($params) > 0) {
+        if (!empty($params)) {
             $query = '&' . self::buildQueryString($params);
         }
 

--- a/frontend/server/libs/Validators.php
+++ b/frontend/server/libs/Validators.php
@@ -261,7 +261,7 @@ class Validators {
                     $bad_elements[] = $element;
                 }
             }
-            if (count($bad_elements) > 0) {
+            if (!empty($bad_elements)) {
                 throw new InvalidParameterException(
                     'parameterNotInExpectedSet',
                     $parameterName,

--- a/frontend/server/libs/dao/Assignments.dao.php
+++ b/frontend/server/libs/dao/Assignments.dao.php
@@ -31,7 +31,7 @@ class AssignmentsDAO extends AssignmentsDAOBase {
         $params[] = $assignmentAlias;
 
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
+++ b/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
@@ -95,7 +95,7 @@ class CoderOfTheMonthDAO extends CoderOfTheMonthDAOBase {
 
         global $conn;
         $results = $conn->getAll($sql, $val);
-        if (count($results) == 0) {
+        if (empty($results)) {
             return null;
         }
         return $results;
@@ -182,7 +182,7 @@ class CoderOfTheMonthDAO extends CoderOfTheMonthDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, []);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return false;
         }
         return $username == $rs['username'];

--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -149,7 +149,7 @@ class ContestsDAO extends ContestsDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
 
@@ -188,7 +188,7 @@ class ContestsDAO extends ContestsDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return $rs;
@@ -198,7 +198,7 @@ class ContestsDAO extends ContestsDAOBase {
         $sql = 'SELECT * FROM Contests WHERE problemset_id = ? LIMIT 0, 1;';
         global $conn;
         $row = $conn->GetRow($sql, [$problemset_id]);
-        if (count($row) == 0) {
+        if (empty($row)) {
             return null;
         }
 
@@ -792,7 +792,7 @@ class ContestsDAO extends ContestsDAOBase {
         $params = [$problemset_id];
 
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             throw new NotFoundException('problemsetNotFound');
         }
         return [

--- a/frontend/server/libs/dao/Groups.dao.php
+++ b/frontend/server/libs/dao/Groups.dao.php
@@ -23,7 +23,7 @@ class GroupsDAO extends GroupsDAOBase {
         $sql = 'SELECT g.* FROM Groups g WHERE g.alias = ? LIMIT 1;';
         $params = [$alias];
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Groups($rs);
@@ -47,7 +47,7 @@ class GroupsDAO extends GroupsDAOBase {
         $sql = 'SELECT g.* from Groups g where g.name = ? LIMIT 1;';
 
         $rs = $conn->GetRow($sql, [$name]);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Groups($rs);

--- a/frontend/server/libs/dao/Groups_Scoreboards.dao.php
+++ b/frontend/server/libs/dao/Groups_Scoreboards.dao.php
@@ -34,7 +34,7 @@ class GroupsScoreboardsDAO extends GroupsScoreboardsDAOBase {
         $sql = 'SELECT * FROM Groups_Scoreboards WHERE alias = ? LIMIT 1;';
         global $conn;
         $rs = $conn->GetRow($sql, [$alias]);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Identities.dao.php
+++ b/frontend/server/libs/dao/Identities.dao.php
@@ -167,7 +167,7 @@ class IdentitiesDAO extends IdentitiesDAOBase {
         $params = [$identity_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return $rs;
@@ -214,7 +214,7 @@ class IdentitiesDAO extends IdentitiesDAOBase {
         $args = [$username];
 
         $rs = $conn->GetRow($sql, $args);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Identities($rs);

--- a/frontend/server/libs/dao/Interviews.dao.php
+++ b/frontend/server/libs/dao/Interviews.dao.php
@@ -16,7 +16,7 @@ class InterviewsDAO extends InterviewsDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs)==0) {
+        if (empty($rs)) {
             return null;
         }
 
@@ -75,7 +75,7 @@ class InterviewsDAO extends InterviewsDAOBase {
 
         global $conn;
         $interviews = $conn->GetRow($sql, [$problemset_id]);
-        if (count($interviews) == 0) {
+        if (empty($interviews)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Languages.dao.php
+++ b/frontend/server/libs/dao/Languages.dao.php
@@ -30,7 +30,7 @@ class LanguagesDAO extends LanguagesDAOBase {
 
         global $conn;
         $row = $conn->GetRow($sql, [$name]);
-        if (count($row) == 0) {
+        if (empty($row)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Problems.dao.php
+++ b/frontend/server/libs/dao/Problems.dao.php
@@ -364,7 +364,7 @@ class ProblemsDAO extends ProblemsDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs)==0) {
+        if (empty($rs)) {
                 return null;
         }
 

--- a/frontend/server/libs/dao/Problemsets.dao.php
+++ b/frontend/server/libs/dao/Problemsets.dao.php
@@ -98,7 +98,7 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
 
         global $conn;
         $problemset = $conn->GetRow($sql, $params);
-        if (count($problemset) == 0) {
+        if (empty($problemset)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Roles.dao.php
+++ b/frontend/server/libs/dao/Roles.dao.php
@@ -28,7 +28,7 @@ class RolesDAO extends RolesDAOBase {
 
         global $conn;
         $row = $conn->GetRow($sql, [$name]);
-        if (count($row) == 0) {
+        if (empty($row)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Submissions.dao.php
+++ b/frontend/server/libs/dao/Submissions.dao.php
@@ -17,7 +17,7 @@ class SubmissionsDAO extends SubmissionsDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Tags.dao.php
+++ b/frontend/server/libs/dao/Tags.dao.php
@@ -24,7 +24,7 @@ class TagsDAO extends TagsDAOBase {
 
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
 

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -18,7 +18,7 @@ class UsersDAO extends UsersDAOBase {
         $sql = 'select u.* from Users u, Emails e where e.email = ? and e.user_id = u.user_id';
         $params = [ $email ];
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs)==0) {
+        if (empty($rs)) {
             return null;
         }
         return new Users($rs);
@@ -28,7 +28,7 @@ class UsersDAO extends UsersDAOBase {
         global  $conn;
         $sql = 'SELECT u.* FROM Users u WHERE username = ? LIMIT 1';
         $rs = $conn->GetRow($sql, [$username]);
-        if (count($rs)==0) {
+        if (empty($rs)) {
             return null;
         }
         return new Users($rs);
@@ -135,7 +135,7 @@ class UsersDAO extends UsersDAOBase {
         $params = [$user_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return $rs;

--- a/frontend/server/libs/dao/base/ACLs.dao.base.php
+++ b/frontend/server/libs/dao/base/ACLs.dao.base.php
@@ -75,7 +75,7 @@ abstract class ACLsDAOBase {
         $params = [$acl_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ACLs($rs);

--- a/frontend/server/libs/dao/base/ACLs.vo.base.php
+++ b/frontend/server/libs/dao/base/ACLs.vo.base.php
@@ -38,11 +38,11 @@ class ACLs extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Announcement.dao.base.php
+++ b/frontend/server/libs/dao/base/Announcement.dao.base.php
@@ -77,7 +77,7 @@ abstract class AnnouncementDAOBase {
         $params = [$announcement_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Announcement($rs);

--- a/frontend/server/libs/dao/base/Announcement.vo.base.php
+++ b/frontend/server/libs/dao/base/Announcement.vo.base.php
@@ -44,11 +44,11 @@ class Announcement extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Assignments.dao.base.php
+++ b/frontend/server/libs/dao/base/Assignments.dao.base.php
@@ -86,7 +86,7 @@ abstract class AssignmentsDAOBase {
         $params = [$assignment_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Assignments($rs);

--- a/frontend/server/libs/dao/base/Assignments.vo.base.php
+++ b/frontend/server/libs/dao/base/Assignments.vo.base.php
@@ -71,11 +71,11 @@ class Assignments extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['start_time', 'finish_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Auth_Tokens.dao.base.php
+++ b/frontend/server/libs/dao/base/Auth_Tokens.dao.base.php
@@ -77,7 +77,7 @@ abstract class AuthTokensDAOBase {
         $params = [$token];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new AuthTokens($rs);

--- a/frontend/server/libs/dao/base/Auth_Tokens.vo.base.php
+++ b/frontend/server/libs/dao/base/Auth_Tokens.vo.base.php
@@ -44,11 +44,11 @@ class AuthTokens extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['create_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Badges.dao.base.php
+++ b/frontend/server/libs/dao/base/Badges.dao.base.php
@@ -78,7 +78,7 @@ abstract class BadgesDAOBase {
         $params = [$badge_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Badges($rs);

--- a/frontend/server/libs/dao/base/Badges.vo.base.php
+++ b/frontend/server/libs/dao/base/Badges.vo.base.php
@@ -47,11 +47,11 @@ class Badges extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Clarifications.dao.base.php
+++ b/frontend/server/libs/dao/base/Clarifications.dao.base.php
@@ -82,7 +82,7 @@ abstract class ClarificationsDAOBase {
         $params = [$clarification_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Clarifications($rs);

--- a/frontend/server/libs/dao/base/Clarifications.vo.base.php
+++ b/frontend/server/libs/dao/base/Clarifications.vo.base.php
@@ -59,11 +59,11 @@ class Clarifications extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Coder_Of_The_Month.dao.base.php
+++ b/frontend/server/libs/dao/base/Coder_Of_The_Month.dao.base.php
@@ -80,7 +80,7 @@ abstract class CoderOfTheMonthDAOBase {
         $params = [$coder_of_the_month_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new CoderOfTheMonth($rs);

--- a/frontend/server/libs/dao/base/Coder_Of_The_Month.vo.base.php
+++ b/frontend/server/libs/dao/base/Coder_Of_The_Month.vo.base.php
@@ -53,11 +53,11 @@ class CoderOfTheMonth extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Contest_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Contest_Log.dao.base.php
@@ -79,7 +79,7 @@ abstract class ContestLogDAOBase {
         $params = [$public_contest_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ContestLog($rs);

--- a/frontend/server/libs/dao/base/Contest_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Contest_Log.vo.base.php
@@ -50,11 +50,11 @@ class ContestLog extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Contests.dao.base.php
+++ b/frontend/server/libs/dao/base/Contests.dao.base.php
@@ -97,7 +97,7 @@ abstract class ContestsDAOBase {
         $params = [$contest_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Contests($rs);

--- a/frontend/server/libs/dao/base/Contests.vo.base.php
+++ b/frontend/server/libs/dao/base/Contests.vo.base.php
@@ -104,11 +104,11 @@ class Contests extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['start_time', 'finish_time', 'last_updated']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Countries.dao.base.php
+++ b/frontend/server/libs/dao/base/Countries.dao.base.php
@@ -75,7 +75,7 @@ abstract class CountriesDAOBase {
         $params = [$country_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Countries($rs);

--- a/frontend/server/libs/dao/base/Countries.vo.base.php
+++ b/frontend/server/libs/dao/base/Countries.vo.base.php
@@ -38,11 +38,11 @@ class Countries extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Courses.dao.base.php
+++ b/frontend/server/libs/dao/base/Courses.dao.base.php
@@ -86,7 +86,7 @@ abstract class CoursesDAOBase {
         $params = [$course_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Courses($rs);

--- a/frontend/server/libs/dao/base/Courses.vo.base.php
+++ b/frontend/server/libs/dao/base/Courses.vo.base.php
@@ -71,11 +71,11 @@ class Courses extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['start_time', 'finish_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Emails.dao.base.php
+++ b/frontend/server/libs/dao/base/Emails.dao.base.php
@@ -76,7 +76,7 @@ abstract class EmailsDAOBase {
         $params = [$email_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Emails($rs);

--- a/frontend/server/libs/dao/base/Emails.vo.base.php
+++ b/frontend/server/libs/dao/base/Emails.vo.base.php
@@ -41,11 +41,11 @@ class Emails extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Favorites.dao.base.php
+++ b/frontend/server/libs/dao/base/Favorites.dao.base.php
@@ -35,7 +35,7 @@ abstract class FavoritesDAOBase {
         $params = [$user_id, $problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Favorites($rs);

--- a/frontend/server/libs/dao/base/Favorites.vo.base.php
+++ b/frontend/server/libs/dao/base/Favorites.vo.base.php
@@ -38,11 +38,11 @@ class Favorites extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Group_Roles.dao.base.php
+++ b/frontend/server/libs/dao/base/Group_Roles.dao.base.php
@@ -35,7 +35,7 @@ abstract class GroupRolesDAOBase {
         $params = [$group_id, $role_id, $acl_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new GroupRoles($rs);

--- a/frontend/server/libs/dao/base/Group_Roles.vo.base.php
+++ b/frontend/server/libs/dao/base/Group_Roles.vo.base.php
@@ -41,11 +41,11 @@ class GroupRoles extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Groups.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups.dao.base.php
@@ -79,7 +79,7 @@ abstract class GroupsDAOBase {
         $params = [$group_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Groups($rs);

--- a/frontend/server/libs/dao/base/Groups.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups.vo.base.php
@@ -50,11 +50,11 @@ class Groups extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['create_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Groups_Identities.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups_Identities.dao.base.php
@@ -78,7 +78,7 @@ abstract class GroupsIdentitiesDAOBase {
         $params = [$group_id, $identity_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new GroupsIdentities($rs);

--- a/frontend/server/libs/dao/base/Groups_Identities.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups_Identities.vo.base.php
@@ -47,11 +47,11 @@ class GroupsIdentities extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Groups_Scoreboards.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards.dao.base.php
@@ -79,7 +79,7 @@ abstract class GroupsScoreboardsDAOBase {
         $params = [$group_scoreboard_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new GroupsScoreboards($rs);

--- a/frontend/server/libs/dao/base/Groups_Scoreboards.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards.vo.base.php
@@ -50,11 +50,11 @@ class GroupsScoreboards extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['create_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Groups_Scoreboards_Problemsets.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards_Problemsets.dao.base.php
@@ -77,7 +77,7 @@ abstract class GroupsScoreboardsProblemsetsDAOBase {
         $params = [$group_scoreboard_id, $problemset_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new GroupsScoreboardsProblemsets($rs);

--- a/frontend/server/libs/dao/base/Groups_Scoreboards_Problemsets.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards_Problemsets.vo.base.php
@@ -44,11 +44,11 @@ class GroupsScoreboardsProblemsets extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Identities.dao.base.php
+++ b/frontend/server/libs/dao/base/Identities.dao.base.php
@@ -83,7 +83,7 @@ abstract class IdentitiesDAOBase {
         $params = [$identity_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Identities($rs);

--- a/frontend/server/libs/dao/base/Identities.vo.base.php
+++ b/frontend/server/libs/dao/base/Identities.vo.base.php
@@ -62,11 +62,11 @@ class Identities extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Identity_Login_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Identity_Login_Log.vo.base.php
@@ -41,11 +41,11 @@ class IdentityLoginLog extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Interviews.dao.base.php
+++ b/frontend/server/libs/dao/base/Interviews.dao.base.php
@@ -80,7 +80,7 @@ abstract class InterviewsDAOBase {
         $params = [$interview_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Interviews($rs);

--- a/frontend/server/libs/dao/base/Interviews.vo.base.php
+++ b/frontend/server/libs/dao/base/Interviews.vo.base.php
@@ -53,11 +53,11 @@ class Interviews extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Languages.dao.base.php
+++ b/frontend/server/libs/dao/base/Languages.dao.base.php
@@ -76,7 +76,7 @@ abstract class LanguagesDAOBase {
         $params = [$language_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Languages($rs);

--- a/frontend/server/libs/dao/base/Languages.vo.base.php
+++ b/frontend/server/libs/dao/base/Languages.vo.base.php
@@ -41,11 +41,11 @@ class Languages extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Messages.dao.base.php
+++ b/frontend/server/libs/dao/base/Messages.dao.base.php
@@ -79,7 +79,7 @@ abstract class MessagesDAOBase {
         $params = [$message_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Messages($rs);

--- a/frontend/server/libs/dao/base/Messages.vo.base.php
+++ b/frontend/server/libs/dao/base/Messages.vo.base.php
@@ -50,11 +50,11 @@ class Messages extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['date']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Permissions.dao.base.php
+++ b/frontend/server/libs/dao/base/Permissions.dao.base.php
@@ -76,7 +76,7 @@ abstract class PermissionsDAOBase {
         $params = [$permission_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Permissions($rs);

--- a/frontend/server/libs/dao/base/Permissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Permissions.vo.base.php
@@ -41,11 +41,11 @@ class Permissions extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.dao.base.php
@@ -77,7 +77,7 @@ abstract class PrivacyStatementConsentLogDAOBase {
         $params = [$privacystatement_consent_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new PrivacyStatementConsentLog($rs);

--- a/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.vo.base.php
@@ -44,11 +44,11 @@ class PrivacyStatementConsentLog extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['timestamp']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/PrivacyStatements.dao.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatements.dao.base.php
@@ -76,7 +76,7 @@ abstract class PrivacyStatementsDAOBase {
         $params = [$privacystatement_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new PrivacyStatements($rs);

--- a/frontend/server/libs/dao/base/PrivacyStatements.vo.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatements.vo.base.php
@@ -41,11 +41,11 @@ class PrivacyStatements extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problem_Of_The_Week.dao.base.php
+++ b/frontend/server/libs/dao/base/Problem_Of_The_Week.dao.base.php
@@ -77,7 +77,7 @@ abstract class ProblemOfTheWeekDAOBase {
         $params = [$problem_of_the_week_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemOfTheWeek($rs);

--- a/frontend/server/libs/dao/base/Problem_Of_The_Week.vo.base.php
+++ b/frontend/server/libs/dao/base/Problem_Of_The_Week.vo.base.php
@@ -44,11 +44,11 @@ class ProblemOfTheWeek extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problem_Viewed.dao.base.php
+++ b/frontend/server/libs/dao/base/Problem_Viewed.dao.base.php
@@ -76,7 +76,7 @@ abstract class ProblemViewedDAOBase {
         $params = [$problem_id, $identity_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemViewed($rs);

--- a/frontend/server/libs/dao/base/Problem_Viewed.vo.base.php
+++ b/frontend/server/libs/dao/base/Problem_Viewed.vo.base.php
@@ -41,11 +41,11 @@ class ProblemViewed extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['view_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems.dao.base.php
@@ -94,7 +94,7 @@ abstract class ProblemsDAOBase {
         $params = [$problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Problems($rs);

--- a/frontend/server/libs/dao/base/Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems.vo.base.php
@@ -95,11 +95,11 @@ class Problems extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['creation_date']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problems_Badges.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems_Badges.dao.base.php
@@ -35,7 +35,7 @@ abstract class ProblemsBadgesDAOBase {
         $params = [$badge_id, $problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsBadges($rs);

--- a/frontend/server/libs/dao/base/Problems_Badges.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Badges.vo.base.php
@@ -38,11 +38,11 @@ class ProblemsBadges extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problems_Languages.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems_Languages.dao.base.php
@@ -35,7 +35,7 @@ abstract class ProblemsLanguagesDAOBase {
         $params = [$problem_id, $language_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsLanguages($rs);

--- a/frontend/server/libs/dao/base/Problems_Languages.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Languages.vo.base.php
@@ -38,11 +38,11 @@ class ProblemsLanguages extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problems_Tags.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems_Tags.dao.base.php
@@ -77,7 +77,7 @@ abstract class ProblemsTagsDAOBase {
         $params = [$problem_id, $tag_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsTags($rs);

--- a/frontend/server/libs/dao/base/Problems_Tags.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Tags.vo.base.php
@@ -44,11 +44,11 @@ class ProblemsTags extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemset_Access_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Access_Log.vo.base.php
@@ -44,11 +44,11 @@ class ProblemsetAccessLog extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemset_Identities.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identities.dao.base.php
@@ -81,7 +81,7 @@ abstract class ProblemsetIdentitiesDAOBase {
         $params = [$identity_id, $problemset_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsetIdentities($rs);

--- a/frontend/server/libs/dao/base/Problemset_Identities.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identities.vo.base.php
@@ -56,11 +56,11 @@ class ProblemsetIdentities extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request.dao.base.php
@@ -79,7 +79,7 @@ abstract class ProblemsetIdentityRequestDAOBase {
         $params = [$identity_id, $problemset_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsetIdentityRequest($rs);

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request.vo.base.php
@@ -50,11 +50,11 @@ class ProblemsetIdentityRequest extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['request_time', 'last_update']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request_History.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request_History.dao.base.php
@@ -79,7 +79,7 @@ abstract class ProblemsetIdentityRequestHistoryDAOBase {
         $params = [$history_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsetIdentityRequestHistory($rs);

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request_History.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request_History.vo.base.php
@@ -50,11 +50,11 @@ class ProblemsetIdentityRequestHistory extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemset_Problem_Opened.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problem_Opened.dao.base.php
@@ -77,7 +77,7 @@ abstract class ProblemsetProblemOpenedDAOBase {
         $params = [$problemset_id, $problem_id, $identity_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsetProblemOpened($rs);

--- a/frontend/server/libs/dao/base/Problemset_Problem_Opened.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problem_Opened.vo.base.php
@@ -44,11 +44,11 @@ class ProblemsetProblemOpened extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['open_time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemset_Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problems.dao.base.php
@@ -79,7 +79,7 @@ abstract class ProblemsetProblemsDAOBase {
         $params = [$problemset_id, $problem_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new ProblemsetProblems($rs);

--- a/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
@@ -50,11 +50,11 @@ class ProblemsetProblems extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Problemsets.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemsets.dao.base.php
@@ -85,7 +85,7 @@ abstract class ProblemsetsDAOBase {
         $params = [$problemset_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Problemsets($rs);

--- a/frontend/server/libs/dao/base/Problemsets.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemsets.vo.base.php
@@ -68,11 +68,11 @@ class Problemsets extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/QualityNomination_Comments.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Comments.dao.base.php
@@ -79,7 +79,7 @@ abstract class QualityNominationCommentsDAOBase {
         $params = [$qualitynomination_comment_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new QualityNominationComments($rs);

--- a/frontend/server/libs/dao/base/QualityNomination_Comments.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Comments.vo.base.php
@@ -50,11 +50,11 @@ class QualityNominationComments extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/QualityNomination_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Log.dao.base.php
@@ -80,7 +80,7 @@ abstract class QualityNominationLogDAOBase {
         $params = [$qualitynomination_log_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new QualityNominationLog($rs);

--- a/frontend/server/libs/dao/base/QualityNomination_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Log.vo.base.php
@@ -53,11 +53,11 @@ class QualityNominationLog extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/QualityNomination_Reviewers.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Reviewers.dao.base.php
@@ -35,7 +35,7 @@ abstract class QualityNominationReviewersDAOBase {
         $params = [$qualitynomination_id, $user_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new QualityNominationReviewers($rs);

--- a/frontend/server/libs/dao/base/QualityNomination_Reviewers.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Reviewers.vo.base.php
@@ -38,11 +38,11 @@ class QualityNominationReviewers extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/QualityNominations.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNominations.dao.base.php
@@ -80,7 +80,7 @@ abstract class QualityNominationsDAOBase {
         $params = [$qualitynomination_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new QualityNominations($rs);

--- a/frontend/server/libs/dao/base/QualityNominations.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNominations.vo.base.php
@@ -53,11 +53,11 @@ class QualityNominations extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Roles.dao.base.php
+++ b/frontend/server/libs/dao/base/Roles.dao.base.php
@@ -76,7 +76,7 @@ abstract class RolesDAOBase {
         $params = [$role_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Roles($rs);

--- a/frontend/server/libs/dao/base/Roles.vo.base.php
+++ b/frontend/server/libs/dao/base/Roles.vo.base.php
@@ -41,11 +41,11 @@ class Roles extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Roles_Permissions.dao.base.php
+++ b/frontend/server/libs/dao/base/Roles_Permissions.dao.base.php
@@ -35,7 +35,7 @@ abstract class RolesPermissionsDAOBase {
         $params = [$role_id, $permission_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new RolesPermissions($rs);

--- a/frontend/server/libs/dao/base/Roles_Permissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Roles_Permissions.vo.base.php
@@ -38,11 +38,11 @@ class RolesPermissions extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Run_Counts.dao.base.php
+++ b/frontend/server/libs/dao/base/Run_Counts.dao.base.php
@@ -76,7 +76,7 @@ abstract class RunCountsDAOBase {
         $params = [$date];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new RunCounts($rs);

--- a/frontend/server/libs/dao/base/Run_Counts.vo.base.php
+++ b/frontend/server/libs/dao/base/Run_Counts.vo.base.php
@@ -41,11 +41,11 @@ class RunCounts extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Runs.dao.base.php
+++ b/frontend/server/libs/dao/base/Runs.dao.base.php
@@ -85,7 +85,7 @@ abstract class RunsDAOBase {
         $params = [$run_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Runs($rs);

--- a/frontend/server/libs/dao/base/Runs.vo.base.php
+++ b/frontend/server/libs/dao/base/Runs.vo.base.php
@@ -68,11 +68,11 @@ class Runs extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Schools.dao.base.php
+++ b/frontend/server/libs/dao/base/Schools.dao.base.php
@@ -77,7 +77,7 @@ abstract class SchoolsDAOBase {
         $params = [$school_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Schools($rs);

--- a/frontend/server/libs/dao/base/Schools.vo.base.php
+++ b/frontend/server/libs/dao/base/Schools.vo.base.php
@@ -44,11 +44,11 @@ class Schools extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/States.dao.base.php
+++ b/frontend/server/libs/dao/base/States.dao.base.php
@@ -76,7 +76,7 @@ abstract class StatesDAOBase {
         $params = [$country_id, $state_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new States($rs);

--- a/frontend/server/libs/dao/base/States.vo.base.php
+++ b/frontend/server/libs/dao/base/States.vo.base.php
@@ -41,11 +41,11 @@ class States extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Submission_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Submission_Log.dao.base.php
@@ -79,7 +79,7 @@ abstract class SubmissionLogDAOBase {
         $params = [$submission_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new SubmissionLog($rs);

--- a/frontend/server/libs/dao/base/Submission_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Submission_Log.vo.base.php
@@ -50,11 +50,11 @@ class SubmissionLog extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Submissions.dao.base.php
+++ b/frontend/server/libs/dao/base/Submissions.dao.base.php
@@ -83,7 +83,7 @@ abstract class SubmissionsDAOBase {
         $params = [$submission_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Submissions($rs);

--- a/frontend/server/libs/dao/base/Submissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Submissions.vo.base.php
@@ -62,11 +62,11 @@ class Submissions extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Tags.dao.base.php
+++ b/frontend/server/libs/dao/base/Tags.dao.base.php
@@ -75,7 +75,7 @@ abstract class TagsDAOBase {
         $params = [$tag_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Tags($rs);

--- a/frontend/server/libs/dao/base/Tags.vo.base.php
+++ b/frontend/server/libs/dao/base/Tags.vo.base.php
@@ -38,11 +38,11 @@ class Tags extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/User_Rank.dao.base.php
+++ b/frontend/server/libs/dao/base/User_Rank.dao.base.php
@@ -82,7 +82,7 @@ abstract class UserRankDAOBase {
         $params = [$user_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new UserRank($rs);

--- a/frontend/server/libs/dao/base/User_Rank.vo.base.php
+++ b/frontend/server/libs/dao/base/User_Rank.vo.base.php
@@ -59,11 +59,11 @@ class UserRank extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/User_Rank_Cutoffs.vo.base.php
+++ b/frontend/server/libs/dao/base/User_Rank_Cutoffs.vo.base.php
@@ -41,11 +41,11 @@ class UserRankCutoffs extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/User_Roles.dao.base.php
+++ b/frontend/server/libs/dao/base/User_Roles.dao.base.php
@@ -35,7 +35,7 @@ abstract class UserRolesDAOBase {
         $params = [$user_id, $role_id, $acl_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new UserRoles($rs);

--- a/frontend/server/libs/dao/base/User_Roles.vo.base.php
+++ b/frontend/server/libs/dao/base/User_Roles.vo.base.php
@@ -41,11 +41,11 @@ class UserRoles extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Users.dao.base.php
+++ b/frontend/server/libs/dao/base/Users.dao.base.php
@@ -96,7 +96,7 @@ abstract class UsersDAOBase {
         $params = [$user_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new Users($rs);

--- a/frontend/server/libs/dao/base/Users.vo.base.php
+++ b/frontend/server/libs/dao/base/Users.vo.base.php
@@ -101,11 +101,11 @@ class Users extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Users_Badges.dao.base.php
+++ b/frontend/server/libs/dao/base/Users_Badges.dao.base.php
@@ -77,7 +77,7 @@ abstract class UsersBadgesDAOBase {
         $params = [$badge_id, $user_id];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new UsersBadges($rs);

--- a/frontend/server/libs/dao/base/Users_Badges.vo.base.php
+++ b/frontend/server/libs/dao/base/Users_Badges.vo.base.php
@@ -44,11 +44,11 @@ class UsersBadges extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime(['time']);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/server/libs/dao/base/Users_Experiments.vo.base.php
+++ b/frontend/server/libs/dao/base/Users_Experiments.vo.base.php
@@ -38,11 +38,11 @@ class UsersExperiments extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 
     /**

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -51,7 +51,7 @@ class Utils {
         $sql = 'SELECT NOW() n';
         $rs = $conn->GetRow($sql);
 
-        if (count($rs) === 0) {
+        if (empty($rs)) {
             return null;
         }
 
@@ -66,7 +66,7 @@ class Utils {
         $params = [$time];
         $rs = $conn->GetRow($sql, $params);
 
-        if (count($rs) === 0) {
+        if (empty($rs)) {
             return null;
         }
 

--- a/frontend/www/schools/index.php
+++ b/frontend/www/schools/index.php
@@ -10,7 +10,7 @@ try {
 }
 
 if (isset($course)
-    && (count($course['student']) != 0 || count($course['admin']) != 0)) {
+    && (!empty($course['student']) || !empty($course['admin']))) {
     die(header('Location: /course'));
 } else {
     $smarty->display('../templates/schools.intro.tpl');

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -81,7 +81,7 @@ abstract class {{ table.class_name }}DAOBase {
         $params = [{{ table.columns|selectattr('primary_key')|listformat('${.name}')|join(', ') }}];
         global $conn;
         $rs = $conn->GetRow($sql, $params);
-        if (count($rs) == 0) {
+        if (empty($rs)) {
             return null;
         }
         return new {{ table.class_name }}($rs);

--- a/stuff/dao_templates/vo.php
+++ b/stuff/dao_templates/vo.php
@@ -45,11 +45,11 @@ class {{ table.class_name }} extends VO {
      * Converts date fields to timestamps
      */
     public function toUnixTime(array $fields = []) {
-        if (count($fields) > 0) {
-            parent::toUnixTime($fields);
-        } else {
+        if (empty($fields)) {
             parent::toUnixTime([{{ table.columns|selectattr('type', 'equalto', ('timestamp',))|map(attribute='name')|listformat("'{}'")|join(', ') }}]);
+            return;
         }
+        parent::toUnixTime($fields);
     }
 {%- for column in table.columns %}
 


### PR DESCRIPTION
Este cambio hace que usemos `empty()` más seguido.

```shell
git grep -l 'count.*==\s*0' *.php | \
    xargs sed -i 's/count(\([^)]\+\))\s*=\+\s*0/empty(\1)/'
git grep -l 'count.*>\s*0' *.php | \
    xargs sed -i 's/count(\([^)]\+\))\s*>\s*0/!empty(\1)/'
```