### PR TITLE
Dejando de usar gmdate() sin Time::get()

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -519,7 +519,7 @@ class ContestController extends Controller {
             ProblemsetIdentityRequestDAO::save(new ProblemsetIdentityRequest([
                 'identity_id' => $r->identity->identity_id,
                 'problemset_id' => $contest->problemset_id,
-                'request_time' => gmdate('Y-m-d H:i:s'),
+                'request_time' => gmdate('Y-m-d H:i:s', Time::get()),
             ]));
         } catch (Exception $e) {
             self::$log->error('Failed to create new ProblemsetIdentityRequest: ' . $e->getMessage());
@@ -2122,7 +2122,7 @@ class ContestController extends Controller {
 
         $request->accepted = $resolution;
         $request->extra_note = $r['note'];
-        $request->last_update = gmdate('Y-m-d H:i:s');
+        $request->last_update = gmdate('Y-m-d H:i:s', Time::get());
 
         ProblemsetIdentityRequestDAO::save($request);
 

--- a/frontend/server/libs/dao/base/Announcement.dao.base.php
+++ b/frontend/server/libs/dao/base/Announcement.dao.base.php
@@ -155,7 +155,7 @@ abstract class AnnouncementDAOBase {
      */
     final public static function create(Announcement $Announcement) {
         if (is_null($Announcement->time)) {
-            $Announcement->time = gmdate('Y-m-d H:i:s');
+            $Announcement->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Announcement (`user_id`, `time`, `description`) VALUES (?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Auth_Tokens.dao.base.php
+++ b/frontend/server/libs/dao/base/Auth_Tokens.dao.base.php
@@ -155,7 +155,7 @@ abstract class AuthTokensDAOBase {
      */
     final public static function create(AuthTokens $Auth_Tokens) {
         if (is_null($Auth_Tokens->create_time)) {
-            $Auth_Tokens->create_time = gmdate('Y-m-d H:i:s');
+            $Auth_Tokens->create_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Auth_Tokens (`user_id`, `identity_id`, `token`, `create_time`) VALUES (?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Clarifications.dao.base.php
+++ b/frontend/server/libs/dao/base/Clarifications.dao.base.php
@@ -160,7 +160,7 @@ abstract class ClarificationsDAOBase {
      */
     final public static function create(Clarifications $Clarifications) {
         if (is_null($Clarifications->time)) {
-            $Clarifications->time = gmdate('Y-m-d H:i:s');
+            $Clarifications->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($Clarifications->public)) {
             $Clarifications->public = false;

--- a/frontend/server/libs/dao/base/Contest_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Contest_Log.dao.base.php
@@ -157,7 +157,7 @@ abstract class ContestLogDAOBase {
      */
     final public static function create(ContestLog $Contest_Log) {
         if (is_null($Contest_Log->time)) {
-            $Contest_Log->time = gmdate('Y-m-d H:i:s');
+            $Contest_Log->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Contest_Log (`contest_id`, `user_id`, `from_admission_mode`, `to_admission_mode`, `time`) VALUES (?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Contests.dao.base.php
+++ b/frontend/server/libs/dao/base/Contests.dao.base.php
@@ -181,7 +181,7 @@ abstract class ContestsDAOBase {
             $Contests->finish_time = '2000-01-01 06:00:00';
         }
         if (is_null($Contests->last_updated)) {
-            $Contests->last_updated = gmdate('Y-m-d H:i:s');
+            $Contests->last_updated = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($Contests->admission_mode)) {
             $Contests->admission_mode = 'private';

--- a/frontend/server/libs/dao/base/Groups.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups.dao.base.php
@@ -157,7 +157,7 @@ abstract class GroupsDAOBase {
      */
     final public static function create(Groups $Groups) {
         if (is_null($Groups->create_time)) {
-            $Groups->create_time = gmdate('Y-m-d H:i:s');
+            $Groups->create_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Groups (`acl_id`, `create_time`, `alias`, `name`, `description`) VALUES (?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Groups_Scoreboards.dao.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards.dao.base.php
@@ -157,7 +157,7 @@ abstract class GroupsScoreboardsDAOBase {
      */
     final public static function create(GroupsScoreboards $Groups_Scoreboards) {
         if (is_null($Groups_Scoreboards->create_time)) {
-            $Groups_Scoreboards->create_time = gmdate('Y-m-d H:i:s');
+            $Groups_Scoreboards->create_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Groups_Scoreboards (`group_id`, `create_time`, `alias`, `name`, `description`) VALUES (?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Identity_Login_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Identity_Login_Log.dao.base.php
@@ -63,7 +63,7 @@ abstract class IdentityLoginLogDAOBase {
      */
     final public static function create(IdentityLoginLog $Identity_Login_Log) {
         if (is_null($Identity_Login_Log->time)) {
-            $Identity_Login_Log->time = gmdate('Y-m-d H:i:s');
+            $Identity_Login_Log->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Identity_Login_Log (`identity_id`, `ip`, `time`) VALUES (?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Messages.dao.base.php
+++ b/frontend/server/libs/dao/base/Messages.dao.base.php
@@ -160,7 +160,7 @@ abstract class MessagesDAOBase {
             $Messages->read = false;
         }
         if (is_null($Messages->date)) {
-            $Messages->date = gmdate('Y-m-d H:i:s');
+            $Messages->date = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Messages (`read`, `sender_id`, `recipient_id`, `message`, `date`) VALUES (?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Notifications.dao.base.php
+++ b/frontend/server/libs/dao/base/Notifications.dao.base.php
@@ -156,7 +156,7 @@ abstract class NotificationsDAOBase {
      */
     final public static function create(Notifications $Notifications) {
         if (is_null($Notifications->timestamp)) {
-            $Notifications->timestamp = gmdate('Y-m-d H:i:s');
+            $Notifications->timestamp = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($Notifications->read)) {
             $Notifications->read = false;

--- a/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.dao.base.php
@@ -155,7 +155,7 @@ abstract class PrivacyStatementConsentLogDAOBase {
      */
     final public static function create(PrivacyStatementConsentLog $PrivacyStatement_Consent_Log) {
         if (is_null($PrivacyStatement_Consent_Log->timestamp)) {
-            $PrivacyStatement_Consent_Log->timestamp = gmdate('Y-m-d H:i:s');
+            $PrivacyStatement_Consent_Log->timestamp = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO PrivacyStatement_Consent_Log (`identity_id`, `privacystatement_id`, `timestamp`) VALUES (?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Problem_Viewed.dao.base.php
+++ b/frontend/server/libs/dao/base/Problem_Viewed.dao.base.php
@@ -154,7 +154,7 @@ abstract class ProblemViewedDAOBase {
      */
     final public static function create(ProblemViewed $Problem_Viewed) {
         if (is_null($Problem_Viewed->view_time)) {
-            $Problem_Viewed->view_time = gmdate('Y-m-d H:i:s');
+            $Problem_Viewed->view_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Problem_Viewed (`problem_id`, `identity_id`, `view_time`) VALUES (?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Problems.dao.base.php
+++ b/frontend/server/libs/dao/base/Problems.dao.base.php
@@ -193,7 +193,7 @@ abstract class ProblemsDAOBase {
             $Problems->accepted = 0;
         }
         if (is_null($Problems->creation_date)) {
-            $Problems->creation_date = gmdate('Y-m-d H:i:s');
+            $Problems->creation_date = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($Problems->order)) {
             $Problems->order = 'normal';

--- a/frontend/server/libs/dao/base/Problemset_Access_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Access_Log.dao.base.php
@@ -63,7 +63,7 @@ abstract class ProblemsetAccessLogDAOBase {
      */
     final public static function create(ProblemsetAccessLog $Problemset_Access_Log) {
         if (is_null($Problemset_Access_Log->time)) {
-            $Problemset_Access_Log->time = gmdate('Y-m-d H:i:s');
+            $Problemset_Access_Log->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Problemset_Access_Log (`problemset_id`, `identity_id`, `ip`, `time`) VALUES (?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request.dao.base.php
@@ -157,7 +157,7 @@ abstract class ProblemsetIdentityRequestDAOBase {
      */
     final public static function create(ProblemsetIdentityRequest $Problemset_Identity_Request) {
         if (is_null($Problemset_Identity_Request->request_time)) {
-            $Problemset_Identity_Request->request_time = gmdate('Y-m-d H:i:s');
+            $Problemset_Identity_Request->request_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Problemset_Identity_Request (`identity_id`, `problemset_id`, `request_time`, `last_update`, `accepted`, `extra_note`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request_History.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request_History.dao.base.php
@@ -157,7 +157,7 @@ abstract class ProblemsetIdentityRequestHistoryDAOBase {
      */
     final public static function create(ProblemsetIdentityRequestHistory $Problemset_Identity_Request_History) {
         if (is_null($Problemset_Identity_Request_History->time)) {
-            $Problemset_Identity_Request_History->time = gmdate('Y-m-d H:i:s');
+            $Problemset_Identity_Request_History->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Problemset_Identity_Request_History (`identity_id`, `problemset_id`, `time`, `accepted`, `admin_id`) VALUES (?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Problemset_Problem_Opened.dao.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problem_Opened.dao.base.php
@@ -155,7 +155,7 @@ abstract class ProblemsetProblemOpenedDAOBase {
      */
     final public static function create(ProblemsetProblemOpened $Problemset_Problem_Opened) {
         if (is_null($Problemset_Problem_Opened->open_time)) {
-            $Problemset_Problem_Opened->open_time = gmdate('Y-m-d H:i:s');
+            $Problemset_Problem_Opened->open_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Problemset_Problem_Opened (`problemset_id`, `problem_id`, `identity_id`, `open_time`) VALUES (?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/QualityNomination_Comments.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Comments.dao.base.php
@@ -157,7 +157,7 @@ abstract class QualityNominationCommentsDAOBase {
      */
     final public static function create(QualityNominationComments $QualityNomination_Comments) {
         if (is_null($QualityNomination_Comments->time)) {
-            $QualityNomination_Comments->time = gmdate('Y-m-d H:i:s');
+            $QualityNomination_Comments->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO QualityNomination_Comments (`qualitynomination_id`, `user_id`, `time`, `vote`, `contents`) VALUES (?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/QualityNomination_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Log.dao.base.php
@@ -158,7 +158,7 @@ abstract class QualityNominationLogDAOBase {
      */
     final public static function create(QualityNominationLog $QualityNomination_Log) {
         if (is_null($QualityNomination_Log->time)) {
-            $QualityNomination_Log->time = gmdate('Y-m-d H:i:s');
+            $QualityNomination_Log->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($QualityNomination_Log->from_status)) {
             $QualityNomination_Log->from_status = 'open';

--- a/frontend/server/libs/dao/base/QualityNominations.dao.base.php
+++ b/frontend/server/libs/dao/base/QualityNominations.dao.base.php
@@ -161,7 +161,7 @@ abstract class QualityNominationsDAOBase {
             $QualityNominations->nomination = 'suggestion';
         }
         if (is_null($QualityNominations->time)) {
-            $QualityNominations->time = gmdate('Y-m-d H:i:s');
+            $QualityNominations->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($QualityNominations->status)) {
             $QualityNominations->status = 'open';

--- a/frontend/server/libs/dao/base/Runs.dao.base.php
+++ b/frontend/server/libs/dao/base/Runs.dao.base.php
@@ -178,7 +178,7 @@ abstract class RunsDAOBase {
             $Runs->score = (float)0;
         }
         if (is_null($Runs->time)) {
-            $Runs->time = gmdate('Y-m-d H:i:s');
+            $Runs->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Runs (`submission_id`, `version`, `status`, `verdict`, `runtime`, `penalty`, `memory`, `score`, `contest_score`, `time`, `judged_by`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Submission_Log.dao.base.php
+++ b/frontend/server/libs/dao/base/Submission_Log.dao.base.php
@@ -157,7 +157,7 @@ abstract class SubmissionLogDAOBase {
      */
     final public static function create(SubmissionLog $Submission_Log) {
         if (is_null($Submission_Log->time)) {
-            $Submission_Log->time = gmdate('Y-m-d H:i:s');
+            $Submission_Log->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Submission_Log (`problemset_id`, `submission_id`, `user_id`, `identity_id`, `ip`, `time`) VALUES (?, ?, ?, ?, ?, ?);';
         $params = [

--- a/frontend/server/libs/dao/base/Submissions.dao.base.php
+++ b/frontend/server/libs/dao/base/Submissions.dao.base.php
@@ -161,7 +161,7 @@ abstract class SubmissionsDAOBase {
      */
     final public static function create(Submissions $Submissions) {
         if (is_null($Submissions->time)) {
-            $Submissions->time = gmdate('Y-m-d H:i:s');
+            $Submissions->time = gmdate('Y-m-d H:i:s', Time::get());
         }
         if (is_null($Submissions->submit_delay)) {
             $Submissions->submit_delay = 0;

--- a/frontend/server/libs/dao/base/Users_Badges.dao.base.php
+++ b/frontend/server/libs/dao/base/Users_Badges.dao.base.php
@@ -155,7 +155,7 @@ abstract class UsersBadgesDAOBase {
      */
     final public static function create(UsersBadges $Users_Badges) {
         if (is_null($Users_Badges->assignation_time)) {
-            $Users_Badges->assignation_time = gmdate('Y-m-d H:i:s');
+            $Users_Badges->assignation_time = gmdate('Y-m-d H:i:s', Time::get());
         }
         $sql = 'INSERT INTO Users_Badges (`user_id`, `badge_alias`, `assignation_time`) VALUES (?, ?, ?);';
         $params = [

--- a/frontend/www/api/ApiCaller.php
+++ b/frontend/www/api/ApiCaller.php
@@ -228,7 +228,7 @@ class ApiCaller {
     private static function setHttpHeaders(array $response) {
         // Scumbag IE y su cache agresivo.
         header('Expires: Tue, 03 Jul 2001 06:00:00 GMT');
-        header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s', Time::get()) . ' GMT');
         header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
         header('Cache-Control: post-check=0, pre-check=0', false);
         header('Pragma: no-cache');

--- a/frontend/www/api/CallApiLoader.php
+++ b/frontend/www/api/CallApiLoader.php
@@ -4,7 +4,7 @@ require_once('../../server/inc/bootstrap.php');
 
 // Scumbag IE y su cache agresivo.
 header('Expires: Tue, 03 Jul 2001 06:00:00 GMT');
-header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s', Time::get()) . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Cache-Control: post-check=0, pre-check=0', false);
 header('Pragma: no-cache');

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -182,7 +182,7 @@ abstract class {{ table.class_name }}DAOBase {
 {%- for column in table.columns|selectattr('default') %}
         if (is_null(${{ table.name }}->{{ column.name }})) {
 {%- if column.default == 'CURRENT_TIMESTAMP' %}
-            ${{ table.name }}->{{ column.name }} = gmdate('Y-m-d H:i:s');
+            ${{ table.name }}->{{ column.name }} = gmdate('Y-m-d H:i:s', Time::get());
 {%- elif 'tinyint' in column.type %}
             ${{ table.name }}->{{ column.name }} = {{ 'true' if column.default == '1' else 'false' }};
 {%- elif 'int' in column.type %}


### PR DESCRIPTION
Este cambio hace que siempre que se use `gmdate()`, se utilice un
timestamp explícito (por default usando `Time::get()`). Uno de los
objetivos de esto es para que todos los objetos insertados por los DAOs
en las pruebas utilicen el tiempo falso.