### PR TITLE
Mejorando la interfaz de Cache

### DIFF
--- a/frontend/server/controllers/IdentityController.php
+++ b/frontend/server/controllers/IdentityController.php
@@ -365,20 +365,15 @@ class IdentityController extends Controller {
             throw new InvalidParameterException('parameterNotFound', 'Identity');
         }
 
-        $response = [];
-
-        Cache::getFromCacheOrSet(
+        $response = Cache::getFromCacheOrSet(
             Cache::USER_PROFILE,
             $identity->username,
-            [$identity, $user],
-            function (array $params) {
-                [$identity, $user] = $params;
+            function () use ($identity, $user) {
                 if (!is_null($user)) {
                     return UserController::getProfileImpl($user, $identity);
                 }
                 return IdentityController::getProfileImpl($identity);
-            },
-            $response
+            }
         );
 
         if ($omitRank) {

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1189,22 +1189,19 @@ class ProblemController extends Controller {
         string $commit,
         string $language
     ) : array {
-        $problemStatement = null;
-        Cache::getFromCacheOrSet(
+        return Cache::getFromCacheOrSet(
             Cache::PROBLEM_STATEMENT,
             "{$problem->alias}-{$commit}-{$language}-markdown",
-            [
-                'directory' => 'statements',
-                'alias' => $problem->alias,
-                'commit' => $commit,
-                'language' => $language,
-            ],
-            'ProblemController::getProblemResourceImpl',
-            $problemStatement,
+            function () use ($problem, $commit, $language) {
+                return ProblemController::getProblemResourceImpl([
+                    'directory' => 'statements',
+                    'alias' => $problem->alias,
+                    'commit' => $commit,
+                    'language' => $language,
+                ]);
+            },
             APC_USER_CACHE_PROBLEM_STATEMENT_TIMEOUT
         );
-
-        return $problemStatement;
     }
 
     /**
@@ -1223,22 +1220,19 @@ class ProblemController extends Controller {
         string $commit,
         string $language
     ) : array {
-        $problemSolution = null;
-        Cache::getFromCacheOrSet(
+        return Cache::getFromCacheOrSet(
             Cache::PROBLEM_SOLUTION,
             "{$problem->alias}-{$commit}-{$language}-markdown",
-            [
-                'directory' => 'solutions',
-                'alias' => $problem->alias,
-                'commit' => $commit,
-                'language' => $language,
-            ],
-            'ProblemController::getProblemResourceImpl',
-            $problemSolution,
+            function () use ($problem, $commit, $language) {
+                return ProblemController::getProblemResourceImpl([
+                    'directory' => 'solutions',
+                    'alias' => $problem->alias,
+                    'commit' => $commit,
+                    'language' => $language,
+                ]);
+            },
             APC_USER_CACHE_PROBLEM_STATEMENT_TIMEOUT
         );
-
-        return $problemSolution;
     }
 
     /**
@@ -1252,19 +1246,17 @@ class ProblemController extends Controller {
         Problems $problem,
         string $commit
     ) : array {
-        $problemSettingsDistrib = null;
-        Cache::getFromCacheOrSet(
+        return Cache::getFromCacheOrSet(
             Cache::PROBLEM_SETTINGS_DISTRIB,
             "{$problem->alias}-{$problem->commit}",
-            [
-                'alias' => $problem->alias,
-                'commit' => $problem->commit,
-            ],
-            'ProblemController::getProblemSettingsDistribImpl',
-            $problemSettingsDistrib,
+            function () use ($problem) {
+                return ProblemController::getProblemSettingsDistribImpl([
+                    'alias' => $problem->alias,
+                    'commit' => $problem->commit,
+                ]);
+            },
             APC_USER_CACHE_PROBLEM_STATEMENT_TIMEOUT
         );
-        return $problemSettingsDistrib;
     }
 
     /**
@@ -1486,21 +1478,18 @@ class ProblemController extends Controller {
         );
 
         // Add preferred language of the user.
-        $user_data = [];
         $request = new Request(['omit_rank' => true, 'auth_token' => $r['auth_token']]);
         if (!is_null($r->identity)) {
-            Cache::getFromCacheOrSet(
+            $userData = Cache::getFromCacheOrSet(
                 Cache::USER_PROFILE,
                 $r->identity->username,
-                $request,
-                function (Request $request) {
-                        return UserController::apiProfile($request);
-                },
-                $user_data
+                function () use ($r) {
+                    return UserController::apiProfile($r);
+                }
             );
-        }
-        if (!empty($user_data)) {
-            $response['preferred_language'] = $user_data['userinfo']['preferred_language'];
+            if (!empty($userData)) {
+                $response['preferred_language'] = $userData['userinfo']['preferred_language'];
+            }
         }
 
         // Add the problem the response

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -793,28 +793,29 @@ class RunController extends Controller {
      * @return type
      * @throws InvalidDatabaseOperationException
      */
-    public static function apiCounts(Request $r) {
-        $totals = [];
+    public static function apiCounts(Request $r) : array {
+        return Cache::getFromCacheOrSet(
+            Cache::RUN_COUNTS,
+            '',
+            function () use ($r) {
+                $totals = [];
+                $totals['total'] = [];
+                $totals['ac'] = [];
+                try {
+                    $runCounts = RunCountsDAO::getAll(1, 90, 'date', 'DESC');
 
-        Cache::getFromCacheOrSet(Cache::RUN_COUNTS, '', $r, function (Request $r) {
-            $totals = [];
-            $totals['total'] = [];
-            $totals['ac'] = [];
-            try {
-                $runCounts = RunCountsDAO::getAll(1, 90, 'date', 'DESC');
-
-                foreach ($runCounts as $runCount) {
-                    $totals['total'][$runCount->date] = $runCount->total;
-                    $totals['ac'][$runCount->date] = $runCount->ac_count;
+                    foreach ($runCounts as $runCount) {
+                        $totals['total'][$runCount->date] = $runCount->total;
+                        $totals['ac'][$runCount->date] = $runCount->ac_count;
+                    }
+                } catch (Exception $e) {
+                    throw new InvalidDatabaseOperationException($e);
                 }
-            } catch (Exception $e) {
-                throw new InvalidDatabaseOperationException($e);
-            }
 
-            return $totals;
-        }, $totals, 24*60*60 /*expire in 1 day*/);
-
-        return $totals;
+                return $totals;
+            },
+            24*60*60 /*expire in 1 day*/
+        );
     }
 
     /**

--- a/frontend/server/controllers/SchoolController.php
+++ b/frontend/server/controllers/SchoolController.php
@@ -131,7 +131,7 @@ class SchoolController extends Controller {
             $r['finish_time'] = gmdate('Y-m-d', $r['finish_time']);
         }
 
-        $fetch = function (Request $r) {
+        $fetch = function () use ($r) {
             try {
                 return SchoolsDAO::getRankByUsersAndProblemsWithAC(
                     $r['start_time'],
@@ -144,19 +144,15 @@ class SchoolController extends Controller {
             }
         };
 
-        $result = [];
         if ($canUseCache) {
-            $cache_key = $r['offset'] .'-'. $r['rowcount'];
-            Cache::getFromCacheOrSet(
+            $result = Cache::getFromCacheOrSet(
                 Cache::SCHOOL_RANK,
-                $cache_key,
-                $r,
+                "{$r['offset']}-{$r['rowcount']}",
                 $fetch,
-                $result,
                 60 * 60 * 24 // 1 day
             );
         } else {
-            $result = $fetch($r);
+            $result = $fetch();
         }
 
         return ['status' => 'ok', 'rank' => $result];

--- a/frontend/server/libs/Cache.php
+++ b/frontend/server/libs/Cache.php
@@ -17,30 +17,30 @@ abstract class CacheAdapter {
         return CacheAdapter::$sInstance;
     }
 
-    abstract public function entry($key, $default_var, $ttl = 0);
-    abstract public function add($key, $var, $ttl = 0);
-    abstract public function cas($key, $old, $new);
+    abstract public function entry(string $key, $defaultVar, int $ttl = 0);
+    abstract public function add(string $key, $var, int $ttl = 0) : bool;
+    abstract public function cas(string $key, int $old, int $new) : bool;
     abstract public function clear();
-    abstract public function delete($key);
-    abstract public function fetch($key);
-    abstract public function store($key, $var, $ttl = 0);
+    abstract public function delete(string $key) : bool;
+    abstract public function fetch(string $key);
+    abstract public function store(string $key, $var, int $ttl = 0) : bool;
 }
 
 /**
  * Implementation of CacheAdapter that uses the real APC functions.
  */
 class APCCacheAdapter extends CacheAdapter {
-    public function entry($key, $default_var, $ttl = 0) {
-        return apcu_entry($key, function ($key) use ($default_var) {
-            return $default_var;
+    public function entry(string $key, $defaultVar, int $ttl = 0) {
+        return apcu_entry($key, function ($key) use ($defaultVar) {
+            return $defaultVar;
         }, $ttl);
     }
 
-    public function add($key, $var, $ttl = 0) {
+    public function add(string $key, $var, int $ttl = 0) : bool {
         return apcu_add($key, $var, $ttl);
     }
 
-    public function cas($key, $old, $new) {
+    public function cas(string $key, int $old, int $new) : bool {
         return apcu_cas($key, $old, $new);
     }
 
@@ -48,15 +48,15 @@ class APCCacheAdapter extends CacheAdapter {
         apcu_clear_cache();
     }
 
-    public function delete($key) {
+    public function delete(string $key) : bool {
         return apcu_delete($key);
     }
 
-    public function fetch($key) {
+    public function fetch(string $key) {
         return apcu_fetch($key, $success);
     }
 
-    public function store($key, $var, $ttl = 0) {
+    public function store(string $key, $var, int $ttl = 0) : bool {
         return apcu_store($key, $var, $ttl);
     }
 }
@@ -68,14 +68,14 @@ class APCCacheAdapter extends CacheAdapter {
 class InProcessCacheAdapter extends CacheAdapter {
     private $cache = [];
 
-    public function entry($key, $default_var, $ttl = 0) {
+    public function entry(string $key, $defaultVar, int $ttl = 0) {
         if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = $default_var;
+            $this->cache[$key] = $defaultVar;
         }
         return $this->cache[$key];
     }
 
-    public function add($key, $var, $ttl = 0) {
+    public function add(string $key, $var, int $ttl = 0) : bool {
         if (array_key_exists($key, $this->cache)) {
             return false;
         }
@@ -83,7 +83,7 @@ class InProcessCacheAdapter extends CacheAdapter {
         return true;
     }
 
-    public function cas($key, $old, $new) {
+    public function cas(string $key, int $old, int $new) : bool {
         if (!array_key_exists($key, $this->cache) || $this->cache[$key] !== $old) {
             return false;
         }
@@ -95,7 +95,7 @@ class InProcessCacheAdapter extends CacheAdapter {
         $this->cache = [];
     }
 
-    public function delete($key) {
+    public function delete(string $key) : bool {
         if (!array_key_exists($key, $this->cache)) {
             return false;
         }
@@ -103,14 +103,14 @@ class InProcessCacheAdapter extends CacheAdapter {
         return true;
     }
 
-    public function fetch($key) {
+    public function fetch(string $key) {
         if (!array_key_exists($key, $this->cache)) {
             return false;
         }
         return $this->cache[$key];
     }
 
-    public function store($key, $var, $ttl = 0) {
+    public function store(string $key, $var, int $ttl = 0) : bool {
         $this->cache[$key] = $var;
         return true;
     }
@@ -143,16 +143,14 @@ class Cache {
     private $log;
     protected $key;
 
-    public static $cacheResults = true;
-
     /**
      * Inicializa el cache para el key dado
      * @param string $key el id del cache
      */
-    public function __construct($prefix, $id = '') {
+    public function __construct(string $prefix, string $id = '') {
         $this->log = Logger::getLogger('cache');
 
-        if (!self::cacheEnabled()) {
+        if (!self::isEnabled()) {
             $this->log->debug('Cache disabled');
             return;
         }
@@ -171,8 +169,8 @@ class Cache {
      * @param int $timeout (seconds)
      * @return boolean
      */
-    public function set($value, $timeout = APC_USER_CACHE_TIMEOUT) {
-        if (!self::cacheEnabled()) {
+    public function set($value, int $timeout = APC_USER_CACHE_TIMEOUT) : bool {
+        if (!self::isEnabled()) {
             return false;
         }
         if (CacheAdapter::getInstance()->store($this->key, $value, $timeout) !== true) {
@@ -190,8 +188,8 @@ class Cache {
      *
      * @return boolean
      */
-    public function delete() {
-        if (!self::cacheEnabled()) {
+    public function delete() : bool {
+        if (!self::isEnabled()) {
             return false;
         }
         if (CacheAdapter::getInstance()->delete($this->key) !== true) {
@@ -209,7 +207,7 @@ class Cache {
      * @return mixed
      */
     public function get() {
-        if (!self::cacheEnabled()) {
+        if (!self::isEnabled()) {
             return null;
         }
         if (($result = CacheAdapter::getInstance()->fetch($this->key)) === false) {
@@ -221,48 +219,43 @@ class Cache {
     }
 
     /**
-     *
-     * If value exists from cache, get it from cache.
-     * Otherwise, executes the $setFunc to generate a value that will be
-     * stored in the cache and it will return it.
-     *
-     * Returns true if cache was used, false if it had to be set
+     * If the specified $id exists in cache, gets its associated value from the
+     * cache.  Otherwise, executes $setFunc() to generate the associated
+     * value, stores it, and returns it.
      *
      * @param string $prefix
      * @param string $id
-     * @param Request $r
      * @param callable $setFunc
      * @param int $timeout (seconds)
-     * @return boolean
+     * @param ?bool &$cacheUsed Whether the $id had a pre-computed value in the cache.
+     * @return mixed the value returned from the cache or $setFunc().
      */
-    public static function getFromCacheOrSet($prefix, $id, $arg, $setFunc, &$returnValue, $timeout = 0) {
-        if (is_null($id)) {
-            // Unconditionally skipping cache.
-            $returnValue = call_user_func($setFunc, $r);
-            return false;
-        }
+    public static function getFromCacheOrSet(
+        string $prefix,
+        string $id,
+        callable $setFunc,
+        int $timeout = 0,
+        ?bool &$cacheUsed = null
+    ) {
         $cache = new Cache($prefix, $id);
         $returnValue = $cache->get();
 
         // If there wasn't a value in the cache for the key ($prefix, $id)
         if (!is_null($returnValue)) {
-            // Cache was used
-            return true;
+            if (!is_null($cacheUsed)) {
+                $cacheUsed = true;
+            }
+            return $returnValue;
         }
 
         // Get the value from the function provided
-        $returnValue = call_user_func($setFunc, $arg);
+        $returnValue = call_user_func($setFunc);
+        $cache->set($returnValue, $timeout);
 
-        // If the $setFunc() didn't disable the cache
-        if (self::$cacheResults === true) {
-            $cache->set($returnValue, $timeout);
-        } else {
-            // Reset value
-            self::$cacheResults = true;
+        if (!is_null($cacheUsed)) {
+            $cacheUsed = false;
         }
-
-        // Cache was not used
-        return false;
+        return $returnValue;
     }
 
     /**
@@ -271,7 +264,7 @@ class Cache {
      * @param string $prefix
      * @param string $id
      */
-    public static function deleteFromCache($prefix, $id = '') {
+    public static function deleteFromCache($prefix, $id = '') : void {
         $cache = new Cache($prefix, $id);
         $cache->delete();
     }
@@ -281,7 +274,7 @@ class Cache {
      *
      * @param string $prefix
      */
-    private static function getVersion($prefix) {
+    private static function getVersion(string $prefix) : int {
         $key = "v{$prefix}";
         return (int) CacheAdapter::getInstance()->entry($key, 0);
     }
@@ -294,8 +287,8 @@ class Cache {
      *
      * @param string $prefix
      */
-    public static function invalidateAllKeys($prefix) {
-        if (!self::cacheEnabled()) {
+    public static function invalidateAllKeys(string $prefix) : void {
+        if (!self::isEnabled()) {
             return;
         }
         $key = "v{$prefix}";
@@ -307,9 +300,9 @@ class Cache {
         } while (!CacheAdapter::getInstance()->cas($key, $version, $version + 1));
     }
 
-    private static function cacheEnabled() {
+    private static function isEnabled() : bool {
         return defined('APC_USER_CACHE_ENABLED') &&
-               APC_USER_CACHE_ENABLED === true;
+            APC_USER_CACHE_ENABLED === true;
     }
 
     /**
@@ -317,7 +310,7 @@ class Cache {
      *
      * Only use this for testing purposes.
      */
-    public static function clearCacheForTesting() {
+    public static function clearCacheForTesting() : void {
         CacheAdapter::getInstance()->clear();
     }
 }


### PR DESCRIPTION
Este cambio le agrega tipos a la interfaz pública de Cache y de paso
mejora la manera en la que se llama Cache::getFromCacheOrSet(), que
necesitaba que se le pasaran los parámetros de una manera anticuada
(antes de la existencia de las funciones anónimas).