### PR TITLE
Reemplazando llamados al objeto Users por Identities

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1973,7 +1973,7 @@ class ProblemController extends Controller {
                     foreach ($runsArray as $run) {
                         $run['time'] = (int)$run['time'];
                         $run['contest_score'] = (float)$run['contest_score'];
-                        $run['username'] = $r->user->username;
+                        $run['username'] = $r->identity->username;
                         $run['alias'] = $r['problem']->alias;
                         array_push($response['runs'], $run);
                     }

--- a/frontend/server/libs/dao/Problems.dao.php
+++ b/frontend/server/libs/dao/Problems.dao.php
@@ -341,7 +341,7 @@ class ProblemsDAO extends ProblemsDAOBase {
             'quality_histogram', 'difficulty_histogram',
         ];
         $problems = [];
-        $hiddenTags = $identityType !== IDENTITY_ANONYMOUS ? UsersDao::getHideTags($identityId) : false;
+        $hiddenTags = $identityType !== IDENTITY_ANONYMOUS ? UsersDAO::getHideTags($identityId) : false;
         if (!is_null($result)) {
             foreach ($result as $row) {
                 $temp = new Problems($row);

--- a/frontend/tests/factories/ContestsFactory.php
+++ b/frontend/tests/factories/ContestsFactory.php
@@ -264,11 +264,33 @@ class ContestsFactory {
         unset($_REQUEST);
     }
 
-    public static function addUser($contestData, $user) {
+    public static function addUser(
+        array $contestData,
+        Users $user
+    ) : void {
         // Prepare our request
         $r = new Request();
         $r['contest_alias'] = $contestData['request']['alias'];
         $r['usernameOrEmail'] = $user->username;
+
+        // Log in the contest director
+        $login = OmegaupTestCase::login($contestData['director']);
+        $r['auth_token'] = $login->auth_token;
+
+        // Call api
+        ContestController::apiAddUser($r);
+
+        unset($_REQUEST);
+    }
+
+    public static function addIdentity(
+        array $contestData,
+        Identities $identitiy
+    ) : void {
+        // Prepare our request
+        $r = new Request();
+        $r['contest_alias'] = $contestData['request']['alias'];
+        $r['usernameOrEmail'] = $identitiy->username;
 
         // Log in the contest director
         $login = OmegaupTestCase::login($contestData['director']);


### PR DESCRIPTION
# Descripción

Primera parte del issue para agregar un mensaje al usuario cuando va a realizar su primer envío
con una identidad que no es la principal. Este cambio arregla todos los llamados a parámetros de
`Users` para remplazarlos por parámetros de `Identities`.

Parte de: #2606 

# Comentarios

Una vez arreglado, se pueden aplicar los cambios del PR que se revirtió, y así buscar en donde 
está la falla que rompía las pruebas de `Selenium`

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
