### PR TITLE
Dejando de usar gmtime()/strtotime() para la base de datos

### DIFF
--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -224,8 +224,9 @@ class CourseController extends Controller {
         self::authenticateRequest($r, true /* requireMainUserIdentity */);
         self::validateClone($r);
         $originalCourse = self::validateCourseExists($r['course_alias']);
+        $originalCourse->toUnixTime();
 
-        $offset = round($r['start_time']) - strtotime($originalCourse->start_time);
+        $offset = round($r['start_time']) - $originalCourse->start_time;
 
         DAO::transBegin();
 
@@ -236,8 +237,8 @@ class CourseController extends Controller {
                 'description' => $originalCourse->description,
                 'alias' => $r['alias'],
                 'school_id' => $originalCourse->school_id,
-                'start_time' => gmdate('Y-m-d H:i:s', $r['start_time']),
-                'finish_time' => gmdate('Y-m-d H:i:s', strtotime($originalCourse->finish_time) + $offset),
+                'start_time' => $r['start_time'],
+                'finish_time' => $originalCourse->finish_time + $offset,
                 'public' => 0,
                 'show_scoreboard' => $originalCourse->show_scoreboard,
                 'needs_basic_information' => $originalCourse->needs_basic_information,
@@ -256,8 +257,8 @@ class CourseController extends Controller {
                     'alias' => $assignmentProblems['assignment_alias'],
                     'publish_time_delay' => $assignmentProblems['publish_time_delay'],
                     'assignment_type' => $assignmentProblems['assignment_type'],
-                    'start_time' => gmdate('Y-m-d H:i:s', strtotime($assignmentProblems['start_time']) + $offset),
-                    'finish_time' => gmdate('Y-m-d H:i:s', strtotime($assignmentProblems['finish_time']) + $offset),
+                    'start_time' => $assignmentProblems['start_time'] + $offset,
+                    'finish_time' => $assignmentProblems['finish_time'] + $offset,
                 ]));
 
                 foreach ($assignmentProblems['problems'] as $problem) {
@@ -301,8 +302,8 @@ class CourseController extends Controller {
             'description' => $r['description'],
             'alias' => $r['alias'],
             'school_id' => $r['school_id'],
-            'start_time' => gmdate('Y-m-d H:i:s', $r['start_time']),
-            'finish_time' => gmdate('Y-m-d H:i:s', $r['finish_time']),
+            'start_time' => $r['start_time'],
+            'finish_time' => $r['finish_time'],
             'public' => $r['public'] ?: false,
             'show_scoreboard' => $r['show_scoreboard'],
             'needs_basic_information' => $r['needs_basic_information'],
@@ -474,8 +475,8 @@ class CourseController extends Controller {
             'alias' => $r['alias'],
             'publish_time_delay' => $r['publish_time_delay'],
             'assignment_type' => $r['assignment_type'],
-            'start_time' => gmdate('Y-m-d H:i:s', $r['start_time']),
-            'finish_time' => gmdate('Y-m-d H:i:s', $r['finish_time']),
+            'start_time' => $r['start_time'],
+            'finish_time' => $r['finish_time'],
         ]));
 
         return ['status' => 'ok'];
