### PR TITLE
Arreglando la clase Authorization

### DIFF
--- a/frontend/server/bootstrap_smarty.php
+++ b/frontend/server/bootstrap_smarty.php
@@ -35,7 +35,10 @@ if (!defined('IS_TEST') || IS_TEST !== true) {
         $smarty->assign('CURRENT_USER_EMAIL', $session['email']);
         $smarty->assign('CURRENT_USER_IS_EMAIL_VERIFIED', empty($session['user']) || $session['user']->verified);
         $smarty->assign('CURRENT_USER_IS_ADMIN', $session['is_admin']);
-        $smarty->assign('CURRENT_USER_IS_REVIEWER', Authorization::isQualityReviewer($session['identity']->identity_id));
+        $smarty->assign(
+            'CURRENT_USER_IS_REVIEWER',
+            Authorization::isQualityReviewer($session['identity'])
+        );
         $smarty->assign('CURRENT_USER_AUTH_TOKEN', $session['auth_token']);
         $smarty->assign('CURRENT_USER_GRAVATAR_URL_128', '<img src="https://secure.gravatar.com/avatar/' . md5($session['email']) . '?s=92">');
         $smarty->assign('CURRENT_USER_GRAVATAR_URL_16', '<img src="https://secure.gravatar.com/avatar/' . md5($session['email']) . '?s=16">');

--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -83,7 +83,7 @@ class ContestController extends Controller {
                 $contests = ContestsDAO::getContestsParticipating($r->identity->identity_id, $page, $page_size, $query);
             } elseif ($public) {
                 $contests = ContestsDAO::getRecentPublicContests($r->identity->identity_id, $page, $page_size, $query);
-            } elseif (Authorization::isSystemAdmin($r->identity->identity_id)) {
+            } elseif (Authorization::isSystemAdmin($r->identity)) {
                 // Get all contests
                 $contests = Cache::getFromCacheOrSet(
                     Cache::CONTESTS_LIST_SYSTEM_ADMIN,
@@ -151,7 +151,7 @@ class ContestController extends Controller {
         // Create array of relevant columns
         $contests = null;
         try {
-            if (Authorization::isSystemAdmin($r->identity->identity_id)) {
+            if (Authorization::isSystemAdmin($r->identity)) {
                 $contests = ContestsDAO::getAllContestsWithScoreboard(
                     $page,
                     $pageSize,
@@ -1603,7 +1603,7 @@ class ContestController extends Controller {
             (int)$problem->problem_id,
             (int)$contest->problemset_id
         ) > 0 &&
-            !Authorization::isSystemAdmin($identity->identity_id)) {
+            !Authorization::isSystemAdmin($identity)) {
             throw new ForbiddenAccessException('cannotRemoveProblemWithSubmissions');
         }
 
@@ -2822,7 +2822,7 @@ class ContestController extends Controller {
         try {
             if ($r['contest_alias'] == 'all-events') {
                 self::authenticateRequest($r);
-                if (Authorization::isSystemAdmin($r->identity->identity_id)) {
+                if (Authorization::isSystemAdmin($r->identity)) {
                     return [
                         'status' => 'ok',
                         'admin' => true
@@ -2856,7 +2856,7 @@ class ContestController extends Controller {
     public static function apiSetRecommended(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
+        if (!Authorization::isSystemAdmin($r->identity)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -174,7 +174,7 @@ class CourseController extends Controller {
         // Only curator can set public
         if (!is_null($r['public'])
             && $r['public'] == true
-            && !Authorization::canCreatePublicCourse($r->identity->identity_id)) {
+            && !Authorization::canCreatePublicCourse($r->identity)) {
             throw new ForbiddenAccessException();
         }
     }
@@ -806,7 +806,7 @@ class CourseController extends Controller {
             (int)$problem->problem_id,
             (int)$problemSet->problemset_id
         ) > 0 &&
-            !Authorization::isSystemAdmin($r->identity->identity_id)) {
+            !Authorization::isSystemAdmin($r->identity)) {
             throw new ForbiddenAccessException('cannotRemoveProblemWithSubmissions');
         }
         ProblemsetProblemsDAO::delete($problemsetProblem);
@@ -955,7 +955,7 @@ class CourseController extends Controller {
         // Courses the user is an admin for.
         $admin_courses = [];
         try {
-            if (Authorization::isSystemAdmin($r->identity->identity_id)) {
+            if (Authorization::isSystemAdmin($r->identity)) {
                 $admin_courses = CoursesDAO::getAll(
                     $page,
                     $pageSize,

--- a/frontend/server/controllers/GraderController.php
+++ b/frontend/server/controllers/GraderController.php
@@ -15,7 +15,7 @@ class GraderController extends Controller {
     private static function validateRequest(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
+        if (!Authorization::isSystemAdmin($r->identity)) {
             throw new ForbiddenAccessException();
         }
     }

--- a/frontend/server/controllers/IdentityController.php
+++ b/frontend/server/controllers/IdentityController.php
@@ -146,7 +146,7 @@ class IdentityController extends Controller {
      */
     private static function validateGroupOwnership(Request $r) {
         self::authenticateRequest($r);
-        if (!Authorization::isGroupIdentityCreator($r->identity->identity_id)) {
+        if (!Authorization::isGroupIdentityCreator($r->identity)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
         $group = GroupController::validateGroup($r['group_alias'], $r->identity);
@@ -280,7 +280,7 @@ class IdentityController extends Controller {
      */
     private static function validateUpdateRequest(Request $r) {
         self::authenticateRequest($r);
-        if (!Authorization::isGroupIdentityCreator($r->identity->identity_id)) {
+        if (!Authorization::isGroupIdentityCreator($r->identity)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
         GroupController::validateGroup($r['group_alias'], $r->identity);
@@ -386,7 +386,7 @@ class IdentityController extends Controller {
         // Do not leak plain emails in case the request is for a profile other than
         // the logged identity's one. Admins can see emails
         if (!is_null($r->identity)
-            && (Authorization::isSystemAdmin($r->identity->identity_id)
+            && (Authorization::isSystemAdmin($r->identity)
                 || $identity->identity_id == $r->identity->identity_id)
         ) {
             return $response;
@@ -394,7 +394,7 @@ class IdentityController extends Controller {
 
         // Mentors can see current coder of the month email.
         if (!is_null($r->identity)
-            && Authorization::canViewEmail($r->identity->identity_id)
+            && Authorization::canViewEmail($r->identity)
             && CoderOfTheMonthDAO::isLastCoderOfTheMonth($identity->username)
         ) {
             return $response;

--- a/frontend/server/controllers/InterviewController.php
+++ b/frontend/server/controllers/InterviewController.php
@@ -7,7 +7,8 @@ class InterviewController extends Controller {
         $is_required = !$is_update;
 
         // Only site-admins and interviewers can create interviews for now
-        if (!Authorization::isSystemAdmin($r->identity->identity_id) && !UsersDAO::IsUserInterviewer($r->user->user_id)) {
+        if (!Authorization::isSystemAdmin($r->identity) &&
+            !UsersDAO::IsUserInterviewer($r->user->user_id)) {
             throw new ForbiddenAccessException();
         }
 

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -93,7 +93,7 @@ class ProblemController extends Controller {
                   $r['problem']->visibility == ProblemController::VISIBILITY_PRIVATE_BANNED)
                     && array_key_exists('visibility', $r)
                     && $r['problem']->visibility != $r['visibility']
-                    && !Authorization::isQualityReviewer($r->identity->identity_id)) {
+                    && !Authorization::isQualityReviewer($r->identity)) {
                 throw new InvalidParameterException('qualityNominationProblemHasBeenBanned', 'visibility');
             }
 
@@ -2310,9 +2310,9 @@ class ProblemController extends Controller {
                 $authorUserId = intval($r->user->user_id);
             }
 
-            if (Authorization::isSystemAdmin($r->identity->identity_id) ||
+            if (Authorization::isSystemAdmin($r->identity) ||
                 Authorization::hasRole(
-                    $r->identity->identity_id,
+                    $r->identity,
                     Authorization::SYSTEM_ACL,
                     Authorization::REVIEWER_ROLE
                 )
@@ -2380,7 +2380,7 @@ class ProblemController extends Controller {
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
 
         try {
-            if (Authorization::isSystemAdmin($r->identity->identity_id)) {
+            if (Authorization::isSystemAdmin($r->identity)) {
                 $problems = ProblemsDAO::getAll(
                     $page,
                     $pageSize,
@@ -2634,9 +2634,7 @@ class ProblemController extends Controller {
         self::authenticateRequest($r, true /* requireMainUserIdentity */);
 
         return [
-            'isSysadmin' => Authorization::isSystemAdmin(
-                $r->identity->identity_id
-            ),
+            'isSysadmin' => Authorization::isSystemAdmin($r->identity),
         ];
     }
 

--- a/frontend/server/controllers/QualityNominationController.php
+++ b/frontend/server/controllers/QualityNominationController.php
@@ -401,7 +401,7 @@ class QualityNominationController extends Controller {
      * @throws ForbiddenAccessException
      */
     private static function validateMemberOfReviewerGroup(Request $r) {
-        if (!Authorization::isQualityReviewer($r->identity->identity_id)) {
+        if (!Authorization::isQualityReviewer($r->identity)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
     }
@@ -502,7 +502,7 @@ class QualityNominationController extends Controller {
         // The nominator can see the nomination, as well as all the members of
         // the reviewer group.
         $currentUserIsNominator = ($r->user->username == $response['nominator']['username']);
-        $currentUserReviewer = Authorization::isQualityReviewer($r->identity->identity_id);
+        $currentUserReviewer = Authorization::isQualityReviewer($r->identity);
         if (!$currentUserIsNominator && !$currentUserReviewer) {
             throw new ForbiddenAccessException('userNotAllowed');
         }

--- a/frontend/server/controllers/ResetController.php
+++ b/frontend/server/controllers/ResetController.php
@@ -60,7 +60,7 @@ class ResetController extends Controller {
     public static function apiGenerateToken(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
+        if (!Authorization::isSupportTeamMember($r->identity)) {
             throw new ForbiddenAccessException();
         }
 
@@ -142,7 +142,7 @@ class ResetController extends Controller {
         }
 
         // Support doesn't need wait to resest passwords
-        if (!is_null($r->identity) && Authorization::isSupportTeamMember($r->identity->identity_id)) {
+        if (!is_null($r->identity) && Authorization::isSupportTeamMember($r->identity)) {
             return;
         }
 

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -115,7 +115,7 @@ class RunController extends Controller {
                         (int)$r['problem']->problem_id,
                         (int)$r->identity->identity_id
                     )
-                            && !Authorization::isSystemAdmin($r->identity->identity_id)) {
+                            && !Authorization::isSystemAdmin($r->identity)) {
                             throw new NotAllowedToSubmitException('runWaitGap');
                     }
 
@@ -835,7 +835,7 @@ class RunController extends Controller {
             $r['rowcount'] = 100;
         }
 
-        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
+        if (!Authorization::isSystemAdmin($r->identity)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
 

--- a/frontend/server/controllers/SessionController.php
+++ b/frontend/server/controllers/SessionController.php
@@ -164,7 +164,7 @@ class SessionController extends Controller {
             'user' => $currentUser,
             'identity' => $currentIdentity,
             'auth_token' => $authToken,
-            'is_admin' => Authorization::isSystemAdmin($currentIdentity->identity_id),
+            'is_admin' => Authorization::isSystemAdmin($currentIdentity),
         ];
     }
 

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -450,7 +450,7 @@ class UserController extends Controller {
         if (isset($r['usernameOrEmail'])) {
             self::authenticateRequest($r);
 
-            if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
+            if (!Authorization::isSupportTeamMember($r->identity)) {
                 throw new ForbiddenAccessException();
             }
 
@@ -511,7 +511,7 @@ class UserController extends Controller {
     public static function apiMailingListBackfill(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
+        if (!Authorization::isSystemAdmin($r->identity)) {
             throw new ForbiddenAccessException();
         }
 
@@ -625,7 +625,7 @@ class UserController extends Controller {
 
         $response = [];
 
-        $is_system_admin = Authorization::isSystemAdmin($r->identity->identity_id);
+        $is_system_admin = Authorization::isSystemAdmin($r->identity);
         if ($r['contest_type'] == 'OMI') {
             if ($r->user->username != 'andreasantillana'
                 && !$is_system_admin
@@ -1146,7 +1146,7 @@ class UserController extends Controller {
         $response = IdentityController::getProfile($r, $r['identity'], $r['user'], boolval($r['omit_rank']));
         if ((is_null($r->identity) || $r->identity->username != $r['identity']->username)
             && (!is_null($r['user']) && $r['user']->is_private == 1)
-            && (is_null($r->identity) || !Authorization::isSystemAdmin($r->identity->identity_id))
+            && (is_null($r->identity) || !Authorization::isSystemAdmin($r->identity))
         ) {
             $response['problems'] = [];
             foreach ($response['userinfo'] as $k => $v) {
@@ -1177,7 +1177,7 @@ class UserController extends Controller {
     public static function apiStatusVerified(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
+        if (!Authorization::isSupportTeamMember($r->identity)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1206,7 +1206,7 @@ class UserController extends Controller {
     public static function apiExtraInformation(Request $r) {
         self::authenticateRequest($r);
 
-        if (!Authorization::isSupportTeamMember($r->identity->identity_id)) {
+        if (!Authorization::isSupportTeamMember($r->identity)) {
             throw new ForbiddenAccessException();
         }
 
@@ -1328,7 +1328,7 @@ class UserController extends Controller {
         self::authenticateRequest($r);
         $currentTimestamp = Time::get();
 
-        if (!Authorization::isMentor($r->identity->identity_id)) {
+        if (!Authorization::isMentor($r->identity)) {
             throw new ForbiddenAccessException('userNotAllowed');
         }
         if (!Authorization::canChooseCoder($currentTimestamp)) {
@@ -1598,7 +1598,8 @@ class UserController extends Controller {
         }
 
         if ((is_null($r->identity) || $r->identity->username != $identity->username)
-            && (is_null($r->identity) || (!is_null($r->identity) && !Authorization::isSystemAdmin($r->identity->identity_id)))
+            && (is_null($r->identity) || (!is_null($r->identity) &&
+                !Authorization::isSystemAdmin($r->identity)))
             && (!is_null($user) && $user->is_private == 1)
         ) {
             throw new ForbiddenAccessException('userProfileIsPrivate');
@@ -2154,7 +2155,8 @@ class UserController extends Controller {
     }
 
     private static function validateAddRemoveRole(Request $r) {
-        if (!Authorization::isSystemAdmin($r->identity->identity_id) && !OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT) {
+        if (!Authorization::isSystemAdmin($r->identity) &&
+            !OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT) {
             throw new ForbiddenAccessException();
         }
 
@@ -2298,7 +2300,7 @@ class UserController extends Controller {
     private static function validateAddRemoveExperiment(Request $r) {
         global $experiments;
 
-        if (!Authorization::isSystemAdmin($r->identity->identity_id)) {
+        if (!Authorization::isSystemAdmin($r->identity)) {
             throw new ForbiddenAccessException();
         }
 

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -111,9 +111,9 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
      * Mentor can see the last coder of the month email
      */
     public function testMentorCanSeeLastCoderOfTheMonthEmail() {
-        $mentor = UserFactory::createMentorIdentity();
+        [$mentorUser,] = UserFactory::createMentorIdentity();
 
-        $login = self::login($mentor);
+        $login = self::login($mentorUser);
         $response = UserController::apiCoderOfTheMonthList(new Request([
             'auth_token' => $login->auth_token
         ]));
@@ -157,7 +157,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
      * already has a coder of the month selected
      */
     public function testMentorSelectsUserAsCoderOfTheMonth() {
-        $mentor = UserFactory::createMentorIdentity();
+        [$mentorUser,] = UserFactory::createMentorIdentity();
 
         // Setting time to the 15th of next month.
         $runCreationDate = new DateTimeImmutable(date('Y-m-d', Time::get()));
@@ -181,7 +181,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         Time::setTimeForTesting(strtotime($firstDayOfNextMonth->format('Y-m-d')));
 
         // Selecting one user as coder of the month
-        $login = self::login($mentor);
+        $login = self::login($mentorUser);
 
         // Call api. This should fail.
         try {
@@ -225,10 +225,10 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         $this->createRuns(null, null, 3);
         $this->createRuns(null, null, 2);
 
-        $mentor = UserFactory::createMentorIdentity();
+        [$mentorUser, $mentorIdentity] = UserFactory::createMentorIdentity();
 
-        $login = self::login($mentor);
-        $this->assertTrue(Authorization::isMentor($mentor->main_identity_id));
+        $login = self::login($mentorUser);
+        $this->assertTrue(Authorization::isMentor($mentorIdentity));
 
         // Testing with an intermediate day of the month
         $timestampTest = Time::get();

--- a/frontend/tests/controllers/IdentityCreateTest.php
+++ b/frontend/tests/controllers/IdentityCreateTest.php
@@ -14,14 +14,13 @@ class IdentityCreateTest extends OmegaupTestCase {
     public function testIdentityHasContestOrganizerRole() {
         $creator = UserFactory::createGroupIdentityCreator();
         $creatorIdentity = IdentitiesDAO::getByPK($creator->main_identity_id);
-        $mentor = UserFactory::createMentorIdentity();
-        $mentorIdentity = IdentitiesDAO::getByPK($mentor->main_identity_id);
+        [, $mentorIdentity] = UserFactory::createMentorIdentity();
 
-        $isCreatorMember = Authorization::isGroupIdentityCreator($creatorIdentity->identity_id);
+        $isCreatorMember = Authorization::isGroupIdentityCreator($creatorIdentity);
         // Asserting that user belongs to the  identity creator group
         $this->assertTrue($isCreatorMember);
 
-        $isCreatorMember = Authorization::isGroupIdentityCreator($mentorIdentity->identity_id);
+        $isCreatorMember = Authorization::isGroupIdentityCreator($mentorIdentity);
         // Asserting that user doesn't belong to the identity creator group
         $this->assertFalse($isCreatorMember);
     }

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -113,9 +113,9 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * Logs in a user and returns the auth_token
+     * Logs in an identity and returns the auth_token
      *
-     * @param Users $user to be logged in
+     * @param $identity to be logged in
      *
      * @return string auth_token
      */
@@ -126,7 +126,7 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
         $oldCookieSetting = SessionController::$setCookieOnRegisterSession;
         SessionController::$setCookieOnRegisterSession = false;
 
-        // Inflate request with user data
+        // Inflate request with identity data
         $r = new Request([
             'usernameOrEmail' => $identity->username,
             'password' => $identity->password,

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -113,23 +113,23 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * Logs in a identity an returns the auth_token
+     * Logs in a user and returns the auth_token
      *
-     * @param $identity the identity to be logged in
+     * @param Users $user to be logged in
      *
      * @return string auth_token
      */
-    public static function login($identity) {
+    public static function login($user) : ScopedLoginToken {
         UserController::$sendEmailOnVerify = false;
 
         // Deactivate cookie setting
         $oldCookieSetting = SessionController::$setCookieOnRegisterSession;
         SessionController::$setCookieOnRegisterSession = false;
 
-        // Inflate request with identity data
+        // Inflate request with user data
         $r = new Request([
-            'usernameOrEmail' => $identity->username,
-            'password' => $identity->password,
+            'usernameOrEmail' => $user->username,
+            'password' => $user->password,
         ]);
 
         // Call the API

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -119,7 +119,7 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
      *
      * @return string auth_token
      */
-    public static function login($user) : ScopedLoginToken {
+    public static function login($identity) : ScopedLoginToken {
         UserController::$sendEmailOnVerify = false;
 
         // Deactivate cookie setting
@@ -128,8 +128,8 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
 
         // Inflate request with user data
         $r = new Request([
-            'usernameOrEmail' => $user->username,
-            'password' => $user->password,
+            'usernameOrEmail' => $identity->username,
+            'password' => $identity->password,
         ]);
 
         // Call the API

--- a/frontend/tests/controllers/UserSupportTest.php
+++ b/frontend/tests/controllers/UserSupportTest.php
@@ -10,18 +10,14 @@ class UserSupportTest extends OmegaupTestCase {
      * Basic test for users with support role
      */
     public function testUserHasSupportRole() {
-        $support = UserFactory::createSupportUser();
-        $support_identity = IdentitiesDAO::getByPK($support->main_identity_id);
-        $mentor = UserFactory::createMentorIdentity();
-        $mentor_identity = IdentitiesDAO::getByPK($mentor->main_identity_id);
+        [, $supportIdentity] = UserFactory::createSupportUser();
+        [, $mentorIdentity] = UserFactory::createMentorIdentity();
 
-        $is_support_member = Authorization::isSupportTeamMember($support_identity->identity_id);
         // Asserting that user belongs to the support group
-        $this->assertEquals(1, $is_support_member);
+        $this->assertTrue(Authorization::isSupportTeamMember($supportIdentity));
 
-        $is_support_member = Authorization::isSupportTeamMember($mentor_identity->identity_id);
         // Asserting that user doesn't belong to the support group
-        $this->assertNotEquals(1, $is_support_member);
+        $this->assertFalse(Authorization::isSupportTeamMember($mentorIdentity));
     }
 
     /**
@@ -29,7 +25,7 @@ class UserSupportTest extends OmegaupTestCase {
      */
     public function testVerifyUser() {
         // Support team member will verify $user
-        $support = UserFactory::createSupportUser();
+        [$supportUser,] = UserFactory::createSupportUser();
 
         // Creates a user
         $email = Utils::CreateRandomString().'@mail.com';
@@ -39,7 +35,7 @@ class UserSupportTest extends OmegaupTestCase {
         ]));
 
         // Call api using support team member
-        $supportLogin = self::login($support);
+        $supportLogin = self::login($supportUser);
 
         $response = UserController::apiExtraInformation(new Request([
             'auth_token' => $supportLogin->auth_token,
@@ -69,14 +65,14 @@ class UserSupportTest extends OmegaupTestCase {
      */
     public function testUserGeneratesValidToken() {
         // Support team member will verify $user
-        $support = UserFactory::createSupportUser();
+        [$supportUser,] = UserFactory::createSupportUser();
 
         // Creates a user
         $email = Utils::CreateRandomString().'@mail.com';
         $user = UserFactory::createUser(new UserParams(['email' => $email]));
 
         // Call api using support team member
-        $supportLogin = self::login($support);
+        $supportLogin = self::login($supportUser);
 
         // Support tries to generate token without a request
         $response = UserController::apiExtraInformation(new Request([
@@ -119,14 +115,14 @@ class UserSupportTest extends OmegaupTestCase {
      */
     public function testUserGeneratesExpiredToken() {
         // Support team member will verify $user
-        $support = UserFactory::createSupportUser();
+        [$supportUser, ] = UserFactory::createSupportUser();
 
         // Creates a user
         $email = Utils::CreateRandomString().'@mail.com';
         $user = UserFactory::createUser(new UserParams(['email' => $email]));
 
         // Call api using support team member
-        $supportLogin = self::login($support);
+        $supportLogin = self::login($supportUser);
 
         // time travel
         $reset_sent_at =

--- a/frontend/tests/factories/UserFactory.php
+++ b/frontend/tests/factories/UserFactory.php
@@ -190,13 +190,13 @@ class UserFactory {
      * @param string $email
      * @return Identity
      */
-    public static function createMentorIdentity($params = null) {
+    public static function createMentorIdentity($params = null) : array {
         $user = self::createUser($params);
         $identity = IdentitiesDAO::getByPK($user->main_identity_id);
 
         self::addMentorRole($identity);
 
-        return $user;
+        return [$user, $identity];
     }
 
     /**
@@ -207,13 +207,13 @@ class UserFactory {
      * @param string $email
      * @return User
      */
-    public static function createSupportUser($params = null) {
+    public static function createSupportUser($params = null) : array {
         $user = self::createUser($params);
         $identity = IdentitiesDAO::getByPK($user->main_identity_id);
 
         self::addSupportRole($identity);
 
-        return $user;
+        return [$user, $identity];
     }
 
     /**
@@ -224,7 +224,7 @@ class UserFactory {
      * @param string $email
      * @return User
      */
-    public static function createGroupIdentityCreator($params = null) {
+    public static function createGroupIdentityCreator($params = null) : Users {
         $user = self::createUser($params);
         $identity = IdentitiesDAO::getByPK($user->main_identity_id);
 

--- a/frontend/www/admin/support.php
+++ b/frontend/www/admin/support.php
@@ -4,7 +4,7 @@ require_once('../../server/bootstrap_smarty.php');
 
 UITools::redirectToLoginIfNotLoggedIn();
 
-if (!Authorization::isSupportTeamMember($session['identity']->identity_id)) {
+if (!Authorization::isSupportTeamMember($session['identity'])) {
     header('HTTP/1.1 404 Not found');
     die();
 }

--- a/frontend/www/coderofthemonth.php
+++ b/frontend/www/coderofthemonth.php
@@ -19,7 +19,7 @@ try {
         'auth_token' => $session['auth_token'],
         'date' => $currentDate,
     ]));
-    $isMentor = $session['valid'] && Authorization::isMentor($session['identity']->identity_id);
+    $isMentor = $session['valid'] && Authorization::isMentor($session['identity']);
 
     $response = [
         'codersOfCurrentMonth' => $responseCodersOfTheMonth['coders'],

--- a/frontend/www/groupedit.php
+++ b/frontend/www/groupedit.php
@@ -10,7 +10,7 @@ if (is_null($session['identity'])) {
 }
 
 $is_organizer = $experiments->isEnabled(Experiments::IDENTITIES) &&
-    Authorization::canCreateGroupIdentities($session['identity']->identity_id);
+    Authorization::canCreateGroupIdentities($session['identity']);
 $smarty->assign('IS_ORGANIZER', $is_organizer);
 $smarty->assign('payload', [
     'countries' => CountriesDAO::getAll(null, null, 'name'),


### PR DESCRIPTION
# Descripción

En el PR se incluyen los siguientes cambios:

- Todos los métodos reciben Identities como parámetro  en vez de identity_id.
- Se tipan todos los métodos

# Checklist:

- [X] El código sigue la [guía de  estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
