### PR TITLE
Dejando de pasar Request como parámetro en ContestController

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -751,6 +751,9 @@ class ContestController extends Controller {
             throw new ForbiddenAccessException();
         }
 
+        // Hack to send info into Cahce
+        $r['contest'] = $response['contest'];
+
         $result = [];
         self::getCachedDetails($r, $result);
 

--- a/frontend/server/controllers/ProblemsetController.php
+++ b/frontend/server/controllers/ProblemsetController.php
@@ -211,8 +211,10 @@ class ProblemsetController extends Controller {
             if (isset($r['tokens']) && count($r['tokens']) >= 4) {
                 $request['token'] = $r['tokens'][3];
             }
-            ContestController::validateDetails($request);
+            $response = ContestController::validateDetails($request);
             $request['problemset'] = $r['problemset'];
+            $request['contest_alias'] = $response['contest_alias'];
+            $request['contest_admin'] = $response['contest_admin'];
             return $request;
         }
         return $r;

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -2151,9 +2151,9 @@ class UserController extends Controller {
                     if (count($tokens) >= 4) {
                         $r2['token'] = $tokens[3];
                     }
-                    ContestController::validateDetails($r2);
-                    if ($r2['contest_admin']) {
-                        $response['contest_admin'][] = $r2['contest_alias'];
+                    $contestResponse = ContestController::validateDetails($r2);
+                    if ($contestResponse['contest_admin']) {
+                        $response['contest_admin'][] = $contestResponse['contest_alias'];
                     }
                     break;
                 case 'problemset':


### PR DESCRIPTION
# Descripción

Se deja de enviar `Request` como parámetro entre funciones. Algunas de ellas aún lo incluyen, pero sólo para validar información, no para asignar más valores al mismo.

# Comentarios

El cambio no lo pude partir debido a que muchas de las funciones se relacionan entre sí.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
