### PR TITLE
Creando api y pruebas para obtener la fecha de asignación de un badge

### DIFF
--- a/frontend/server/controllers/BadgeController.php
+++ b/frontend/server/controllers/BadgeController.php
@@ -67,5 +67,34 @@ class BadgeController extends Controller {
             throw new InvalidDatabaseOperationException($e);
         }
     }
-    // TODO: apiUserHasBadge
+
+    /**
+     * Returns a the assignation timestamp of a badge
+     * for current user.
+     *
+     * @param Request $r
+     * @return array
+     * @throws InvalidDatabaseOperationException
+     */
+    public static function apiMyBadgeAssignationTime(Request $r) {
+        self::authenticateRequest($r);
+        try {
+            if (is_null($r->user)) {
+                throw new NotFoundException('userNotExist');
+            }
+            $allBadges = BadgeController::apiList($r);
+            $badge = $r['badge_alias'];
+            if (!in_array($badge, $allBadges)) {
+                throw new notFoundException('badgeNotExist');
+            }
+            return [
+                'status' => 'ok',
+                'assignation_time' => UsersBadgesDAO::getUserBadgeAssignationTime($r->user, $badge),
+            ];
+        } catch (ApiException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            throw new InvalidDatabaseOperationException($e);
+        }
+    }
 }

