### PR TITLE
Haciendo que MySQL regrese los tipos correctos

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -201,6 +201,7 @@ $conn = null;
 try {
     $conn = ADONewConnection(OMEGAUP_DB_DRIVER);
     $conn->debug = OMEGAUP_DB_DEBUG;
+    array_push($conn->optionFlags, [MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true]);
     $conn->SetFetchMode(ADODB_FETCH_ASSOC);
     $conn->PConnect(OMEGAUP_DB_HOST, OMEGAUP_DB_USER, OMEGAUP_DB_PASS, OMEGAUP_DB_NAME);
 } catch (Exception $databaseConectionException) {

--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -418,7 +418,7 @@ class ContestListTest extends OmegaupTestCase {
         $this->assertArrayContainsInKey(
             $response['results'],
             'contest_id',
-            (string)$currentContestData['contest']->contest_id
+            $currentContestData['contest']->contest_id
         );
         $this->assertArrayNotContainsInKey(
             $response['results'],


### PR DESCRIPTION
Este cambio enciende la bandera que hace que los resultados de todas las
consultas de MySQL se regresen con los tipos correctos (enteros,
flotantes y cadenas), en vez de que todo sea cadena siempre.