### PR TITLE
Separando los rewrites que se tienen que hacer en Puppet

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -12,42 +12,6 @@ location /preguntas/ {
 	}
 }
 
-# Backendv1 WebSockets endpoint.
-# TODO(lhchavez): Remove once we migrate to backendv2.
-location ^~ /api/contest/events/ {
-	rewrite ^/api/contest/events/(.*) /$1 break;
-	proxy_pass            http://localhost:39613;
-	proxy_read_timeout    90;
-	proxy_connect_timeout 90;
-	proxy_redirect        off;
-	proxy_set_header      Upgrade $http_upgrade;
-	proxy_set_header      Connection "upgrade";
-	proxy_set_header      Host $host;
-	proxy_http_version 1.1;
-}
-
-# Backendv2 WebSockets endpoint.
-location ^~ /events/ {
-	rewrite ^/events/(.*) /$1 break;
-	proxy_pass            http://localhost:22291;
-	proxy_read_timeout    90;
-	proxy_connect_timeout 90;
-	proxy_redirect        off;
-	proxy_set_header      Upgrade $http_upgrade;
-	proxy_set_header      Connection "upgrade";
-	proxy_set_header      Host $host;
-	proxy_http_version 1.1;
-}
-
-# Backendv2 grader web interface.
-location /grader/ {
-  try_files $uri $uri/ @grader;
-}
-location @grader {
-	rewrite    ^/grader/(.*) /$1 break;
-	proxy_pass http://localhost:36663;
-}
-
 rewrite ^/admin/user/([a-zA-Z0-9_-]+)/?$ /admin/user.php?username=$1 last;
 rewrite ^/admin/support/?$ /admin/support.php last;
 rewrite ^/arena/?$ /arena/index.php last;


### PR DESCRIPTION
Este cambio hace que el archivo frontend/server/nginx.rewrites se
encargue únicamente de los rewrites que le corresponden a la plataforma.
Todo lo externo se seguirá manejando via Puppet.