### PR TITLE
Hot-Fix: Arreglando problemas en arena por un tipo de variable equivocado

### DIFF
--- a/frontend/www/arena/problem.php
+++ b/frontend/www/arena/problem.php
@@ -61,7 +61,7 @@ if (isset($result['settings']['cases'])
 $result['user'] = [
     'logged_in' => $session['valid'],
     'admin' => $session['valid'] ?
-        Authorization::isProblemAdmin($session['identity']->identity_id, $problem) :
+        Authorization::isProblemAdmin($session['identity'], $problem) :
         false
 ];
 $smarty->assign('problem_admin', $result['user']['admin']);


### PR DESCRIPTION
# Descripción

Se arregla un bug que no permitía mostrar los problemas cuando el usuario está logueado.

Había una variable de tipo equivocado al consultar si el usuario era admin.

Fixes: #2659 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
