### PR TITLE
Eliminando DAO::toUnixTime()

### DIFF
--- a/frontend/server/controllers/ContestController.php
+++ b/frontend/server/controllers/ContestController.php
@@ -448,7 +448,6 @@ class ContestController extends Controller {
      */
     public static function validateDetails(Request $r) : Array {
         [$contest, $problemset] = self::validateBasicDetails($r['contest_alias']);
-        $contest->toUnixTime();
 
         $contestAdmin = false;
         $contestAlias = '';
@@ -578,7 +577,6 @@ class ContestController extends Controller {
         $r->ensureBool('share_user_information', false);
         DAO::transBegin();
         try {
-            $response['contest']->toUnixTime();
             ProblemsetIdentitiesDAO::checkAndSaveFirstTimeAccess(
                 $r->identity,
                 $response['contest'],
@@ -727,12 +725,10 @@ class ContestController extends Controller {
             // Adding timer info separately as it depends on the current user and we don't
             // want this to get generally cached for everybody
             // Save the time of the first access
-            $response['contest']->toUnixTime();
             $problemsetUser = ProblemsetIdentitiesDAO::checkAndSaveFirstTimeAccess(
                 $r->identity,
                 $response['contest']
             );
-            $problemsetUser->toUnixTime();
 
             // Add time left to response
             if ($response['contest']->window_length === null) {
@@ -841,7 +837,6 @@ class ContestController extends Controller {
             $r['contest_alias'],
             $r->identity
         );
-        $originalContest->toUnixTime();
 
         $length = $originalContest->finish_time - $originalContest->start_time;
 
@@ -915,7 +910,6 @@ class ContestController extends Controller {
         if (is_null($originalContest)) {
             throw new NotFoundException('contestNotFound');
         }
-        $originalContest->toUnixTime();
 
         if ($originalContest->finish_time > Time::get()) {
             throw new ForbiddenAccessException('originalContestHasNotEnded');

--- a/frontend/server/controllers/CourseController.php
+++ b/frontend/server/controllers/CourseController.php
@@ -111,7 +111,6 @@ class CourseController extends Controller {
         // in case of update, parameters can be optional.
         $originalCourse = self::validateCourseExists($courseAlias);
 
-        $originalCourse->toUnixTime();
         if (is_null($r['start_time'])) {
             $r['start_time'] = $originalCourse->start_time;
         }
@@ -224,7 +223,6 @@ class CourseController extends Controller {
         self::authenticateRequest($r, true /* requireMainUserIdentity */);
         self::validateClone($r);
         $originalCourse = self::validateCourseExists($r['course_alias']);
-        $originalCourse->toUnixTime();
 
         $offset = round($r['start_time']) - $originalCourse->start_time;
 
@@ -858,7 +856,6 @@ class CourseController extends Controller {
      * @return array
      */
     private static function convertCourseToArray(Courses $course) : array {
-        $course->toUnixTime();
         $relevant_columns = ['alias', 'name', 'start_time', 'finish_time'];
         $arr = $course->asFilteredArray($relevant_columns);
 
@@ -982,7 +979,6 @@ class CourseController extends Controller {
         if (is_null($r['assignment'])) {
             throw new NotFoundException('assignmentNotFound');
         }
-        $r['assignment']->toUnixTime();
 
         $problems = ProblemsetProblemsDAO::getProblems($r['assignment']->problemset_id);
         $letter = 0;
@@ -1627,9 +1623,7 @@ class CourseController extends Controller {
         $courseAdmin = false;
 
         $course = self::validateCourseExists($courseAlias);
-        $course->toUnixTime();
         $assignment = self::validateCourseAssignmentAlias($course, $assignmentAlias);
-        $assignment->toUnixTime();
 
         $assignmentProblemset = AssignmentsDAO::getByIdWithScoreboardUrls($assignment->assignment_id);
         if (is_null($assignmentProblemset)) {
@@ -1669,12 +1663,10 @@ class CourseController extends Controller {
         if (is_null($course)) {
             throw new NotFoundException('courseNotFound');
         }
-        $course->toUnixTime();
         $assignment = AssignmentsDAO::getByAliasAndCourse($assignmentAlias, $course->course_id);
         if (is_null($assignment)) {
             throw new NotFoundException('assignmentNotFound');
         }
-        $assignment->toUnixTime();
 
         // Admins are almighty, no need to check anything else.
         if (Authorization::isCourseAdmin($identity, $course)) {

--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -1011,7 +1011,6 @@ class ProblemController extends Controller {
             if (!Authorization::isAdmin($r->identity, $problemset['problemset'])) {
                 // If the contest is private, verify that our user is invited
                 if (!empty($problemset['contest'])) {
-                    $problemset['contest']->toUnixTime();
                     if (!ContestController::isPublic($problemset['contest']->admission_mode)) {
                         if (is_null(ProblemsetIdentitiesDAO::getByPK(
                             $r->identity->identity_id,
@@ -1461,7 +1460,6 @@ class ProblemController extends Controller {
                 $container = ProblemsetsDAO::getProblemsetContainer(
                     $problemset->problemset_id
                 );
-                $container->toUnixTime();
                 ProblemsetIdentitiesDAO::checkAndSaveFirstTimeAccess(
                     $r->identity,
                     $container,

--- a/frontend/server/controllers/ResetController.php
+++ b/frontend/server/controllers/ResetController.php
@@ -136,7 +136,6 @@ class ResetController extends Controller {
         if (is_null($user)) {
             throw new InvalidParameterException('invalidUser');
         }
-        $user->toUnixTime();
 
         if (!$user->verified) {
             throw new InvalidParameterException('unverifiedUser');
@@ -164,7 +163,6 @@ class ResetController extends Controller {
             || is_null($password_confirmation)) {
             throw new InvalidParameterException('invalidParameters');
         }
-        $user->toUnixtime();
 
         if ($user->reset_digest !== hash('sha1', $reset_token)) {
             throw new InvalidParameterException('invalidResetToken');

--- a/frontend/server/controllers/RunController.php
+++ b/frontend/server/controllers/RunController.php
@@ -151,7 +151,6 @@ class RunController extends Controller {
         }
 
         // No one should submit after the deadline. Not even admins.
-        $r['container']->toUnixTime();
         if (ProblemsetsDAO::isLateSubmission($r['container'])) {
             throw new NotAllowedToSubmitException('runNotInsideContest');
         }
@@ -217,7 +216,6 @@ class RunController extends Controller {
             $start = null;
             $problemsetId = (int)$r['problemset']->problemset_id;
             if (isset($r['contest'])) {
-                $r['contest']->toUnixTime();
                 $penalty_type = $r['contest']->penalty_type;
 
                 switch ($penalty_type) {
@@ -242,7 +240,6 @@ class RunController extends Controller {
                             //what should be done here?
                             throw new NotAllowedToSubmitException('runEvenOpened');
                         }
-                        $opened->toUnixTime();
 
                         $start = $opened->open_time;
                         break;
@@ -349,10 +346,8 @@ class RunController extends Controller {
             if (!is_null($problemsetIdentity) && !is_null(
                 $problemsetIdentity->end_time
             )) {
-                $problemsetIdentity->toUnixTime();
                 $response['submission_deadline'] = $problemsetIdentity->end_time;
             } elseif (isset($r['container']->finish_time)) {
-                $r['container']->toUnixTime();
                 $response['submission_deadline'] = $r['container']->finish_time;
             }
         }
@@ -410,7 +405,6 @@ class RunController extends Controller {
         }
 
         // Fill response
-        $r['submission']->toUnixTime();
         $filtered = (
             $r['submission']->asFilteredArray([
                 'guid', 'language', 'time', 'submit_delay',

--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1334,7 +1334,6 @@ class UserController extends Controller {
         if (is_null($contest)) {
             throw new NotFoundException('interviewNotFound');
         }
-        $contest->toUnixTime();
 
         // Only admins can view interview details
         if (!Authorization::isContestAdmin($r->identity->identity_id, $contest)) {

--- a/frontend/server/libs/dao/Estructura.php
+++ b/frontend/server/libs/dao/Estructura.php
@@ -110,10 +110,4 @@ abstract class VO {
         }
         return $returnArray;
     }
-
-    protected function toUnixTime(iterable $fieldNames) : void {
-        foreach ($fieldNames as $fieldName) {
-            $this->$fieldName = DAO::fromMySQLTimestamp($this->$fieldName);
-        }
-    }
 }

--- a/frontend/server/libs/dao/Problemset_Identities.dao.php
+++ b/frontend/server/libs/dao/Problemset_Identities.dao.php
@@ -55,7 +55,6 @@ class ProblemsetIdentitiesDAO extends ProblemsetIdentitiesDAOBase {
             $problemsetIdentity->share_user_information = $shareUserInformation;
             ProblemsetIdentitiesDAO::replace($problemsetIdentity);
         }
-        $problemsetIdentity->toUnixTime();
         return $problemsetIdentity;
     }
 

--- a/frontend/server/libs/dao/Problemsets.dao.php
+++ b/frontend/server/libs/dao/Problemsets.dao.php
@@ -60,7 +60,6 @@ class ProblemsetsDAO extends ProblemsetsDAOBase {
             $identity_id,
             $container->problemset_id
         );
-        $problemsetIdentity->toUnixTime();
 
         return Time::get() <= $problemsetIdentity->access_time + $container->window_length * 60;
     }

--- a/frontend/server/libs/dao/base/ACLs.vo.base.php
+++ b/frontend/server/libs/dao/base/ACLs.vo.base.php
@@ -44,17 +44,6 @@ class ACLs extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Announcement.vo.base.php
+++ b/frontend/server/libs/dao/base/Announcement.vo.base.php
@@ -52,17 +52,6 @@ class Announcement extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Identificador del aviso
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Assignments.vo.base.php
+++ b/frontend/server/libs/dao/base/Assignments.vo.base.php
@@ -88,17 +88,6 @@ class Assignments extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['start_time', 'finish_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Auth_Tokens.vo.base.php
+++ b/frontend/server/libs/dao/base/Auth_Tokens.vo.base.php
@@ -52,17 +52,6 @@ class AuthTokens extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['create_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * @access public
       * @var ?int

--- a/frontend/server/libs/dao/base/Clarifications.vo.base.php
+++ b/frontend/server/libs/dao/base/Clarifications.vo.base.php
@@ -72,17 +72,6 @@ class Clarifications extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Coder_Of_The_Month.vo.base.php
+++ b/frontend/server/libs/dao/base/Coder_Of_The_Month.vo.base.php
@@ -64,17 +64,6 @@ class CoderOfTheMonth extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Contest_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Contest_Log.vo.base.php
@@ -60,17 +60,6 @@ class ContestLog extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Contests.vo.base.php
+++ b/frontend/server/libs/dao/base/Contests.vo.base.php
@@ -132,17 +132,6 @@ class Contests extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['start_time', 'finish_time', 'last_updated']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * El identificador unico para cada concurso
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Countries.vo.base.php
+++ b/frontend/server/libs/dao/base/Countries.vo.base.php
@@ -44,17 +44,6 @@ class Countries extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Courses.vo.base.php
+++ b/frontend/server/libs/dao/base/Courses.vo.base.php
@@ -88,17 +88,6 @@ class Courses extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['start_time', 'finish_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Emails.vo.base.php
+++ b/frontend/server/libs/dao/base/Emails.vo.base.php
@@ -48,17 +48,6 @@ class Emails extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Favorites.vo.base.php
+++ b/frontend/server/libs/dao/base/Favorites.vo.base.php
@@ -44,17 +44,6 @@ class Favorites extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Group_Roles.vo.base.php
+++ b/frontend/server/libs/dao/base/Group_Roles.vo.base.php
@@ -48,17 +48,6 @@ class GroupRoles extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Groups.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups.vo.base.php
@@ -60,17 +60,6 @@ class Groups extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['create_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Groups_Identities.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups_Identities.vo.base.php
@@ -56,17 +56,6 @@ class GroupsIdentities extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Groups_Scoreboards.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards.vo.base.php
@@ -60,17 +60,6 @@ class GroupsScoreboards extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['create_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Groups_Scoreboards_Problemsets.vo.base.php
+++ b/frontend/server/libs/dao/base/Groups_Scoreboards_Problemsets.vo.base.php
@@ -52,17 +52,6 @@ class GroupsScoreboardsProblemsets extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Identities.vo.base.php
+++ b/frontend/server/libs/dao/base/Identities.vo.base.php
@@ -76,17 +76,6 @@ class Identities extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Identity_Login_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Identity_Login_Log.vo.base.php
@@ -48,17 +48,6 @@ class IdentityLoginLog extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Identidad del usuario
       * @access public
       * @var int

--- a/frontend/server/libs/dao/base/Interviews.vo.base.php
+++ b/frontend/server/libs/dao/base/Interviews.vo.base.php
@@ -64,17 +64,6 @@ class Interviews extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Languages.vo.base.php
+++ b/frontend/server/libs/dao/base/Languages.vo.base.php
@@ -48,17 +48,6 @@ class Languages extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Messages.vo.base.php
+++ b/frontend/server/libs/dao/base/Messages.vo.base.php
@@ -60,17 +60,6 @@ class Messages extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['date']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Notifications.vo.base.php
+++ b/frontend/server/libs/dao/base/Notifications.vo.base.php
@@ -56,17 +56,6 @@ class Notifications extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['timestamp']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Permissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Permissions.vo.base.php
@@ -48,17 +48,6 @@ class Permissions extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatement_Consent_Log.vo.base.php
@@ -52,17 +52,6 @@ class PrivacyStatementConsentLog extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['timestamp']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Id del consentimiento de privacidad almacenado en el log
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/PrivacyStatements.vo.base.php
+++ b/frontend/server/libs/dao/base/PrivacyStatements.vo.base.php
@@ -48,17 +48,6 @@ class PrivacyStatements extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Id del documento de privacidad
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Problem_Of_The_Week.vo.base.php
+++ b/frontend/server/libs/dao/base/Problem_Of_The_Week.vo.base.php
@@ -52,17 +52,6 @@ class ProblemOfTheWeek extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Problem_Viewed.vo.base.php
+++ b/frontend/server/libs/dao/base/Problem_Viewed.vo.base.php
@@ -48,17 +48,6 @@ class ProblemViewed extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['view_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems.vo.base.php
@@ -120,17 +120,6 @@ class Problems extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['creation_date']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Problems_Forfeited.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Forfeited.vo.base.php
@@ -48,17 +48,6 @@ class ProblemsForfeited extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['forfeited_date']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Identificador de usuario
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problems_Languages.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Languages.vo.base.php
@@ -44,17 +44,6 @@ class ProblemsLanguages extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problems_Tags.vo.base.php
+++ b/frontend/server/libs/dao/base/Problems_Tags.vo.base.php
@@ -52,17 +52,6 @@ class ProblemsTags extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problemset_Access_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Access_Log.vo.base.php
@@ -52,17 +52,6 @@ class ProblemsetAccessLog extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * @access public
       * @var int

--- a/frontend/server/libs/dao/base/Problemset_Identities.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identities.vo.base.php
@@ -72,17 +72,6 @@ class ProblemsetIdentities extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['access_time', 'end_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Identidad del usuario
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request.vo.base.php
@@ -60,17 +60,6 @@ class ProblemsetIdentityRequest extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['request_time', 'last_update']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * Identidad del usuario
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problemset_Identity_Request_History.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Identity_Request_History.vo.base.php
@@ -60,17 +60,6 @@ class ProblemsetIdentityRequestHistory extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Problemset_Problem_Opened.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problem_Opened.vo.base.php
@@ -52,17 +52,6 @@ class ProblemsetProblemOpened extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['open_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemset_Problems.vo.base.php
@@ -60,17 +60,6 @@ class ProblemsetProblems extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Problemsets.vo.base.php
+++ b/frontend/server/libs/dao/base/Problemsets.vo.base.php
@@ -84,17 +84,6 @@ class Problemsets extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       * El identificador único para cada conjunto de problemas
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/QualityNomination_Comments.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Comments.vo.base.php
@@ -60,17 +60,6 @@ class QualityNominationComments extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/QualityNomination_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Log.vo.base.php
@@ -64,17 +64,6 @@ class QualityNominationLog extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/QualityNomination_Reviewers.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNomination_Reviewers.vo.base.php
@@ -44,17 +44,6 @@ class QualityNominationReviewers extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/QualityNominations.vo.base.php
+++ b/frontend/server/libs/dao/base/QualityNominations.vo.base.php
@@ -64,17 +64,6 @@ class QualityNominations extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Roles.vo.base.php
+++ b/frontend/server/libs/dao/base/Roles.vo.base.php
@@ -48,17 +48,6 @@ class Roles extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Roles_Permissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Roles_Permissions.vo.base.php
@@ -44,17 +44,6 @@ class RolesPermissions extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Run_Counts.vo.base.php
+++ b/frontend/server/libs/dao/base/Run_Counts.vo.base.php
@@ -48,17 +48,6 @@ class RunCounts extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Runs.vo.base.php
+++ b/frontend/server/libs/dao/base/Runs.vo.base.php
@@ -84,17 +84,6 @@ class Runs extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Schools.vo.base.php
+++ b/frontend/server/libs/dao/base/Schools.vo.base.php
@@ -52,17 +52,6 @@ class Schools extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/States.vo.base.php
+++ b/frontend/server/libs/dao/base/States.vo.base.php
@@ -48,17 +48,6 @@ class States extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Submission_Log.vo.base.php
+++ b/frontend/server/libs/dao/base/Submission_Log.vo.base.php
@@ -60,17 +60,6 @@ class SubmissionLog extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * @access public
       * @var ?int

--- a/frontend/server/libs/dao/base/Submissions.vo.base.php
+++ b/frontend/server/libs/dao/base/Submissions.vo.base.php
@@ -76,17 +76,6 @@ class Submissions extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Tags.vo.base.php
+++ b/frontend/server/libs/dao/base/Tags.vo.base.php
@@ -44,17 +44,6 @@ class Tags extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/User_Rank.vo.base.php
+++ b/frontend/server/libs/dao/base/User_Rank.vo.base.php
@@ -72,17 +72,6 @@ class UserRank extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/User_Rank_Cutoffs.vo.base.php
+++ b/frontend/server/libs/dao/base/User_Rank_Cutoffs.vo.base.php
@@ -48,17 +48,6 @@ class UserRankCutoffs extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * @access public
       * @var float

--- a/frontend/server/libs/dao/base/User_Roles.vo.base.php
+++ b/frontend/server/libs/dao/base/User_Roles.vo.base.php
@@ -48,17 +48,6 @@ class UserRoles extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * @access public

--- a/frontend/server/libs/dao/base/Users.vo.base.php
+++ b/frontend/server/libs/dao/base/Users.vo.base.php
@@ -108,17 +108,6 @@ class Users extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['reset_sent_at']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Users_Badges.vo.base.php
+++ b/frontend/server/libs/dao/base/Users_Badges.vo.base.php
@@ -52,17 +52,6 @@ class UsersBadges extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime(['assignation_time']);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * Llave Primaria
       * Auto Incremento

--- a/frontend/server/libs/dao/base/Users_Experiments.vo.base.php
+++ b/frontend/server/libs/dao/base/Users_Experiments.vo.base.php
@@ -44,17 +44,6 @@ class UsersExperiments extends VO {
     }
 
     /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
-
-    /**
       *  [Campo no documentado]
       * @access public
       * @var int

--- a/frontend/tests/controllers/LoginTest.php
+++ b/frontend/tests/controllers/LoginTest.php
@@ -205,7 +205,6 @@ class LoginTest extends OmegaupTestCase {
 
         // Expire token manually
         $authToken = AuthTokensDAO::getByPK($login->auth_token);
-        $authToken->toUnixTime();
         $authToken->create_time -= 9 * 3600;  // 9 hours
         AuthTokensDAO::update($authToken);
 

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -147,7 +147,6 @@ class RunCreateTest extends OmegaupTestCase {
         $this->assertEquals(ip2long('127.0.0.1'), $log->ip);
 
         if (!is_null($contest)) {
-            $contest->toUnixTime();
             $this->assertEquals(
                 (Time::get() - $contest->start_time) / 60,
                 $run->penalty,

--- a/stuff/dao_templates/vo.php
+++ b/stuff/dao_templates/vo.php
@@ -50,17 +50,6 @@ class {{ table.class_name }} extends VO {
         }
 {%- endfor %}
     }
-
-    /**
-     * Converts date fields to timestamps
-     */
-    public function toUnixTime(iterable $fields = []) : void {
-        if (empty($fields)) {
-            parent::toUnixTime([{{ table.columns|selectattr('type', 'in', [('timestamp',), ('datetime',)])|map(attribute='name')|listformat("'{}'")|join(', ') }}]);
-            return;
-        }
-        parent::toUnixTime($fields);
-    }
 {%- for column in table.columns %}
 
     /**


### PR DESCRIPTION
Esta función ya no se usa porque los DAOs ya se crean siempre con POSIX
timestamps en vez de cadenas.