### PR TITLE
Agregando  interfaz para cambiar contraseña de identidades en grupos

### DIFF
--- a/frontend/www/js/omegaup/api.js
+++ b/frontend/www/js/omegaup/api.js
@@ -368,6 +368,8 @@ export default {
   },
 
   Identity: {
+    changePassword: _call('/api/identity/changePassword/'),
+
     create: _call('/api/identity/create/'),
 
     bulkCreate: _call('/api/identity/bulkCreate/'),

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -34,6 +34,96 @@
         </tr>
       </tbody>
     </table>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>{{ T.wordsIdentity }}</th>
+          <th>{{ T.wordsName }}</th>
+          <th>{{ T.profileCountry }}</th>
+          <th>{{ T.profileState }}</th>
+          <th>{{ T.profileSchool }}</th>
+          <th>{{ T.wordsActions }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="identity in identitiesCsv">
+          <td><omegaup-user-username v-bind:classname="identity.classname"
+                                 v-bind:linkify="true"
+                                 v-bind:username="identity.username"></omegaup-user-username></td>
+          <td>{{ identity.name }}</td>
+          <td>{{ identity.country }}</td>
+          <td>{{ identity.state }}</td>
+          <td>{{ identity.school }}</td>
+          <td>
+            <a class="glyphicon glyphicon-lock"
+                href="#"
+                v-bind:title="T.groupEditMembersChangePassword"
+                v-on:click="onChangePass(identity.username)"></a>
+          </td>
+        </tr>
+      </tbody>
+    </table><!-- Modal Change Password-->
+    <div class="modal fade modal-change-password"
+         role="dialog">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <form class="form-horizontal"
+                role="form"
+                v-on:submit.prevent="onChangePasswordMember">
+            <div class="modal-header">
+              <button class="close"
+                   data-dismiss="modal"
+                   type="button">×</button>
+              <h4 class="modal-title">{{ T.userEditChangePassword }}</h4>
+            </div>
+            <div class="modal-body">
+              <div class="panel-body">
+                <div class="form-group">
+                  <label class="col-md-4 col-sm-4 control-label"
+                       for="username">{{ T.username }}</label>
+                  <div class="col-md-7 col-sm-7">
+                    <input class="form-control"
+                         disabled="disabled"
+                         name="username"
+                         size="30"
+                         type="text"
+                         v-bind:value="username">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-md-4 col-sm-4 control-label"
+                       for="new-password-1">{{ T.userEditChangePasswordNewPassword }}</label>
+                  <div class="col-md-7 col-sm-7">
+                    <input class="form-control"
+                         name="new-password-1"
+                         size="30"
+                         type="password"
+                         v-model="newPassword">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-md-4 col-sm-4 control-label"
+                       for="new-password-2">{{ T.userEditChangePasswordRepeatNewPassword }}</label>
+                  <div class="col-md-7 col-sm-7">
+                    <input class="form-control"
+                         name="new-password-2"
+                         size="30"
+                         type="password"
+                         v-model="newPasswordRepeat">
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-default"
+                   data-dismiss="modal"
+                   type="button">{{ T.wordsCancel }}</button> <button class="btn btn-primary"
+                   type="submit">{{ T.wordsSaveChanges }}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -49,12 +139,15 @@ import user_Username from '../user/Username.vue';
 export default {
   props: {
     identities: Array,
+    identitiesCsv: Array,
   },
   data: function() {
     return {
       T: T,
       memberUsername: '',
       username: '',
+      newPassword: '',
+      newPasswordRepeat: '',
     };
   },
   mounted: function() {
@@ -76,6 +169,14 @@ export default {
         this.memberUsername = $('input.typeahead.tt-input', this.$el).val();
       }
       this.$emit('add-member', this, this.memberUsername);
+    },
+    onChangePass: function(username) {
+      this.username = username;
+      $('.modal-change-password').modal();
+    },
+    onChangePasswordMember: function() {
+      this.$emit('change-password-identity-member', this, this.username,
+                 this.newPassword, this.newPasswordRepeat);
     },
     onRemove: function(username) { this.$emit('remove', username);},
     reset: function() {

--- a/frontend/www/js/omegaup/group/members.js
+++ b/frontend/www/js/omegaup/group/members.js
@@ -12,6 +12,7 @@ OmegaUp.on('ready', function() {
       return createElement('omegaup-group-members', {
         props: {
           identities: this.identities,
+          identitiesCsv: this.identitiesCsv,
           countries: this.countries,
         },
         on: {
@@ -27,6 +28,29 @@ OmegaUp.on('ready', function() {
                 })
                 .fail(UI.apiError);
           },
+          'change-password-identity-member': function(
+              groupMembersInstance, username, newPassword, newPasswordRepeat) {
+            if (newPassword !== newPasswordRepeat) {
+              $('.modal').modal('hide');
+              UI.error(T.userPasswordMustBeSame);
+              return;
+            }
+
+            API.Identity.changePassword({
+                          group_alias: groupAlias,
+                          password: newPassword,
+                          username: username,
+                        })
+                .then(function(data) {
+                  refreshMemberList();
+                  UI.success(T.groupEditMemberPasswordUpdated);
+                  groupMembersInstance.reset();
+                })
+                .fail(function(response) {
+                  $('.modal').modal('hide');
+                  UI.apiError(response);
+                });
+          },
           remove: function(username) {
             API.Group.removeUser(
                          {group_alias: groupAlias, usernameOrEmail: username})
@@ -41,6 +65,7 @@ OmegaUp.on('ready', function() {
     },
     data: {
       identities: [],
+      identitiesCsv: [],
       countries: payload.countries,
     },
     components: {
@@ -49,6 +74,7 @@ OmegaUp.on('ready', function() {
   });
 
   function refreshMemberList() {
+    $('.modal').modal('hide');
     API.Group.members({group_alias: groupAlias})
         .then(function(data) {
           groupMembers.identities = [];


### PR DESCRIPTION
# Descripción

Se agrega la opción de cambiar la contraseña a las identidades que pertenecen a un grupo, esta es la continuación del `PR` #2523 

Part of: #2154

# Checklist:

- [X] El código sigue la [guía de  estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de  omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
