### PR TITLE
Arreglando más errores de producción

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -633,16 +633,26 @@ class ContestController extends Controller {
             // Insert into PrivacyStatement_Consent_Log whether request
             // user info is optional or required
             if ($requestsUserInformation != 'no') {
-                $privacystatement_id = PrivacyStatementsDAO::getId($r['privacy_git_object_id'], $r['statement_type']);
-                $privacystatement_consent_id = PrivacyStatementConsentLogDAO::saveLog(
-                    $r->identity->identity_id,
-                    $privacystatement_id
+                $privacyStatementId = PrivacyStatementsDAO::getId(
+                    $r['privacy_git_object_id'],
+                    $r['statement_type']
                 );
+
+                $privacyStatementConsentId = PrivacyStatementConsentLogDAO::getId(
+                    $r->identity->identity_id,
+                    $privacyStatementId
+                );
+                if (is_null($privacyStatementConsentId)) {
+                    $privacyStatementConsentId = PrivacyStatementConsentLogDAO::saveLog(
+                        $r->identity->identity_id,
+                        $privacyStatementId
+                    );
+                }
 
                 ProblemsetIdentitiesDAO::updatePrivacyStatementConsent(new ProblemsetIdentities([
                     'identity_id' => $r->identity->identity_id,
                     'problemset_id' => $response['contest']->problemset_id,
-                    'privacystatement_consent_id' => $privacystatement_consent_id
+                    'privacystatement_consent_id' => $privacyStatementConsentId,
                 ]));
             }
 

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -2454,15 +2454,17 @@ class UserController extends Controller {
         $identity = self::resolveTargetIdentity($r);
 
         try {
-            $response = PrivacyStatementConsentLogDAO::saveLog(
+            PrivacyStatementConsentLogDAO::saveLog(
                 $identity->identity_id,
                 $privacystatement_id
             );
-            $sessionController = new SessionController();
-            $sessionController->InvalidateCache();
         } catch (Exception $e) {
-            throw new DuplicatedEntryInDatabaseException('userAlreadyAcceptedPrivacyPolicy');
+            if (DAO::isDuplicateEntryException($e)) {
+                throw new DuplicatedEntryInDatabaseException('userAlreadyAcceptedPrivacyPolicy');
+            }
+            throw new InvalidDatabaseOperationException($e);
         }
+        (new SessionController())->InvalidateCache();
 
         return ['status' => 'ok'];
     }

--- a/frontend/server/libs/dao/Privacy_Statement_Consent_Log.dao.php
+++ b/frontend/server/libs/dao/Privacy_Statement_Consent_Log.dao.php
@@ -23,7 +23,14 @@ class PrivacyStatementConsentLogDAO extends PrivacyStatementConsentLogDAOBase {
         return $conn->GetOne($sql, [$identity_id, $privacystatement_id]) > 0;
     }
 
-    public static function saveLog($identity_id, $privacystatement_id) {
+    /**
+     * Saves the user's consent into the database.
+     *
+     * @param int $identityId the identity of the user giving consent.
+     * @param int $privacyStatementId the id of the privacy statement.
+     * @return the ID of the newly inserted consent.
+     */
+    public static function saveLog(int $identityId, int $privacyStatementId) : int {
         $sql = 'INSERT INTO
                   PrivacyStatement_Consent_Log (
                     `identity_id`,
@@ -31,13 +38,19 @@ class PrivacyStatementConsentLogDAO extends PrivacyStatementConsentLogDAOBase {
                   )
                 VALUES
                   (?, ?)';
-        $params = [$identity_id, $privacystatement_id];
         global $conn;
-        $conn->Execute($sql, $params);
+        $conn->Execute($sql, [$identityId, $privacyStatementId]);
         return $conn->Insert_ID();
     }
 
-    public static function getId($identity_id, $privacystatement_id) {
+    /**
+     * Gets the user's consent ID from the database.
+     *
+     * @param int $identityId the identity of the user giving consent.
+     * @param int $privacyStatementId the id of the privacy statement.
+     * @return the ID of the consent, null if missing.
+     */
+    public static function getId(int $identityId, int $privacyStatementId) : ?int {
         $sql = 'SELECT
                   `privacystatement_consent_id`
                 FROM
@@ -49,6 +62,6 @@ class PrivacyStatementConsentLogDAO extends PrivacyStatementConsentLogDAOBase {
                   privacystatement_id DESC
                 LIMIT 1';
         global $conn;
-        return $conn->GetOne($sql, [$identity_id, $privacystatement_id]);
+        return $conn->GetOne($sql, [$identityId, $privacyStatementId]);
     }
 }

--- a/frontend/server/libs/dao/Tags.dao.php
+++ b/frontend/server/libs/dao/Tags.dao.php
@@ -31,7 +31,7 @@ class TagsDAO extends TagsDAOBase {
 
     public static function findByName(string $name) : array {
         global $conn;
-        $sql = "SELECT name FROM Tags WHERE name LIKE CONCAT('%', ?, '%') LIMIT 100";
+        $sql = "SELECT * FROM Tags WHERE name LIKE CONCAT('%', ?, '%') LIMIT 100";
         $args = [$name];
 
         $rs = $conn->GetAll($sql, $args);


### PR DESCRIPTION
Este cambio arregla unos errores que ocurren si un usuario intenta abrir
un concurso que usa una política de privacidad a la que ya dio
consentimiento.