### PR TITLE
Arreglando los tipos en UrlHelper

### DIFF
--- a/frontend/server/libs/UrlHelper.php
+++ b/frontend/server/libs/UrlHelper.php
@@ -5,9 +5,9 @@ class UrlHelper {
      * Wrapper of file_get_contents
      *
      * @param string $url
-     * @param resource $context
+     * @param null|resource $context
      */
-    public function fetchUrl($url, $context = null) {
-        return file_get_contents($url, false /*use_include_path*/, $context);
+    public function fetchUrl(string $url, $context = null) : string {
+        return file_get_contents($url, /*use_include_path=*/false, $context);
     }
 }


### PR DESCRIPTION
Este cambio hace que frontend/server/libs/UrlHelper.php tenga
los tipos correctos para que psalm ya no se queje más.

Esto hace que los errores bajen de 5405 a 5404.