### PR TITLE
Usando el nombre correcto para el esquema de autenticación via token

### DIFF
--- a/frontend/server/libs/SecurityTools.php
+++ b/frontend/server/libs/SecurityTools.php
@@ -128,7 +128,7 @@ class SecurityTools {
      */
     public static function getGitserverAuthorizationHeader(string $problem, string $username) : string {
         if (OMEGAUP_GITSERVER_SECRET_TOKEN != '') {
-            return 'Authorization: Bearer ' . OMEGAUP_GITSERVER_SECRET_TOKEN . ' ' . $username;
+            return 'Authorization: OmegaUpSharedSecret ' . OMEGAUP_GITSERVER_SECRET_TOKEN . ' ' . $username;
         }
 
         return 'Authorization: Bearer ' . self::getGitserverAuthorizationToken($problem, $username);

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -43,7 +43,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.18/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.19/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.


### PR DESCRIPTION
Este cambio usa OmegaUpSharedSecret en vez de Bearer para hacer
autenticación vía token compartido.