### PR TITLE
Agregando plugin para copiar los badge icons a www/media/dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ frontend/.DS_Store
 
 # Ignore stuff in www
 frontend/www/apc.php
+frontend/www/badges/
 frontend/www/coverage/
 frontend/www/img/
 frontend/www/js/google-analytics.js

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ frontend/.DS_Store
 
 # Ignore stuff in www
 frontend/www/apc.php
-frontend/www/badges/
+frontend/www/media/dist/badges/
 frontend/www/coverage/
 frontend/www/img/
 frontend/www/js/google-analytics.js

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,6 @@ frontend/.DS_Store
 
 # Ignore stuff in www
 frontend/www/apc.php
-frontend/www/media/dist/badges/
 frontend/www/coverage/
 frontend/www/img/
 frontend/www/js/google-analytics.js
@@ -92,6 +91,9 @@ frontend/www/js/dist/
 
 # Ignore SASS-CSS build files.
 frontend/www/css/dist/
+
+# Ignore media/dist folder
+frontend/www/media/dist/
 
 # Ignore C++ / Pascal docs
 frontend/www/docs/cpp

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/plugin-transform-async-to-generator": "^7.2.0",
     "@babel/polyfill": "^7.2.5",
     "codemirror": "^5.38.0",
+    "copy-webpack-plugin": "^5.0.3",
     "jszip": "^3.1.5",
     "monaco-editor": "^0.15.6",
     "monaco-editor-webpack-plugin": "^1.7.0",

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -25,6 +25,7 @@ stage_before_script() {
 
 stage_script() {
 	rm -rf frontend/www/{js,css}/dist
+	rm -rf frontend/www/media/dist/badges
 	yarn install
 	yarn run build
 	yarn test
@@ -39,7 +40,7 @@ stage_after_success() {
 
 		# Upload a tarball with the build artifacts.
 		local tarball="build/webpack-artifacts/${TRAVIS_COMMIT}.tar.xz"
-		tar --xz --create --file "${tarball}" -C frontend/www js/dist css/dist
+		tar --xz --create --file "${tarball}" -C frontend/www js/dist css/dist media/dist/badges
 		aws s3 cp "${tarball}" "s3://omegaup-build-artifacts/webpack-artifacts/${TRAVIS_COMMIT}.tar.xz"
 
 		# Start a deployment now that the build artifacts are done.

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -24,8 +24,7 @@ stage_before_script() {
 }
 
 stage_script() {
-	rm -rf frontend/www/{js,css}/dist
-	rm -rf frontend/www/media/dist/badges
+	rm -rf frontend/www/{js,css,media}/dist
 	yarn install
 	yarn run build
 	yarn test
@@ -40,7 +39,7 @@ stage_after_success() {
 
 		# Upload a tarball with the build artifacts.
 		local tarball="build/webpack-artifacts/${TRAVIS_COMMIT}.tar.xz"
-		tar --xz --create --file "${tarball}" -C frontend/www js/dist css/dist media/dist/badges
+		tar --xz --create --file "${tarball}" -C frontend/www js/dist css/dist media/dist
 		aws s3 cp "${tarball}" "s3://omegaup-build-artifacts/webpack-artifacts/${TRAVIS_COMMIT}.tar.xz"
 
 		# Start a deployment now that the build artifacts are done.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const RemoveSourceWebpackPlugin = require('remove-source-webpack-plugin');
@@ -216,6 +217,16 @@ let config = [
       new MonacoWebpackPlugin({
         output: './js/dist',
       }),
+      new CopyWebpackPlugin([{
+        from: './frontend/badges/**/*.svg',
+        to: path.resolve(__dirname, './frontend/www/img/badges'),
+        transformPath(targetPath, absolutePath) {
+          if (path.basename(absolutePath, '.svg') !== 'icon') {
+            return `badges/${path.basename(absolutePath)}`;
+          }
+          return `badges/${path.basename(path.dirname(absolutePath))}.svg`;
+        },
+      }]),
     ],
     output: {
       path: path.resolve(__dirname, './frontend/www/'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const WrapperPlugin = require('wrapper-webpack-plugin');
 
 const omegaupStylesRegExp = /omegaup_styles\.js/;
+const defaultBadgeIcon = fs.readFileSync('./frontend/badges/default_icon.svg');
 
 let config = [
   {
@@ -218,13 +219,14 @@ let config = [
         output: './js/dist',
       }),
       new CopyWebpackPlugin([{
-        from: './frontend/badges/**/*.svg',
-        to: path.resolve(__dirname, './frontend/www/img/badges'),
+        from: './frontend/badges/**/query.sql',
+        to: path.resolve(__dirname, './frontend/www/media/dist/badges'),
+        transform(content, filepath) {
+          const iconPath = `${path.dirname(filepath)}/icon.svg`;
+          return fs.existsSync(iconPath) ? fs.readFileSync(iconPath) : defaultBadgeIcon;
+        },
         transformPath(targetPath, absolutePath) {
-          if (path.basename(absolutePath, '.svg') !== 'icon') {
-            return `badges/${path.basename(absolutePath)}`;
-          }
-          return `badges/${path.basename(path.dirname(absolutePath))}.svg`;
+          return `media/dist/badges/${path.basename(path.dirname(absolutePath))}.svg`;
         },
       }]),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,6 +1737,24 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-webpack-plugin@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.3.tgz#2179e3c8fd69f13afe74da338896f1f01a875b5c"
+  integrity sha512-PlZRs9CUMnAVylZq+vg2Juew662jWtwOXOqH4lbQD9ZFhRG9R7tVStOgHt21CBGVq7k5yIJaz8TXDLSjV+Lj8Q==
+  dependencies:
+    cacache "^11.3.2"
+    find-cache-dir "^2.1.0"
+    glob-parent "^3.1.0"
+    globby "^7.1.1"
+    is-glob "^4.0.1"
+    loader-utils "^1.2.3"
+    minimatch "^3.0.4"
+    normalize-path "^3.0.0"
+    p-limit "^2.2.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    webpack-log "^2.0.0"
+
 core-js-compat@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.1.3.tgz#0cc3ba4c7f62928c2837e1cffbe8dc78b4f1ae14"
@@ -2053,6 +2071,13 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dir-glob@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
+    path-type "^3.0.0"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -2444,7 +2469,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -2700,6 +2725,18 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 globule@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.1.tgz#5dffb1b191f22d20797a9369b49eab4e9839696d"
@@ -2954,6 +2991,11 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^3.3.5:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -3168,7 +3210,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -4218,7 +4260,7 @@ p-is-promise@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
@@ -4350,6 +4392,13 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.17"
@@ -5140,6 +5189,11 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
 slash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Descripción

Para que los íconos de los badges puedan ser mostrados en el cliente
deben estar en www/. Este cambio agrega un plugin que copia todos
los archivos `.svg` en `frontend/badges/` hacia `www/media/dist/badges/`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
