### PR TITLE
Arreglando el tipo de school_id en la creación/actualización de cursos

### DIFF
--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -155,6 +155,7 @@ class CourseController extends Controller {
         );
 
         $r->ensureBool('public', false /*isRequired*/);
+        $r->ensureInt('school_id', null, null, false /*isRequired*/);
 
         if (is_null($r['school_id'])) {
             $school = null;


### PR DESCRIPTION
Resulta que si se elige una escuela ya existente al intentar
crear/actualizar un curso, el ID de esa escuela se pasa como cadena y
eso arroja un error de tipos.