### PR TITLE
Agregando pruebas de aceptar/rechazar solicitudes a concursos

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -2146,7 +2146,7 @@ class ContestController extends Controller {
         foreach ($db_results as $result) {
             $admin_id = $result['admin_id'];
             if (!array_key_exists($admin_id, $admin_infos)) {
-                $data = UsersDAO::getByPK($admin_id);
+                $data = IdentitiesDAO::findByUserId($admin_id ?? 0);
                 if (!is_null($data)) {
                     $admin_infos[$admin_id]['user_id'] = $data->user_id;
                     $admin_infos[$admin_id]['username'] = $data->username;

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -2145,8 +2145,8 @@ class ContestController extends Controller {
         $admin_infos = [];
         foreach ($db_results as $result) {
             $admin_id = $result['admin_id'];
-            if (!array_key_exists($admin_id, $admin_infos)) {
-                $data = IdentitiesDAO::findByUserId($admin_id ?? 0);
+            if (!empty($admin_id) && !array_key_exists($admin_id, $admin_infos)) {
+                $data = IdentitiesDAO::findByUserId($admin_id);
                 if (!is_null($data)) {
                     $admin_infos[$admin_id]['user_id'] = $data->user_id;
                     $admin_infos[$admin_id]['username'] = $data->username;

--- a/frontend/tests/controllers/ContestRequestsTest.php
+++ b/frontend/tests/controllers/ContestRequestsTest.php
@@ -7,9 +7,7 @@
  * @author juan.pablo@omegaup.com
  */
 class ContestRequestsTest extends OmegaupTestCase {
-    private function preparePublicContestWithRegistration(
-        bool $addSecondaryAdmin = true
-    ) : array {
+    private function preparePublicContestWithRegistration() : array {
         // create a contest and its admin
         $contestAdmin = UserFactory::createUser();
         $contestData = ContestsFactory::createContest(new ContestParams([
@@ -29,12 +27,6 @@ class ContestRequestsTest extends OmegaupTestCase {
             'mainAdmin' => $contestAdmin,
             'contestData' => $contestData,
         ];
-
-        if ($addSecondaryAdmin) {
-            $user = UserFactory::createUser();
-            ContestsFactory::addAdminUser($contestData, $user);
-            $result['secondaryAdminLogin'] = $user;
-        }
 
         return $result;
     }
@@ -102,9 +94,7 @@ class ContestRequestsTest extends OmegaupTestCase {
         [
             'mainAdmin' => $admin,
             'contestData' => $contestData,
-        ] = $this->preparePublicContestWithRegistration(
-            /*$addSecondaryAdmin*/ false
-        );
+        ] = $this->preparePublicContestWithRegistration();
 
         // some user asks for contest
         $contestant = UserFactory::createUser();
@@ -126,9 +116,12 @@ class ContestRequestsTest extends OmegaupTestCase {
     public function testRejectedAndAcceptedRequestsByTwoDifferentAdmins() {
         [
             'mainAdmin' => $mainAdmin,
-            'secondaryAdminLogin' => $secondaryAdminLogin,
             'contestData' => $contestData,
         ] = $this->preparePublicContestWithRegistration();
+
+        // Adding secondary admin
+        $secondaryAdminLogin = UserFactory::createUser();
+        ContestsFactory::addAdminUser($contestData, $secondaryAdminLogin);
 
         // some users ask for contest
         $contestants = [];
@@ -203,8 +196,7 @@ class ContestRequestsTest extends OmegaupTestCase {
         ContestController::apiArbitrateRequest(new Request([
             'contest_alias' => $contestData['request']['alias'],
             'auth_token' => $adminLogin->auth_token,
-            'username' => $ua
-                ,
+            'username' => $ua,
             'resolution' => true,
         ]));
         $acceptedUsers[] = $ua;

--- a/frontend/tests/controllers/ContestRequestsTest.php
+++ b/frontend/tests/controllers/ContestRequestsTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * Any admin can accept / reject participant requests for a public contest with
+ * registration
+ *
+ * @author juan.pablo@omegaup.com
+ */
+class ContestRequestsTest extends OmegaupTestCase {
+    private function preparePublicContestWithRegistration(
+        bool $addSecondaryAdmin = true
+    ) : array {
+        // create a contest and its admin
+        $contestAdmin = UserFactory::createUser();
+        $contestData = ContestsFactory::createContest(new ContestParams([
+            'contestDirector' => $contestAdmin,
+        ]));
+        $problemData = ProblemsFactory::createProblem();
+        ContestsFactory::addProblemToContest($problemData, $contestData);
+
+        $adminLogin = self::login($contestAdmin);
+        ContestController::apiUpdate(new Request([
+            'contest_alias' => $contestData['request']['alias'],
+            'admission_mode' => 'registration',
+            'auth_token' => $adminLogin->auth_token,
+        ]));
+
+        $result = [
+            'mainAdmin' => $contestAdmin,
+            'contestData' => $contestData,
+        ];
+
+        if ($addSecondaryAdmin) {
+            $user = UserFactory::createUser();
+            ContestsFactory::addAdminUser($contestData, $user);
+            $result['secondaryAdminLogin'] = $user;
+        }
+
+        return $result;
+    }
+
+    private function registerUserForContest(
+        Users $contestant,
+        Request $contest
+    ) : void {
+        $contestantLogin = self::login($contestant);
+
+        ContestController::apiRegisterForContest(new Request([
+            'contest_alias' => $contest['alias'],
+            'auth_token' => $contestantLogin->auth_token,
+        ]));
+    }
+
+    private function assertDefaultParamsInRequest(
+        array $userRequest,
+        bool $hasRequestResponse = false
+    ) : void {
+        $this->assertArrayHasKey('username', $userRequest);
+        $this->assertArrayHasKey('country', $userRequest);
+        $this->assertArrayHasKey('request_time', $userRequest);
+        $this->assertArrayHasKey('accepted', $userRequest);
+        $this->assertArrayHasKey('last_update', $userRequest);
+        $this->assertArrayHasKey('admin', $userRequest);
+
+        if (!$hasRequestResponse) {
+            // No one has accepted or rejected the request
+            $this->assertEmpty($userRequest['admin']);
+            $this->assertNull($userRequest['accepted']);
+            $this->assertNotEmpty($userRequest['request_time']);
+        }
+    }
+
+    private function assertParamsInRequest(
+        int $numberOfContestants,
+        array $contestants,
+        array $result,
+        Users $mainAdmin,
+        array $arbitratedUsers,
+        array $acceptedUsers
+    ) {
+        // Asserting request results
+        for ($i = 0; $i < $numberOfContestants; $i++) {
+            $hasRequestResponse = false;
+            if (in_array($contestants[$i]->username, $arbitratedUsers)) {
+                if (in_array($contestants[$i]->username, $acceptedUsers)) {
+                    $this->assertTrue($result['users'][$i]['accepted']);
+                }
+                $this->assertEquals(
+                    $result['users'][$i]['admin']['user_id'],
+                    $mainAdmin->user_id
+                );
+                $hasRequestResponse = true;
+            }
+            $this->assertDefaultParamsInRequest(
+                $result['users'][$i],
+                $hasRequestResponse
+            );
+        }
+    }
+
+    public function testSimpleContestRequestWithoutResolution() {
+        [
+            'mainAdmin' => $admin,
+            'contestData' => $contestData,
+        ] = $this->preparePublicContestWithRegistration(
+            /*$addSecondaryAdmin*/ false
+        );
+
+        // some user asks for contest
+        $contestant = UserFactory::createUser();
+
+        $this->registerUserForContest($contestant, $contestData['request']);
+
+        // admin lists registrations
+        $adminLogin = self::login($admin);
+        $result = ContestController::apiRequests(new Request([
+            'contest_alias' => $contestData['request']['alias'],
+            'auth_token' => $adminLogin->auth_token,
+        ]));
+        $this->assertEquals(count($result['users']), 1);
+        [$userRequest] = $result['users'];
+
+        $this->assertDefaultParamsInRequest($userRequest);
+    }
+
+    public function testRejectedAndAcceptedRequestsByTwoDifferentAdmins() {
+        [
+            'mainAdmin' => $mainAdmin,
+            'secondaryAdminLogin' => $secondaryAdminLogin,
+            'contestData' => $contestData,
+        ] = $this->preparePublicContestWithRegistration();
+
+        // some users ask for contest
+        $contestants = [];
+        $numberOfContestants = 4;
+        $arbitratedUsers = [];
+        $acceptedUsers = [];
+        for ($i = 0; $i < $numberOfContestants; $i++) {
+            $contestants[$i] = UserFactory::createUser();
+            $this->registerUserForContest(
+                $contestants[$i],
+                $contestData['request']
+            );
+        }
+        [
+            $acceptedContestantByMainAdmin,
+            $rejectedContestantByMainAdminAndAcceptedByTheSecondOne,
+            $rejectedContestantAndThenAcceptedByTheSameAdmin,
+            $nonAcceptedNorRejectedContestant,
+        ] = $contestants;
+
+        // admin lists registrations
+        $adminLogin = self::login($mainAdmin);
+        $contestRequest = new Request([
+            'contest_alias' => $contestData['request']['alias'],
+            'auth_token' => $adminLogin->auth_token,
+        ]);
+        $result = ContestController::apiRequests($contestRequest);
+        $this->assertEquals(count($result['users']), $numberOfContestants);
+
+        for ($i = 0; $i < $numberOfContestants; $i++) {
+            $this->assertDefaultParamsInRequest($result['users'][$i]);
+        }
+
+        // Main admin arbitrates some requests
+        $contestRequest['username'] = $acceptedContestantByMainAdmin->username;
+        $contestRequest['resolution'] = true;
+        ContestController::apiArbitrateRequest($contestRequest);
+        $arbitratedUsers[] = $contestRequest['username'];
+        $acceptedUsers[] = $contestRequest['username'];
+
+        $contestRequest['username'] =
+            $rejectedContestantByMainAdminAndAcceptedByTheSecondOne->username;
+        $contestRequest['resolution'] = false;
+        ContestController::apiArbitrateRequest($contestRequest);
+        $arbitratedUsers[] = $contestRequest['username'];
+
+        $contestRequest['username'] =
+            $rejectedContestantAndThenAcceptedByTheSameAdmin->username;
+        $contestRequest['resolution'] = false;
+        ContestController::apiArbitrateRequest($contestRequest);
+        $arbitratedUsers[] = $contestRequest['username'];
+
+        $result = ContestController::apiRequests($contestRequest);
+
+        $this->assertParamsInRequest(
+            $numberOfContestants,
+            $contestants,
+            $result,
+            $mainAdmin,
+            $arbitratedUsers,
+            $acceptedUsers
+        );
+
+        // Second round of arbitrate requests
+        $contestRequest['resolution'] = true;
+        ContestController::apiArbitrateRequest($contestRequest);
+        $acceptedUsers[] = $contestRequest['username'];
+
+        // Now we login with the secondary admin
+        $adminLogin = self::login($secondaryAdminLogin);
+        $ua = $rejectedContestantByMainAdminAndAcceptedByTheSecondOne->username;
+        ContestController::apiArbitrateRequest(new Request([
+            'contest_alias' => $contestData['request']['alias'],
+            'auth_token' => $adminLogin->auth_token,
+            'username' => $ua
+                ,
+            'resolution' => true,
+        ]));
+        $acceptedUsers[] = $ua;
+
+        $result = ContestController::apiRequests(new Request([
+            'contest_alias' => $contestData['request']['alias'],
+            'auth_token' => $adminLogin->auth_token,
+        ]));
+
+        $this->assertParamsInRequest(
+            $numberOfContestants,
+            $contestants,
+            $result,
+            $mainAdmin,
+            $arbitratedUsers,
+            $acceptedUsers
+        );
+    }
+}


### PR DESCRIPTION
# Descripción

Se agregan más pruebas de aceptar / rechazar solicitudes a concursos para cubrir la 
mayor parte de escenarios posibles

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
