### PR TITLE
Restringiendo los aliases de grupos

### DIFF
--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -344,10 +344,6 @@ class CourseController extends Controller {
         Courses $course,
         Users $creator
     ) : Courses {
-        if ($course->alias == 'new') {
-            throw new DuplicatedEntryInDatabaseException('aliasInUse');
-        }
-
         if (!is_null(CoursesDAO::getByAlias($course->alias))) {
             throw new DuplicatedEntryInDatabaseException('aliasInUse');
         }

--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -28,7 +28,7 @@ class GroupController extends Controller {
 
             GroupsDAO::save($group);
 
-            self::$log->info('Group ' . $alias . ' created.');
+            self::$log->info("Group {$alias} created.");
 
             DAO::transEnd();
         } catch (Exception $e) {

--- a/frontend/server/libs/Validators.php
+++ b/frontend/server/libs/Validators.php
@@ -101,19 +101,37 @@ class Validators {
 
         if (!is_string($parameter) ||
             empty($parameter) ||
-            strlen($parameter) > 32 ||
-            !self::isValidAlias($parameter)
+            strlen($parameter) > 32
         ) {
+            throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
+        }
+        if (self::isRestrictedAlias($parameter)) {
+            throw new DuplicatedEntryInDatabaseException('aliasInUse');
+        }
+        if (!self::isValidAlias($parameter)) {
             throw new InvalidParameterException('parameterInvalidAlias', $parameterName);
         }
     }
 
     /**
-     * @param string $parameter
+     * Returns whether the alias is valid and is not a restricted alias.
+     *
+     * @param string $alias
      * @return boolean
      */
-    public static function isValidAlias(string $parameter) : bool {
-        return preg_match('/^[a-zA-Z0-9_-]+$/', $parameter) === 1;
+    public static function isValidAlias(string $alias) : bool {
+        return preg_match('/^[a-zA-Z0-9_-]+$/', $alias) === 1 && !self::isRestrictedAlias($alias);
+    }
+
+    /**
+     * Returns whether the alias is restricted.
+     *
+     * @param string $alias the alias.
+     * @return boolean whether the alias is restricted.
+     */
+    public static function isRestrictedAlias(string $alias) : bool {
+        $restrictedAliases = ['new', 'admin', 'problem', 'list', 'mine', 'omegaup'];
+        return in_array(strtolower($alias), $restrictedAliases);
     }
 
     /**

--- a/frontend/tests/controllers/GroupsTest.php
+++ b/frontend/tests/controllers/GroupsTest.php
@@ -34,6 +34,26 @@ class GroupsTest extends OmegaupTestCase {
     }
 
     /**
+     * Attempts to create groups with a restricted alias should fail.
+     */
+    public function testCreateGroupRestrictedAlias() {
+        $owner = UserFactory::createUser();
+
+        try {
+            $login = self::login($owner);
+            GroupController::apiCreate(new Request([
+                'auth_token' => $login->auth_token,
+                'name' => Utils::CreateRandomString(),
+                'alias' => 'omegaup',
+                'description' => Utils::CreateRandomString(),
+            ]));
+            $this->fail('Group creation should have failed');
+        } catch (DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals($e->getMessage(), 'aliasInUse');
+        }
+    }
+
+    /**
      * Add user to group
      */
     public function testAddUserToGroup() {


### PR DESCRIPTION
Este cambio hace que no se puedan crear grupos con los nombres 'new',
'admin', 'problem', 'list', 'mine', u 'omegaup'.