### PR TITLE
Abandonando la interfaz de ADOdb para MySQLConnection

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -195,14 +195,14 @@ $log = Logger::getLogger('bootstrap');
 require_once('libs/Database.php');
 
 global $conn;
-$conn = null;
 
 try {
-    $conn = ADONewConnection(OMEGAUP_DB_DRIVER);
-    $conn->debug = OMEGAUP_DB_DEBUG;
-    array_push($conn->optionFlags, [MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true]);
-    $conn->SetFetchMode(ADODB_FETCH_ASSOC);
-    $conn->PConnect(OMEGAUP_DB_HOST, OMEGAUP_DB_USER, OMEGAUP_DB_PASS, OMEGAUP_DB_NAME);
+    $conn = new MySQLConnection(
+        OMEGAUP_DB_HOST,
+        OMEGAUP_DB_USER,
+        OMEGAUP_DB_PASS,
+        OMEGAUP_DB_NAME
+    );
 } catch (Exception $databaseConectionException) {
     $log->error($databaseConectionException);
 
@@ -217,8 +217,6 @@ try {
         'errorcode' => 1,
     ]));
 }
-$conn->SetCharSet('utf8');
-$conn->EXECUTE('SET NAMES \'utf8\';');
 
 $session = SessionController::apiCurrentSession(new Request($_REQUEST))['session'];
 $experiments = new Experiments(

--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -13,6 +13,7 @@ try_define('OMEGAUP_ROOT', '/opt/omegaup/frontend');
 try_define('OMEGAUP_LOCKDOWN_DOMAIN', 'localhost-lockdown');
 try_define('OMEGAUP_COOKIE_DOMAIN', null);
 try_define('OMEGAUP_AUTH_TOKEN_COOKIE_NAME', 'ouat');
+try_define('OMEGAUP_MD5_SALT', 'omegaup');
 try_define('OMEGAUP_URL', 'http://localhost');
 try_define('OMEGAUP_ENVIRONMENT', 'production');
 try_define('OMEGAUP_MAINTENANCE', null);
@@ -25,15 +26,6 @@ try_define('OMEGAUP_DB_USER', 'omegaup');
 try_define('OMEGAUP_DB_PASS', '');
 try_define('OMEGAUP_DB_HOST', 'localhost');
 try_define('OMEGAUP_DB_NAME', 'omegaup');
-try_define('OMEGAUP_DB_DRIVER', 'mysqli');
-try_define('OMEGAUP_DB_DEBUG', false);
-try_define('OMEGAUP_MD5_SALT', 'omegaup');
-
-try_define('OMEGAUP_SLAVE_DB_USER', 'omegaup');
-try_define('OMEGAUP_SLAVE_DB_PASS', '');
-try_define('OMEGAUP_SLAVE_DB_HOST', '8.8.8.8');
-try_define('OMEGAUP_SLAVE_DB_NAME', 'omegaup');
-try_define('OMEGAUP_SLAVE_DB_DRIVER', 'mysqlt');
 
 # ####################################
 # EXPERIMENTS


### PR DESCRIPTION
Este cambio hace que MySQLConnection ya no tenga que tener
compatibilidad completa con la interfaz de ADOdb. Poco a poco se irá
transformando en algo independiente.