### PR TITLE
Corrigiendo desfase en el tooltip de badges

### DIFF
--- a/frontend/www/js/omegaup/components/badge/Badge.vue
+++ b/frontend/www/js/omegaup/components/badge/Badge.vue
@@ -20,6 +20,7 @@
 .badge-icon {
   display: block;
   height: 70%;
+  width: 100%;
 }
 .badge-icon img {
   max-height: 100%;


### PR DESCRIPTION

![badgesFixed](https://user-images.githubusercontent.com/20785082/62308900-fa83cf80-b44b-11e9-9faf-f1055414eb49.gif)


Fixes: #2730 

# Comentarios

También ocurría en Edge.


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
