### PR TITLE
Arreglando las transacciones antes de llamar al Grader

### DIFF
--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -307,12 +307,19 @@ class RunController extends Controller {
         ]);
 
         try {
-            // Push run into DB
-            SubmissionsDAO::create($submission);
-            $run->submission_id = $submission->submission_id;
-            RunsDAO::create($run);
-            $submission->current_run_id = $run->run_id;
-            SubmissionsDAO::update($submission);
+            try {
+                DAO::transBegin();
+                // Push run into DB
+                SubmissionsDAO::create($submission);
+                $run->submission_id = $submission->submission_id;
+                RunsDAO::create($run);
+                $submission->current_run_id = $run->run_id;
+                SubmissionsDAO::update($submission);
+                DAO::transEnd();
+            } catch (Exception $e) {
+                DAO::transRollback();
+                throw $e;
+            }
 
             // Call Grader
             try {
@@ -477,8 +484,15 @@ class RunController extends Controller {
         self::$log->info('Run being rejudged!!');
 
         // Reset fields.
-        $r['run']->status = 'new';
-        RunsDAO::update($r['run']);
+        try {
+            DAO::transBegin();
+            $r['run']->status = 'new';
+            RunsDAO::update($r['run']);
+            DAO::transEnd();
+        } catch (Exception $e) {
+            DAO::transRollback();
+            throw $e;
+        }
 
         try {
             Grader::getInstance()->rejudge([$r['run']], $r['debug'] || false);


### PR DESCRIPTION
Este cambio hace que se cree (y haga commit de) una transacción antes de
interactuar con el Grader. Esto causa que los cambios del frontend sean
visibles en la base de datos antes de llamar al Grader.