### PR TITLE
Actualizando la nueva interfaz de gitserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ yarn-error.log
 #ignore crated-by-test stuff
 frontend/server/api/tests/problems/
 frontend/server/api/tests/submissions/
+frontend/tests/controllers/gitserver.config.json
 frontend/tests/controllers/gitserver.log
 frontend/tests/controllers/gitserver.pid
 frontend/tests/controllers/grade/

--- a/frontend/server/libs/ProblemDeployer.php
+++ b/frontend/server/libs/ProblemDeployer.php
@@ -332,9 +332,7 @@ class ProblemDeployer {
             );
             $output = curl_exec($curl);
             $retval = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-            if ($output !== false && $retval == 200) {
-                $retval = 0;
-            }
+            $retval = ($output !== false && $retval == 200) ? 0 : 1;
             $result = [
                 'retval' => $retval,
                 'output' => (string)$output,

--- a/frontend/tests/controllers/gitserver-start.sh
+++ b/frontend/tests/controllers/gitserver-start.sh
@@ -13,10 +13,22 @@ ROOT_PATH="$2"
 
 "${DIR}/gitserver-stop.sh"
 
+cat > "${DIR}/gitserver.config.json" <<EOF
+{
+	"Logging": {
+		"File": ""
+	},
+	"Gitserver": {
+		"Port": ${PORT},
+		"PprofPort": 0,
+		"SecretToken": "cbaf89d3bb2ee6b0a90bc7a90d937f9ade16739ed9f573c76e1ac72064e397aac2b35075040781dd0df9a8f1d6fc4bd4a4941eb6b0b62541b0a35fb0f89cfc3f",
+		"PublicKey": "",
+		"AllowDirectPushToMaster": true,
+		"RootPath": "${ROOT_PATH}"
+	}
+}
+EOF
+
 /usr/bin/nohup /usr/bin/omegaup-gitserver \
-	"-port=${PORT}" -pprof-port=-1 \
-	-secret-token=cbaf89d3bb2ee6b0a90bc7a90d937f9ade16739ed9f573c76e1ac72064e397aac2b35075040781dd0df9a8f1d6fc4bd4a4941eb6b0b62541b0a35fb0f89cfc3f \
-	-public-key= \
-	-allow-direct-push-to-master \
-	"-root=${ROOT_PATH}" >> "${DIR}/gitserver.log" 2>&1 &
+	-config="${DIR}/gitserver.config.json" >> "${DIR}/gitserver.log" 2>&1 &
 echo $! > "${DIR}/gitserver.pid"

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -43,11 +43,11 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.10/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.18/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.
-	DOWNLOAD_URL='https://github.com/omegaup/libinteractive/releases/download/v2.0.23/libinteractive.jar'
+	DOWNLOAD_URL='https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar'
 	TARGET='/usr/share/java/libinteractive.jar'
 	sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
 }

--- a/stuff/travis/nginx/gitserver-start.sh
+++ b/stuff/travis/nginx/gitserver-start.sh
@@ -6,7 +6,18 @@ DIR="$(realpath "$(dirname "$0")")"
 
 "${DIR}/gitserver-stop.sh"
 
+cat > "/tmp/omegaup/gitserver.config.json" <<EOF
+{
+	"Logging": {
+		"File": ""
+	},
+	"Gitserver": {
+		"AllowDirectPushToMaster": true,
+		"RootPath": "/tmp/omegaup/problems.git"
+	}
+}
+EOF
+
 /usr/bin/nohup /usr/bin/omegaup-gitserver \
-	-allow-direct-push-to-master \
-	"-root=/tmp/omegaup/problems.git/" >> /tmp/omegaup/gitserver.log 2>&1 &
+	-config=/tmp/omegaup/gitserver.config.json >> /tmp/omegaup/gitserver.log 2>&1 &
 echo $! > /tmp/omegaup/gitserver.pid


### PR DESCRIPTION
Este cambio hace que las pruebas utilicen la nueva interfaz para
ejecutar gitserver, usando el archivo de configuración en vez de las
banderas.