### PR TITLE
Ocultando provisionalmente la campanita de notificaciones.

### DIFF
--- a/frontend/www/js/omegaup/components/notification/List.vue
+++ b/frontend/www/js/omegaup/components/notification/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="dropdown">
+  <li class="dropdown hide">
     <a aria-expanded="true"
         aria-haspopup="true"
         class="notification-btn dropdown-toggle"


### PR DESCRIPTION
Fixes: #2679 

# Comentarios
Cuando migremos a Boostrap 4, esta campanita regresará :')

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