--- a/frontend/server/controllers/BadgeController.php
+++ b/frontend/server/controllers/BadgeController.php
@@ -39,11 +39,7 @@ class BadgeController extends Controller {
      * @throws InvalidDatabaseOperationException
      */
     public static function apiMyList(Request $r) {
-        try {
-            self::authenticateRequest($r);
-        } catch (UnauthorizedException $e) {
-            // Do nothing
-        }
+        self::authenticateRequest($r);
         return [
             'status' => 'ok',
             'badges' => is_null($r->user) ?
@@ -85,11 +81,7 @@ class BadgeController extends Controller {
      * @throws InvalidDatabaseOperationException
      */
     public static function apiMyBadgeAssignationTime(Request $r) {
-        try {
-            self::authenticateRequest($r);
-        } catch (UnauthorizedException $e) {
-            // Do nothing
-        }
+        self::authenticateRequest($r);
         Validators::validateStringNonEmpty($r['badge_alias'], 'badge_alias');
         $allBadges = self::getAllBadges();
         $badge = $r['badge_alias'];

--- a/frontend/server/libs/dao/Users_Badges.dao.php
+++ b/frontend/server/libs/dao/Users_Badges.dao.php
@@ -25,4 +25,17 @@ class UsersBadgesDAO extends UsersBadgesDAOBase {
         $args = [$user->user_id];
         return $conn->GetAll($sql, $args);
     }
+
+    public static function getUserBadgeAssignationTime(Users $user, string $badge) {
+        global $conn;
+        $sql = 'SELECT
+                    ub.assignation_time
+                FROM
+                    Users_Badges ub
+                WHERE
+                    ub.user_id = ? AND ub.badge_alias = ?;';
+        $args = [$user->user_id, $badge];
+        $rs = $conn->getRow($sql, $args);
+        return empty($rs) ? null : $rs['assignation_time'];
+    }
 }

--- a/frontend/server/libs/dao/Users_Badges.dao.php
+++ b/frontend/server/libs/dao/Users_Badges.dao.php
@@ -29,7 +29,7 @@ class UsersBadgesDAO extends UsersBadgesDAOBase {
     public static function getUserBadgeAssignationTime(Users $user, string $badge) {
         global $conn;
         $sql = 'SELECT
-                    ub.assignation_time
+                    UNIX_TIMESTAMP(ub.assignation_time) AS assignation_time
                 FROM
                     Users_Badges ub
                 WHERE

--- a/frontend/server/libs/dao/Users_Badges.dao.php
+++ b/frontend/server/libs/dao/Users_Badges.dao.php
@@ -29,13 +29,12 @@ class UsersBadgesDAO extends UsersBadgesDAOBase {
     public static function getUserBadgeAssignationTime(Users $user, string $badge): ?int {
         global $conn;
         $sql = 'SELECT
-                    UNIX_TIMESTAMP(ub.assignation_time) AS assignation_time
+                    UNIX_TIMESTAMP(ub.assignation_time)
                 FROM
                     Users_Badges ub
                 WHERE
                     ub.user_id = ? AND ub.badge_alias = ?;';
         $args = [$user->user_id, $badge];
-        $rs = $conn->getRow($sql, $args);
-        return empty($rs) ? null : $rs['assignation_time'];
+        return $conn->getOne($sql, $args);
     }
 }

--- a/frontend/server/libs/dao/Users_Badges.dao.php
+++ b/frontend/server/libs/dao/Users_Badges.dao.php
@@ -12,7 +12,7 @@ require_once('base/Users_Badges.vo.base.php');
   *
   */
 class UsersBadgesDAO extends UsersBadgesDAOBase {
-    public static function getUserOwnedBadges(Users $user) {
+    public static function getUserOwnedBadges(Users $user): array {
         global $conn;
         $sql = 'SELECT
                     ub.badge_alias, ub.assignation_time
@@ -26,7 +26,7 @@ class UsersBadgesDAO extends UsersBadgesDAOBase {
         return $conn->GetAll($sql, $args);
     }
 
-    public static function getUserBadgeAssignationTime(Users $user, string $badge) {
+    public static function getUserBadgeAssignationTime(Users $user, string $badge): ?int {
         global $conn;
         $sql = 'SELECT
                     UNIX_TIMESTAMP(ub.assignation_time) AS assignation_time

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -259,7 +259,7 @@ class BadgesTest extends BadgesTestCase {
             'user' => $user,
             'badge_alias' => 'problemSetter',
         ]));
-        $timeDifference = (strtotime($problemSetterResult['assignation_time']) - $previousTime) / 60;
+        $timeDifference = ($problemSetterResult['assignation_time'] - $previousTime) / 60;
         $this->assertTrue($timeDifference < 10);
 
         $contestManagerResult = BadgeController::apiMyBadgeAssignationTime(new Request([
@@ -267,6 +267,6 @@ class BadgesTest extends BadgesTestCase {
             'user' => $user,
             'badge_alias' => 'contestManager',
         ]));
-        $this->assertNull($contestManagerResult['assignation_time']);
+        $this->assertFalse($contestManagerResult['assignation_time']);
     }
 }

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -269,11 +269,5 @@ class BadgesTest extends BadgesTestCase {
             'badge_alias' => 'contestManager',
         ]));
         $this->assertNull($contestManagerResult['assignation_time']);
-
-        $nonLoggedUser = BadgeController::apiMyBadgeAssignationTime(new Request([
-            'user' => UserFactory::createUser(),
-            'badge_alias' => 'contestManager',
-        ]));
-        $this->assertNull($nonLoggedUser['assignation_time']);
     }
 }

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -10,7 +10,7 @@ require_once 'libs/FileUploader.php';
  * @author carlosabcs
  */
 class BadgesTest extends BadgesTestCase {
-    private static function getSortedExpectedResults(array $expected) {
+    private static function getSortedExpectedResults(array $expected): array {
         $results = [];
         foreach ($expected as $username) {
             // From each username, obtaining its ID
@@ -21,7 +21,7 @@ class BadgesTest extends BadgesTestCase {
         return $results;
     }
 
-    private static function RunRequest(array $apicall) {
+    private static function RunRequest(array $apicall): void {
         $login = self::login(new Identities([
             'username' => $apicall['username'],
             'password' => $apicall['password'],
@@ -53,7 +53,7 @@ class BadgesTest extends BadgesTestCase {
         }
     }
 
-    public function apicallTest(array $actions, array $expectedResults, string $queryPath) {
+    public function apicallTest(array $actions, array $expectedResults, string $queryPath): void {
         foreach ($actions as $action) {
             switch ($action['type']) {
                 case 'changeTime':
@@ -91,7 +91,7 @@ class BadgesTest extends BadgesTestCase {
         Time::setTimeForTesting(null);
     }
 
-    public function phpUnitTest($badge) {
+    public function phpUnitTest($badge): void {
         $testPath = static::BADGES_TESTS_ROOT . "/${badge}Test.php";
         $this->assertTrue(
             file_exists($testPath),
@@ -99,7 +99,7 @@ class BadgesTest extends BadgesTestCase {
         );
     }
 
-    public function runBadgeTest($testPath, $queryPath, $badge) {
+    public function runBadgeTest($testPath, $queryPath, $badge): void {
         FileHandler::SetFileUploader($this->createFileUploaderMock());
         $content = json_decode(file_get_contents($testPath), true);
         Utils::CleanupFilesAndDb();
@@ -259,6 +259,7 @@ class BadgesTest extends BadgesTestCase {
             'user' => $user,
             'badge_alias' => 'problemSetter',
         ]));
+        $this->assertNotNull($problemSetterResult['assignation_time']);
         $timeDifference = ($problemSetterResult['assignation_time'] - $previousTime) / 60;
         $this->assertTrue($timeDifference < 10);
 
@@ -267,6 +268,12 @@ class BadgesTest extends BadgesTestCase {
             'user' => $user,
             'badge_alias' => 'contestManager',
         ]));
-        $this->assertFalse($contestManagerResult['assignation_time']);
+        $this->assertNull($contestManagerResult['assignation_time']);
+
+        $nonLoggedUser = BadgeController::apiMyBadgeAssignationTime(new Request([
+            'user' => UserFactory::createUser(),
+            'badge_alias' => 'contestManager',
+        ]));
+        $this->assertNull($nonLoggedUser['assignation_time']);
     }
 }


### PR DESCRIPTION
Fixes: #2632 

# Comentarios

Esta API function será usada en la vista individual de un badge para mostrar si el usuario accediendo a la vista ya ha adquirido el badge  o no, además de que sirve para decidir si mostrar la badge como bloqueada o a color.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