@@ -543,12 +544,8 @@ class CourseController extends Controller {
         $valueProperties = [
             'name',
             'description',
-            'start_time' => ['transform' => function ($value) {
-                return gmdate('Y-m-d H:i:s', $value);
-            }],
-            'finish_time' => ['transform' => function ($value) {
-                return gmdate('Y-m-d H:i:s', $value);
-            }],
+            'start_time',
+            'finish_time',
             'assignment_type',
         ];
         self::updateValueProperties($r, $assignment, $valueProperties);
@@ -1888,12 +1885,8 @@ class CourseController extends Controller {
             'alias',
             'name',
             'description',
-            'start_time' => ['transform' => function ($value) {
-                return gmdate('Y-m-d H:i:s', $value);
-            }],
-            'finish_time' => ['transform' => function ($value) {
-                return gmdate('Y-m-d H:i:s', $value);
-            }],
+            'start_time',
+            'finish_time',
             'school_id',
             'show_scoreboard' => ['transform' => function ($value) {
                 return $value == 'true' ? 1 : 0;

--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -255,7 +255,7 @@ class GroupController extends Controller {
             'name' => $r['name'],
             'description' =>$r['description'],
             'alias' => $r['alias'],
-            'create_time' => gmdate('Y-m-d H:i:s', Time::get())
+            'create_time' => Time::get(),
         ]));
 
         self::$log->info("New scoreboard created {$r['alias']}");

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1011,8 +1011,12 @@ class ProblemController extends Controller {
             if (!Authorization::isAdmin($r->identity, $problemset['problemset'])) {
                 // If the contest is private, verify that our user is invited
                 if (!empty($problemset['contest'])) {
+                    $problemset['contest']->toUnixTime();
                     if (!ContestController::isPublic($problemset['contest']->admission_mode)) {
-                        if (is_null(ProblemsetIdentitiesDAO::getByPK($r->identity->identity_id, $problemset['problemset']->problemset_id))) {
+                        if (is_null(ProblemsetIdentitiesDAO::getByPK(
+                            $r->identity->identity_id,
+                            $problemset['problemset']->problemset_id
+                        ))) {
                             throw new ForbiddenAccessException();
                         }
                     }
@@ -1024,8 +1028,7 @@ class ProblemController extends Controller {
                     if (!Authorization::canSubmitToProblemset(
                         $r->identity,
                         $problemset['problemset']
-                    )
-                    ) {
+                    )) {
                         throw new ForbiddenAccessException();
                     }
                     // TODO: Check start times.
@@ -1424,7 +1427,7 @@ class ProblemController extends Controller {
                 'name' => is_null($problemsetter->name) ?
                           $problemsetter->username :
                           $problemsetter->name,
-                'creation_date' => strtotime($response['creation_date']),
+                'creation_date' => DAO::fromMySQLTimestamp($response['creation_date']),
             ];
         } else {
             unset($response['source']);
@@ -1478,7 +1481,7 @@ class ProblemController extends Controller {
                 ProblemsetProblemOpenedDAO::create(new ProblemsetProblemOpened([
                     'problemset_id' => $problemset->problemset_id,
                     'problem_id' => $problem->problem_id,
-                    'open_time' => gmdate('Y-m-d H:i:s', Time::get()),
+                    'open_time' => Time::get(),
                     'identity_id' => $r->identity->identity_id
                 ]));
             }

--- a/frontend/server/controllers/ResetController.php
+++ b/frontend/server/controllers/ResetController.php
@@ -136,6 +136,7 @@ class ResetController extends Controller {
         if (is_null($user)) {
             throw new InvalidParameterException('invalidUser');
         }
+        $user->toUnixTime();
 
         if (!$user->verified) {
             throw new InvalidParameterException('unverifiedUser');
@@ -146,7 +147,7 @@ class ResetController extends Controller {
             return;
         }
 
-        $seconds = Time::get() - strtotime($user->reset_sent_at);
+        $seconds = Time::get() - $user->reset_sent_at;
         if ($seconds < PASSWORD_RESET_MIN_WAIT) {
             throw new InvalidParameterException('passwordResetMinWait');
         }
@@ -163,6 +164,7 @@ class ResetController extends Controller {
             || is_null($password_confirmation)) {
             throw new InvalidParameterException('invalidParameters');
         }
+        $user->toUnixtime();
 
         if ($user->reset_digest !== hash('sha1', $reset_token)) {
             throw new InvalidParameterException('invalidResetToken');
@@ -174,7 +176,7 @@ class ResetController extends Controller {
 
         SecurityTools::testStrongPassword($password);
 
-        $seconds = Time::get() - strtotime($user->reset_sent_at);
+        $seconds = Time::get() - $user->reset_sent_at;
         if ($seconds > PASSWORD_RESET_TIMEOUT) {
             throw new InvalidParameterException('passwordResetResetExpired');
         }

--- a/frontend/server/libs/Broadcaster.php
+++ b/frontend/server/libs/Broadcaster.php
@@ -10,18 +10,18 @@ class Broadcaster {
         $this->log = Logger::getLogger('broadcaster');
     }
 
-    public function broadcastClarification(Request $r, $time) {
+    public function broadcastClarification(Request $r, Clarifications $clarification) {
         try {
             $message = json_encode([
                 'message' => '/clarification/update/',
                 'clarification' => [
-                    'clarification_id' => (int)$r['clarification']->clarification_id,
+                    'clarification_id' => (int)$clarification->clarification_id,
                     'problem_alias' => $r['problem']->alias,
                     'author' => $r['user']->username,
-                    'message' => $r['clarification']->message,
-                    'answer' => $r['clarification']->answer,
-                    'time' => $time,
-                    'public' => $r['clarification']->public != '0'
+                    'message' => $clarification->message,
+                    'answer' => $clarification->answer,
+                    'time' => $clarification->time,
+                    'public' => boolval($clarification->public),
                 ]
             ]);
 
@@ -31,15 +31,15 @@ class Broadcaster {
                 is_null($r['contest']) ? null : (int)$r['contest']->problemset_id,
                 is_null($r['problem']) ? null : $r['problem']->alias,
                 $message,
-                $r['clarification']->public != '0',
+                boolval($clarification->public),
                 $r['user']->username,
-                (int)$r['clarification']->author_id,
+                (int)$clarification->author_id,
                 false  // user_only
             );
         } catch (Exception $e) {
-            $this->log->error('Failed to send to broadcaster ' . $e->getMessage());
+            $this->log->error('Failed to send to broadcaster', $e);
         }
-        $this->sendClarificationEmail($r, $time);
+        $this->sendClarificationEmail($r, $clarification->time);
     }
 
     protected function sendClarificationEmail(Request $r) {

--- a/frontend/server/libs/dao/Contests.dao.php
+++ b/frontend/server/libs/dao/Contests.dao.php
@@ -226,11 +226,11 @@ class ContestsDAO extends ContestsDAOBase {
     }
 
     public static function hasStarted(Contests $contest) {
-        return Time::get() >= strtotime($contest->start_time);
+        return Time::get() >= $contest->start_time;
     }
 
     public static function hasFinished(Contests $contest) {
-        return Time::get() >= strtotime($contest->finish_time);
+        return Time::get() >= $contest->finish_time;
     }
 
     public static function getContestsParticipated($identity_id) {

--- a/frontend/server/libs/dao/Courses.dao.php
+++ b/frontend/server/libs/dao/Courses.dao.php
@@ -64,8 +64,8 @@ class CoursesDAO extends CoursesDAOBase {
         foreach ($rs as $row) {
             unset($row['assignment_id']);
             unset($row['course_id']);
-            $row['start_time'] =  strtotime($row['start_time']);
-            $row['finish_time'] = strtotime($row['finish_time']);
+            $row['start_time'] =  DAO::fromMySQLTimestamp($row['start_time']);
+            $row['finish_time'] = DAO::fromMySQLTimestamp($row['finish_time']);
             array_push($ar, $row);
         }
 

--- a/frontend/server/libs/dao/Problemset_Identities.dao.php
+++ b/frontend/server/libs/dao/Problemset_Identities.dao.php
@@ -43,7 +43,7 @@ class ProblemsetIdentitiesDAO extends ProblemsetIdentitiesDAOBase {
         }
         if (is_null($problemsetIdentity->access_time)) {
             // If its set to default time, update it
-            $problemsetIdentity->access_time = gmdate('Y-m-d H:i:s', $currentTime);
+            $problemsetIdentity->access_time = $currentTime;
             $finishTime = $container->finish_time;
             if (!empty($container->window_length)) {
                 $finishTime = min(
@@ -51,7 +51,7 @@ class ProblemsetIdentitiesDAO extends ProblemsetIdentitiesDAOBase {
                     $finishTime
                 );
             }
-            $problemsetIdentity->end_time = gmdate('Y-m-d H:i:s', $finishTime);
+            $problemsetIdentity->end_time = $finishTime;
             $problemsetIdentity->share_user_information = $shareUserInformation;
             ProblemsetIdentitiesDAO::replace($problemsetIdentity);
         }

--- a/frontend/server/libs/dao/Problemset_Problems.dao.php
+++ b/frontend/server/libs/dao/Problemset_Problems.dao.php
@@ -37,8 +37,10 @@ class ProblemsetProblemsDAO extends ProblemsetProblemsDAOBase {
         // Build SQL statement
         $sql = '
             SELECT
-                a.name, a.alias AS assignment_alias,a.description, a.start_time,
-                a.finish_time, a.assignment_type, p.alias AS problem_alias,
+                a.name, a.alias AS assignment_alias,a.description,
+                UNIX_TIMESTAMP(a.start_time) AS start_time,
+                UNIX_TIMESTAMP(a.finish_time) AS finish_time,
+                a.assignment_type, p.alias AS problem_alias,
                 a.publish_time_delay, p.problem_id
             FROM
                 Problems p

--- a/frontend/server/libs/dao/Problemsets.dao.php
+++ b/frontend/server/libs/dao/Problemsets.dao.php
@@ -41,13 +41,13 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
      */
     public static function isLateSubmission($container) {
         return isset($container->finish_time) &&
-               (Time::get() > strtotime($container->finish_time));
+               (Time::get() > $container->finish_time);
     }
 
     public static function insideSubmissionWindow($container, $identity_id) {
         if (isset($container->finish_time)) {
-            if (Time::get() > strtotime($container->finish_time) ||
-                Time::get() < strtotime($container->start_time)) {
+            if (Time::get() > $container->finish_time ||
+                Time::get() < $container->start_time) {
                 return false;
             }
         }
@@ -56,13 +56,13 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
             return true;
         }
 
-        $problemset_identity = ProblemsetIdentitiesDAO::getByPK(
+        $problemsetIdentity = ProblemsetIdentitiesDAO::getByPK(
             $identity_id,
             $container->problemset_id
         );
-        $first_access_time = $problemset_identity->access_time;
+        $problemsetIdentity->toUnixTime();
 
-        return Time::get() <= strtotime($first_access_time) + $container->window_length * 60;
+        return Time::get() <= $problemsetIdentity->access_time + $container->window_length * 60;
     }
 
     public static function getWithTypeByPK($problemset_id) {

--- a/frontend/server/libs/dao/Schools.dao.php
+++ b/frontend/server/libs/dao/Schools.dao.php
@@ -48,13 +48,18 @@ class SchoolsDAO extends SchoolsDAOBase {
     /**
      * Returns rank of schools by # of distinct users with at least one AC and # of distinct problems solved.
      *
-     * @param  string (DateTime) $startDate
-     * @param  string (DateTime) $finishDate
-     * @param  int   $offset
-     * @param  int   $rowcount
+     * @param  int $startTime
+     * @param  int $finishTime
+     * @param  int $offset
+     * @param  int $rowcount
      * @return array
      */
-    public static function getRankByUsersAndProblemsWithAC($startDate, $finishDate, $offset, $rowcount) {
+    public static function getRankByUsersAndProblemsWithAC(
+        int $startDate,
+        int $finishDate,
+        int $offset,
+        int $rowcount
+    ) {
         global  $conn;
 
         $sql = '
@@ -75,7 +80,7 @@ class SchoolsDAO extends SchoolsDAOBase {
               Problems p ON p.problem_id = su.problem_id
             WHERE
               r.verdict = "AC" AND p.visibility >= 1 AND
-              su.time BETWEEN CAST(? AS DATETIME) AND CAST(? AS DATETIME)
+              su.time BETWEEN CAST(FROM_UNIXTIME(?) AS DATETIME) AND CAST(FROM_UNIXTIME(?) AS DATETIME)
             GROUP BY
               s.school_id
             ORDER BY

--- a/frontend/tests/controllers/LoginTest.php
+++ b/frontend/tests/controllers/LoginTest.php
@@ -205,7 +205,8 @@ class LoginTest extends OmegaupTestCase {
 
         // Expire token manually
         $authToken = AuthTokensDAO::getByPK($login->auth_token);
-        $authToken->create_time = date('Y-m-d H:i:s', strtotime($authToken->create_time . ' - 9 hour'));
+        $authToken->toUnixTime();
+        $authToken->create_time -= 9 * 3600;  // 9 hours
         AuthTokensDAO::update($authToken);
 
         $login2 = self::login($user);

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -147,8 +147,9 @@ class RunCreateTest extends OmegaupTestCase {
         $this->assertEquals(ip2long('127.0.0.1'), $log->ip);
 
         if (!is_null($contest)) {
+            $contest->toUnixTime();
             $this->assertEquals(
-                (Utils::GetPhpUnixTimestamp() - intval(strtotime($contest->start_time))) / 60,
+                (Utils::GetPhpUnixTimestamp() - $contest->start_time) / 60,
                 $run->penalty,
                 '',
                 0.5

--- a/frontend/tests/factories/ContestsFactory.php
+++ b/frontend/tests/factories/ContestsFactory.php
@@ -320,10 +320,13 @@ class ContestsFactory {
         ContestController::apiAddGroupAdmin($r);
     }
 
-    public static function forcePublic($contestData, $last_updated = null) {
+    public static function forcePublic(
+        array $contestData,
+        ?int $lastUpdated = null
+    ) {
         $contest = ContestsDAO::getByAlias($contestData['request']['alias']);
         $contest->admission_mode = 'public';
-        $contest->last_updated = gmdate('Y-m-d H:i:s', $last_updated);
+        $contest->last_updated = $lastUpdated;
         ContestsDAO::update($contest);
     }
 


### PR DESCRIPTION
Este cambio elimina las llamadas a gmtime()/strtotime() en los lugares
asociados con la base de datos. En vez, se prefiere usar
DAO::toUnixTime().