### PR TITLE
Mostrando sólo a los invitados por default

### DIFF
--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -160,15 +160,15 @@ def test_user_ranking_contest(driver):
             '"user"]')
         assert run_wrong_user.text == user2, run_wrong_user
 
-        users_full_set = {user1, user2, user3, driver.user_username}
-        compare_contestants_list(driver, users_full_set)
+        users_invited_set = {user1, user2, driver.user_username}
+        compare_contestants_list(driver, users_invited_set)
 
         driver.wait.until(
             EC.element_to_be_clickable(
                 (By.XPATH, '//input[@class = "toggle-contestants"]'))).click()
 
-        users_invited_set = {user1, user2, driver.user_username}
-        compare_contestants_list(driver, users_invited_set)
+        users_full_set = {user1, user2, user3, driver.user_username}
+        compare_contestants_list(driver, users_full_set)
 
 
 @util.no_javascript_errors()

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -79,7 +79,7 @@ export default {
   data: function() {
     return {
       UI: UI,
-      onlyShowExplicitlyInvited: false,
+      onlyShowExplicitlyInvited: true,
     };
   },
   computed: {


### PR DESCRIPTION
Este cambio hace que por default sólo se muestren los participantes
explícitamente invitados de un concurso.