### PR TITLE
Permitiendo agregar identidades nuevas a cursos y concursos

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1660,18 +1660,17 @@ class UserController extends Controller {
         }
 
         try {
-            $identities = UsersDAO::findByUsernameOrName($r[$param]);
+            $identities = IdentitiesDAO::findByUsernameOrName($r[$param]);
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);
         }
 
         $response = [];
         foreach ($identities as $identity) {
-            $entry = [
+            array_push($response, [
                 'label' => $identity->username,
                 'value' => $identity->username
-            ];
-            array_push($response, $entry);
+            ]);
         }
 
         return $response;

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1660,14 +1660,17 @@ class UserController extends Controller {
         }
 
         try {
-            $users = UsersDAO::FindByUsernameOrName($r[$param]);
+            $identities = UsersDAO::findByUsernameOrName($r[$param]);
         } catch (Exception $e) {
             throw new InvalidDatabaseOperationException($e);
         }
 
         $response = [];
-        foreach ($users as $user) {
-            $entry = ['label' => $user->username, 'value' => $user->username];
+        foreach ($identities as $identity) {
+            $entry = [
+                'label' => $identity->username,
+                'value' => $identity->username
+            ];
             array_push($response, $entry);
         }
 

--- a/frontend/server/libs/dao/Identities.dao.php
+++ b/frontend/server/libs/dao/Identities.dao.php
@@ -50,6 +50,34 @@ class IdentitiesDAO extends IdentitiesDAOBase {
         return new Identities($rs);
     }
 
+    public static function findByUsernameOrName(string $usernameOrName) : array {
+        global  $conn;
+        $sql = "
+            SELECT
+                i.*
+            FROM
+                Identities i
+            WHERE
+                i.username = ? OR i.name = ?
+            UNION DISTINCT
+            SELECT DISTINCT
+                i.*
+            FROM
+                Identities i
+            WHERE
+                i.username LIKE CONCAT('%', ?, '%') OR
+                i.username LIKE CONCAT('%', ?, '%')
+            LIMIT 20";
+        $args = [$usernameOrName, $usernameOrName, $usernameOrName, $usernameOrName];
+
+        $rs = $conn->GetAll($sql, $args);
+        $result = [];
+        foreach ($rs as $identityData) {
+            array_push($result, new Identities($identityData));
+        }
+        return $result;
+    }
+
     public static function FindByUserId($user_id) {
         global  $conn;
         $sql = 'SELECT

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -47,30 +47,30 @@ class UsersDAO extends UsersDAOBase {
         return $conn->GetOne($sql, $params) > 0;
     }
 
-    public static function FindByUsernameOrName($usernameOrName) {
+    public static function findByUsernameOrName($usernameOrName) {
         global  $conn;
         $sql = "
             SELECT
-                u.*
+                i.*
             FROM
-                Users u
+                Identities i
             WHERE
-                u.username = ? OR u.name = ?
+                i.username = ? OR i.name = ?
             UNION DISTINCT
             SELECT DISTINCT
-                u.*
+                i.*
             FROM
-                Users u
+                Identities i
             WHERE
-                u.username LIKE CONCAT('%', ?, '%') OR
-                u.username LIKE CONCAT('%', ?, '%')
-            LIMIT 10";
+                i.username LIKE CONCAT('%', ?, '%') OR
+                i.username LIKE CONCAT('%', ?, '%')
+            LIMIT 50";
         $args = [$usernameOrName, $usernameOrName, $usernameOrName, $usernameOrName];
 
         $rs = $conn->GetAll($sql, $args);
         $result = [];
-        foreach ($rs as $user_data) {
-            array_push($result, new Users($user_data));
+        foreach ($rs as $identityData) {
+            array_push($result, new Users($identityData));
         }
         return $result;
     }

--- a/frontend/server/libs/dao/Users.dao.php
+++ b/frontend/server/libs/dao/Users.dao.php
@@ -47,34 +47,6 @@ class UsersDAO extends UsersDAOBase {
         return $conn->GetOne($sql, $params) > 0;
     }
 
-    public static function findByUsernameOrName($usernameOrName) {
-        global  $conn;
-        $sql = "
-            SELECT
-                i.*
-            FROM
-                Identities i
-            WHERE
-                i.username = ? OR i.name = ?
-            UNION DISTINCT
-            SELECT DISTINCT
-                i.*
-            FROM
-                Identities i
-            WHERE
-                i.username LIKE CONCAT('%', ?, '%') OR
-                i.username LIKE CONCAT('%', ?, '%')
-            LIMIT 50";
-        $args = [$usernameOrName, $usernameOrName, $usernameOrName, $usernameOrName];
-
-        $rs = $conn->GetAll($sql, $args);
-        $result = [];
-        foreach ($rs as $identityData) {
-            array_push($result, new Users($identityData));
-        }
-        return $result;
-    }
-
     public static function FindResetInfoByEmail($email) {
         $user = self::FindByEmail($email);
         if (is_null($user)) {

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -229,6 +229,7 @@ let UI = {
             {
               source: UI.typeaheadWrapper(searchFn),
               async: true,
+              limit: 20,
               display: 'label',
               templates: {
                 suggestion: function(val) {


### PR DESCRIPTION
# Descripción

Se arregla la consulta que obtiene la lista de usuarios para mostrarse en el listado cuando 
se agregan estos a un curso o un concurso. Ahora se obtiene la información de la tabla de
identidades, debido a que con el Refactor de Identidad, ahora pueden existir identidades
que no están asociadas a un usuario en específico.

Fixes: #2636 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
