### PR TITLE
Refactor de Validators

### DIFF
--- a/frontend/server/controllers/ClarificationController.php
+++ b/frontend/server/controllers/ClarificationController.php
@@ -26,11 +26,11 @@ class ClarificationController extends Controller {
      * @throws NotFoundException
      */
     private static function validateCreate(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
-        Validators::isStringNonEmpty($r['username'], 'username', false);
-        Validators::isStringNonEmpty($r['message'], 'message');
-        Validators::isStringOfMaxLength($r['message'], 'message', 200);
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['username'], 'username', false);
+        Validators::validateStringNonEmpty($r['message'], 'message');
+        Validators::validateStringOfLengthInRange($r['message'], 'message', null, 200);
 
         try {
             $r['contest'] = ContestsDAO::getByAlias($r['contest_alias']);
@@ -109,7 +109,7 @@ class ClarificationController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateDetails(Request $r) {
-        Validators::isNumber($r['clarification_id'], 'clarification_id');
+        Validators::validateNumber($r['clarification_id'], 'clarification_id');
 
         // Check that the clarification actually exists
         try {
@@ -161,10 +161,10 @@ class ClarificationController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateUpdate(Request $r) {
-        Validators::isNumber($r['clarification_id'], 'clarificaion_id');
-        Validators::isStringNonEmpty($r['answer'], 'answer', false /* not required */);
-        Validators::isInEnum($r['public'], 'public', ['0', '1'], false /* not required */);
-        Validators::isStringNonEmpty($r['message'], 'message', false /* not required */);
+        Validators::validateNumber($r['clarification_id'], 'clarificaion_id');
+        Validators::validateStringNonEmpty($r['answer'], 'answer', false /* not required */);
+        Validators::validateInEnum($r['public'], 'public', ['0', '1'], false /* not required */);
+        Validators::validateStringNonEmpty($r['message'], 'message', false /* not required */);
 
         // Check that clarification exists
         try {

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -30,8 +30,8 @@ class ContestController extends Controller {
 
         try {
             $contests = [];
-            Validators::isNumber($r['page'], 'page', false);
-            Validators::isNumber($r['page_size'], 'page_size', false);
+            Validators::validateNumber($r['page'], 'page', false);
+            Validators::validateNumber($r['page_size'], 'page_size', false);
 
             $page = (isset($r['page']) ? intval($r['page']) : 1);
             $page_size = (isset($r['page_size']) ? intval($r['page_size']) : 20);
@@ -40,16 +40,16 @@ class ContestController extends Controller {
                 : ActiveStatus::ALL;
             // If the parameter was not set, the default should be ALL which is
             // a number and should pass this check.
-            Validators::isNumber($active_contests, 'active', true /* required */);
+            Validators::validateNumber($active_contests, 'active', true /* required */);
             $recommended = isset($r['recommended'])
                 ? RecommendedStatus::getIntValue($r['recommended'])
                 : RecommendedStatus::ALL;
             // Same as above.
-            Validators::isNumber($recommended, 'recommended', true /* required */);
+            Validators::validateNumber($recommended, 'recommended', true /* required */);
             $participating = isset($r['participating'])
                 ? ParticipatingStatus::getIntValue($r['participating'])
                 : ParticipatingStatus::NO;
-            Validators::isInEnum($r['admission_mode'], 'admission_mode', [
+            Validators::validateInEnum($r['admission_mode'], 'admission_mode', [
                 'public',
                 'private',
                 'registration'
@@ -62,7 +62,7 @@ class ContestController extends Controller {
                 throw new InvalidParameterException('parameterInvalid', 'participating');
             }
             $query = $r['query'];
-            Validators::isStringOfMaxLength($query, 'query', 255, false /* not required */);
+            Validators::validateStringOfLengthInRange($query, 'query', null, 255, false /* not required */);
             $cache_key = "$active_contests-$recommended-$page-$page_size";
             if ($r['current_user_id'] === null) {
                 // Get all public contests
@@ -140,8 +140,8 @@ class ContestController extends Controller {
     public static function apiAdminList(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
+        Validators::validateNumber($r['page'], 'page', false);
+        Validators::validateNumber($r['page_size'], 'page_size', false);
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -183,8 +183,8 @@ class ContestController extends Controller {
     public static function getContestListInternal(Request $r, $callback_user_function) {
         self::authenticateRequest($r);
 
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
+        Validators::validateNumber($r['page'], 'page', false);
+        Validators::validateNumber($r['page_size'], 'page_size', false);
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -298,7 +298,7 @@ class ContestController extends Controller {
      *
      */
     private static function validateBasicDetails(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
         // If the contest is private, verify that our user is invited
         try {
             $contest_problemset = ContestsDAO::getByAliasWithExtraInformation($r['contest_alias']);
@@ -444,7 +444,7 @@ class ContestController extends Controller {
     }
 
     public static function apiPublicDetails(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $result = [];
 
@@ -893,7 +893,7 @@ class ContestController extends Controller {
 
         $contestLength = $finishTime - $startTime;
 
-        Validators::isNumber($r['start_time'], 'start_time', false);
+        Validators::validateNumber($r['start_time'], 'start_time', false);
         $r['start_time'] = !is_null($r['start_time']) ? $r['start_time'] : Time::get();
 
         // Initialize contest
@@ -1071,11 +1071,11 @@ class ContestController extends Controller {
             }
         }
 
-        Validators::isStringNonEmpty($r['title'], 'title', $is_required);
-        Validators::isStringNonEmpty($r['description'], 'description', $is_required);
+        Validators::validateStringNonEmpty($r['title'], 'title', $is_required);
+        Validators::validateStringNonEmpty($r['description'], 'description', $is_required);
 
-        Validators::isNumber($r['start_time'], 'start_time', $is_required);
-        Validators::isNumber($r['finish_time'], 'finish_time', $is_required);
+        Validators::validateNumber($r['start_time'], 'start_time', $is_required);
+        Validators::validateNumber($r['finish_time'], 'finish_time', $is_required);
 
         // Get the actual start and finish time of the contest, considering that
         // in case of update, parameters can be optional
@@ -1097,7 +1097,7 @@ class ContestController extends Controller {
 
         // Window_length is optional
         if (!empty($r['window_length'])) {
-            Validators::isNumberInRange(
+            Validators::validateNumberInRange(
                 $r['window_length'],
                 'window_length',
                 0,
@@ -1106,20 +1106,20 @@ class ContestController extends Controller {
             );
         }
 
-        Validators::isInEnum($r['admission_mode'], 'admission_mode', [
+        Validators::validateInEnum($r['admission_mode'], 'admission_mode', [
             'public',
             'private',
             'registration'
         ], false);
-        Validators::isValidAlias($r['alias'], 'alias', $is_required);
-        Validators::isNumberInRange($r['scoreboard'], 'scoreboard', 0, 100, $is_required);
-        Validators::isNumberInRange($r['points_decay_factor'], 'points_decay_factor', 0, 1, $is_required);
-        Validators::isInEnum($r['partial_score'], 'partial_score', ['0', '1'], false);
-        Validators::isNumberInRange($r['submissions_gap'] == null ? null : floor($r['submissions_gap']/60), 'submissions_gap', 1, floor($contest_length / 60), $is_required);
+        Validators::validateValidAlias($r['alias'], 'alias', $is_required);
+        Validators::validateNumberInRange($r['scoreboard'], 'scoreboard', 0, 100, $is_required);
+        Validators::validateNumberInRange($r['points_decay_factor'], 'points_decay_factor', 0, 1, $is_required);
+        Validators::validateInEnum($r['partial_score'], 'partial_score', ['0', '1'], false);
+        Validators::validateNumberInRange($r['submissions_gap'] == null ? null : floor($r['submissions_gap']/60), 'submissions_gap', 1, floor($contest_length / 60), $is_required);
 
-        Validators::isInEnum($r['feedback'], 'feedback', ['no', 'yes', 'partial'], $is_required);
-        Validators::isInEnum($r['penalty_type'], 'penalty_type', ['contest_start', 'problem_open', 'runtime', 'none'], $is_required);
-        Validators::isInEnum($r['penalty_calc_policy'], 'penalty_calc_policy', ['sum', 'max'], false);
+        Validators::validateInEnum($r['feedback'], 'feedback', ['no', 'yes', 'partial'], $is_required);
+        Validators::validateInEnum($r['penalty_type'], 'penalty_type', ['contest_start', 'problem_open', 'runtime', 'none'], $is_required);
+        Validators::validateInEnum($r['penalty_calc_policy'], 'penalty_calc_policy', ['sum', 'max'], false);
 
         // Problems is optional
         if (!is_null($r['problems'])) {
@@ -1147,12 +1147,12 @@ class ContestController extends Controller {
         }
 
         // Show scoreboard is always optional
-        Validators::isInEnum($r['show_scoreboard_after'], 'show_scoreboard_after', ['false', 'true'], false);
+        Validators::validateInEnum($r['show_scoreboard_after'], 'show_scoreboard_after', ['false', 'true'], false);
 
         // languages is always optional
         if (!empty($r['languages'])) {
             foreach ($r['languages'] as $language) {
-                Validators::isInEnum($language, 'languages', array_keys(RunController::$kSupportedLanguages), false);
+                Validators::validateInEnum($language, 'languages', array_keys(RunController::$kSupportedLanguages), false);
             }
         }
 
@@ -1200,7 +1200,7 @@ class ContestController extends Controller {
         // Authenticate user
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         // Only director is allowed to create problems in contest
         try {
@@ -1288,7 +1288,7 @@ class ContestController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateAddToContestRequest(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         // Only director is allowed to create problems in contest
         try {
@@ -1307,7 +1307,7 @@ class ContestController extends Controller {
             throw new ForbiddenAccessException('cannotAddProb');
         }
 
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1328,8 +1328,8 @@ class ContestController extends Controller {
             throw new ForbiddenAccessException('problemIsPrivate');
         }
 
-        Validators::isNumberInRange($r['points'], 'points', 0, INF);
-        Validators::isNumberInRange($r['order_in_contest'], 'order_in_contest', 0, INF, false);
+        Validators::validateNumberInRange($r['points'], 'points', 0, INF);
+        Validators::validateNumberInRange($r['order_in_contest'], 'order_in_contest', 0, INF, false);
 
         return [
             'contest' => $contest,
@@ -1380,7 +1380,7 @@ class ContestController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateRemoveFromContestRequest(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -1398,7 +1398,7 @@ class ContestController extends Controller {
             throw new ForbiddenAccessException('cannotRemoveProblem');
         }
 
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1441,9 +1441,9 @@ class ContestController extends Controller {
     public static function apiRunsDiff(Request $r) : array {
         self::authenticateRequest($r);
 
-        Validators::isValidAlias($r['problem_alias'], 'problem_alias');
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
-        Validators::isStringNonEmpty($r['version'], 'version');
+        Validators::validateValidAlias($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['version'], 'version');
 
         try {
             $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -1497,7 +1497,7 @@ class ContestController extends Controller {
         $r['user'] = null;
 
         // Check contest_alias
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $r['user'] = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -1552,8 +1552,6 @@ class ContestController extends Controller {
                 'is_invited' => '1',
             ]));
         } catch (Exception $e) {
-            // Operation failed in the data layer
-            self::$log->error('Failed to create new ContestUser: ' . $e->getMessage());
             throw new InvalidDatabaseOperationException($e);
         }
 
@@ -1601,7 +1599,7 @@ class ContestController extends Controller {
         self::authenticateRequest($r);
 
         // Check contest_alias
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -1635,7 +1633,7 @@ class ContestController extends Controller {
         self::authenticateRequest($r);
 
         // Check contest_alias
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -1678,7 +1676,7 @@ class ContestController extends Controller {
         self::authenticateRequest($r);
 
         // Check contest_alias
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $group = GroupsDAO::FindByAlias($r['group']);
 
@@ -1716,7 +1714,7 @@ class ContestController extends Controller {
         self::authenticateRequest($r);
 
         // Check contest_alias
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         $group = GroupsDAO::FindByAlias($r['group']);
 
@@ -1749,7 +1747,7 @@ class ContestController extends Controller {
      */
     private static function validateClarifications(Request $r) {
         // Check contest_alias
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $r['contest'] = ContestsDAO::getByAlias($r['contest_alias']);
@@ -1762,8 +1760,8 @@ class ContestController extends Controller {
             throw new NotFoundException('contestNotFound');
         }
 
-        Validators::isNumber($r['offset'], 'offset', false /* optional */);
-        Validators::isNumber($r['rowcount'], 'rowcount', false /* optional */);
+        Validators::validateNumber($r['offset'], 'offset', false /* optional */);
+        Validators::validateNumber($r['rowcount'], 'rowcount', false /* optional */);
     }
 
     /**
@@ -1885,10 +1883,10 @@ class ContestController extends Controller {
         // Get the current user
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['contest_aliases'], 'contest_aliases');
+        Validators::validateStringNonEmpty($r['contest_aliases'], 'contest_aliases');
         $contest_aliases = explode(',', $r['contest_aliases']);
 
-        Validators::isStringNonEmpty($r['usernames_filter'], 'usernames_filter', false);
+        Validators::validateStringNonEmpty($r['usernames_filter'], 'usernames_filter', false);
 
         $usernames_filter = [];
         if (isset($r['usernames_filter'])) {
@@ -2012,7 +2010,7 @@ class ContestController extends Controller {
         // Authenticate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -2093,7 +2091,7 @@ class ContestController extends Controller {
     public static function apiArbitrateRequest(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         if (is_null($r['resolution'])) {
             throw new InvalidParameterException('invalidParameters');
@@ -2159,7 +2157,7 @@ class ContestController extends Controller {
         // Authenticate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -2201,7 +2199,7 @@ class ContestController extends Controller {
         // Authenticate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $contest = ContestsDAO::getByAlias($r['contest_alias']);
@@ -2382,7 +2380,7 @@ class ContestController extends Controller {
             $r['rowcount'] = 100;
         }
 
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $r['contest'] = ContestsDAO::getByAlias($r['contest_alias']);
@@ -2399,14 +2397,14 @@ class ContestController extends Controller {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
-        Validators::isNumber($r['offset'], 'offset', false);
-        Validators::isNumber($r['rowcount'], 'rowcount', false);
-        Validators::isInEnum($r['status'], 'status', ['new', 'waiting', 'compiling', 'running', 'ready'], false);
-        Validators::isInEnum($r['verdict'], 'verdict', ['AC', 'PA', 'WA', 'TLE', 'MLE', 'OLE', 'RTE', 'RFE', 'CE', 'JE', 'NO-AC'], false);
+        Validators::validateNumber($r['offset'], 'offset', false);
+        Validators::validateNumber($r['rowcount'], 'rowcount', false);
+        Validators::validateInEnum($r['status'], 'status', ['new', 'waiting', 'compiling', 'running', 'ready'], false);
+        Validators::validateInEnum($r['verdict'], 'verdict', ['AC', 'PA', 'WA', 'TLE', 'MLE', 'OLE', 'RTE', 'RFE', 'CE', 'JE', 'NO-AC'], false);
 
         // Check filter by problem, is optional
         if (!is_null($r['problem_alias'])) {
-            Validators::isStringNonEmpty($r['problem_alias'], 'problem');
+            Validators::validateStringNonEmpty($r['problem_alias'], 'problem');
 
             try {
                 $r['problem'] = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -2420,7 +2418,7 @@ class ContestController extends Controller {
             }
         }
 
-        Validators::isInEnum($r['language'], 'language', array_keys(RunController::$kSupportedLanguages), false);
+        Validators::validateInEnum($r['language'], 'language', array_keys(RunController::$kSupportedLanguages), false);
 
         // Get user if we have something in username
         if (!is_null($r['username'])) {
@@ -2483,7 +2481,7 @@ class ContestController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateStats(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         try {
             $r['contest'] = ContestsDAO::getByAlias($r['contest_alias']);
@@ -2584,7 +2582,7 @@ class ContestController extends Controller {
         $scoreboard = new Scoreboard($params);
 
         // Check the filter if we have one
-        Validators::isStringNonEmpty($r['filterBy'], 'filterBy', false /* not required */);
+        Validators::validateStringNonEmpty($r['filterBy'], 'filterBy', false /* not required */);
 
         $contestReport = $scoreboard->generate(
             true, // with run details for reporting
@@ -2791,7 +2789,7 @@ class ContestController extends Controller {
         }
 
         // Validate value param
-        Validators::isInEnum($r['value'], 'value', ['0', '1']);
+        Validators::validateInEnum($r['value'], 'value', ['0', '1']);
 
         $r['contest']->recommended = $r['value'];
 

--- a/frontend/server/controllers/Controller.php
+++ b/frontend/server/controllers/Controller.php
@@ -76,7 +76,7 @@ class Controller {
         $user = $r['current_user'];
 
         if (!is_null($r['username'])) {
-            Validators::isStringNonEmpty($r['username'], 'username');
+            Validators::validateStringNonEmpty($r['username'], 'username');
 
             try {
                 $user = UsersDAO::FindByUsername($r['username']);
@@ -113,7 +113,7 @@ class Controller {
         if (is_null($r['username'])) {
             return $identity;
         }
-        Validators::isStringNonEmpty($r['username'], 'username');
+        Validators::validateStringNonEmpty($r['username'], 'username');
 
         try {
             $identity = IdentitiesDAO::FindByUsername($r['username']);

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -61,24 +61,24 @@ class CourseController extends Controller {
         $course_start_time = strtotime($course->start_time);
         $course_finish_time = strtotime($course->finish_time);
 
-        Validators::isStringNonEmpty($r['name'], 'name', $is_required);
-        Validators::isStringNonEmpty($r['description'], 'description', $is_required);
+        Validators::validateStringNonEmpty($r['name'], 'name', $is_required);
+        Validators::validateStringNonEmpty($r['description'], 'description', $is_required);
 
-        Validators::isNumber($r['start_time'], 'start_time', $is_required);
-        Validators::isNumber($r['finish_time'], 'finish_time', $is_required);
+        Validators::validateNumber($r['start_time'], 'start_time', $is_required);
+        Validators::validateNumber($r['finish_time'], 'finish_time', $is_required);
 
         if ($r['start_time'] > $r['finish_time']) {
             throw new InvalidParameterException('courseInvalidStartTime');
         }
 
-        Validators::isNumberInRange(
+        Validators::validateNumberInRange(
             $r['start_time'],
             'start_time',
             $course_start_time,
             $course_finish_time,
             $is_required
         );
-        Validators::isNumberInRange(
+        Validators::validateNumberInRange(
             $r['finish_time'],
             'finish_time',
             $course_start_time,
@@ -86,8 +86,8 @@ class CourseController extends Controller {
             $is_required
         );
 
-        Validators::isInEnum($r['assignment_type'], 'assignment_type', ['test', 'homework'], $is_required);
-        Validators::isValidAlias($r['alias'], 'alias', $is_required);
+        Validators::validateInEnum($r['assignment_type'], 'assignment_type', ['test', 'homework'], $is_required);
+        Validators::validateValidAlias($r['alias'], 'alias', $is_required);
     }
 
     /**
@@ -98,18 +98,18 @@ class CourseController extends Controller {
     private static function validateCreateOrUpdate(Request $r, $is_update = false) {
         $is_required = true;
 
-        Validators::isStringNonEmpty($r['name'], 'name', $is_required);
-        Validators::isStringNonEmpty($r['description'], 'description', $is_required);
+        Validators::validateStringNonEmpty($r['name'], 'name', $is_required);
+        Validators::validateStringNonEmpty($r['description'], 'description', $is_required);
 
-        Validators::isNumber($r['start_time'], 'start_time', !$is_update);
-        Validators::isNumber($r['finish_time'], 'finish_time', !$is_update);
+        Validators::validateNumber($r['start_time'], 'start_time', !$is_update);
+        Validators::validateNumber($r['finish_time'], 'finish_time', !$is_update);
 
-        Validators::isValidAlias($r['alias'], 'alias', $is_required);
+        Validators::validateValidAlias($r['alias'], 'alias', $is_required);
 
         // Show scoreboard is always optional
-        Validators::isInEnum($r['show_scoreboard'], 'show_scoreboard', ['false', 'true'], false /*is_required*/);
+        Validators::validateInEnum($r['show_scoreboard'], 'show_scoreboard', ['false', 'true'], false /*is_required*/);
 
-        Validators::isInEnum($r['public'], 'public', ['0', '1'], false /*is_required*/);
+        Validators::validateInEnum($r['public'], 'public', ['0', '1'], false /*is_required*/);
 
         if (empty($r['school_id'])) {
             $r['school'] = null;
@@ -156,7 +156,7 @@ class CourseController extends Controller {
      * @throws NotFoundException
      */
     private static function validateCourseExists(Request $r, $column_name) {
-        Validators::isStringNonEmpty($r[$column_name], $column_name, true /*is_required*/);
+        Validators::validateStringNonEmpty($r[$column_name], $column_name, true /*is_required*/);
         $r['course'] = CoursesDAO::getByAlias($r[$column_name]);
         if (is_null($r['course'])) {
             throw new NotFoundException('courseNotFound');
@@ -419,7 +419,7 @@ class CourseController extends Controller {
         if (is_null($r['start_time'])) {
             $r['start_time'] = $r['assignment']->start_time;
         } else {
-            Validators::isNumberInRange(
+            Validators::validateNumberInRange(
                 $r['start_time'],
                 'start_time',
                 $r['course']->start_time,
@@ -430,7 +430,7 @@ class CourseController extends Controller {
         if (is_null($r['start_time'])) {
             $r['finish_time'] = $r['assignment']->finish_time;
         } else {
-            Validators::isNumberInRange(
+            Validators::validateNumberInRange(
                 $r['finish_time'],
                 'finish_time',
                 $r['course']->start_time,
@@ -847,8 +847,8 @@ class CourseController extends Controller {
 
         self::authenticateRequest($r);
 
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
+        Validators::validateNumber($r['page'], 'page', false);
+        Validators::validateNumber($r['page_size'], 'page_size', false);
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -1168,7 +1168,7 @@ class CourseController extends Controller {
         // Authenticate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['course_alias'], 'course_alias');
+        Validators::validateStringNonEmpty($r['course_alias'], 'course_alias');
 
         try {
             $course = CoursesDAO::getByAlias($r['course_alias']);
@@ -1204,7 +1204,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
 
         // Check course_alias
-        Validators::isStringNonEmpty($r['course_alias'], 'course_alias');
+        Validators::validateStringNonEmpty($r['course_alias'], 'course_alias');
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -1238,7 +1238,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
 
         // Check course_alias
-        Validators::isStringNonEmpty($r['course_alias'], 'course_alias');
+        Validators::validateStringNonEmpty($r['course_alias'], 'course_alias');
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -1281,7 +1281,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
 
         // Check course_alias
-        Validators::isStringNonEmpty($r['course_alias'], 'course_alias');
+        Validators::validateStringNonEmpty($r['course_alias'], 'course_alias');
 
         $group = GroupsDAO::FindByAlias($r['group']);
 
@@ -1319,7 +1319,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
 
         // Check course_alias
-        Validators::isStringNonEmpty($r['course_alias'], 'course_alias');
+        Validators::validateStringNonEmpty($r['course_alias'], 'course_alias');
 
         $group = GroupsDAO::FindByAlias($r['group']);
 
@@ -1509,8 +1509,8 @@ class CourseController extends Controller {
     }
 
     private static function validateAssignmentDetails(Request $r) {
-        Validators::isStringNonEmpty($r['course'], 'course', true /* is_required */);
-        Validators::isStringNonEmpty($r['assignment'], 'assignment', true /* is_required */);
+        Validators::validateStringNonEmpty($r['course'], 'course', true /* is_required */);
+        Validators::validateStringNonEmpty($r['assignment'], 'assignment', true /* is_required */);
         $r['course'] = CoursesDAO::getByAlias($r['course']);
         if (is_null($r['course'])) {
             throw new NotFoundException('courseNotFound');
@@ -1648,8 +1648,8 @@ class CourseController extends Controller {
             $r['rowcount'] = 100;
         }
 
-        Validators::isStringNonEmpty($r['course_alias'], 'course_alias');
-        Validators::isStringNonEmpty($r['assignment_alias'], 'assignment_alias');
+        Validators::validateStringNonEmpty($r['course_alias'], 'course_alias');
+        Validators::validateStringNonEmpty($r['assignment_alias'], 'assignment_alias');
 
         try {
             $r['course'] = CoursesDAO::getByAlias($r['course_alias']);
@@ -1678,14 +1678,14 @@ class CourseController extends Controller {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
-        Validators::isNumber($r['offset'], 'offset', false);
-        Validators::isNumber($r['rowcount'], 'rowcount', false);
-        Validators::isInEnum($r['status'], 'status', ['new', 'waiting', 'compiling', 'running', 'ready'], false);
-        Validators::isInEnum($r['verdict'], 'verdict', ['AC', 'PA', 'WA', 'TLE', 'MLE', 'OLE', 'RTE', 'RFE', 'CE', 'JE', 'NO-AC'], false);
+        Validators::validateNumber($r['offset'], 'offset', false);
+        Validators::validateNumber($r['rowcount'], 'rowcount', false);
+        Validators::validateInEnum($r['status'], 'status', ['new', 'waiting', 'compiling', 'running', 'ready'], false);
+        Validators::validateInEnum($r['verdict'], 'verdict', ['AC', 'PA', 'WA', 'TLE', 'MLE', 'OLE', 'RTE', 'RFE', 'CE', 'JE', 'NO-AC'], false);
 
         // Check filter by problem, is optional
         if (!is_null($r['problem_alias'])) {
-            Validators::isStringNonEmpty($r['problem_alias'], 'problem');
+            Validators::validateStringNonEmpty($r['problem_alias'], 'problem');
 
             try {
                 $r['problem'] = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1699,7 +1699,7 @@ class CourseController extends Controller {
             }
         }
 
-        Validators::isInEnum($r['language'], 'language', array_keys(RunController::$kSupportedLanguages), false);
+        Validators::validateInEnum($r['language'], 'language', array_keys(RunController::$kSupportedLanguages), false);
 
         // Get user if we have something in username
         if (!is_null($r['username'])) {
@@ -1910,7 +1910,7 @@ class CourseController extends Controller {
      * @param Groups $group
      */
     public static function shouldShowScoreboard($identity_id, Courses $course, Groups $group) {
-        Validators::isNumber($identity_id, 'identity_id', true);
+        Validators::validateNumber($identity_id, 'identity_id', true);
         return Authorization::canViewCourse($identity_id, $course, $group) &&
             $course->show_scoreboard;
     }

--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -52,9 +52,9 @@ class GroupController extends Controller {
     public static function apiCreate(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isValidAlias($r['alias'], 'alias', true);
-        Validators::isStringNonEmpty($r['name'], 'name', true);
-        Validators::isStringNonEmpty($r['description'], 'description', false);
+        Validators::validateValidAlias($r['alias'], 'alias', true);
+        Validators::validateStringNonEmpty($r['name'], 'name', true);
+        Validators::validateStringNonEmpty($r['description'], 'description', false);
 
         self::createGroup(
             $r['alias'],
@@ -76,7 +76,7 @@ class GroupController extends Controller {
      * @throws ForbiddenAccessException
      */
     public static function validateGroup($groupAlias, $identityId) {
-        Validators::isStringNonEmpty($groupAlias, 'group_alias');
+        Validators::validateStringNonEmpty($groupAlias, 'group_alias');
         try {
             $group = GroupsDAO::FindByAlias($groupAlias);
 
@@ -282,9 +282,9 @@ class GroupController extends Controller {
         self::authenticateRequest($r);
         $group = self::validateGroup($r['group_alias'], $r['current_identity_id']);
 
-        Validators::isValidAlias($r['alias'], 'alias', true);
-        Validators::isStringNonEmpty($r['name'], 'name', true);
-        Validators::isStringNonEmpty($r['description'], 'description', false);
+        Validators::validateValidAlias($r['alias'], 'alias', true);
+        Validators::validateStringNonEmpty($r['name'], 'name', true);
+        Validators::validateStringNonEmpty($r['description'], 'description', false);
 
         try {
             $groupScoreboard = new GroupsScoreboards([

--- a/frontend/server/controllers/GroupScoreboardController.php
+++ b/frontend/server/controllers/GroupScoreboardController.php
@@ -17,7 +17,7 @@ class GroupScoreboardController extends Controller {
     private static function validateGroupScoreboard($groupAlias, $identityId, $scoreboardAlias) {
         GroupController::validateGroup($groupAlias, $identityId);
 
-        Validators::isValidAlias($scoreboardAlias, 'scoreboard_alias');
+        Validators::validateValidAlias($scoreboardAlias, 'scoreboard_alias');
         try {
             $scoreboard = GroupsScoreboardsDAO::getByAlias($scoreboardAlias);
         } catch (Exception $ex) {
@@ -43,7 +43,7 @@ class GroupScoreboardController extends Controller {
     private static function validateGroupScoreboardAndContest($groupAlias, $identityId, $scoreboardAlias, $contestAlias) {
         $scoreboard = self::validateGroupScoreboard($groupAlias, $identityId, $scoreboardAlias);
 
-        Validators::isValidAlias($contestAlias, 'contest_alias');
+        Validators::validateValidAlias($contestAlias, 'contest_alias');
         try {
             $contest = ContestsDAO::getByAlias($contestAlias);
         } catch (Exception $ex) {
@@ -72,8 +72,8 @@ class GroupScoreboardController extends Controller {
         self::authenticateRequest($r);
         $contestScoreboard = self::validateGroupScoreboardAndContest($r['group_alias'], $r['current_identity_id'], $r['scoreboard_alias'], $r['contest_alias']);
 
-        Validators::isInEnum($r['only_ac'], 'only_ac', [0,1]);
-        Validators::isNumber($r['weight'], 'weight');
+        Validators::validateInEnum($r['only_ac'], 'only_ac', [0,1]);
+        Validators::validateNumber($r['weight'], 'weight');
 
         try {
             $groupScoreboardProblemset = new GroupsScoreboardsProblemsets([

--- a/frontend/server/controllers/IdentityController.php
+++ b/frontend/server/controllers/IdentityController.php
@@ -29,7 +29,7 @@ class IdentityController extends Controller {
      * @throws ApiException
      */
     public static function resolveIdentity($userOrEmail) {
-        Validators::isStringNonEmpty($userOrEmail, 'usernameOrEmail');
+        Validators::validateStringNonEmpty($userOrEmail, 'usernameOrEmail');
         try {
             $identity = IdentitiesDAO::FindByEmail($userOrEmail);
             if (!is_null($identity)) {
@@ -293,19 +293,19 @@ class IdentityController extends Controller {
             throw new InvalidParameterException('parameterInvalid', 'group_alias');
         }
         // Validate request
-        Validators::isValidUsernameIdentity($username, 'username');
+        Validators::validateValidUsernameIdentity($username, 'username');
 
         if (!is_null($name)) {
             $name = trim($name);
-            Validators::isStringNonEmpty($name, 'name', true);
-            Validators::isStringOfMaxLength($name, 'name', 50);
+            Validators::validateStringNonEmpty($name, 'name', true);
+            Validators::validateStringOfLengthInRange($name, 'name', null, 50);
         }
 
         if (!is_null($gender)) {
             $gender = trim($gender);
         }
         if (!empty($gender)) {
-            Validators::isInEnum($gender, 'gender', UserController::ALLOWED_GENDER_OPTIONS, false);
+            Validators::validateInEnum($gender, 'gender', UserController::ALLOWED_GENDER_OPTIONS, false);
         }
     }
 

--- a/frontend/server/controllers/InterviewController.php
+++ b/frontend/server/controllers/InterviewController.php
@@ -11,10 +11,10 @@ class InterviewController extends Controller {
             throw new ForbiddenAccessException();
         }
 
-        Validators::isStringNonEmpty($r['title'], 'title', $is_required);
-        Validators::isStringNonEmpty($r['description'], 'description', false);
-        Validators::isNumberInRange($r['duration'], 'duration', 60, 60 * 5, false);
-        Validators::isValidAlias($r['alias'], 'alias', $is_required);
+        Validators::validateStringNonEmpty($r['title'], 'title', $is_required);
+        Validators::validateStringNonEmpty($r['description'], 'description', false);
+        Validators::validateNumberInRange($r['duration'], 'duration', 60, 60 * 5, false);
+        Validators::validateValidAlias($r['alias'], 'alias', $is_required);
     }
 
     public static function apiCreate(Request $r) {
@@ -81,7 +81,7 @@ class InterviewController extends Controller {
         // Authenticate logged user
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['usernameOrEmailsCSV'], 'usernameOrEmailsCSV', true);
+        Validators::validateStringNonEmpty($r['usernameOrEmailsCSV'], 'usernameOrEmailsCSV', true);
         $usersToAdd = explode(',', $r['usernameOrEmailsCSV']);
 
         foreach ($usersToAdd as $addThisUser) {
@@ -95,8 +95,8 @@ class InterviewController extends Controller {
     }
 
     private static function addUserInternal($r) {
-        Validators::isStringNonEmpty($r['interview_alias'], 'interview_alias');
-        Validators::isStringNonEmpty($r['usernameOrEmail'], 'usernameOrEmail');
+        Validators::validateStringNonEmpty($r['interview_alias'], 'interview_alias');
+        Validators::validateStringNonEmpty($r['usernameOrEmail'], 'usernameOrEmail');
 
         // Does the interview exist ?
         try {

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -48,7 +48,7 @@ class ProblemController extends Controller {
             $is_required = false;
 
             // We need to check problem_alias
-            Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+            Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
             try {
                 $r['problem'] = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -82,7 +82,7 @@ class ProblemController extends Controller {
                 if ($r['problem']->visibility == ProblemController::VISIBILITY_PROMOTED) {
                     throw new InvalidParameterException('qualityNominationProblemHasBeenPromoted', 'visibility');
                 } else {
-                    Validators::isInEnum(
+                    Validators::validateInEnum(
                         $r['visibility'],
                         'visibility',
                         [
@@ -94,7 +94,7 @@ class ProblemController extends Controller {
                     );
                 }
             }
-            Validators::isInEnum(
+            Validators::validateInEnum(
                 $r['update_published'],
                 'update_published',
                 [
@@ -106,45 +106,37 @@ class ProblemController extends Controller {
                 false
             );
         } else {
-            Validators::isValidAlias($r['problem_alias'], 'problem_alias');
-            Validators::isInEnum(
+            Validators::validateValidAlias($r['problem_alias'], 'problem_alias');
+            Validators::validateInEnum(
                 $r['visibility'],
                 'visibility',
                 [ProblemController::VISIBILITY_PRIVATE, ProblemController::VISIBILITY_PUBLIC]
             );
             $r['selected_tags'] = json_decode($r['selected_tags']);
-            $tagsHaveErrors = false;
             if (!empty($r['selected_tags'])) {
                 foreach ($r['selected_tags'] as $tag) {
-                    if (!isset($tag->tagname)) {
+                    if (empty($tag->tagname)) {
                         throw new InvalidParameterException('parameterEmpty', 'tagname');
-                    }
-                    if (!Validators::isStringNonEmpty($tag->tagname, 'tagname', false)) {
-                        $tagsHaveErrors = true;
-                        break;
                     }
                 }
             }
-            if ($tagsHaveErrors) {
-                throw new InvalidParameterException('parameterEmpty', 'tagname');
-            }
         }
 
-        Validators::isStringNonEmpty($r['title'], 'title', $is_required);
-        Validators::isStringNonEmpty($r['source'], 'source', $is_required);
-        Validators::isInEnum(
+        Validators::validateStringNonEmpty($r['title'], 'title', $is_required);
+        Validators::validateStringNonEmpty($r['source'], 'source', $is_required);
+        Validators::validateInEnum(
             $r['validator'],
             'validator',
             ['token', 'token-caseless', 'token-numeric', 'custom', 'literal'],
             $is_required
         );
-        Validators::isNumberInRange($r['time_limit'], 'time_limit', 0, INF, $is_required);
-        Validators::isNumberInRange($r['validator_time_limit'], 'validator_time_limit', 0, INF, $is_required);
-        Validators::isNumberInRange($r['overall_wall_time_limit'], 'overall_wall_time_limit', 0, 60000, $is_required);
-        Validators::isNumberInRange($r['extra_wall_time'], 'extra_wall_time', 0, 5000, $is_required);
-        Validators::isNumberInRange($r['memory_limit'], 'memory_limit', 0, INF, $is_required);
-        Validators::isNumberInRange($r['output_limit'], 'output_limit', 0, INF, $is_required);
-        Validators::isNumberInRange($r['input_limit'], 'input_limit', 0, INF, $is_required);
+        Validators::validateNumberInRange($r['time_limit'], 'time_limit', 0, INF, $is_required);
+        Validators::validateNumberInRange($r['validator_time_limit'], 'validator_time_limit', 0, INF, $is_required);
+        Validators::validateNumberInRange($r['overall_wall_time_limit'], 'overall_wall_time_limit', 0, 60000, $is_required);
+        Validators::validateNumberInRange($r['extra_wall_time'], 'extra_wall_time', 0, 5000, $is_required);
+        Validators::validateNumberInRange($r['memory_limit'], 'memory_limit', 0, INF, $is_required);
+        Validators::validateNumberInRange($r['output_limit'], 'output_limit', 0, INF, $is_required);
+        Validators::validateNumberInRange($r['input_limit'], 'input_limit', 0, INF, $is_required);
 
         // HACK! I don't know why "languages" doesn't make it into $r, and I've spent far too much time
         // on it already, so I'll just leave this here for now...
@@ -153,7 +145,7 @@ class ProblemController extends Controller {
         } elseif (isset($r['languages']) && is_array($r['languages'])) {
             $r['languages'] = implode(',', $r['languages']);
         }
-        Validators::isValidSubset(
+        Validators::validateValidSubset(
             $r['languages'],
             'languages',
             array_keys(RunController::$kSupportedLanguages),
@@ -266,7 +258,7 @@ class ProblemController extends Controller {
      */
     private static function validateRejudge(Request $r) {
         // We need to check problem_alias
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         try {
             $r['problem'] = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -306,7 +298,7 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
 
         // Check problem_alias
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -348,7 +340,7 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
 
         // Check problem_alias
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         $group = GroupsDAO::FindByAlias($r['group']);
 
@@ -383,8 +375,8 @@ class ProblemController extends Controller {
      */
     public static function apiAddTag(Request $r) {
         // Check problem_alias
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
-        Validators::isStringNonEmpty($r['name'], 'name');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['name'], 'name');
 
         // Authenticate logged user
         self::authenticateRequest($r);
@@ -465,7 +457,7 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
 
         // Check problem_alias
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
@@ -504,7 +496,7 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
 
         // Check problem_alias
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         $group = GroupsDAO::FindByAlias($r['group']);
 
@@ -542,8 +534,8 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
 
         // Check whether problem exists
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
-        Validators::isStringNonEmpty($r['name'], 'name');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['name'], 'name');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -592,7 +584,7 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
 
         // Check whether problem exists
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -630,7 +622,7 @@ class ProblemController extends Controller {
         // Authenticate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -660,7 +652,7 @@ class ProblemController extends Controller {
         // Authenticate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
         $includeAutogenerated = ($r['include_autogenerated'] == 'true');
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -736,7 +728,7 @@ class ProblemController extends Controller {
         self::validateCreateOrUpdate($r, true /* is update */);
 
         // Validate commit message.
-        Validators::isStringNonEmpty($r['message'], 'message');
+        Validators::validateStringNonEmpty($r['message'], 'message');
 
         // Update the Problem object
         $valueProperties = [
@@ -898,8 +890,8 @@ class ProblemController extends Controller {
         $problem = $r['problem'];
 
         // Validate statement
-        Validators::isStringNonEmpty($r['statement'], 'statement');
-        Validators::isStringNonEmpty($r['message'], 'message');
+        Validators::validateStringNonEmpty($r['statement'], 'statement');
+        Validators::validateStringNonEmpty($r['message'], 'message');
 
         // Check that lang is in the ISO 639-1 code list, default is "es".
         $iso639_1 = ['ab', 'aa', 'af', 'ak', 'sq', 'am', 'ar', 'an', 'hy',
@@ -918,7 +910,7 @@ class ProblemController extends Controller {
             'ta', 'te', 'tg', 'th', 'ti', 'bo', 'tk', 'tl', 'tn', 'to', 'tr', 'ts',
             'tt', 'tw', 'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'cy',
             'wo', 'fy', 'xh', 'yi', 'yo', 'za', 'zu'];
-        Validators::isInEnum($r['lang'], 'lang', $iso639_1, false /* is_required */);
+        Validators::validateInEnum($r['lang'], 'lang', $iso639_1, false /* is_required */);
         if (is_null($r['lang'])) {
             $r['lang'] = UserController::getPreferredLanguage($r);
         }
@@ -1003,12 +995,12 @@ class ProblemController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateDetails(Request $r) {
-        Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias', false);
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias', false);
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         // Lang is optional. Default is user's preferred.
         if (!is_null($r['lang'])) {
-            Validators::isStringOfMaxLength($r['lang'], 'lang', 2);
+            Validators::validateStringOfLengthInRange($r['lang'], 'lang', 2, 2);
         } else {
             $r['lang'] = UserController::getPreferredLanguage($r);
         }
@@ -1230,7 +1222,7 @@ class ProblemController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateDownload(Request $r) {
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1516,7 +1508,7 @@ class ProblemController extends Controller {
     public static function apiVersions(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isValidAlias($r['problem_alias'], 'problem_alias');
+        Validators::validateValidAlias($r['problem_alias'], 'problem_alias');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1568,11 +1560,11 @@ class ProblemController extends Controller {
     public static function apiSelectVersion(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isValidAlias($r['problem_alias'], 'problem_alias');
-        Validators::isStringNonEmpty($r['commit'], 'commit');
+        Validators::validateValidAlias($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['commit'], 'commit');
         // ProblemController::UPDATE_PUBLISHED_NONE is not allowed here because
         // it would not make any sense!
-        Validators::isInEnum(
+        Validators::validateInEnum(
             $r['update_published'],
             'update_published',
             [
@@ -1697,8 +1689,8 @@ class ProblemController extends Controller {
     public static function apiRunsDiff(Request $r) : array {
         self::authenticateRequest($r);
 
-        Validators::isValidAlias($r['problem_alias'], 'problem_alias');
-        Validators::isStringNonEmpty($r['version'], 'version');
+        Validators::validateValidAlias($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['version'], 'version');
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1777,7 +1769,7 @@ class ProblemController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateRuns(Request $r) {
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
         // Is the problem valid?
         try {
@@ -2036,8 +2028,8 @@ class ProblemController extends Controller {
      * @param Request $r
      */
     private static function validateList(Request $r) {
-        Validators::isNumber($r['offset'], 'offset', false);
-        Validators::isNumber($r['rowcount'], 'rowcount', false);
+        Validators::validateNumber($r['offset'], 'offset', false);
+        Validators::validateNumber($r['rowcount'], 'rowcount', false);
 
         // Defaults for offset and rowcount
         if (!isset($r['page'])) {
@@ -2049,7 +2041,7 @@ class ProblemController extends Controller {
             }
         }
 
-        Validators::isStringNonEmpty($r['query'], 'query', false);
+        Validators::validateStringNonEmpty($r['query'], 'query', false);
     }
 
     /**
@@ -2165,8 +2157,8 @@ class ProblemController extends Controller {
     public static function apiAdminList(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
+        Validators::validateNumber($r['page'], 'page', false);
+        Validators::validateNumber($r['page_size'], 'page_size', false);
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -2214,8 +2206,8 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
         self::validateList($r);
 
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
+        Validators::validateNumber($r['page'], 'page', false);
+        Validators::validateNumber($r['page_size'], 'page_size', false);
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -88,7 +88,7 @@ class ProblemsetController extends Controller {
      * @return Array
      */
     public static function apiDetails(Request $r) {
-        Validators::isNumber($r['problemset_id'], 'problemset_id');
+        Validators::validateNumber($r['problemset_id'], 'problemset_id');
         $r = self::wrapRequest($r);
 
         if ($r['problemset']['type'] == 'Contest') {
@@ -122,7 +122,7 @@ class ProblemsetController extends Controller {
      * @return Array
      */
     public static function apiScoreboard(Request $r) {
-        Validators::isNumber($r['problemset_id'], 'problemset_id');
+        Validators::validateNumber($r['problemset_id'], 'problemset_id');
         $r = self::wrapRequest($r);
 
         if ($r['problemset']['type'] == 'Contest') {
@@ -155,7 +155,7 @@ class ProblemsetController extends Controller {
      * @throws NotFoundException
      */
     public static function apiScoreboardEvents(Request $r) {
-        Validators::isNumber($r['problemset_id'], 'problemset_id');
+        Validators::validateNumber($r['problemset_id'], 'problemset_id');
         $r = self::wrapRequest($r);
 
         if ($r['problemset']['type'] != 'Contest') {
@@ -180,7 +180,7 @@ class ProblemsetController extends Controller {
      * @throws NotFoundException
      */
     public static function wrapRequest(Request $r) {
-        Validators::isNumber($r['problemset_id'], 'problemset_id');
+        Validators::validateNumber($r['problemset_id'], 'problemset_id');
 
         try {
             $r['problemset'] = ProblemsetsDAO::getWithTypeByPK($r['problemset_id']);

--- a/frontend/server/controllers/QualityNominationController.php
+++ b/frontend/server/controllers/QualityNominationController.php
@@ -72,9 +72,9 @@ class QualityNominationController extends Controller {
         // Validate request
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
-        Validators::isInEnum($r['nomination'], 'nomination', ['suggestion', 'promotion', 'demotion', 'dismissal']);
-        Validators::isStringNonEmpty($r['contents'], 'contents');
+        Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
+        Validators::validateInEnum($r['nomination'], 'nomination', ['suggestion', 'promotion', 'demotion', 'dismissal']);
+        Validators::validateStringNonEmpty($r['contents'], 'contents');
         $contents = json_decode($r['contents'], true /*assoc*/);
         if (!is_array($contents)) {
             throw new InvalidParameterException('parameterInvalid', 'contents');
@@ -229,8 +229,8 @@ class QualityNominationController extends Controller {
             throw new ForbiddenAccessException('lockdown');
         }
 
-        Validators::isInEnum($r['status'], 'status', ['open', 'approved', 'denied'], true /*is_required*/);
-        Validators::isStringNonEmpty($r['rationale'], 'rationale', true /*is_required*/);
+        Validators::validateInEnum($r['status'], 'status', ['open', 'approved', 'denied'], true /*is_required*/);
+        Validators::validateStringNonEmpty($r['rationale'], 'rationale', true /*is_required*/);
 
         // Validate request
         self::authenticateRequest($r);
@@ -365,8 +365,8 @@ class QualityNominationController extends Controller {
      * @return array The response.
      */
     private static function getListImpl(Request $r, $nominator, $assignee) {
-        Validators::isNumber($r['page'], 'page', false);
-        Validators::isNumber($r['page_size'], 'page_size', false);
+        Validators::validateNumber($r['page'], 'page', false);
+        Validators::validateNumber($r['page_size'], 'page_size', false);
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -493,7 +493,7 @@ class QualityNominationController extends Controller {
         // Validate request
         self::authenticateRequest($r);
 
-        Validators::isNumber($r['qualitynomination_id'], 'qualitynomination_id');
+        Validators::validateNumber($r['qualitynomination_id'], 'qualitynomination_id');
         $response = QualityNominationsDAO::getByID($r['qualitynomination_id']);
         if (is_null($response)) {
             throw new NotFoundException('qualityNominationNotFound');

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -46,7 +46,7 @@ class RunController extends Controller {
 
         $allowedLanguages = array_keys(RunController::$kSupportedLanguages);
         try {
-            Validators::isStringNonEmpty($r['problem_alias'], 'problem_alias');
+            Validators::validateStringNonEmpty($r['problem_alias'], 'problem_alias');
 
             // Check that problem exists
             $r['problem'] = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -63,12 +63,12 @@ class RunController extends Controller {
                 $allowedLanguages,
                 explode(',', $r['problem']->languages)
             );
-            Validators::isInEnum(
+            Validators::validateInEnum(
                 $r['language'],
                 'language',
                 $allowedLanguages
             );
-            Validators::isStringNonEmpty($r['source'], 'source');
+            Validators::validateStringNonEmpty($r['source'], 'source');
 
             // Can't set both problemset_id and contest_alias at the same time.
             if (!empty($r['problemset_id']) && !empty($r['contest_alias'])) {
@@ -86,7 +86,7 @@ class RunController extends Controller {
             } elseif (!empty($r['contest_alias'])) {
                 // Got a contest alias, need to fetch the problemset id.
                 // Validate contest
-                Validators::isStringNonEmpty($r['contest_alias'], 'contest_alias');
+                Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
                 $r['contest'] = ContestsDAO::getByAlias($r['contest_alias']);
 
                 if ($r['contest'] == null) {
@@ -138,7 +138,7 @@ class RunController extends Controller {
                     explode(',', $r['problemset']->languages)
                 );
             }
-            Validators::isInEnum(
+            Validators::validateInEnum(
                 $r['language'],
                 'language',
                 $allowedLanguages
@@ -395,7 +395,7 @@ class RunController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateDetailsRequest(Request $r) {
-        Validators::isStringNonEmpty($r['run_alias'], 'run_alias');
+        Validators::validateStringNonEmpty($r['run_alias'], 'run_alias');
 
         // If user is not judge, must be the run's owner.
         try {
@@ -667,7 +667,7 @@ class RunController extends Controller {
         // Get the user who is calling this API
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['run_alias'], 'run_alias');
+        Validators::validateStringNonEmpty($r['run_alias'], 'run_alias');
         if (!RunController::downloadSubmission($r['run_alias'], $r['current_identity_id'], /*passthru=*/true)) {
             http_response_code(404);
         }
@@ -832,14 +832,14 @@ class RunController extends Controller {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
-        Validators::isNumber($r['offset'], 'offset', false);
-        Validators::isNumber($r['rowcount'], 'rowcount', false);
-        Validators::isInEnum($r['status'], 'status', ['new', 'waiting', 'compiling', 'running', 'ready'], false);
-        Validators::isInEnum($r['verdict'], 'verdict', ['AC', 'PA', 'WA', 'TLE', 'MLE', 'OLE', 'RTE', 'RFE', 'CE', 'JE', 'NO-AC'], false);
+        Validators::validateNumber($r['offset'], 'offset', false);
+        Validators::validateNumber($r['rowcount'], 'rowcount', false);
+        Validators::validateInEnum($r['status'], 'status', ['new', 'waiting', 'compiling', 'running', 'ready'], false);
+        Validators::validateInEnum($r['verdict'], 'verdict', ['AC', 'PA', 'WA', 'TLE', 'MLE', 'OLE', 'RTE', 'RFE', 'CE', 'JE', 'NO-AC'], false);
 
         // Check filter by problem, is optional
         if (!is_null($r['problem_alias'])) {
-            Validators::isStringNonEmpty($r['problem_alias'], 'problem');
+            Validators::validateStringNonEmpty($r['problem_alias'], 'problem');
 
             try {
                 $r['problem'] = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -853,7 +853,7 @@ class RunController extends Controller {
             }
         }
 
-        Validators::isInEnum(
+        Validators::validateInEnum(
             $r['language'],
             'language',
             array_keys(RunController::$kSupportedLanguages),

--- a/frontend/server/controllers/SchoolController.php
+++ b/frontend/server/controllers/SchoolController.php
@@ -48,7 +48,7 @@ class SchoolController extends Controller {
     public static function apiCreate(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['name'], 'name');
+        Validators::validateStringNonEmpty($r['name'], 'name');
 
         $state = self::getStateIdFromCountryAndState($r['country_id'], $r['state_id']);
 
@@ -96,10 +96,10 @@ class SchoolController extends Controller {
      * @throws InvalidParameterException
      */
     public static function apiRank(Request $r) {
-        Validators::isNumber($r['offset'], 'offset', false);
-        Validators::isNumberInRange($r['rowcount'], 'rowcount', 100, 100, false);
-        Validators::isNumber($r['start_time'], 'start_time', false); // Unix timestamp
-        Validators::isNumber($r['finish_time'], 'finish_time', false); // Unix timestamp
+        Validators::validateNumber($r['offset'], 'offset', false);
+        Validators::validateNumberInRange($r['rowcount'], 'rowcount', 100, 100, false);
+        Validators::validateNumber($r['start_time'], 'start_time', false); // Unix timestamp
+        Validators::validateNumber($r['finish_time'], 'finish_time', false); // Unix timestamp
 
         try {
             self::authenticateRequest($r);

--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -250,7 +250,7 @@ class SessionController extends Controller {
         $username = substr($s_Email, 0, $idx);
 
         try {
-            Validators::isValidUsername($username, 'username');
+            Validators::validateValidUsername($username, 'username');
         } catch (InvalidParameterException $e) {
             // How can we know whats wrong with the username?
             // Things that could go wrong:

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -40,15 +40,15 @@ class UserController extends Controller {
      */
     public static function apiCreate(Request $r) {
         // Validate request
-        Validators::isValidUsername($r['username'], 'username');
+        Validators::validateValidUsername($r['username'], 'username');
 
-        Validators::isEmail($r['email'], 'email');
+        Validators::validateEmail($r['email'], 'email');
 
         if (empty($r['scholar_degree'])) {
             $r['scholar_degree'] = 'none';
         }
 
-        Validators::isInEnum(
+        Validators::validateInEnum(
             $r['scholar_degree'],
             'scholar_degree',
             UserController::ALLOWED_SCHOLAR_DEGREES
@@ -390,7 +390,7 @@ class UserController extends Controller {
             if (is_null(self::$permissionKey) || self::$permissionKey != $r['permission_key']) {
                 throw new ForbiddenAccessException();
             }
-            Validators::isStringNonEmpty($r['username'], 'username');
+            Validators::validateStringNonEmpty($r['username'], 'username');
 
             try {
                 $user = UsersDAO::FindByUsername($r['username']);
@@ -412,7 +412,7 @@ class UserController extends Controller {
 
             if ($user->password != null) {
                 // Check the old password
-                Validators::isStringNonEmpty($r['old_password'], 'old_password');
+                Validators::validateStringNonEmpty($r['old_password'], 'old_password');
 
                 $old_password_valid = SecurityTools::compareHashedStrings(
                     $r['old_password'],
@@ -469,14 +469,14 @@ class UserController extends Controller {
 
             self::$log->info('Admin verifiying user...' . $r['usernameOrEmail']);
 
-            Validators::isStringNonEmpty($r['usernameOrEmail'], 'usernameOrEmail');
+            Validators::validateStringNonEmpty($r['usernameOrEmail'], 'usernameOrEmail');
 
             $user = self::resolveUser($r['usernameOrEmail']);
 
             self::$redirectOnVerify = false;
         } else {
             // Normal user verification path
-            Validators::isStringNonEmpty($r['id'], 'id');
+            Validators::validateStringNonEmpty($r['id'], 'id');
 
             try {
                 $users = UsersDAO::getByVerification($r['id']);
@@ -566,7 +566,7 @@ class UserController extends Controller {
      * @throws InvalidParameterException
      */
     public static function resolveUser($userOrEmail) {
-        Validators::isStringNonEmpty($userOrEmail, 'usernameOrEmail');
+        Validators::validateStringNonEmpty($userOrEmail, 'usernameOrEmail');
 
         $user = null;
 
@@ -1326,7 +1326,7 @@ class UserController extends Controller {
     public static function apiCoderOfTheMonth(Request $r) {
         $currentTimestamp = Time::get();
         if (!empty($r['date'])) {
-            Validators::isDate($r['date'], 'date', false);
+            Validators::validateDate($r['date'], 'date', false);
             $firstDay = date('Y-m-01', strtotime($r['date']));
         } else {
             // Get first day of the current month
@@ -1427,7 +1427,7 @@ class UserController extends Controller {
         if (!Authorization::canChooseCoder($currentTimestamp)) {
             throw new ForbiddenAccessException('coderOfTheMonthIsNotInPeriodToBeChosen');
         }
-        Validators::isStringNonEmpty($r['username'], 'username');
+        Validators::validateStringNonEmpty($r['username'], 'username');
 
         $currentDate = date('Y-m-d', $currentTimestamp);
         $firstDayOfNextMonth = new DateTime($currentDate);
@@ -1490,8 +1490,8 @@ class UserController extends Controller {
     public static function apiInterviewStats(Request $r) {
         self::authenticateOrAllowUnauthenticatedRequest($r);
 
-        Validators::isStringNonEmpty($r['interview'], 'interview');
-        Validators::isStringNonEmpty($r['username'], 'username');
+        Validators::validateStringNonEmpty($r['interview'], 'interview');
+        Validators::validateStringNonEmpty($r['username'], 'username');
 
         $contest = ContestsDAO::getByAlias($r['interview']);
         if (is_null($contest)) {
@@ -1722,7 +1722,7 @@ class UserController extends Controller {
                 throw new InvalidParameterException('parameterUsernameInUse', 'username');
             }
 
-            Validators::isValidUsername($r['username'], 'username');
+            Validators::validateValidUsername($r['username'], 'username');
             $r['current_user']->username = $r['username'];
         }
 
@@ -1762,7 +1762,7 @@ class UserController extends Controller {
         self::authenticateRequest($r);
 
         if (!is_null($r['username'])) {
-            Validators::isValidUsername($r['username'], 'username');
+            Validators::validateValidUsername($r['username'], 'username');
             $user = null;
             try {
                 $user = UsersDAO::FindByUsername($r['username']);
@@ -1776,15 +1776,14 @@ class UserController extends Controller {
         }
 
         if (!is_null($r['name'])) {
-            Validators::isStringNonEmpty($r['name'], 'name', true);
-            Validators::isStringOfMaxLength($r['name'], 'name', 50);
+            Validators::validateStringOfLengthInRange($r['name'], 'name', 1, 50);
         }
 
         $state = null;
         if (!is_null($r['country_id']) || !is_null($r['state_id'])) {
             // Both state and country must be specified together.
-            Validators::isStringNonEmpty($r['country_id'], 'country_id', true);
-            Validators::isStringNonEmpty($r['state_id'], 'state_id', true);
+            Validators::validateStringNonEmpty($r['country_id'], 'country_id', true);
+            Validators::validateStringNonEmpty($r['state_id'], 'state_id', true);
 
             try {
                 $state = StatesDAO::getByPK($r['country_id'], $r['state_id']);
@@ -1825,13 +1824,13 @@ class UserController extends Controller {
             }
         }
 
-        Validators::isStringNonEmpty($r['scholar_degree'], 'scholar_degree', false);
+        Validators::validateStringNonEmpty($r['scholar_degree'], 'scholar_degree', false);
 
         if (!is_null($r['graduation_date'])) {
             if (is_numeric($r['graduation_date'])) {
                 $r['graduation_date'] = (int)$r['graduation_date'];
             } else {
-                Validators::isDate($r['graduation_date'], 'graduation_date', false);
+                Validators::validateDate($r['graduation_date'], 'graduation_date', false);
                 $r['graduation_date'] = strtotime($r['graduation_date']);
             }
         }
@@ -1839,7 +1838,7 @@ class UserController extends Controller {
             if (is_numeric($r['birth_date'])) {
                 $r['birth_date'] = (int)$r['birth_date'];
             } else {
-                Validators::isDate($r['birth_date'], 'birth_date', false);
+                Validators::validateDate($r['birth_date'], 'birth_date', false);
                 $r['birth_date'] = strtotime($r['birth_date']);
             }
 
@@ -1859,15 +1858,15 @@ class UserController extends Controller {
         }
 
         if (!is_null($r['is_private'])) {
-            Validators::isNumber($r['is_private'], 'is_private', true);
+            Validators::validateNumber($r['is_private'], 'is_private', true);
         }
 
         if (!is_null($r['hide_problem_tags'])) {
-            Validators::isNumber($r['hide_problem_tags'], 'hide_problem_tags', true);
+            Validators::validateNumber($r['hide_problem_tags'], 'hide_problem_tags', true);
         }
 
         if (!is_null($r['gender'])) {
-            Validators::isInEnum($r['gender'], 'gender', UserController::ALLOWED_GENDER_OPTIONS, true);
+            Validators::validateInEnum($r['gender'], 'gender', UserController::ALLOWED_GENDER_OPTIONS, true);
         }
 
         $valueProperties = [
@@ -1923,12 +1922,12 @@ class UserController extends Controller {
      */
 
     public static function apiRankByProblemsSolved(Request $r) {
-        Validators::isNumber($r['offset'], 'offset', false);
-        Validators::isNumber($r['rowcount'], 'rowcount', false);
+        Validators::validateNumber($r['offset'], 'offset', false);
+        Validators::validateNumber($r['rowcount'], 'rowcount', false);
 
         $r['user'] = null;
         if (!is_null($r['username'])) {
-            Validators::isStringNonEmpty($r['username'], 'username');
+            Validators::validateStringNonEmpty($r['username'], 'username');
             try {
                 $r['user'] = UsersDAO::FindByUsername($r['username']);
                 if (is_null($r['user'])) {
@@ -1940,7 +1939,7 @@ class UserController extends Controller {
                 throw new InvalidDatabaseOperationException($e);
             }
         }
-        Validators::isInEnum($r['filter'], 'filter', ['', 'country', 'state', 'school'], false);
+        Validators::validateInEnum($r['filter'], 'filter', ['', 'country', 'state', 'school'], false);
 
         // Defaults for offset and rowcount
         if (null == $r['offset']) {
@@ -2039,7 +2038,7 @@ class UserController extends Controller {
     public static function apiUpdateMainEmail(Request $r) {
         self::authenticateRequest($r);
 
-        Validators::isEmail($r['email'], 'email');
+        Validators::validateEmail($r['email'], 'email');
 
         try {
             // Update email
@@ -2103,7 +2102,7 @@ class UserController extends Controller {
      * @param Request $r
      */
     public static function apiValidateFilter(Request $r) {
-        Validators::isStringNonEmpty($r['filter'], 'filter');
+        Validators::validateStringNonEmpty($r['filter'], 'filter');
 
         $response = [
             'status' => 'ok',
@@ -2198,7 +2197,7 @@ class UserController extends Controller {
 
     private static function validateUser(Request $r) {
         // Validate request
-        Validators::isValidUsername($r['username'], 'username');
+        Validators::validateValidUsername($r['username'], 'username');
         try {
             $r['user'] = UsersDAO::FindByUsername($r['username']);
         } catch (Exception $e) {
@@ -2216,7 +2215,7 @@ class UserController extends Controller {
 
         self::validateUser($r);
 
-        Validators::isStringNonEmpty($r['role'], 'role');
+        Validators::validateStringNonEmpty($r['role'], 'role');
         $r['role'] = RolesDAO::getByName($r['role']);
         if (is_null($r['role'])) {
             throw new InvalidParameterException('parameterNotFound', 'role');
@@ -2235,7 +2234,7 @@ class UserController extends Controller {
 
         self::validateUser($r);
 
-        Validators::isStringNonEmpty($r['group'], 'group');
+        Validators::validateStringNonEmpty($r['group'], 'group');
         $r['group'] = GroupsDAO::getByName($r['group']);
         if (is_null($r['group'])) {
             throw new InvalidParameterException('parameterNotFound', 'group');
@@ -2360,7 +2359,7 @@ class UserController extends Controller {
 
         self::validateUser($r);
 
-        Validators::isStringNonEmpty($r['experiment'], 'experiment');
+        Validators::validateStringNonEmpty($r['experiment'], 'experiment');
         if (!in_array($r['experiment'], $experiments->getAllKnownExperiments())) {
             throw new InvalidParameterException('parameterNotFound', 'experiment');
         }
@@ -2527,8 +2526,8 @@ class UserController extends Controller {
         $experiments->ensureEnabled(Experiments::IDENTITIES);
         self::authenticateRequest($r);
 
-        Validators::isStringNonEmpty($r['username'], 'username');
-        Validators::isStringNonEmpty($r['password'], 'password');
+        Validators::validateStringNonEmpty($r['username'], 'username');
+        Validators::validateStringNonEmpty($r['password'], 'password');
 
         $identity = IdentitiesDAO::getUnassociatedIdentity($r['username']);
 

--- a/frontend/server/libs/PrivacyStatement.php
+++ b/frontend/server/libs/PrivacyStatement.php
@@ -9,7 +9,7 @@ class PrivacyStatement {
         if ($requests_user_information == 'no') {
             return null;
         }
-        Validators::isInEnum(
+        Validators::validateInEnum(
             $requests_user_information,
             'requests_user_information',
             ['required', 'optional']
@@ -23,7 +23,7 @@ class PrivacyStatement {
     }
 
     public static function getForConsent($language_id, $type) {
-        Validators::isStringNonEmpty($type, 'type', true);
+        Validators::validateStringNonEmpty($type, 'type', true);
         $language = self::getLanguage($language_id);
 
         return file_get_contents(

--- a/frontend/server/libs/Request.php
+++ b/frontend/server/libs/Request.php
@@ -47,7 +47,13 @@ class Request extends ArrayObject {
      * @param string $key The key.
      */
     public function offsetGet($key) {
-        return (isset($this[$key]) && parent::offsetGet($key) !== 'null') ? parent::offsetGet($key) : ($this->parent != null ? $this->parent->offsetGet($key) : null);
+        if (isset($this[$key]) && parent::offsetGet($key) !== 'null') {
+            return parent::offsetGet($key);
+        }
+        if ($this->parent != null) {
+            return $this->parent->offsetGet($key);
+        }
+        return null;
     }
 
     /**

--- a/frontend/server/libs/SecurityTools.php
+++ b/frontend/server/libs/SecurityTools.php
@@ -43,8 +43,7 @@ class SecurityTools {
 
     public static function testStrongPassword($s_Password) {
         // Setting max passwd length to 72 to avoid DoS attacks
-        Validators::isStringOfMinLength($s_Password, 'password', 8);
-        Validators::isStringOfMaxLength($s_Password, 'password', 72);
+        Validators::validateStringOfLengthInRange($s_Password, 'password', 8, 72);
 
         return true;
     }

--- a/frontend/server/libs/Validators.php
+++ b/frontend/server/libs/Validators.php
@@ -12,17 +12,19 @@ class Validators {
      * @param string $email
      * @param string $parameterName Name of parameter that will appear en error message
      * @param boolean $required If $required is TRUE and the parameter is not present, check fails.
-     * @return boolean
      * @throws InvalidArgumentException
      */
-    public static function isEmail($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        if ($isPresent && !filter_var($parameter, FILTER_VALIDATE_EMAIL)) {
+    public static function validateEmail(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
+        if (!filter_var($parameter, FILTER_VALIDATE_EMAIL)) {
             throw new InvalidParameterException('parameterInvalid', $parameterName);
         }
-
-        return true;
     }
 
     /**
@@ -31,61 +33,55 @@ class Validators {
      * @param string $parameter
      * @param string $parameterName Name of parameter that will appear en error message
      * @param boolean $required If $required is TRUE and the parameter is not present, check fails.
-     * @return boolean
      * @throws InvalidArgumentException
      */
-    public static function isStringNonEmpty($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
+    public static function validateStringNonEmpty(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
 
         // Validate data is string
-        if ($isPresent && (!is_string($parameter) || strlen($parameter) < 1)) {
+        if (!is_string($parameter) || empty($parameter)) {
             throw new InvalidParameterException('parameterEmpty', $parameterName);
         }
-
-        // Validation passed
-        return true;
     }
 
     /**
-     *
-     * @param string $parameter
+     * @param mixed  $parameter
      * @param string $parameterName
-     * @param int $maxLength
-     * @param boolean $required
+     * @param ?int   $minLength
+     * @param ?int   $maxLength
+     * @param bool   $required
      */
-    public static function isStringOfMaxLength($parameter, $parameterName, $maxLength, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        if ($isPresent && !(is_string($parameter) && strlen($parameter) <= $maxLength)) {
-            throw new InvalidParameterException(
-                'parameterStringTooLong',
-                $parameterName,
-                ['max_length' => $maxLength]
-            );
+    public static function validateStringOfLengthInRange(
+        $parameter,
+        string $parameterName,
+        ?int $minLength,
+        ?int $maxLength,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
         }
 
-        return true;
-    }
-
-    /**
-     *
-     * @param string $parameter
-     * @param string $parameterName
-     * @param int $minLength
-     * @param boolean $required
-     */
-    public static function isStringOfMinLength($parameter, $parameterName, $minLength, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        if ($isPresent && !(is_string($parameter) && strlen($parameter) >= $minLength)) {
+        if (!is_null($minLength) && strlen($parameter) < $minLength) {
             throw new InvalidParameterException(
                 'parameterStringTooShort',
                 $parameterName,
                 ['min_length' => $minLength]
             );
         }
-
-        return true;
+        if (!is_null($maxLength) && strlen($parameter) > $maxLength) {
+            throw new InvalidParameterException(
+                'parameterStringTooLong',
+                $parameterName,
+                ['max_length' => $maxLength]
+            );
+        }
     }
 
     /**
@@ -94,18 +90,22 @@ class Validators {
      * @param string $parameterName
      * @param boolean $required
      */
-    public static function isValidAlias($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        if ($isPresent &&
-                !(is_string($parameter) &&
-                strlen($parameter) > 0 &&
-                strlen($parameter) <= 32 &&
-                preg_match('/^[a-zA-Z0-9-_]+$/', $parameter) === 1)) {
-                    throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
+    public static function validateValidAlias(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
         }
 
-        return true;
+        if (!is_string($parameter) ||
+            empty($parameter) ||
+            strlen($parameter) > 32 ||
+            preg_match('/^[a-zA-Z0-9-_]+$/', $parameter) !== 1
+        ) {
+            throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
+        }
     }
 
     /**
@@ -116,14 +116,19 @@ class Validators {
      * @param boolean $required
      * @throws InvalidParameterException
      */
-    public static function isValidUsername($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
+    public static function validateValidUsername(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
+        self::validateStringOfLengthInRange($parameter, $parameterName, 2, null, $required);
 
-        if ($isPresent && preg_match('/[^a-zA-Z0-9_.-]/', $parameter)) {
+        if (preg_match('/[^a-zA-Z0-9_.-]/', $parameter)) {
             throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
         }
-
-        Validators::isStringOfMinLength($parameter, $parameterName, 2);
     }
 
     /**
@@ -134,14 +139,19 @@ class Validators {
      * @param boolean $required
      * @throws InvalidParameterException
      */
-    public static function isValidUsernameIdentity($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
+    public static function validateValidUsernameIdentity(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
+        self::validateStringOfLengthInRange($parameter, $parameterName, 2, null, $required);
 
-        if ($isPresent && !preg_match('/^[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+$/', $parameter)) {
+        if (!preg_match('/^[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+$/', $parameter)) {
             throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
         }
-
-        Validators::isStringOfMinLength($parameter, $parameterName, 2);
     }
 
     /**
@@ -149,73 +159,82 @@ class Validators {
      * @param date $parameter
      * @param string $parameterName
      * @param boolean $required
-     * @return boolean
      * @throws InvalidParameterException
      */
-    public static function isDate($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
+    public static function validateDate(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
 
         // Validate that we are working with a date
         // @TODO This strtotime() allows nice strings like "next Thursday".
-        if ($isPresent && strtotime($parameter) === false) {
+        if (strtotime($parameter) === false) {
             throw new InvalidParameterException('parameterInvalid', $parameterName);
         }
-
-        return true;
     }
 
     /**
      *
-     * @param string $parameter
-     * @param string $parameterName
-     * @param int $lowerBound
-     * @param int $upperBound
-     * @param boolean $required
-     * @return boolean
+     * @param mixed     $parameter
+     * @param string    $parameterName
+     * @param int|float $lowerBound
+     * @param int|float $upperBound
+     * @param boolean   $required
      * @throws InvalidParameterException
      */
-    public static function isNumberInRange($parameter, $parameterName, $lowerBound, $upperBound, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        self::isNumber($parameter, $parameterName, $required);
-
-        // Validate that is target number is inside the range
-        if ($isPresent) {
-            if ($parameter < $lowerBound) {
-                throw new InvalidParameterException(
-                    'parameterNumberTooSmall',
-                    $parameterName,
-                    ['lower_bound' => $lowerBound]
-                );
-            } elseif ($parameter > $upperBound) {
-                throw new InvalidParameterException(
-                    'parameterNumberTooLarge',
-                    $parameterName,
-                    ['upper_bound' => $upperBound]
-                );
-            }
+    public static function validateNumberInRange(
+        $parameter,
+        string $parameterName,
+        $lowerBound,
+        $upperBound,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
         }
-
-        return true;
-    }
-
-    /**
-     *
-     * @param int $parameter
-     * @param string $parameterName
-     * @param bool $required
-     * @return boolean
-     * @throws InvalidParameterException
-     */
-    public static function isNumber($parameter, $parameterName, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        // Validate that we are working with a number
-        if ($isPresent && !is_numeric($parameter)) {
+        if (!is_numeric($parameter)) {
             throw new InvalidParameterException('parameterNotANumber', $parameterName);
         }
+        // Coerce $parameter into a numeric value.
+        $parameter = $parameter + 0;
+        if (!is_null($lowerBound) && $parameter < $lowerBound) {
+            throw new InvalidParameterException(
+                'parameterNumberTooSmall',
+                $parameterName,
+                ['lower_bound' => $lowerBound]
+            );
+        }
+        if (!is_null($upperBound) && $parameter > $upperBound) {
+            throw new InvalidParameterException(
+                'parameterNumberTooLarge',
+                $parameterName,
+                ['upper_bound' => $upperBound]
+            );
+        }
+    }
 
-        return true;
+    /**
+     *
+     * @param mixed  $parameter
+     * @param string $parameterName
+     * @param bool   $required
+     * @throws InvalidParameterException
+     */
+    public static function validateNumber(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
+        if (!is_numeric($parameter)) {
+            throw new InvalidParameterException('parameterNotANumber', $parameterName);
+        }
     }
 
     /**
@@ -224,21 +243,25 @@ class Validators {
      * @param string $parameterName
      * @param array $enum
      * @param type $required
-     * @return boolean
      * @throws InvalidParameterException
      */
-    public static function isInEnum($parameter, $parameterName, array $enum, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
+    public static function validateInEnum(
+        $parameter,
+        string $parameterName,
+        array $enum,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
+        }
 
-        if ($isPresent && !in_array($parameter, $enum)) {
+        if (!in_array($parameter, $enum)) {
             throw new InvalidParameterException(
                 'parameterNotInExpectedSet',
                 $parameterName,
                 ['bad_elements' => $parameter, 'expected_set' => implode(', ', $enum)]
             );
         }
-
-        return true;
     }
 
     /**
@@ -247,30 +270,32 @@ class Validators {
      * @param string $parameterName
      * @param array $enum
      * @param type $required
-     * @return boolean
      * @throws InvalidParameterException
      */
-    public static function isValidSubset($parameter, $parameterName, array $enum, $required = true) {
-        $isPresent = self::throwIfNotPresent($parameter, $parameterName, $required);
-
-        if ($isPresent) {
-            $bad_elements = [];
-            $elements = array_filter(explode(',', $parameter));
-            foreach ($elements as $element) {
-                if (!in_array($element, $enum)) {
-                    $bad_elements[] = $element;
-                }
-            }
-            if (!empty($bad_elements)) {
-                throw new InvalidParameterException(
-                    'parameterNotInExpectedSet',
-                    $parameterName,
-                    ['bad_elements' => implode(',', $bad_elements), 'expected_set' => implode(', ', $enum)]
-                );
-            }
+    public static function validateValidSubset(
+        $parameter,
+        string $parameterName,
+        array $enum,
+        bool $required = true
+    ) : void {
+        if (!self::isPresent($parameter, $parameterName, $required)) {
+            return;
         }
 
-        return true;
+        $badElements = [];
+        $elements = array_filter(explode(',', $parameter));
+        foreach ($elements as $element) {
+            if (!in_array($element, $enum)) {
+                $badElements[] = $element;
+            }
+        }
+        if (!empty($badElements)) {
+            throw new InvalidParameterException(
+                'parameterNotInExpectedSet',
+                $parameterName,
+                ['bad_elements' => implode(',', $badElements), 'expected_set' => implode(', ', $enum)]
+            );
+        }
     }
 
     /**
@@ -278,16 +303,19 @@ class Validators {
      * @param type $parameter
      * @param type $parameterName
      * @param boolean $required
-     * @return boolean
      * @throws InvalidParameterException
      */
-    private static function throwIfNotPresent($parameter, $parameterName, $required = true) {
-        $isPresent = !is_null($parameter);
-
-        if ($required && !$isPresent) {
+    private static function isPresent(
+        $parameter,
+        string $parameterName,
+        bool $required = true
+    ) : bool {
+        if (!is_null($parameter)) {
+            return true;
+        }
+        if ($required) {
             throw new InvalidParameterException('parameterEmpty', $parameterName);
         }
-
-        return $isPresent;
+        return false;
     }
 }

--- a/frontend/tests/controllers/CourseDetailsTest.php
+++ b/frontend/tests/controllers/CourseDetailsTest.php
@@ -30,8 +30,8 @@ class CourseDetailsTest extends OmegaupTestCase {
 
         $this->assertEquals('ok', $response['status']);
         $this->assertEquals($courseData['course_alias'], $response['alias']);
-        Validators::isNumber($response['start_time'], 'start_time', true);
-        Validators::isNumber($response['finish_time'], 'finish_time', true);
+        Validators::validateNumber($response['start_time'], 'start_time', true);
+        Validators::validateNumber($response['finish_time'], 'finish_time', true);
 
         // Both assignments added should be visible since the caller is an
         // admin.
@@ -46,8 +46,8 @@ class CourseDetailsTest extends OmegaupTestCase {
             $this->assertNotNull($assignment['start_time']);
             $this->assertNotNull($assignment['finish_time']);
 
-            Validators::isNumber($assignment['start_time'], 'start_time', true);
-            Validators::isNumber($assignment['finish_time'], 'finish_time', true);
+            Validators::validateNumber($assignment['start_time'], 'start_time', true);
+            Validators::validateNumber($assignment['finish_time'], 'finish_time', true);
         }
     }
 
@@ -79,8 +79,8 @@ class CourseDetailsTest extends OmegaupTestCase {
 
         $this->assertEquals('ok', $response['status']);
         $this->assertEquals($courseData['course_alias'], $response['alias']);
-        Validators::isNumber($response['start_time'], 'start_time', true);
-        Validators::isNumber($response['finish_time'], 'finish_time', true);
+        Validators::validateNumber($response['start_time'], 'start_time', true);
+        Validators::validateNumber($response['finish_time'], 'finish_time', true);
 
         // Only the course that has started should be visible.
         $this->assertEquals(false, $response['is_admin']);

--- a/frontend/tests/controllers/CourseListTest.php
+++ b/frontend/tests/controllers/CourseListTest.php
@@ -36,7 +36,7 @@ class CourseListTest extends OmegaupTestCase {
 
         $this->assertEquals(1, count($response['admin']));
         $course_array = $response['admin'][0];
-        Validators::isNumber(
+        Validators::validateNumber(
             $course_array['finish_time'],
             'finish_time',
             true /* required */
@@ -57,7 +57,7 @@ class CourseListTest extends OmegaupTestCase {
 
         $this->assertEquals(1, count($response['student']));
         $course_array = $response['student'][0];
-        Validators::isNumber(
+        Validators::validateNumber(
             $course_array['finish_time'],
             'finish_time',
             true /* required */


### PR DESCRIPTION
Este cambio hace que todos los métodos de Validators sean void porque
todos regresaban true incondicionalmente si no arrojaban una excepción.
Como son void, ahora todos empiezan con "validate" en vez de "is" para
que no parezcan booleanos.