### PR TITLE
Habilitando experimento de Identidades en pruebas de Selenium

### DIFF
--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -366,6 +366,14 @@ class Driver:  # pylint: disable=too-many-instance-attributes
             SELECT LAST_INSERT_ID();
             ''') % (username, password),
             dbname='omegaup', auth=self.mysql_auth())
+        util.database_utils.mysql(
+            ('''
+            INSERT INTO
+                Users_Experiments(`user_id`, `experiment`)
+            VALUES
+                ('%s', 'identities');
+            ''') % (user_id),
+            dbname='omegaup', auth=self.mysql_auth())
         identity_id = util.database_utils.mysql(
             ('''
             INSERT INTO


### PR DESCRIPTION
# Descripción

Se almacenan en la base de datos los usuarios de las pruebas de `Selenium`
para que puedan realizar las operaciones que aún se ecuentran cómo experimento
de Identidades.

Part of: #2664 

# Comentarios

Falta revisar si esta es la mejor opción, y en caso de serla, también habría que 
buscar la forma de eliminar estos registros una vez terminadas las pruebas.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
