### PR TITLE
Quitando UNIQUE KEY a Users_Badges en el campo badge_alias.

### DIFF
--- a/frontend/database/91_userBadges_and_notifications.sql
+++ b/frontend/database/91_userBadges_and_notifications.sql
@@ -26,7 +26,6 @@ CREATE TABLE `Users_Badges` (
   `assignation_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`user_badge_id`),
   KEY `user_id` (`user_id`),
-  UNIQUE KEY `badge_alias` (`badge_alias`),
   CONSTRAINT `fk_ubu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Badges de Usuario';
 

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -908,7 +908,6 @@ CREATE TABLE `Users_Badges` (
   `badge_alias` varchar(32) NOT NULL COMMENT 'Identificador de badge',
   `assignation_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`user_badge_id`),
-  UNIQUE KEY `badge_alias` (`badge_alias`),
   KEY `user_id` (`user_id`),
   CONSTRAINT `fk_ubu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Badges de Usuario';


### PR DESCRIPTION
# Comentarios

Cuando creé la tabla `Users_Badges` asigné al campo `badge_alias` la UNIQUE constraint. Ahora que ando haciendo el script para asignar los badges y crear las notificaciones, me doy cuenta que esa constraint no permitirá que se asigne el mismo badge a varios usuarios.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
