### PR TITLE
Arreglando un error en consulta que obtiene coders del mes

### DIFF
--- a/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
+++ b/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
@@ -144,11 +144,17 @@ class CoderOfTheMonthDAO extends CoderOfTheMonthDAOBase {
         $date = date('Y-m-01', strtotime($firstDay));
         $sql = '
           SELECT
-            cm.time, u.username, COALESCE(u.country_id, "xx") AS country_id, e.email, u.user_id
+            cm.time,
+            i.username,
+            COALESCE(i.country_id, "xx") AS country_id,
+            e.email,
+            u.user_id
           FROM
             Coder_Of_The_Month cm
           INNER JOIN
             Users u ON u.user_id = cm.user_id
+          INNER JOIN
+            Identities i ON u.user_id = i.user_id
           LEFT JOIN
             Emails e ON e.user_id = u.user_id
           WHERE

--- a/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
+++ b/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
@@ -242,22 +242,4 @@ class CoderOfTheMonthDAO extends CoderOfTheMonthDAOBase {
         $endTime = $firstDayOfCurrentMonth->format('Y-m-d');
         return self::calculateCoderOfTheMonth($startTime, $endTime);
     }
-
-    public static function processCodersList(array $coders) : array {
-        $response = [];
-        foreach ($coders as $coder) {
-            $userInfo = UsersDAO::FindByUsername($coder['username']);
-            $classname = UsersDAO::getRankingClassName($userInfo->user_id);
-            $hashEmail = md5($coder['email']);
-            $avatar = 'https://secure.gravatar.com/avatar/{$hashEmail}?s=32';
-            $response[] = [
-                'username' => $coder['username'],
-                'country_id' => $coder['country_id'],
-                'gravatar_32' => $avatar,
-                'date' => $coder['time'],
-                'classname' => $classname,
-            ];
-        }
-        return $response;
-    }
 }

--- a/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
+++ b/frontend/server/libs/dao/Coder_Of_The_Month.dao.php
@@ -242,4 +242,21 @@ class CoderOfTheMonthDAO extends CoderOfTheMonthDAOBase {
         $endTime = $firstDayOfCurrentMonth->format('Y-m-d');
         return self::calculateCoderOfTheMonth($startTime, $endTime);
     }
+
+    public static function processCodersList(array $coders) : array {
+        foreach ($coders as $coder) {
+            $userInfo = UsersDAO::FindByUsername($coder['username']);
+            $classname = UsersDAO::getRankingClassName($userInfo->user_id);
+            $hashEmail = md5($coder['email']);
+            $avatar = 'https://secure.gravatar.com/avatar/{$hashEmail}?s=32';
+            $response[] = [
+                'username' => $coder['username'],
+                'country_id' => $coder['country_id'],
+                'gravatar_32' => $avatar,
+                'date' => $coder['time'],
+                'classname' => $classname,
+            ];
+        }
+        return $response;
+    }
 }

--- a/frontend/www/coderofthemonth.php
+++ b/frontend/www/coderofthemonth.php
@@ -2,43 +2,20 @@
 
 require_once('../server/bootstrap_smarty.php');
 
-$session = SessionController::apiCurrentSession(new Request([
-    'auth_token' => array_key_exists('ouat', $_REQUEST) ? $_REQUEST['ouat'] : null,
-]))['session'];
-
-$currentTimeStamp = Time::get();
-$currentDate = date('Y-m-d', $currentTimeStamp);
-$firstDayOfNextMonth = new DateTime($currentDate);
-$firstDayOfNextMonth->modify('first day of next month');
-$dateToSelect = $firstDayOfNextMonth->format('Y-m-d');
 try {
-    $responseCodersOfTheMonth = UserController::apiCoderOfTheMonthList(new Request([
-        'auth_token' => $session['auth_token'],
-    ]));
-    $responseCodersOfPreviousMonth = UserController::apiCoderOfTheMonthList(new Request([
-        'auth_token' => $session['auth_token'],
-        'date' => $currentDate,
-    ]));
-    $isMentor = $session['valid'] && Authorization::isMentor($session['identity']->identity_id);
-
-    $response = [
-        'codersOfCurrentMonth' => $responseCodersOfTheMonth['coders'],
-        'codersOfPreviousMonth' => $responseCodersOfPreviousMonth['coders'],
-        'isMentor' => $isMentor,
-    ];
-
-    if ($isMentor) {
-        $response['options'] = [
-            'bestCoders' => CoderOfTheMonthDAO::calculateCoderOfMonthByGivenDate($dateToSelect),
-            'canChooseCoder' => Authorization::canChooseCoder($currentTimeStamp),
-            'coderIsSelected' => !empty(CoderOfTheMonthDAO::getByTime($dateToSelect)),
-        ];
-    }
-
-    $smarty->assign('payload', $response);
-
-    $smarty->display('../templates/codersofthemonth.tpl');
-} catch (APIException $e) {
-    header('HTTP/1.1 404 Not Found');
-    die();
+    $session = SessionController::apiCurrentSession(
+        new Request($_REQUEST)
+    )['session'];
+    $smartyProperties = UserController::getCoderOfTheMonthDetailsForSmarty(
+        new Request($_REQUEST),
+        $session['identity']
+    );
+} catch (Exception  $e) {
+    ApiCaller::handleException($e);
 }
+
+foreach ($smartyProperties as $key => $value) {
+    $smarty->assign($key, $value);
+}
+
+$smarty->display('../templates/codersofthemonth.tpl');


### PR DESCRIPTION
# Descripción

Se arregla una consulta que intentaba obtener el país del coder del mes desde la tabla `Users`, dado que este campo ya está eliminado. Esto estaba sucediendo porque la consulta era llamada solamente desde el archivo `coderofthemonth.php` y este no tiene forma de ser revisado con `PHPUnit`. Así que también se mueve la lógica de dicho archivo a `UserController` siguiendo con la convención del cambio de #2665. También se agregan las pruebas para que esto no vuelva a ocurrir. 

Fixes: #2737 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.

