### PR TITLE
Dejando de poner al usuario y la identidad en Request

### DIFF
--- a/frontend/server/controllers/ClarificationController.php
+++ b/frontend/server/controllers/ClarificationController.php
@@ -71,13 +71,13 @@ class ClarificationController extends Controller {
         $time = Time::get();
         $receiver_id = $r['identity'] ? $r['identity']->identity_id : null;
         $r['clarification'] = new Clarifications([
-            'author_id' => $r['current_identity_id'],
+            'author_id' => $r->identity->identity_id,
             'receiver_id' => $receiver_id,
             'problemset_id' => $r['contest']->problemset_id,
             'problem_id' => $r['problem']->problem_id,
             'message' => $r['message'],
             'time' => gmdate('Y-m-d H:i:s', $time),
-            'public' => $receiver_id == $r['current_identity_id'] ? '1' : '0',
+            'public' => $receiver_id == $r->identity->identity_id ? '1' : '0',
         ]);
 
         // Insert new Clarification
@@ -89,7 +89,7 @@ class ClarificationController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        $r['user'] = $r['current_user'];
+        $r['user'] = $r->user;
         self::clarificationUpdated($r, $time);
 
         return [
@@ -122,7 +122,7 @@ class ClarificationController extends Controller {
 
         // If the clarification is private, verify that our user is invited or is contest director
         if ($r['clarification']->public != 1) {
-            if (!(Authorization::canViewClarification($r['current_identity_id'], $r['clarification']))) {
+            if (!(Authorization::canViewClarification($r->identity->identity_id, $r['clarification']))) {
                 throw new ForbiddenAccessException();
             }
         }
@@ -171,7 +171,7 @@ class ClarificationController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        if (!Authorization::canEditClarification($r['current_identity_id'], $r['clarification'])) {
+        if (!Authorization::canEditClarification($r->identity->identity_id, $r['clarification'])) {
             throw new ForbiddenAccessException();
         }
     }

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -64,7 +64,7 @@ class ContestController extends Controller {
             $query = $r['query'];
             Validators::validateStringOfLengthInRange($query, 'query', null, 255, false /* not required */);
             $cache_key = "$active_contests-$recommended-$page-$page_size";
-            if ($r['current_user_id'] === null) {
+            if (is_null($r->identity)) {
                 // Get all public contests
                 Cache::getFromCacheOrSet(
                     Cache::CONTESTS_LIST_PUBLIC,
@@ -76,10 +76,10 @@ class ContestController extends Controller {
                     $contests
                 );
             } elseif ($participating == ParticipatingStatus::YES) {
-                $contests = ContestsDAO::getContestsParticipating($r['current_identity_id'], $page, $page_size, $query);
+                $contests = ContestsDAO::getContestsParticipating($r->identity->identity_id, $page, $page_size, $query);
             } elseif ($public) {
-                $contests = ContestsDAO::getRecentPublicContests($r['current_identity_id'], $page, $page_size, $query);
-            } elseif (Authorization::isSystemAdmin($r['current_identity_id'])) {
+                $contests = ContestsDAO::getRecentPublicContests($r->identity->identity_id, $page, $page_size, $query);
+            } elseif (Authorization::isSystemAdmin($r->identity->identity_id)) {
                 // Get all contests
                 Cache::getFromCacheOrSet(
                     Cache::CONTESTS_LIST_SYSTEM_ADMIN,
@@ -92,7 +92,7 @@ class ContestController extends Controller {
                 );
             } else {
                 // Get all public+private contests
-                $contests = ContestsDAO::getAllContestsForIdentity($r['current_identity_id'], $page, $page_size, $active_contests, $recommended, $query);
+                $contests = ContestsDAO::getAllContestsForIdentity($r->identity->identity_id, $page, $page_size, $active_contests, $recommended, $query);
             }
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);
@@ -149,7 +149,7 @@ class ContestController extends Controller {
         // Create array of relevant columns
         $contests = null;
         try {
-            if (Authorization::isSystemAdmin($r['current_identity_id'])) {
+            if (Authorization::isSystemAdmin($r->identity->identity_id)) {
                 $contests = ContestsDAO::getAllContestsWithScoreboard(
                     $page,
                     $pageSize,
@@ -158,7 +158,7 @@ class ContestController extends Controller {
                 );
             } else {
                 $contests = ContestsDAO::getAllContestsAdminedByIdentity(
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     $page,
                     $pageSize
                 );
@@ -191,7 +191,7 @@ class ContestController extends Controller {
         $query = $r['query'];
         $contests = null;
         $identity_id = $callback_user_function == 'ContestsDAO::getContestsParticipating'
-          ? $r['current_identity_id'] : $r['current_user_id'];
+          ? $r->identity->identity_id : $r->user->user_id;
         try {
             $contests = call_user_func(
                 $callback_user_function,
@@ -348,12 +348,10 @@ class ContestController extends Controller {
             // Half-authenticate, in case there is no session in place.
             $session = SessionController::apiCurrentSession($r)['session'];
             if ($session['valid'] && !is_null($session['identity'])) {
-                $r['current_identity'] = $session['identity'];
-                $r['current_identity_id'] = $session['identity']->identity_id;
+                $r->identity = $session['identity'];
 
                 if (!is_null($session['user'])) {
-                    $r['current_user'] = $session['user'];
-                    $r['current_user_id'] = $session['user']->user_id;
+                    $r->user = $session['user'];
                 }
 
                 // Privacy Statement Information
@@ -373,11 +371,11 @@ class ContestController extends Controller {
                     self::isPublic($contest->admission_mode) ? ContestController::SHOW_INTRO : !ContestController::SHOW_INTRO;
                 return $result;
             }
-            self::canAccessContest($contest, $r['current_identity_id']);
+            self::canAccessContest($contest, $r->identity->identity_id);
         } catch (Exception $e) {
             // Could not access contest. Private contests must not be leaked, so
             // unless they were manually added beforehand, show them a 404 error.
-            if (!self::isInvitedToContest($contest, $r['current_user_id'], $r['current_identity_id'])) {
+            if (!self::isInvitedToContest($contest, $r->user->user_id, $r->identity->identity_id)) {
                 throw $e;
             }
             self::$log->error('Exception while trying to verify access: ' . $e);
@@ -387,7 +385,7 @@ class ContestController extends Controller {
 
         // You already started the contest.
         $contestOpened = ProblemsetIdentitiesDAO::getByPK(
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $contest->problemset_id
         );
         if (!is_null($contestOpened) && !is_null($contestOpened->access_time)) {
@@ -418,9 +416,9 @@ class ContestController extends Controller {
         if (is_null($r['token'])) {
             // Crack the request to get the current user
             self::authenticateRequest($r);
-            self::canAccessContest($contest, $r['current_identity_id']);
+            self::canAccessContest($contest, $r->identity->identity_id);
 
-            $contestAdmin = Authorization::isContestAdmin($r['current_identity_id'], $contest);
+            $contestAdmin = Authorization::isContestAdmin($r->identity->identity_id, $contest);
             if (!ContestsDAO::hasStarted($contest) && !$contestAdmin) {
                 $exception = new PreconditionFailedException('contestNotStarted');
                 $exception->addCustomMessageToArray('start_time', strtotime($contest->start_time));
@@ -519,7 +517,7 @@ class ContestController extends Controller {
 
         try {
             ProblemsetIdentityRequestDAO::save(new ProblemsetIdentityRequest([
-                'identity_id' => $r['current_identity_id'],
+                'identity_id' => $r->identity->identity_id,
                 'problemset_id' => $contest->problemset_id,
                 'request_time' => gmdate('Y-m-d H:i:s'),
             ]));
@@ -551,7 +549,7 @@ class ContestController extends Controller {
         DAO::transBegin();
         try {
             ProblemsetIdentitiesDAO::checkAndSaveFirstTimeAccess(
-                $r['current_identity_id'],
+                $r->identity->identity_id,
                 $response['contest']->problemset_id,
                 true,
                 $r['share_user_information']
@@ -562,12 +560,12 @@ class ContestController extends Controller {
             if ($needsInformation['requests_user_information'] != 'no') {
                 $privacystatement_id = PrivacyStatementsDAO::getId($r['privacy_git_object_id'], $r['statement_type']);
                 $privacystatement_consent_id = PrivacyStatementConsentLogDAO::saveLog(
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     $privacystatement_id
                 );
 
                 ProblemsetIdentitiesDAO::updatePrivacyStatementConsent(new ProblemsetIdentities([
-                    'identity_id' => $r['current_identity_id'],
+                    'identity_id' => $r->identity->identity_id,
                     'problemset_id' => $response['contest']->problemset_id,
                     'privacystatement_consent_id' => $privacystatement_consent_id
                 ]));
@@ -579,7 +577,7 @@ class ContestController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        self::$log->info("User '{$r['current_identity']->username}' joined contest '{$response['contest']->alias}'");
+        self::$log->info("User '{$r->identity->username}' joined contest '{$response['contest']->alias}'");
         return ['status' => 'ok'];
     }
 
@@ -697,7 +695,7 @@ class ContestController extends Controller {
             // Save the time of the first access
             try {
                 $problemset_user = ProblemsetIdentitiesDAO::checkAndSaveFirstTimeAccess(
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     $response['contest']->problemset_id
                 );
             } catch (ApiException $e) {
@@ -716,11 +714,11 @@ class ContestController extends Controller {
                     strtotime($problemset_user->access_time) + $response['contest']->window_length * 60
                 );
             }
-            $result['admin'] = Authorization::isContestAdmin($r['current_identity_id'], $response['contest']);
+            $result['admin'] = Authorization::isContestAdmin($r->identity->identity_id, $response['contest']);
 
             // Log the operation.
             ProblemsetAccessLogDAO::create(new ProblemsetAccessLog([
-                'identity_id' => $r['current_identity_id'],
+                'identity_id' => $r->identity->identity_id,
                 'problemset_id' => $response['contest']->problemset_id,
                 'ip' => ip2long($_SERVER['REMOTE_ADDR']),
             ]));
@@ -745,7 +743,7 @@ class ContestController extends Controller {
     public static function apiAdminDetails(Request $r) {
         $response = self::validateDetails($r);
 
-        if (!Authorization::isContestAdmin($r['current_identity_id'], $response['contest'])) {
+        if (!Authorization::isContestAdmin($r->identity->identity_id, $response['contest'])) {
             throw new ForbiddenAccessException();
         }
 
@@ -753,7 +751,7 @@ class ContestController extends Controller {
         self::getCachedDetails($r['contest_alias'], $response['contest'], $result);
 
         $result['opened'] = ProblemsetIdentitiesDAO::checkProblemsetOpened(
-            (int)$r['current_identity_id'],
+            (int)$r->identity->identity_id,
             (int)$response['contest']->problemset_id
         );
         $result['available_languages'] = RunController::$kSupportedLanguages;
@@ -811,7 +809,7 @@ class ContestController extends Controller {
         // Authenticate user
         self::authenticateRequest($r);
 
-        $originalContest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $originalContest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         $length = strtotime($originalContest->finish_time) -
                   strtotime($originalContest->start_time);
@@ -843,7 +841,7 @@ class ContestController extends Controller {
         DAO::transBegin();
         try {
             // Create the contest
-            self::createContest($problemset, $contest, $r['current_user_id']);
+            self::createContest($problemset, $contest, $r->user->user_id);
 
             $problemsetProblems = ProblemsetProblemsDAO::getProblemsetProblems(
                 $originalContest->problemset_id
@@ -859,7 +857,7 @@ class ContestController extends Controller {
                     $problem,
                     $problemsetProblem['commit'],
                     $problemsetProblem['version'],
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     $problemsetProblem['points'],
                     $problemsetProblem['order'] ?: 1
                 );
@@ -941,7 +939,7 @@ class ContestController extends Controller {
         self::createContest(
             $problemset,
             $contest,
-            $r['current_user_id'],
+            $r->user->user_id,
             $originalContest->problemset_id
         );
 
@@ -1068,7 +1066,7 @@ class ContestController extends Controller {
             'show_scoreboard_after' => $r['show_scoreboard_after'] ?? true,
         ]);
 
-        self::createContest($problemset, $contest, $r['current_user_id']);
+        self::createContest($problemset, $contest, $r->user->user_id);
 
         return ['status' => 'ok'];
     }
@@ -1154,7 +1152,7 @@ class ContestController extends Controller {
                 if (is_null($p)) {
                     throw new InvalidParameterException('parameterNotFound', 'problems');
                 }
-                ProblemsetController::validateAddProblemToProblemset(null, $p, $r['current_identity_id']);
+                ProblemsetController::validateAddProblemToProblemset(null, $p, $r->identity->identity_id);
                 array_push($problems, [
                     'id' => $p->problem_id,
                     'alias' => $problem->problem,
@@ -1197,7 +1195,7 @@ class ContestController extends Controller {
      * @throws InvalidParameterException
      */
     private static function validateUpdate(Request $r) : Contests {
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         self::validateCommonCreateOrUpdate($r, $contest, false /* is required*/);
 
@@ -1279,7 +1277,7 @@ class ContestController extends Controller {
         Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
         // Only director is allowed to create problems in contest
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id'], 'cannotAddProb');
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id, 'cannotAddProb');
 
         $problemset = ProblemsetsDAO::getByPK($contest->problemset_id);
 
@@ -1308,7 +1306,7 @@ class ContestController extends Controller {
         self::authenticateRequest($r);
 
         // Validate the request and get the problem and the contest in an array
-        $params = self::validateAddToContestRequest($r, $r['contest_alias'], $r['problem_alias'], $r['current_identity_id']);
+        $params = self::validateAddToContestRequest($r, $r['contest_alias'], $r['problem_alias'], $r->identity->identity_id);
 
         self::forbiddenInVirtual($params['contest']);
 
@@ -1329,7 +1327,7 @@ class ContestController extends Controller {
             $params['problem'],
             $masterCommit,
             $currentVersion,
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $r['points'],
             is_null($r['order_in_contest']) ? 1 : $r['order_in_contest']
         );
@@ -1373,7 +1371,7 @@ class ContestController extends Controller {
             throw new InvalidParameterException('parameterNotFound', 'contest_alias');
         }
         // Only contest admin is allowed to create problems in contest
-        if (!Authorization::isContestAdmin($r['current_identity_id'], $contest)) {
+        if (!Authorization::isContestAdmin($r->identity->identity_id, $contest)) {
             throw new ForbiddenAccessException('cannotAddProb');
         }
 
@@ -1419,7 +1417,7 @@ class ContestController extends Controller {
         self::authenticateRequest($r);
 
         // Validate the request and get the problem and the contest in an array
-        $params = self::validateRemoveFromContestRequest($r['contest_alias'], $r['problem_alias'], $r['current_identity_id']);
+        $params = self::validateRemoveFromContestRequest($r['contest_alias'], $r['problem_alias'], $r->identity->identity_id);
 
         self::forbiddenInVirtual($params['contest']);
 
@@ -1521,7 +1519,7 @@ class ContestController extends Controller {
         Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
         Validators::validateStringNonEmpty($r['version'], 'version');
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         try {
             $problem = ProblemsDAO::getByAlias($r['problem_alias']);
@@ -1597,7 +1595,7 @@ class ContestController extends Controller {
 
         // Authenticate logged user
         self::authenticateRequest($r);
-        [$user, $contest] = self::validateAddRemoveUser($r['contest_alias'], $r['usernameOrEmail'], $r['current_identity_id']);
+        [$user, $contest] = self::validateAddRemoveUser($r['contest_alias'], $r['usernameOrEmail'], $r->identity->identity_id);
 
         // Save the contest to the DB
         try {
@@ -1626,7 +1624,7 @@ class ContestController extends Controller {
     public static function apiRemoveUser(Request $r) {
         // Authenticate logged user
         self::authenticateRequest($r);
-        [$user, $contest] = self::validateAddRemoveUser($r['contest_alias'], $r['usernameOrEmail'], $r['current_identity_id']);
+        [$user, $contest] = self::validateAddRemoveUser($r['contest_alias'], $r['usernameOrEmail'], $r->identity->identity_id);
 
         try {
             ProblemsetIdentitiesDAO::delete(new ProblemsetIdentities([
@@ -1661,7 +1659,7 @@ class ContestController extends Controller {
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         ACLController::addUser($contest->acl_id, $user->user_id);
 
@@ -1685,7 +1683,7 @@ class ContestController extends Controller {
 
         $user = UserController::resolveUser($r['usernameOrEmail']);
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         // Check if admin to delete is actually an admin
         if (!Authorization::isContestAdmin($user->main_identity_id, $contest)) {
@@ -1722,7 +1720,7 @@ class ContestController extends Controller {
             throw new InvalidParameterException('invalidParameters');
         }
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         ACLController::addGroup($contest->acl_id, $group->group_id);
 
@@ -1750,7 +1748,7 @@ class ContestController extends Controller {
             throw new InvalidParameterException('invalidParameters');
         }
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         ACLController::removeGroup($contest->acl_id, $group->group_id);
 
@@ -1798,7 +1796,7 @@ class ContestController extends Controller {
         $contest = self::validateClarifications($r);
 
         $is_contest_director = Authorization::isContestAdmin(
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $contest
         );
 
@@ -1806,7 +1804,7 @@ class ContestController extends Controller {
             $clarifications = ClarificationsDAO::GetProblemsetClarifications(
                 $contest->problemset_id,
                 $is_contest_director,
-                $r['current_identity_id'],
+                $r->identity->identity_id,
                 $r['offset'],
                 $r['rowcount']
             );
@@ -1841,7 +1839,7 @@ class ContestController extends Controller {
 
         $params = ScoreboardParams::fromContest($response['contest']);
         $params['admin'] = (
-            Authorization::isContestAdmin($r['current_identity_id'], $response['contest']) &&
+            Authorization::isContestAdmin($r->identity->identity_id, $response['contest']) &&
             !ContestsDAO::isVirtual($response['contest'])
         );
         $params['show_all_runs'] = !ContestsDAO::isVirtual($response['contest']);
@@ -1872,9 +1870,9 @@ class ContestController extends Controller {
             // Get the current user
             self::authenticateRequest($r);
 
-            self::canAccessContest($contest, $r['current_identity_id']);
+            self::canAccessContest($contest, $r->identity->identity_id);
 
-            if (Authorization::isContestAdmin($r['current_identity_id'], $contest)) {
+            if (Authorization::isContestAdmin($r->identity->identity_id, $contest)) {
                 $showAllRuns = true;
             }
         } else {
@@ -2033,7 +2031,7 @@ class ContestController extends Controller {
 
         Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         try {
             $db_results = ProblemsetIdentityRequestDAO::getRequestsForProblemset($contest->problemset_id);
@@ -2106,7 +2104,7 @@ class ContestController extends Controller {
             throw new InvalidParameterException('invalidParameters');
         }
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         $targetIdentity = IdentitiesDAO::FindByUsername($r['username']);
 
@@ -2133,7 +2131,7 @@ class ContestController extends Controller {
             'identity_id' => $request->identity_id,
             'problemset_id' => $contest->problemset_id,
             'time' => $request->last_update,
-            'admin_id' => $r['current_user_id'],
+            'admin_id' => $r->user->user_id,
             'accepted' => $request->accepted,
         ]));
 
@@ -2156,7 +2154,7 @@ class ContestController extends Controller {
 
         Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         // Get identities from DB
         try {
@@ -2186,7 +2184,7 @@ class ContestController extends Controller {
 
         Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         return [
             'status' => 'ok',
@@ -2285,7 +2283,7 @@ class ContestController extends Controller {
             DAO::transBegin();
 
             // Save the contest object with data sent by user to the database
-            self::updateContest($contest, $originalContest, $r['current_user_id']);
+            self::updateContest($contest, $originalContest, $r->user->user_id);
 
             if ($updateProblemset) {
                 // Save the problemset object with data sent by user to the database
@@ -2365,7 +2363,7 @@ class ContestController extends Controller {
 
         Validators::validateStringNonEmpty($r['contest_alias'], 'contest_alias');
 
-        $contest = self::validateContestAdmin($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateContestAdmin($r['contest_alias'], $r->identity->identity_id);
 
         $r->ensureInt('offset', null, null, false);
         $r->ensureInt('rowcount', null, null, false);
@@ -2473,7 +2471,7 @@ class ContestController extends Controller {
         // Get user
         self::authenticateRequest($r);
 
-        $contest = self::validateStats($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateStats($r['contest_alias'], $r->identity->identity_id);
 
         try {
             $pendingRunGuids = RunsDAO::getPendingRunGuidsOfProblemset((int)$contest->problemset_id);
@@ -2539,7 +2537,7 @@ class ContestController extends Controller {
     public static function apiReport(Request $r) {
         self::authenticateRequest($r);
 
-        $contest = self::validateStats($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateStats($r['contest_alias'], $r->identity->identity_id);
 
         $params = ScoreboardParams::fromContest($contest);
         $params['admin'] = true;
@@ -2568,7 +2566,7 @@ class ContestController extends Controller {
     public static function apiCsvReport(Request $r) {
         self::authenticateRequest($r);
 
-        $contest = self::validateStats($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateStats($r['contest_alias'], $r->identity->identity_id);
 
         // Get full Report API of the contest
         $contestReport = self::apiReport(new Request([
@@ -2682,7 +2680,7 @@ class ContestController extends Controller {
     public static function apiDownload(Request $r) {
         self::authenticateRequest($r);
 
-        $contest = self::validateStats($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateStats($r['contest_alias'], $r->identity->identity_id);
 
         include_once 'libs/third_party/ZipStream.php';
         $zip = new ZipStream("{$r['contest_alias']}.zip");
@@ -2703,7 +2701,7 @@ class ContestController extends Controller {
         try {
             if ($r['contest_alias'] == 'all-events') {
                 self::authenticateRequest($r);
-                if (Authorization::isSystemAdmin($r['current_identity_id'])) {
+                if (Authorization::isSystemAdmin($r->identity->identity_id)) {
                     return [
                         'status' => 'ok',
                         'admin' => true
@@ -2737,7 +2735,7 @@ class ContestController extends Controller {
     public static function apiSetRecommended(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSystemAdmin($r['current_identity_id'])) {
+        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
@@ -2779,7 +2777,7 @@ class ContestController extends Controller {
     public static function apiContestants(Request $r) {
         self::authenticateRequest($r);
 
-        $contest = self::validateStats($r['contest_alias'], $r['current_identity_id']);
+        $contest = self::validateStats($r['contest_alias'], $r->identity->identity_id);
 
         if (!ContestsDAO::requestsUserInformation($contest->contest_id)) {
             throw new ForbiddenAccessException('contestInformationNotRequired');

--- a/frontend/server/controllers/Controller.php
+++ b/frontend/server/controllers/Controller.php
@@ -26,18 +26,14 @@ class Controller {
     protected static function authenticateRequest(Request $r) {
         $session = SessionController::apiCurrentSession($r)['session'];
         if (is_null($session['identity'])) {
-            $r['current_user'] = null;
-            $r['current_user_id'] = null;
-            $r['current_identity'] = null;
-            $r['current_identity_id'] = null;
+            $r->user = null;
+            $r->identity = null;
             throw new UnauthorizedException();
         }
         if (!is_null($session['user'])) {
-            $r['current_user'] = $session['user'];
-            $r['current_user_id'] = $session['user']->user_id;
+            $r->user = $session['user'];
         }
-        $r['current_identity'] = $session['identity'];
-        $r['current_identity_id'] = $session['identity']->identity_id;
+        $r->identity = $session['identity'];
     }
 
     /**
@@ -73,7 +69,7 @@ class Controller {
      */
     protected static function resolveTargetUser(Request $r) {
         // By default use current user
-        $user = $r['current_user'];
+        $user = $r->user;
 
         if (!is_null($r['username'])) {
             Validators::validateStringNonEmpty($r['username'], 'username');
@@ -108,7 +104,7 @@ class Controller {
      */
     protected static function resolveTargetIdentity(Request $r) {
         // By default use current identity
-        $identity = $r['current_identity'];
+        $identity = $r->identity;
 
         if (is_null($r['username'])) {
             return $identity;

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -156,7 +156,7 @@ class CourseController extends Controller {
         // Only curator can set public
         if (!is_null($r['public'])
             && $r['public'] == true
-            && !Authorization::canCreatePublicCourse($r['current_identity_id'])) {
+            && !Authorization::canCreatePublicCourse($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
     }
@@ -312,11 +312,11 @@ class CourseController extends Controller {
             $r['alias'],
             'students-' . $r['alias'],
             'students-' . $r['alias'],
-            $r['current_user_id']
+            $r->user->user_id
         );
 
         try {
-            $acl = new ACLs(['owner_id' => $r['current_user_id']]);
+            $acl = new ACLs(['owner_id' => $r->user->user_id]);
             ACLsDAO::save($acl);
 
             GroupRolesDAO::create(new GroupRoles([
@@ -371,7 +371,7 @@ class CourseController extends Controller {
         $course = self::validateCourseExists($r['course_alias']);
         self::validateCreateAssignment($r, $course);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -433,9 +433,9 @@ class CourseController extends Controller {
         [$course, $assignment] = self::validateAssignmentDetails(
             $r['course'],
             $r['assignment'],
-            $r['current_identity_id']
+            $r->identity->identity_id
         );
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -518,7 +518,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -552,7 +552,7 @@ class CourseController extends Controller {
             $problem,
             $masterCommit,
             $currentVersion,
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $points
         );
 
@@ -583,7 +583,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -633,7 +633,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -662,7 +662,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -695,7 +695,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -726,7 +726,7 @@ class CourseController extends Controller {
             (int)$problem->problem_id,
             (int)$problemSet->problemset_id
         ) > 0 &&
-            !Authorization::isSystemAdmin($r['current_identity_id'])) {
+            !Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException('cannotRemoveProblemWithSubmissions');
         }
         ProblemsetProblemsDAO::delete($problemsetProblem);
@@ -760,7 +760,7 @@ class CourseController extends Controller {
 
         // Only Course Admins or Group Members (students) can see these results
         if (!Authorization::canViewCourse(
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $course,
             $group
         )) {
@@ -776,7 +776,7 @@ class CourseController extends Controller {
         }
 
         $isAdmin = Authorization::isCourseAdmin(
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $course
         );
 
@@ -820,7 +820,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -878,7 +878,7 @@ class CourseController extends Controller {
         // Courses the user is an admin for.
         $admin_courses = [];
         try {
-            if (Authorization::isSystemAdmin($r['current_identity_id'])) {
+            if (Authorization::isSystemAdmin($r->identity->identity_id)) {
                 $admin_courses = CoursesDAO::getAll(
                     $page,
                     $pageSize,
@@ -887,7 +887,7 @@ class CourseController extends Controller {
                 );
             } else {
                 $admin_courses = CoursesDAO::getAllCoursesAdminedByIdentity(
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     $page,
                     $pageSize
                 );
@@ -899,7 +899,7 @@ class CourseController extends Controller {
         // Courses the user is a student in.
         $student_courses = [];
         try {
-            $student_courses = CoursesDAO::getCoursesForStudent($r['current_identity_id']);
+            $student_courses = CoursesDAO::getCoursesForStudent($r->identity->identity_id);
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);
         }
@@ -932,7 +932,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -960,7 +960,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1032,7 +1032,7 @@ class CourseController extends Controller {
 
         // Only Course Admins or Group Members (students) can see these results
         if (!Authorization::canViewCourse(
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $course,
             $group
         )) {
@@ -1044,7 +1044,7 @@ class CourseController extends Controller {
         try {
             $assignments = CoursesDAO::getAssignmentsProgress(
                 $course->course_id,
-                $r['current_identity_id']
+                $r->identity->identity_id
             );
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);
@@ -1076,9 +1076,9 @@ class CourseController extends Controller {
         }
 
         // Only course admins or users adding themselves when the course is public
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)
             && ($course->public == false
-            || $r['identity']->identity_id !== $r['current_identity_id'])
+            || $r['identity']->identity_id !== $r->identity->identity_id)
             && $course->requests_user_information == 'no'
             && is_null($r['accept_teacher'])
         ) {
@@ -1101,7 +1101,7 @@ class CourseController extends Controller {
             ]));
 
             // Only users adding themselves are saved in consent log
-            if ($r['identity']->identity_id === $r['current_identity_id']
+            if ($r['identity']->identity_id === $r->identity->identity_id
                  && $course->requests_user_information != 'no') {
                 $privacystatement_id = PrivacyStatementsDAO::getId($r['privacy_git_object_id'], $r['statement_type']);
                 if (!PrivacyStatementConsentLogDAO::hasAcceptedPrivacyStatement($r['identity']->identity_id, $privacystatement_id)) {
@@ -1115,7 +1115,7 @@ class CourseController extends Controller {
 
                 $groupIdentity->privacystatement_consent_id = $privacystatement_consent_id;
             }
-            if ($r['identity']->identity_id === $r['current_identity_id']
+            if ($r['identity']->identity_id === $r->identity->identity_id
                  && !empty($r['accept_teacher'])) {
                 $privacystatement_id = PrivacyStatementsDAO::getId($r['accept_teacher_git_object_id'], 'accept_teacher');
                 if (!PrivacyStatementConsentLogDAO::hasAcceptedPrivacyStatement($r['identity']->identity_id, $privacystatement_id)) {
@@ -1150,7 +1150,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1197,7 +1197,7 @@ class CourseController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1237,7 +1237,7 @@ class CourseController extends Controller {
         }
 
         // Only director is allowed to make modifications
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1271,7 +1271,7 @@ class CourseController extends Controller {
         }
 
         // Only admin is alowed to make modifications
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1318,7 +1318,7 @@ class CourseController extends Controller {
         }
 
         // Only admins are allowed to modify course
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1356,7 +1356,7 @@ class CourseController extends Controller {
         }
 
         // Only admin is alowed to make modifications
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1380,11 +1380,11 @@ class CourseController extends Controller {
         $course = self::validateCourseExists($r['course_alias']);
         $group = self::resolveGroup($course, $r['group']);
 
-        $shouldShowIntro = !Authorization::canViewCourse($r['current_identity_id'], $course, $group);
+        $shouldShowIntro = !Authorization::canViewCourse($r->identity->identity_id, $course, $group);
         $isFirstTimeAccess = false;
         $showAcceptTeacher = false;
-        if (!Authorization::isGroupAdmin($r['current_identity_id'], $group)) {
-            $sharingInformation = CoursesDAO::getSharingInformation($r['current_identity_id'], $course, $group);
+        if (!Authorization::isGroupAdmin($r->identity->identity_id, $group)) {
+            $sharingInformation = CoursesDAO::getSharingInformation($r->identity->identity_id, $course, $group);
             $isFirstTimeAccess = $sharingInformation['share_user_information'] == null;
             $showAcceptTeacher = $sharingInformation['accept_teacher'] == null;
         }
@@ -1393,7 +1393,7 @@ class CourseController extends Controller {
         }
 
         $user_session = SessionController::apiCurrentSession($r)['session']['user'];
-        $result = self::getCommonCourseDetails($course, $r['current_identity_id'], true /*onlyIntroDetails*/);
+        $result = self::getCommonCourseDetails($course, $r->identity->identity_id, true /*onlyIntroDetails*/);
         $result['showAcceptTeacher'] = $showAcceptTeacher;
 
         // Privacy Statement Information
@@ -1507,11 +1507,11 @@ class CourseController extends Controller {
         $course = self::validateCourseExists($r['alias']);
         $group = self::resolveGroup($course, $r['group']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
-        return self::getCommonCourseDetails($course, $r['current_identity_id'], false /*onlyIntroDetails*/);
+        return self::getCommonCourseDetails($course, $r->identity->identity_id, false /*onlyIntroDetails*/);
     }
 
     /**
@@ -1525,7 +1525,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1560,12 +1560,12 @@ class CourseController extends Controller {
             [$course, $assignment] = self::validateAssignmentDetails(
                 $courseAlias,
                 $assignmentAlias,
-                $r['current_identity_id']
+                $r->identity->identity_id
             );
 
             return [
                 'hasToken' => false,
-                'courseAdmin' => Authorization::isCourseAdmin($r['current_identity_id'], $course),
+                'courseAdmin' => Authorization::isCourseAdmin($r->identity->identity_id, $course),
                 'assignment' => $assignment,
                 'course' => $course,
             ];
@@ -1678,7 +1678,7 @@ class CourseController extends Controller {
         // Log the operation only when there is not a token in request
         if (!$tokenAuthenticationResult['hasToken']) {
             ProblemsetAccessLogDAO::create(new ProblemsetAccessLog([
-                'identity_id' => $r['current_identity_id'],
+                'identity_id' => $r->identity->identity_id,
                 'problemset_id' => $tokenAuthenticationResult['assignment']->problemset_id,
                 'ip' => ip2long($_SERVER['REMOTE_ADDR']),
             ]));
@@ -1788,7 +1788,7 @@ class CourseController extends Controller {
             throw new NotFoundException('assignmentNotFound');
         }
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $r['course'])) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $r['course'])) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
@@ -1837,14 +1837,14 @@ class CourseController extends Controller {
 
         // Only Course Admins or Group Members (students) can see these results
         if (!Authorization::canViewCourse(
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $course,
             $group
         )) {
             throw new ForbiddenAccessException();
         }
 
-        return self::getCommonCourseDetails($course, $r['current_identity_id'], false /*onlyIntroDetails*/);
+        return self::getCommonCourseDetails($course, $r->identity->identity_id, false /*onlyIntroDetails*/);
     }
 
     /**
@@ -1860,7 +1860,7 @@ class CourseController extends Controller {
 
         self::authenticateRequest($r);
         $originalCourse = self::validateUpdate($r, $r['course_alias']);
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $originalCourse)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $originalCourse)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1917,7 +1917,7 @@ class CourseController extends Controller {
         $group = self::resolveGroup($tokenAuthenticationResult['course'], $r['group']);
 
         if (!$tokenAuthenticationResult['hasToken'] &&
-            !Authorization::canViewCourse($r['current_identity_id'], $tokenAuthenticationResult['course'], $group)) {
+            !Authorization::canViewCourse($r->identity->identity_id, $tokenAuthenticationResult['course'], $group)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1981,7 +1981,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
         try {
@@ -2007,7 +2007,7 @@ class CourseController extends Controller {
         self::authenticateRequest($r);
         $course = self::validateCourseExists($r['course_alias']);
 
-        if (!Authorization::isCourseAdmin($r['current_identity_id'], $course)) {
+        if (!Authorization::isCourseAdmin($r->identity->identity_id, $course)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 

--- a/frontend/server/controllers/GraderController.php
+++ b/frontend/server/controllers/GraderController.php
@@ -15,7 +15,7 @@ class GraderController extends Controller {
     private static function validateRequest(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSystemAdmin($r['current_identity_id'])) {
+        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
     }

--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -60,7 +60,7 @@ class GroupController extends Controller {
             $r['alias'],
             $r['name'],
             $r['description'],
-            $r['current_user_id']
+            $r->user->user_id
         );
 
         return ['status' => 'ok'];
@@ -112,7 +112,7 @@ class GroupController extends Controller {
      */
     public static function apiAddUser(Request $r) {
         self::authenticateRequest($r);
-        $group = self::validateGroupAndOwner($r['group_alias'], $r['current_identity_id']);
+        $group = self::validateGroupAndOwner($r['group_alias'], $r->identity->identity_id);
         $r['identity'] = IdentityController::resolveIdentity($r['usernameOrEmail']);
 
         try {
@@ -135,7 +135,7 @@ class GroupController extends Controller {
      */
     public static function apiRemoveUser(Request $r) {
         self::authenticateRequest($r);
-        $group = self::validateGroupAndOwner($r['group_alias'], $r['current_identity_id']);
+        $group = self::validateGroupAndOwner($r['group_alias'], $r->identity->identity_id);
         $r['identity'] = IdentityController::resolveIdentity($r['usernameOrEmail']);
 
         try {
@@ -172,8 +172,8 @@ class GroupController extends Controller {
 
         try {
             $groups = GroupsDAO::getAllGroupsAdminedByUser(
-                $r['current_user_id'],
-                $r['current_identity_id']
+                $r->user->user_id,
+                $r->identity->identity_id
             );
 
             foreach ($groups as $group) {
@@ -223,7 +223,7 @@ class GroupController extends Controller {
      */
     public static function apiDetails(Request $r) {
         self::authenticateRequest($r);
-        $group = self::validateGroupAndOwner($r['group_alias'], $r['current_identity_id']);
+        $group = self::validateGroupAndOwner($r['group_alias'], $r->identity->identity_id);
 
         if (is_null($group)) {
             return [
@@ -259,7 +259,7 @@ class GroupController extends Controller {
      */
     public static function apiMembers(Request $r) {
         self::authenticateRequest($r);
-        $group = self::validateGroupAndOwner($r['group_alias'], $r['current_identity_id']);
+        $group = self::validateGroupAndOwner($r['group_alias'], $r->identity->identity_id);
 
         $response = [];
 
@@ -280,7 +280,7 @@ class GroupController extends Controller {
      */
     public static function apiCreateScoreboard(Request $r) {
         self::authenticateRequest($r);
-        $group = self::validateGroup($r['group_alias'], $r['current_identity_id']);
+        $group = self::validateGroup($r['group_alias'], $r->identity->identity_id);
 
         Validators::validateValidAlias($r['alias'], 'alias', true);
         Validators::validateStringNonEmpty($r['name'], 'name', true);

--- a/frontend/server/controllers/GroupScoreboardController.php
+++ b/frontend/server/controllers/GroupScoreboardController.php
@@ -72,7 +72,7 @@ class GroupScoreboardController extends Controller {
         self::authenticateRequest($r);
         $contestScoreboard = self::validateGroupScoreboardAndContest(
             $r['group_alias'],
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $r['scoreboard_alias'],
             $r['contest_alias']
         );
@@ -109,7 +109,7 @@ class GroupScoreboardController extends Controller {
      */
     public static function apiRemoveContest(Request $r) {
         self::authenticateRequest($r);
-        $contestScoreboard = self::validateGroupScoreboardAndContest($r['group_alias'], $r['current_identity_id'], $r['scoreboard_alias'], $r['contest_alias']);
+        $contestScoreboard = self::validateGroupScoreboardAndContest($r['group_alias'], $r->identity->identity_id, $r['scoreboard_alias'], $r['contest_alias']);
 
         try {
             $gscs = GroupsScoreboardsProblemsetsDAO::getByPK(
@@ -140,7 +140,7 @@ class GroupScoreboardController extends Controller {
      */
     public static function apiDetails(Request $r) {
         self::authenticateRequest($r);
-        $scoreboard = self::validateGroupScoreboard($r['group_alias'], $r['current_identity_id'], $r['scoreboard_alias']);
+        $scoreboard = self::validateGroupScoreboard($r['group_alias'], $r->identity->identity_id, $r['scoreboard_alias']);
 
         $response = [];
 
@@ -213,7 +213,7 @@ class GroupScoreboardController extends Controller {
      */
     public static function apiList(Request $r) {
         self::authenticateRequest($r);
-        $group = GroupController::validateGroup($r['group_alias'], $r['current_identity_id']);
+        $group = GroupController::validateGroup($r['group_alias'], $r->identity->identity_id);
 
         $response = [];
         $response['scoreboards'] = [];

--- a/frontend/server/controllers/IdentityController.php
+++ b/frontend/server/controllers/IdentityController.php
@@ -141,10 +141,10 @@ class IdentityController extends Controller {
      */
     private static function validateGroupOwnership(Request $r) {
         self::authenticateRequest($r);
-        if (!Authorization::isGroupIdentityCreator($r['current_identity_id'])) {
+        if (!Authorization::isGroupIdentityCreator($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
-        $group = GroupController::validateGroup($r['group_alias'], $r['current_identity_id']);
+        $group = GroupController::validateGroup($r['group_alias'], $r->identity->identity_id);
         if (!is_array($r['identities']) && (!isset($r['username']) && !isset($r['name']) && !isset($r['group_alias']))) {
             throw new InvalidParameterException('parameterInvalid', 'identities');
         }
@@ -275,10 +275,10 @@ class IdentityController extends Controller {
      */
     private static function validateUpdateRequest(Request $r) {
         self::authenticateRequest($r);
-        if (!Authorization::isGroupIdentityCreator($r['current_identity_id'])) {
+        if (!Authorization::isGroupIdentityCreator($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
-        GroupController::validateGroup($r['group_alias'], $r['current_identity_id']);
+        GroupController::validateGroup($r['group_alias'], $r->identity->identity_id);
         if (!is_array($r['identities']) && (!isset($r['username']) && !isset($r['name']) && !isset($r['group_alias']))) {
             throw new InvalidParameterException('parameterInvalid', 'identities');
         }
@@ -350,8 +350,13 @@ class IdentityController extends Controller {
      * @param Request $r
      * @return type
      */
-    public static function getProfile(Request $r) {
-        if (is_null($r['identity'])) {
+    public static function getProfile(
+        Request $r,
+        ?Identities $identity,
+        ?Users $user,
+        bool $omitRank
+    ) : array {
+        if (is_null($identity)) {
             throw new InvalidParameterException('parameterNotFound', 'Identity');
         }
 
@@ -359,33 +364,38 @@ class IdentityController extends Controller {
 
         Cache::getFromCacheOrSet(
             Cache::USER_PROFILE,
-            $r['identity']->username,
-            $r,
-            function (Request $r) {
-                if (!is_null($r['user'])) {
-                    return UserController::getProfileImpl($r['user'], $r['identity']);
+            $identity->username,
+            [$identity, $user],
+            function (array $params) {
+                [$identity, $user] = $params;
+                if (!is_null($user)) {
+                    return UserController::getProfileImpl($user, $identity);
                 }
-                return IdentityController::getProfileImpl($r['identity']);
+                return IdentityController::getProfileImpl($identity);
             },
             $response
         );
 
-        if (!empty($r['omit_rank'])) {
-            $response['userinfo']['rankinfo'] = UserController::getRankByProblemsSolved($r);
-        } else {
+        if ($omitRank) {
             $response['userinfo']['rankinfo'] = [];
+        } else {
+            $response['userinfo']['rankinfo'] = UserController::getRankByProblemsSolved($r);
         }
 
         // Do not leak plain emails in case the request is for a profile other than
         // the logged identity's one. Admins can see emails
-        if (Authorization::isSystemAdmin($r['current_identity_id'])
-              || $r['identity']->identity_id == $r['current_identity_id']) {
+        if (!is_null($r->identity)
+            && (Authorization::isSystemAdmin($r->identity->identity_id)
+                || $identity->identity_id == $r->identity->identity_id)
+        ) {
             return $response;
         }
 
         // Mentors can see current coder of the month email.
-        if (Authorization::canViewEmail($r['current_identity_id']) &&
-              CoderOfTheMonthDAO::isLastCoderOfTheMonth($r['identity']->username)) {
+        if (!is_null($r->identity)
+            && Authorization::canViewEmail($r->identity->identity_id)
+            && CoderOfTheMonthDAO::isLastCoderOfTheMonth($identity->username)
+        ) {
             return $response;
         }
         unset($response['userinfo']['email']);

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -39,7 +39,7 @@ class ProblemController extends Controller {
     private static function validateCreateOrUpdate(Request $r, $is_update = false) {
         $is_required = true;
         // https://github.com/omegaup/omegaup/issues/739
-        if ($r['current_user']->username == 'omi') {
+        if ($r->user->username == 'omi') {
             throw new ForbiddenAccessException();
         }
 
@@ -60,7 +60,7 @@ class ProblemController extends Controller {
             }
 
             // We need to check that the user can actually edit the problem
-            if (!Authorization::canEditProblem($r['current_identity_id'], $r['problem'])) {
+            if (!Authorization::canEditProblem($r->identity->identity_id, $r['problem'])) {
                 throw new ForbiddenAccessException();
             }
 
@@ -69,7 +69,7 @@ class ProblemController extends Controller {
                   $r['problem']->visibility == ProblemController::VISIBILITY_PRIVATE_BANNED)
                     && array_key_exists('visibility', $r)
                     && $r['problem']->visibility != $r['visibility']
-                    && !Authorization::isQualityReviewer($r['current_identity_id'])) {
+                    && !Authorization::isQualityReviewer($r->identity->identity_id)) {
                 throw new InvalidParameterException('qualityNominationProblemHasBeenBanned', 'visibility');
             }
 
@@ -186,7 +186,7 @@ class ProblemController extends Controller {
         $acceptsSubmissions = $r['languages'] !== '';
 
         $acl = new ACLs();
-        $acl->owner_id = $r['current_user_id'];
+        $acl->owner_id = $r->user->user_id;
 
         // Insert new problem
         try {
@@ -199,7 +199,7 @@ class ProblemController extends Controller {
             );
             $problemDeployer->commit(
                 'Initial commit',
-                $r['current_user'],
+                $r->user,
                 ProblemDeployer::CREATE,
                 $problemSettings
             );
@@ -274,7 +274,7 @@ class ProblemController extends Controller {
 
         // We need to check that the user actually has admin privileges over
         // the problem.
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $r['problem'])) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $r['problem'])) {
             throw new ForbiddenAccessException();
         }
     }
@@ -311,7 +311,7 @@ class ProblemController extends Controller {
         }
 
         // Only an admin can add other problem admins
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $problem)) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -356,7 +356,7 @@ class ProblemController extends Controller {
         }
 
         // Only an admin can add other problem group admins
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $problem)) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -386,7 +386,7 @@ class ProblemController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -475,7 +475,7 @@ class ProblemController extends Controller {
         }
 
         // Only admin is alowed to make modifications
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $problem)) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -521,7 +521,7 @@ class ProblemController extends Controller {
         }
 
         // Only admin is alowed to make modifications
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $problem)) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -559,7 +559,7 @@ class ProblemController extends Controller {
             throw new NotFoundException('tag');
         }
 
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -605,7 +605,7 @@ class ProblemController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -645,7 +645,7 @@ class ProblemController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $problem)) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -681,7 +681,7 @@ class ProblemController extends Controller {
         $response = [];
         $response['tags'] = ProblemsTagsDAO::getProblemTags(
             $problem,
-            !Authorization::canEditProblem($r['current_identity_id'], $problem),
+            !Authorization::canEditProblem($r->identity->identity_id, $problem),
             $includeAutogenerated
         );
 
@@ -794,7 +794,7 @@ class ProblemController extends Controller {
             );
             $problemDeployer->commit(
                 $r['message'],
-                $r['current_user'],
+                $r->user,
                 $operation,
                 $problemSettings
             );
@@ -818,7 +818,7 @@ class ProblemController extends Controller {
                 if ($updatePublished != ProblemController::UPDATE_PUBLISHED_NON_PROBLEMSET) {
                     ProblemsetProblemsDAO::updateVersionToCurrent(
                         $problem,
-                        $r['current_user'],
+                        $r->user,
                         $updatePublished
                     );
                 }
@@ -943,7 +943,7 @@ class ProblemController extends Controller {
             $problemDeployer = new ProblemDeployer($r['problem_alias']);
             $problemDeployer->commitStatements(
                 "{$r['lang']}.markdown: {$r['message']}",
-                $r['current_user'],
+                $r->user,
                 [
                     "statements/{$r['lang']}.markdown" => $r['statement'],
                 ]
@@ -956,7 +956,7 @@ class ProblemController extends Controller {
                 if ($updatePublished != ProblemController::UPDATE_PUBLISHED_NON_PROBLEMSET) {
                     ProblemsetProblemsDAO::updateVersionToCurrent(
                         $problem,
-                        $r['current_user'],
+                        $r->user,
                         $updatePublished
                     );
                 }
@@ -1039,11 +1039,11 @@ class ProblemController extends Controller {
         // If we request a problem inside a contest
         $problemset = self::validateProblemset($problem, $r['problemset_id'], $r['contest_alias']);
         if (!is_null($problemset) && isset($problemset['problemset'])) {
-            if (!Authorization::isAdmin($r['current_identity_id'], $problemset['problemset'])) {
+            if (!Authorization::isAdmin($r->identity->identity_id, $problemset['problemset'])) {
                 // If the contest is private, verify that our user is invited
                 if (!empty($problemset['contest'])) {
                     if (!ContestController::isPublic($problemset['contest']->admission_mode)) {
-                        if (is_null(ProblemsetIdentitiesDAO::getByPK($r['current_identity_id'], $problemset['problemset']->problemset_id))) {
+                        if (is_null(ProblemsetIdentitiesDAO::getByPK($r->identity->identity_id, $problemset['problemset']->problemset_id))) {
                             throw new ForbiddenAccessException();
                         }
                     }
@@ -1053,7 +1053,7 @@ class ProblemController extends Controller {
                     }
                 } else {    // Not a contest, but we still have a problemset
                     if (!Authorization::canSubmitToProblemset(
-                        $r['current_identity_id'],
+                        $r->identity->identity_id,
                         $problemset['problemset']
                     )
                     ) {
@@ -1063,7 +1063,9 @@ class ProblemController extends Controller {
                 }
             }
         } else {
-            if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+            if (is_null($r->identity)
+                || !Authorization::canEditProblem($r->identity->identity_id, $problem)
+            ) {
                 // If the problem is requested outside a contest, we need to
                 // check that it is not private
                 if (!ProblemsDAO::isVisible($problem)) {
@@ -1287,7 +1289,7 @@ class ProblemController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1415,10 +1417,10 @@ class ProblemController extends Controller {
         // Add preferred language of the user.
         $user_data = [];
         $request = new Request(['omit_rank' => true, 'auth_token' => $r['auth_token']]);
-        if (!is_null($r['current_user'])) {
+        if (!is_null($r->identity)) {
             Cache::getFromCacheOrSet(
                 Cache::USER_PROFILE,
-                $r['current_user']->username,
+                $r->identity->username,
                 $request,
                 function (Request $request) {
                         return UserController::apiProfile($request);
@@ -1442,7 +1444,7 @@ class ProblemController extends Controller {
         // If the problem is public or if the user has admin privileges, show the
         // problem source and alias of owner.
         if (ProblemsDAO::isVisible($problem['problem']) ||
-            Authorization::isProblemAdmin($r['current_identity_id'], $problem['problem'])) {
+            Authorization::isProblemAdmin($r->identity->identity_id, $problem['problem'])) {
             $acl = ACLsDAO::getByPK($problem['problem']->acl_id);
             $problemsetter = UsersDAO::getByPK($acl->owner_id);
             $response['problemsetter'] = [
@@ -1459,13 +1461,13 @@ class ProblemController extends Controller {
         $problemset = $problem['problemset'];
         $problemsetId = !is_null($problemset) ? (int)$problemset->problemset_id : null;
 
-        if (!is_null($r['current_user_id'])) {
+        if (!is_null($r->identity)) {
             // Get all the available runs done by the current_user
             try {
                 $runsArray = RunsDAO::getForProblemDetails(
                     (int)$problem['problem']->problem_id,
                     $problemsetId,
-                    (int)$r['current_identity_id']
+                    (int)$r->identity->identity_id
                 );
             } catch (Exception $e) {
                 // Operation failed in the data layer
@@ -1476,7 +1478,7 @@ class ProblemController extends Controller {
             $response['runs'] = [];
             foreach ($runsArray as $run) {
                 $run['alias'] = $problem['problem']->alias;
-                $run['username'] = $r['current_user']->username;
+                $run['username'] = $r->identity->username;
                 $run['time'] = (int)$run['time'];
                 $run['contest_score'] = (float)$run['contest_score'];
                 array_push($response['runs'], $run);
@@ -1484,15 +1486,15 @@ class ProblemController extends Controller {
         }
 
         if (!is_null($problemset)) {
-            $result['admin'] = Authorization::isAdmin($r['current_identity_id'], $problemset);
+            $result['admin'] = Authorization::isAdmin($r->identity->identity_id, $problemset);
             if (!$result['admin'] || $r['prevent_problemset_open'] !== 'true') {
                 // At this point, contestant_user relationship should be established.
                 try {
                     ProblemsetIdentitiesDAO::checkAndSaveFirstTimeAccess(
-                        $r['current_identity_id'],
+                        $r->identity->identity_id,
                         $problemset->problemset_id,
                         Authorization::canSubmitToProblemset(
-                            $r['current_identity_id'],
+                            $r->identity->identity_id,
                             $problem['problemset']
                         )
                     );
@@ -1508,7 +1510,7 @@ class ProblemController extends Controller {
             if (!ProblemsetProblemOpenedDAO::getByPK(
                 $problemsetId,
                 $problem['problem']->problem_id,
-                $r['current_identity_id']
+                $r->identity->identity_id
             )) {
                 try {
                     // Save object in the DB
@@ -1516,7 +1518,7 @@ class ProblemController extends Controller {
                         'problemset_id' => $problemset->problemset_id,
                         'problem_id' => $problem['problem']->problem_id,
                         'open_time' => gmdate('Y-m-d H:i:s', Time::get()),
-                        'identity_id' => $r['current_identity_id']
+                        'identity_id' => $r->identity->identity_id
                     ]));
                 } catch (Exception $e) {
                     // Operation failed in the data layer
@@ -1527,9 +1529,9 @@ class ProblemController extends Controller {
             $response['solvers'] = RunsDAO::getBestSolvingRunsForProblem((int)$problem['problem']->problem_id);
         }
 
-        if (!is_null($r['current_identity_id'])) {
+        if (!is_null($r->identity)) {
             ProblemViewedDAO::MarkProblemViewed(
-                $r['current_identity_id'],
+                $r->identity->identity_id,
                 $problem['problem']->problem_id
             );
         }
@@ -1539,12 +1541,16 @@ class ProblemController extends Controller {
         $response['languages'] = array_filter(explode(',', $response['languages']));
 
         $response['points'] = round(100.0 / (log(max($response['accepted'], 1.0) + 1, 2)), 2);
-        $response['score'] = self::bestScore(
-            $problem['problem'],
-            $problemsetId,
-            $r['contest_alias'],
-            $r['current_identity_id']
-        );
+        if (is_null($r->identity)) {
+            $response['score'] = 0.0;
+        } else {
+            $response['score'] = self::bestScore(
+                $problem['problem'],
+                $problemsetId,
+                $r['contest_alias'],
+                $r->identity->identity_id
+            );
+        }
         $response['status'] = 'ok';
         $response['exists'] = true;
         return $response;
@@ -1571,7 +1577,7 @@ class ProblemController extends Controller {
         $problemset = $problem['problemset'];
         $problem = $problem['problem'];
 
-        if (!Authorization::canViewProblemSolution($r['current_identity_id'], $problem)) {
+        if (!Authorization::canViewProblemSolution($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException('problemSolutionNotVisible');
         }
 
@@ -1625,7 +1631,7 @@ class ProblemController extends Controller {
         if (is_null($problem)) {
             throw new NotFoundException('problemNotFound');
         }
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1695,7 +1701,7 @@ class ProblemController extends Controller {
         if (is_null($problem)) {
             throw new NotFoundException('problemNotFound');
         }
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1728,7 +1734,7 @@ class ProblemController extends Controller {
             $problemDeployer->updatePublished(
                 ((new ProblemArtifacts($problem->alias, 'published'))->commit())['commit'],
                 $problem->commit,
-                $r['current_user']
+                $r->user
             );
 
             RunsDAO::createRunsForVersion($problem);
@@ -1736,7 +1742,7 @@ class ProblemController extends Controller {
             if ($updatePublished != ProblemController::UPDATE_PUBLISHED_NON_PROBLEMSET) {
                 ProblemsetProblemsDAO::updateVersionToCurrent(
                     $problem,
-                    $r['current_user'],
+                    $r->user,
                     $updatePublished
                 );
             }
@@ -1807,7 +1813,7 @@ class ProblemController extends Controller {
         if (is_null($problem)) {
             throw new NotFoundException('problemNotFound');
         }
-        if (!Authorization::canEditProblem($r['current_identity_id'], $problem)) {
+        if (!Authorization::canEditProblem($r->identity->identity_id, $problem)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1906,7 +1912,7 @@ class ProblemController extends Controller {
         $response = [];
 
         if ($r['show_all']) {
-            if (!Authorization::isProblemAdmin($r['current_identity_id'], $r['problem'])) {
+            if (!Authorization::isProblemAdmin($r->identity->identity_id, $r['problem'])) {
                 throw new ForbiddenAccessException();
             }
             if (!is_null($r['username'])) {
@@ -1950,7 +1956,7 @@ class ProblemController extends Controller {
                 $runsArray = RunsDAO::getForProblemDetails(
                     (int)$r['problem']->problem_id,
                     null,
-                    (int)$r['current_identity_id']
+                    (int)$r->identity->identity_id
                 );
 
                 // Add each filtered run to an array
@@ -1959,7 +1965,7 @@ class ProblemController extends Controller {
                     foreach ($runsArray as $run) {
                         $run['time'] = (int)$run['time'];
                         $run['contest_score'] = (float)$run['contest_score'];
-                        $run['username'] = $r['current_user']->username;
+                        $run['username'] = $r->user->username;
                         $run['alias'] = $r['problem']->alias;
                         array_push($response['runs'], $run);
                     }
@@ -1986,13 +1992,13 @@ class ProblemController extends Controller {
         self::authenticateRequest($r);
         self::validateRuns($r);
 
-        $is_problem_admin = Authorization::isProblemAdmin($r['current_identity_id'], $r['problem']);
+        $is_problem_admin = Authorization::isProblemAdmin($r->identity->identity_id, $r['problem']);
 
         try {
             $clarifications = ClarificationsDAO::GetProblemClarifications(
                 $r['problem']->problem_id,
                 $is_problem_admin,
-                $r['current_identity_id'],
+                $r->identity->identity_id,
                 $r['offset'],
                 $r['rowcount']
             );
@@ -2029,7 +2035,7 @@ class ProblemController extends Controller {
         self::validateRuns($r);
 
         // We need to check that the user has priviledges on the problem
-        if (!Authorization::isProblemAdmin($r['current_identity_id'], $r['problem'])) {
+        if (!Authorization::isProblemAdmin($r->identity->identity_id, $r['problem'])) {
             throw new ForbiddenAccessException();
         }
 
@@ -2195,12 +2201,12 @@ class ProblemController extends Controller {
         // - Logged in users with normal permissions: Normal
         // - Logged in users with administrative rights: Admin
         $identityType = IDENTITY_ANONYMOUS;
-        if (!is_null($r['current_identity_id'])) {
-            $authorIdentityId = intval($r['current_identity_id']);
-            $authorUserId = intval($r['current_user_id']);
-            if (Authorization::isSystemAdmin($r['current_identity_id']) ||
+        if (!is_null($r->identity)) {
+            $authorIdentityId = intval($r->identity->identity_id);
+            $authorUserId = intval($r->user->user_id);
+            if (Authorization::isSystemAdmin($r->identity->identity_id) ||
                 Authorization::hasRole(
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     Authorization::SYSTEM_ACL,
                     Authorization::REVIEWER_ROLE
                 )
@@ -2268,7 +2274,7 @@ class ProblemController extends Controller {
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
 
         try {
-            if (Authorization::isSystemAdmin($r['current_identity_id'])) {
+            if (Authorization::isSystemAdmin($r->identity->identity_id)) {
                 $problems = ProblemsDAO::getAll(
                     $page,
                     $pageSize,
@@ -2277,7 +2283,7 @@ class ProblemController extends Controller {
                 );
             } else {
                 $problems = ProblemsDAO::getAllProblemsAdminedByIdentity(
-                    $r['current_identity_id'],
+                    $r->identity->identity_id,
                     $page,
                     $pageSize
                 );
@@ -2288,7 +2294,7 @@ class ProblemController extends Controller {
 
         $addedProblems = [];
 
-        $hiddenTags = UsersDao::getHideTags($r['current_identity_id']);
+        $hiddenTags = UsersDao::getHideTags($r->identity->identity_id);
         foreach ($problems as $problem) {
             $problemArray = $problem->asArray();
             $problemArray['tags'] = $hiddenTags ? [] : ProblemsDAO::getTagsForProblem($problem, false);
@@ -2318,7 +2324,7 @@ class ProblemController extends Controller {
 
         try {
             $problems = ProblemsDAO::getAllProblemsOwnedByUser(
-                $r['current_user_id'],
+                $r->user->user_id,
                 $page,
                 $pageSize
             );
@@ -2328,7 +2334,7 @@ class ProblemController extends Controller {
 
         $addedProblems = [];
 
-        $hiddenTags = UsersDao::getHideTags($r['current_identity_id']);
+        $hiddenTags = UsersDao::getHideTags($r->identity->identity_id);
         foreach ($problems as $problem) {
             $problemArray = $problem->asArray();
             $problemArray['tags'] = $hiddenTags ? [] : ProblemsDAO::getTagsForProblem($problem, false);
@@ -2360,7 +2366,7 @@ class ProblemController extends Controller {
             $problem['problem'],
             $r['problemset_id'],
             $r['contest_alias'],
-            $r['current_identity_id'],
+            $r->identity->identity_id,
             $identity
         );
         $response['status'] = 'ok';
@@ -2386,14 +2392,10 @@ class ProblemController extends Controller {
         Problems $problem,
         $problemsetId,
         $contestAlias,
-        $currentLoggedIdentityId,
-        Identities $identity = null
+        int $currentLoggedIdentityId,
+        ?Identities $identity = null
     ) : float {
         $currentIdentityId = (is_null($identity) ? $currentLoggedIdentityId : $identity->identity_id);
-
-        if (is_null($currentIdentityId)) {
-            return 0.0;
-        }
 
         $score = 0.0;
         try {

--- a/frontend/server/controllers/QualityNominationController.php
+++ b/frontend/server/controllers/QualityNominationController.php
@@ -87,7 +87,7 @@ class QualityNominationController extends Controller {
         if ($r['nomination'] != 'demotion') {
             // All nominations types, except demotions, are only allowed for
             // uses who have already solved the problem.
-            if (!ProblemsDAO::isProblemSolved($problem, (int)$r['current_identity_id'])) {
+            if (!ProblemsDAO::isProblemSolved($problem, (int)$r->identity->identity_id)) {
                 throw new PreconditionFailedException('qualityNominationMustHaveSolvedProblem');
             }
         }
@@ -188,7 +188,7 @@ class QualityNominationController extends Controller {
 
         // Create object
         $nomination = new QualityNominations([
-            'user_id' => $r['current_user_id'],
+            'user_id' => $r->user->user_id,
             'problem_id' => $problem->problem_id,
             'nomination' => $r['nomination'],
             'contents' => json_encode($contents), // re-encoding it for normalization.
@@ -280,7 +280,7 @@ class QualityNominationController extends Controller {
         $r['visibility'] = $newProblemVisibility;
 
         $qualitynominationlog = new QualityNominationLog([
-            'user_id' => $r['current_user_id'],
+            'user_id' => $r->user->user_id,
             'qualitynomination_id' => $qualitynomination->qualitynomination_id,
             'from_status' => $qualitynomination->status,
             'to_status' => $r['status'],
@@ -401,7 +401,7 @@ class QualityNominationController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateMemberOfReviewerGroup(Request $r) {
-        if (!Authorization::isQualityReviewer($r['current_identity_id'])) {
+        if (!Authorization::isQualityReviewer($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
     }
@@ -453,7 +453,7 @@ class QualityNominationController extends Controller {
         self::authenticateRequest($r);
         self::validateMemberOfReviewerGroup($r);
 
-        return self::getListImpl($r, null /* nominator */, $r['current_user_id']);
+        return self::getListImpl($r, null /* nominator */, $r->user->user_id);
     }
 
     /**
@@ -473,7 +473,7 @@ class QualityNominationController extends Controller {
         // Validate request
         self::authenticateRequest($r);
 
-        return self::getListImpl($r, $r['current_user_id'], null /* assignee */);
+        return self::getListImpl($r, $r->user->user_id, null /* assignee */);
     }
 
     /**
@@ -501,8 +501,8 @@ class QualityNominationController extends Controller {
 
         // The nominator can see the nomination, as well as all the members of
         // the reviewer group.
-        $currentUserIsNominator = ($r['current_user']->username == $response['nominator']['username']);
-        $currentUserReviewer = Authorization::isQualityReviewer($r['current_identity_id']);
+        $currentUserIsNominator = ($r->user->username == $response['nominator']['username']);
+        $currentUserReviewer = Authorization::isQualityReviewer($r->identity->identity_id);
         if (!$currentUserIsNominator && !$currentUserReviewer) {
             throw new ForbiddenAccessException('userNotAllowed');
         }

--- a/frontend/server/controllers/ResetController.php
+++ b/frontend/server/controllers/ResetController.php
@@ -60,7 +60,7 @@ class ResetController extends Controller {
     public static function apiGenerateToken(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSupportTeamMember($r['current_identity_id'])) {
+        if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
 
@@ -142,7 +142,7 @@ class ResetController extends Controller {
         }
 
         // Support doesn't need wait to resest passwords
-        if (Authorization::isSupportTeamMember($r['current_identity_id'])) {
+        if (!is_null($r->identity) && Authorization::isSupportTeamMember($r->identity->identity_id)) {
             return;
         }
 

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -40,7 +40,7 @@ class RunController extends Controller {
      */
     private static function validateCreateRequest(Request $r) {
         // https://github.com/omegaup/omegaup/issues/739
-        if ($r['current_identity']->username == 'omi') {
+        if ($r->identity->username == 'omi') {
             throw new ForbiddenAccessException();
         }
 
@@ -107,15 +107,15 @@ class RunController extends Controller {
                 // Check for practice or public problem, there is no contest info
                 // in this scenario.
                 if (ProblemsDAO::isVisible($r['problem']) ||
-                      Authorization::isProblemAdmin($r['current_identity_id'], $r['problem']) ||
+                      Authorization::isProblemAdmin($r->identity->identity_id, $r['problem']) ||
                       Time::get() > ProblemsDAO::getPracticeDeadline($r['problem']->problem_id)) {
                     if (!RunsDAO::isRunInsideSubmissionGap(
                         null,
                         null,
                         (int)$r['problem']->problem_id,
-                        (int)$r['current_identity_id']
+                        (int)$r->identity->identity_id
                     )
-                            && !Authorization::isSystemAdmin($r['current_identity_id'])) {
+                            && !Authorization::isSystemAdmin($r->identity->identity_id)) {
                             throw new NotAllowedToSubmitException('runWaitGap');
                     }
 
@@ -158,11 +158,11 @@ class RunController extends Controller {
             }
 
             // Contest admins can skip following checks
-            if (!Authorization::isAdmin($r['current_identity_id'], $r['problemset'])) {
+            if (!Authorization::isAdmin($r->identity->identity_id, $r['problemset'])) {
                 // Before submit something, user had to open the problem/problemset.
-                if (!ProblemsetIdentitiesDAO::getByPK($r['current_identity_id'], $problemset_id) &&
+                if (!ProblemsetIdentitiesDAO::getByPK($r->identity->identity_id, $problemset_id) &&
                     !Authorization::canSubmitToProblemset(
-                        $r['current_identity_id'],
+                        $r->identity->identity_id,
                         $r['problemset']
                     )
                 ) {
@@ -170,7 +170,7 @@ class RunController extends Controller {
                 }
 
                 // Validate that the run is timely inside contest
-                if (!ProblemsetsDAO::insideSubmissionWindow($r['container'], $r['current_identity_id'])) {
+                if (!ProblemsetsDAO::insideSubmissionWindow($r['container'], $r->identity->identity_id)) {
                     throw new NotAllowedToSubmitException('runNotInsideContest');
                 }
 
@@ -179,7 +179,7 @@ class RunController extends Controller {
                     (int)$problemset_id,
                     $r['contest'],
                     (int)$r['problem']->problem_id,
-                    (int)$r['current_identity_id']
+                    (int)$r->identity->identity_id
                 )) {
                     throw new NotAllowedToSubmitException('runWaitGap');
                 }
@@ -241,7 +241,7 @@ class RunController extends Controller {
                         $opened = ProblemsetProblemOpenedDAO::getByPK(
                             $problemset_id,
                             $r['problem']->problem_id,
-                            $r['current_identity_id']
+                            $r->identity->identity_id
                         );
 
                         if (is_null($opened)) {
@@ -279,14 +279,14 @@ class RunController extends Controller {
 
             // If user is admin and is in virtual contest, then admin will be treated as contestant
 
-            $type = (Authorization::isAdmin($r['current_identity_id'], $r['problemset']) &&
+            $type = (Authorization::isAdmin($r->identity->identity_id, $r['problemset']) &&
                 !is_null($r['contest']) &&
                 !ContestsDAO::isVirtual($r['contest'])) ? 'test' : 'normal';
         }
 
         // Populate new run+submission object
         $submission = new Submissions([
-            'identity_id' => $r['current_identity_id'],
+            'identity_id' => $r->identity->identity_id,
             'problem_id' => $r['problem']->problem_id,
             'problemset_id' => $problemset_id,
             'guid' => md5(uniqid(rand(), true)),
@@ -335,8 +335,8 @@ class RunController extends Controller {
             }
 
             SubmissionLogDAO::create(new SubmissionLog([
-                'user_id' => $r['current_user_id'],
-                'identity_id' => $r['current_identity_id'],
+                'user_id' => $r->user->user_id,
+                'identity_id' => $r->identity->identity_id,
                 'submission_id' => $submission->submission_id,
                 'problemset_id' => $submission->problemset_id,
                 'ip' => ip2long($_SERVER['REMOTE_ADDR'])
@@ -354,7 +354,7 @@ class RunController extends Controller {
         } else {
             // Add remaining time to the response
             try {
-                $contest_user = ProblemsetIdentitiesDAO::getByPK($r['current_identity_id'], $problemset_id);
+                $contest_user = ProblemsetIdentitiesDAO::getByPK($r->identity->identity_id, $problemset_id);
 
                 if (isset($r['container']->finish_time)) {
                     $response['submission_deadline'] = strtotime($r['container']->finish_time);
@@ -430,7 +430,7 @@ class RunController extends Controller {
 
         self::validateDetailsRequest($r);
 
-        if (!(Authorization::canViewSubmission($r['current_identity_id'], $r['submission']))) {
+        if (!(Authorization::canViewSubmission($r->identity->identity_id, $r['submission']))) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
@@ -452,8 +452,8 @@ class RunController extends Controller {
         if ($filtered['contest_score'] != null) {
             $filtered['contest_score'] = round((float) $filtered['contest_score'], 2);
         }
-        if ($r['submission']->identity_id == $r['current_identity_id']) {
-            $filtered['username'] = $r['current_identity']->username;
+        if ($r['submission']->identity_id == $r->identity->identity_id) {
+            $filtered['username'] = $r->identity->username;
         }
         return $filtered;
     }
@@ -472,7 +472,7 @@ class RunController extends Controller {
 
         self::validateDetailsRequest($r);
 
-        if (!(Authorization::canEditSubmission($r['current_identity_id'], $r['submission']))) {
+        if (!(Authorization::canEditSubmission($r->identity->identity_id, $r['submission']))) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
@@ -511,7 +511,7 @@ class RunController extends Controller {
 
         self::validateDetailsRequest($r);
 
-        if (!Authorization::canEditSubmission($r['current_identity_id'], $r['submission'])) {
+        if (!Authorization::canEditSubmission($r->identity->identity_id, $r['submission'])) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
@@ -575,19 +575,19 @@ class RunController extends Controller {
             throw new NotFoundException('problemNotFound');
         }
 
-        if (!(Authorization::canViewSubmission($r['current_identity_id'], $r['submission']))) {
+        if (!(Authorization::canViewSubmission($r->identity->identity_id, $r['submission']))) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
         // Get the source
         $response = [
             'status' => 'ok',
-            'admin' => Authorization::isProblemAdmin($r['current_identity_id'], $r['problem']),
+            'admin' => Authorization::isProblemAdmin($r->identity->identity_id, $r['problem']),
             'guid' => $r['submission']->guid,
             'language' => $r['submission']->language,
         ];
         $showDetails = $response['admin'] ||
-            ProblemsDAO::isProblemSolved($r['problem'], (int)$r['current_identity_id']);
+            ProblemsDAO::isProblemSolved($r['problem'], (int)$r->identity->identity_id);
 
         // Get the details, compile error, logs, etc.
         RunController::populateRunDetails($r['submission'], $r['run'], $showDetails, $response);
@@ -616,7 +616,7 @@ class RunController extends Controller {
 
         self::validateDetailsRequest($r);
 
-        if (!(Authorization::canViewSubmission($r['current_identity_id'], $r['submission']))) {
+        if (!(Authorization::canViewSubmission($r->identity->identity_id, $r['submission']))) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 
@@ -668,7 +668,7 @@ class RunController extends Controller {
         self::authenticateRequest($r);
 
         Validators::validateStringNonEmpty($r['run_alias'], 'run_alias');
-        if (!RunController::downloadSubmission($r['run_alias'], $r['current_identity_id'], /*passthru=*/true)) {
+        if (!RunController::downloadSubmission($r['run_alias'], $r->identity->identity_id, /*passthru=*/true)) {
             http_response_code(404);
         }
         exit;
@@ -828,7 +828,7 @@ class RunController extends Controller {
             $r['rowcount'] = 100;
         }
 
-        if (!Authorization::isSystemAdmin($r['current_identity_id'])) {
+        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -384,7 +384,7 @@ class UserController extends Controller {
         self::authenticateRequest($r);
 
         $hashedPassword = null;
-        $user = $r['current_user'];
+        $user = $r->user;
         if (isset($r['username']) && $r['username'] != $user->username) {
             // This is usable only in tests.
             if (is_null(self::$permissionKey) || self::$permissionKey != $r['permission_key']) {
@@ -463,7 +463,7 @@ class UserController extends Controller {
         if (isset($r['usernameOrEmail'])) {
             self::authenticateRequest($r);
 
-            if (!Authorization::isSupportTeamMember($r['current_identity_id'])) {
+            if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
                 throw new ForbiddenAccessException();
             }
 
@@ -524,7 +524,7 @@ class UserController extends Controller {
     public static function apiMailingListBackfill(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSystemAdmin($r['current_identity_id'])) {
+        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
 
@@ -646,9 +646,9 @@ class UserController extends Controller {
 
         $response = [];
 
-        $is_system_admin = Authorization::isSystemAdmin($r['current_identity_id']);
+        $is_system_admin = Authorization::isSystemAdmin($r->identity->identity_id);
         if ($r['contest_type'] == 'OMI') {
-            if ($r['current_user']->username != 'andreasantillana'
+            if ($r->user->username != 'andreasantillana'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -691,7 +691,7 @@ class UserController extends Controller {
                 'OMI2019-INV' => 4,
             ];
         } elseif ($r['contest_type'] == 'OMIP') {
-            if ($r['current_user']->username != 'andreasantillana'
+            if ($r->user->username != 'andreasantillana'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -732,7 +732,7 @@ class UserController extends Controller {
                 'OMIP2019-ZAC' => 25,
             ];
         } elseif ($r['contest_type'] == 'OMIS') {
-            if ($r['current_user']->username != 'andreasantillana'
+            if ($r->user->username != 'andreasantillana'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -773,7 +773,7 @@ class UserController extends Controller {
                 'OMIS2019-ZAC' => 25,
             ];
         } elseif ($r['contest_type'] == 'OMIPN') {
-            if ($r['current_user']->username != 'andreasantillana'
+            if ($r->user->username != 'andreasantillana'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -815,7 +815,7 @@ class UserController extends Controller {
                 'OMIP2019-INV' => 4,
             ];
         } elseif ($r['contest_type'] == 'OMISN') {
-            if ($r['current_user']->username != 'andreasantillana'
+            if ($r->user->username != 'andreasantillana'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -857,7 +857,7 @@ class UserController extends Controller {
                 'OMIS2019-INV' => 4,
             ];
         } elseif ($r['contest_type'] == 'ORIG') {
-            if ($r['current_user']->username != 'kuko.coder'
+            if ($r->user->username != 'kuko.coder'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -876,7 +876,7 @@ class UserController extends Controller {
                 'ORIG1516-VDS' => 15,
             ];
         } elseif ($r['contest_type'] == 'OMIZAC-2018') {
-            if ($r['current_user']->username != 'rsolis'
+            if ($r->user->username != 'rsolis'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -886,7 +886,7 @@ class UserController extends Controller {
                 'OMIZAC-2018' => 20
             ];
         } elseif ($r['contest_type'] == 'Pr8oUAIE') {
-            if ($r['current_user']->username != 'rsolis'
+            if ($r->user->username != 'rsolis'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -896,7 +896,7 @@ class UserController extends Controller {
                 'Pr8oUAIE' => 20
             ];
         } elseif ($r['contest_type'] == 'OMIZAC') {
-            if ($r['current_user']->username != 'rsolis'
+            if ($r->user->username != 'rsolis'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -908,7 +908,7 @@ class UserController extends Controller {
                 'OMIZAC-Prepa' => 60
             ];
         } elseif ($r['contest_type'] == 'ProgUAIE') {
-            if ($r['current_user']->username != 'rsolis'
+            if ($r->user->username != 'rsolis'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -923,7 +923,7 @@ class UserController extends Controller {
                 'Sec-UAIE-Jalpa' => 30
             ];
         } elseif ($r['contest_type'] == 'OMIAGS-2018') {
-            if ($r['current_user']->username != 'EfrenGonzalez'
+            if ($r->user->username != 'EfrenGonzalez'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -933,7 +933,7 @@ class UserController extends Controller {
                 'OMIAGS-2018' => 30
             ];
         } elseif ($r['contest_type'] == 'OMIAGS-2017') {
-            if ($r['current_user']->username != 'EfrenGonzalez'
+            if ($r->user->username != 'EfrenGonzalez'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -943,7 +943,7 @@ class UserController extends Controller {
                 'OMIAGS-2017' => 30
             ];
         } elseif ($r['contest_type'] == 'OMIP-AGS') {
-            if ($r['current_user']->username != 'EfrenGonzalez'
+            if ($r->user->username != 'EfrenGonzalez'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -953,7 +953,7 @@ class UserController extends Controller {
                 'OMIP-AGS' => 30
             ];
         } elseif ($r['contest_type'] == 'OMIS-AGS') {
-            if ($r['current_user']->username != 'EfrenGonzalez'
+            if ($r->user->username != 'EfrenGonzalez'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -963,7 +963,7 @@ class UserController extends Controller {
                 'OMIS-AGS' => 30
             ];
         } elseif ($r['contest_type'] == 'OSI') {
-            if ($r['current_user']->username != 'cope_quintana'
+            if ($r->user->username != 'cope_quintana'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -973,8 +973,8 @@ class UserController extends Controller {
                 'OSI16' => 120
             ];
         } elseif ($r['contest_type'] == 'UNAMFC') {
-            if ($r['current_user']->username != 'manuelalcantara52'
-                && $r['current_user']->username != 'manuel52'
+            if ($r->user->username != 'manuelalcantara52'
+                && $r->user->username != 'manuel52'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -983,7 +983,7 @@ class UserController extends Controller {
                 'UNAMFC16' => 65
             ];
         } elseif ($r['contest_type'] == 'OVI') {
-            if ($r['current_user']->username != 'covi.academico'
+            if ($r->user->username != 'covi.academico'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -992,7 +992,7 @@ class UserController extends Controller {
                 'OVI19' => 200
             ];
         } elseif ($r['contest_type'] == 'UDCCUP') {
-            if ($r['current_user']->username != 'Diego_Briaares'
+            if ($r->user->username != 'Diego_Briaares'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1001,7 +1001,7 @@ class UserController extends Controller {
                 'UDCCUP-2017' => 40
             ];
         } elseif ($r['contest_type'] == 'CCUPITSUR') {
-            if ($r['current_user']->username != 'licgerman-yahoo'
+            if ($r->user->username != 'licgerman-yahoo'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1011,7 +1011,7 @@ class UserController extends Controller {
                 'CCUPITSUR-16' => 50,
             ];
         } elseif ($r['contest_type'] == 'CONALEP') {
-            if ($r['current_user']->username != 'reyes811'
+            if ($r->user->username != 'reyes811'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1020,7 +1020,7 @@ class UserController extends Controller {
                 'OIC-16' => 225
             ];
         } elseif ($r['contest_type'] == 'OMIQROO') {
-            if ($r['current_user']->username != 'pablobatun'
+            if ($r->user->username != 'pablobatun'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1031,7 +1031,7 @@ class UserController extends Controller {
                 'OMIROO-Pre-20' => 300,
             ];
         } elseif ($r['contest_type'] == 'TEBAEV') {
-            if ($r['current_user']->username != 'lacj20'
+            if ($r->user->username != 'lacj20'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1040,7 +1040,7 @@ class UserController extends Controller {
                 'TEBAEV' => 250,
             ];
         } elseif ($r['contest_type'] == 'PYE-AGS') {
-            if ($r['current_user']->username != 'joemmanuel'
+            if ($r->user->username != 'joemmanuel'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1049,7 +1049,7 @@ class UserController extends Controller {
                 'PYE-AGS18' => 40,
             ];
         } elseif ($r['contest_type'] == 'CAPKnuth') {
-            if ($r['current_user']->username != 'galloska'
+            if ($r->user->username != 'galloska'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1058,7 +1058,7 @@ class UserController extends Controller {
                 'ESCOM2018' => 50,
             ];
         } elseif ($r['contest_type'] == 'CAPVirtualKnuth') {
-            if ($r['current_user']->username != 'galloska'
+            if ($r->user->username != 'galloska'
                 && !$is_system_admin
             ) {
                 throw new ForbiddenAccessException();
@@ -1239,9 +1239,11 @@ class UserController extends Controller {
         $r['identity'] = self::resolveTargetIdentity($r);
         $r['user'] = self::resolveTargetUser($r);
 
-        $response = IdentityController::getProfile($r);
-        if ((is_null($r['current_identity']) || $r['current_identity']->username != $r['identity']->username)
-            && (!is_null($r['user']) && $r['user']->is_private == 1) && !Authorization::isSystemAdmin($r['current_identity_id'])) {
+        $response = IdentityController::getProfile($r, $r['identity'], $r['user'], boolval($r['omit_rank']));
+        if ((is_null($r->identity) || $r->identity->username != $r['identity']->username)
+            && (!is_null($r['user']) && $r['user']->is_private == 1)
+            && (is_null($r->identity) || !Authorization::isSystemAdmin($r->identity->identity_id))
+        ) {
             $response['problems'] = [];
             foreach ($response['userinfo'] as $k => $v) {
                 $response['userinfo'][$k] = null;
@@ -1271,7 +1273,7 @@ class UserController extends Controller {
     public static function apiStatusVerified(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSupportTeamMember($r['current_identity_id'])) {
+        if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1300,7 +1302,7 @@ class UserController extends Controller {
     public static function apiExtraInformation(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSupportTeamMember($r['current_identity_id'])) {
+        if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1421,7 +1423,7 @@ class UserController extends Controller {
         self::authenticateRequest($r);
         $currentTimestamp = Time::get();
 
-        if (!Authorization::isMentor($r['current_identity_id'])) {
+        if (!Authorization::isMentor($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
         if (!Authorization::canChooseCoder($currentTimestamp)) {
@@ -1457,7 +1459,7 @@ class UserController extends Controller {
                     'user_id' => $user['user_id'],
                     'time' => $dateToSelect,
                     'rank' => $index + 1,
-                    'selected_by' => $r['current_identity_id'],
+                    'selected_by' => $r->identity->identity_id,
                 ]));
 
                 return ['status' => 'ok'];
@@ -1499,7 +1501,7 @@ class UserController extends Controller {
         }
 
         // Only admins can view interview details
-        if (!Authorization::isContestAdmin($r['current_identity_id'], $contest)) {
+        if (!Authorization::isContestAdmin($r->identity->identity_id, $contest)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1686,8 +1688,8 @@ class UserController extends Controller {
             $user = self::resolveTargetUser($r);
         }
 
-        if ((is_null($r['current_identity']) || $r['current_identity']->username != $identity->username)
-            && (!is_null($user) && $user->is_private == 1) && !Authorization::isSystemAdmin($r['current_identity_id'])) {
+        if ((is_null($r->identity) || $r->identity->username != $identity->username)
+            && (!is_null($user) && $user->is_private == 1) && !Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException('userProfileIsPrivate');
         }
 
@@ -1715,7 +1717,7 @@ class UserController extends Controller {
         self::authenticateRequest($r);
 
         //Buscar que el nuevo username no este ocupado si es que selecciono uno nuevo
-        if ($r['username'] != $r['current_user']->username) {
+        if ($r['username'] != $r->user->username) {
             $testu = UsersDAO::FindByUsername($r['username']);
 
             if (!is_null($testu)) {
@@ -1723,18 +1725,18 @@ class UserController extends Controller {
             }
 
             Validators::validateValidUsername($r['username'], 'username');
-            $r['current_user']->username = $r['username'];
+            $r->user->username = $r['username'];
         }
 
         SecurityTools::testStrongPassword($r['password']);
         $hashedPassword = SecurityTools::hashString($r['password']);
-        $r['current_user']->password = $hashedPassword;
+        $r->user->password = $hashedPassword;
 
         try {
             DAO::transBegin();
 
-            UsersDAO::save($r['current_user']);
-            IdentityController::convertFromUser($r['current_user']);
+            UsersDAO::save($r->user);
+            IdentityController::convertFromUser($r->user);
 
             DAO::transEnd();
         } catch (Exception $e) {
@@ -1743,7 +1745,7 @@ class UserController extends Controller {
         }
 
         // Expire profile cache
-        Cache::deleteFromCache(Cache::USER_PROFILE, $r['current_user']->username);
+        Cache::deleteFromCache(Cache::USER_PROFILE, $r->user->username);
         $sessionController = new SessionController();
         $sessionController->InvalidateCache();
 
@@ -1770,7 +1772,7 @@ class UserController extends Controller {
                 throw new InvalidDatabaseOperationException($e);
             }
 
-            if ($r['username'] != $r['current_user']->username && !is_null($user)) {
+            if ($r['username'] != $r->user->username && !is_null($user)) {
                 throw new DuplicatedEntryInDatabaseException('usernameInUse');
             }
         }
@@ -1854,7 +1856,7 @@ class UserController extends Controller {
                 throw new InvalidParameterException('invalidLanguage', 'locale');
             }
 
-            $r['current_user']->language_id = $language->language_id;
+            $r->user->language_id = $language->language_id;
         }
 
         $r->ensureBool('is_private', false);
@@ -1883,14 +1885,14 @@ class UserController extends Controller {
             'hide_problem_tags',
         ];
 
-        self::updateValueProperties($r, $r['current_user'], $valueProperties);
+        self::updateValueProperties($r, $r->user, $valueProperties);
 
         try {
             DAO::transBegin();
 
-            UsersDAO::save($r['current_user']);
+            UsersDAO::save($r->user);
 
-            IdentityController::convertFromUser($r['current_user']);
+            IdentityController::convertFromUser($r->user);
 
             DAO::transEnd();
         } catch (Exception $e) {
@@ -1900,7 +1902,7 @@ class UserController extends Controller {
         }
 
         // Expire profile cache
-        Cache::deleteFromCache(Cache::USER_PROFILE, $r['current_user']->username);
+        Cache::deleteFromCache(Cache::USER_PROFILE, $r->user->username);
         $sessionController = new SessionController();
         $sessionController->InvalidateCache();
 
@@ -2037,20 +2039,20 @@ class UserController extends Controller {
 
         try {
             // Update email
-            $email = EmailsDAO::getByPK($r['current_user']->main_email_id);
+            $email = EmailsDAO::getByPK($r->user->main_email_id);
             $email->email = $r['email'];
             EmailsDAO::save($email);
 
             // Add verification_id if not there
-            if ($r['current_user']->verified == '0') {
+            if ($r->user->verified == '0') {
                 self::$log->info('User not verified.');
 
-                if ($r['current_user']->verification_id == null) {
+                if ($r->user->verification_id == null) {
                     self::$log->info('User does not have verification id. Generating.');
 
                     try {
-                        $r['current_user']->verification_id = SecurityTools::randomString(50);
-                        UsersDAO::save($r['current_user']);
+                        $r->user->verification_id = SecurityTools::randomString(50);
+                        UsersDAO::save($r->user);
                     } catch (Exception $e) {
                         // best effort, eat exception
                     }
@@ -2065,10 +2067,10 @@ class UserController extends Controller {
         }
 
         // Delete profile cache
-        Cache::deleteFromCache(Cache::USER_PROFILE, $r['current_user']->username);
+        Cache::deleteFromCache(Cache::USER_PROFILE, $r->user->username);
 
         // Send verification email
-        $r['user'] = $r['current_user'];
+        $r['user'] = $r->user;
         self::sendVerificationEmail($r['user']);
 
         return ['status' => 'ok'];
@@ -2204,7 +2206,7 @@ class UserController extends Controller {
     }
 
     private static function validateAddRemoveRole(Request $r) {
-        if (!Authorization::isSystemAdmin($r['current_identity_id']) && !OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT) {
+        if (!Authorization::isSystemAdmin($r->identity->identity_id) && !OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT) {
             throw new ForbiddenAccessException();
         }
 
@@ -2306,7 +2308,7 @@ class UserController extends Controller {
         self::validateAddRemoveGroup($r);
         try {
             GroupsIdentitiesDAO::save(new GroupsIdentities([
-                'identity_id' => $r['current_identity_id'],
+                'identity_id' => $r->identity->identity_id,
                 'group_id' => $r['group']->group_id
             ]));
         } catch (Exception $e) {
@@ -2333,7 +2335,7 @@ class UserController extends Controller {
 
         try {
             GroupsIdentitiesDAO::delete(new GroupsIdentities([
-                'identity_id' => $r['current_identity_id'],
+                'identity_id' => $r->identity->identity_id,
                 'group_id' => $r['group']->group_id
             ]));
         } catch (Exception $e) {
@@ -2348,7 +2350,7 @@ class UserController extends Controller {
     private static function validateAddRemoveExperiment(Request $r) {
         global $experiments;
 
-        if (!Authorization::isSystemAdmin($r['current_identity_id'])) {
+        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
             throw new ForbiddenAccessException();
         }
 
@@ -2530,7 +2532,7 @@ class UserController extends Controller {
             throw new InvalidParameterException('parameterInvalid', 'username');
         }
 
-        if (IdentitiesDAO::isUserAssociatedWithIdentityOfGroup((int)$r['current_user_id'], (int)$identity->identity_id)) {
+        if (IdentitiesDAO::isUserAssociatedWithIdentityOfGroup((int)$r->user->user_id, (int)$identity->identity_id)) {
             throw new DuplicatedEntryInDatabaseException('identityAlreadyAssociated');
         }
 
@@ -2544,7 +2546,7 @@ class UserController extends Controller {
         }
 
         try {
-            IdentitiesDAO::associateIdentityWithUser($r['current_user_id'], $identity->identity_id);
+            IdentitiesDAO::associateIdentityWithUser($r->user->user_id, $identity->identity_id);
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);
         }
@@ -2566,7 +2568,7 @@ class UserController extends Controller {
         try {
             return [
                 'status' => 'ok',
-                'identities' => IdentitiesDAO::getAssociatedIdentities($r['current_user_id'])
+                'identities' => IdentitiesDAO::getAssociatedIdentities($r->user->user_id)
             ];
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);

--- a/frontend/server/libs/Request.php
+++ b/frontend/server/libs/Request.php
@@ -23,6 +23,11 @@ class Request extends ArrayObject {
     public $user = null;
 
     /**
+     * The object of the identity currently logged in.
+     */
+    public $identity = null;
+
+    /**
      * The method that will be called.
      */
     public $method = null;
@@ -37,7 +42,7 @@ class Request extends ArrayObject {
      *
      * @param string $key The key.
      */
-    public function offsetExists($key) {
+    public function offsetExists($key) : bool {
         return parent::offsetExists($key) || ($this->parent != null && isset($this->parent[$key]));
     }
 
@@ -61,7 +66,7 @@ class Request extends ArrayObject {
      *
      * @param array $contents The (optional) array with the values.
      */
-    public function push($contents = null) {
+    public function push(?array $contents = null) : Request {
         $req = new Request($contents);
         $req->parent = $this;
         $req->user = $this->user;
@@ -86,7 +91,7 @@ class Request extends ArrayObject {
      *
      * @return the global per-request unique(-ish) ID
      */
-    public static function requestId() {
+    public static function requestId() : string {
         return Request::$_requestId;
     }
 
@@ -96,7 +101,7 @@ class Request extends ArrayObject {
     public function ensureBool(
         string $key,
         bool $required = true
-    ) {
+    ) : void {
         $val = self::offsetGet($key);
         if (is_int($val)) {
             $this[$key] = $val == 1;
@@ -121,7 +126,7 @@ class Request extends ArrayObject {
         ?int $lowerBound = null,
         ?int $upperBound = null,
         bool $required = true
-    ) {
+    ) : void {
         if (!self::offsetExists($key)) {
             if (!$required) {
                 return;
@@ -141,7 +146,7 @@ class Request extends ArrayObject {
         ?float $lowerBound = null,
         ?float $upperBound = null,
         bool $required = true
-    ) {
+    ) : void {
         if (!self::offsetExists($key)) {
             if (!$required) {
                 return;

--- a/frontend/tests/controllers/CourseStudentAddTest.php
+++ b/frontend/tests/controllers/CourseStudentAddTest.php
@@ -56,7 +56,6 @@ class CourseStudentAddTest extends OmegaupTestCase {
         $userLogin = OmegaupTestCase::login($student);
         $intro_details = CourseController::apiIntroDetails(new Request([
             'auth_token' => $userLogin->auth_token,
-            'current_user_id' => $student->user_id,
             'course_alias' => $courseData['request']['alias']
         ]));
         // Asserting isFirstTimeAccess
@@ -99,7 +98,6 @@ class CourseStudentAddTest extends OmegaupTestCase {
         // User agrees sharing his information
         $intro_details = CourseController::apiIntroDetails(new Request([
             'auth_token' => $userLogin->auth_token,
-            'current_user_id' => $student->user_id,
             'course_alias' => $courseData['request']['alias']
         ]));
         // Asserting shouldShowResults is off

--- a/frontend/tests/controllers/ProblemListCourseTest.php
+++ b/frontend/tests/controllers/ProblemListCourseTest.php
@@ -43,7 +43,6 @@ class ProblemListCourseTest extends OmegaupTestCase {
             $userLogin[$i] = self::login($user[$i]);
             $intro_details = CourseController::apiIntroDetails(new Request([
                 'auth_token' => $userLogin[$i]->auth_token,
-                'current_user_id' => $user[$i]->user_id,
                 'course_alias' => $courseData['course_alias']
             ]));
             CourseController::apiAddStudent(new Request([
@@ -135,7 +134,6 @@ class ProblemListCourseTest extends OmegaupTestCase {
             $userLogin[$i] = self::login($user[$i]);
             $intro_details = CourseController::apiIntroDetails(new Request([
                 'auth_token' => $userLogin[$i]->auth_token,
-                'current_user_id' => $user[$i]->user_id,
                 'course_alias' => $courseData['course_alias']
             ]));
             CourseController::apiAddStudent(new Request([
@@ -161,7 +159,6 @@ class ProblemListCourseTest extends OmegaupTestCase {
         $userLogin[2] = self::login($user[2]);
         $intro_details = CourseController::apiIntroDetails(new Request([
             'auth_token' => $userLogin[$i]->auth_token,
-            'current_user_id' => $user[$i]->user_id,
             'course_alias' => $courseData['course_alias']
         ]));
         CourseController::apiAddStudent(new Request([

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -808,7 +808,7 @@ class QualityNominationTest extends OmegaupTestCase {
             throw new NotFoundException('problemNotFound');
         }
         $problemDismissed = QualityNominationsDAO::getByUserAndProblem(
-            $r['current_user_id'],
+            $r->user->user_id,
             $problem->problem_id,
             $r['nomination'],
             json_encode([]), // re-encoding it for normalization.
@@ -823,7 +823,7 @@ class QualityNominationTest extends OmegaupTestCase {
         try {
             QualityNominationController::apiCreate($r);
             $pd = QualityNominationsDAO::getByUserAndProblem(
-                $r['current_user_id'],
+                $r->user->user_id,
                 $problem->problem_id,
                 $r['nomination'],
                 json_encode([]), // re-encoding it for normalization.


### PR DESCRIPTION
Este cambio hace que el usuario y la identidad actuales ya no estén en
`$r['current_user']`/`$r['current_identity']`, sino que estén en
`$r->user` y `$r->identity` respectivamente. Esto cierra algunos
potenciales agujeros de seguridad al ya no ser posible el hacer spoofing
de estas variables.