### PR TITLE
Hotfix para arreglar el usuario actual en bootstrap_smarty.php

### DIFF
--- a/frontend/server/bootstrap_smarty.php
+++ b/frontend/server/bootstrap_smarty.php
@@ -48,12 +48,12 @@ if (!defined('IS_TEST') || IS_TEST !== true) {
         $smarty->assign(
             'currentUserInfo',
             [
-                'username' => $session['username'],
+                'username' => $session['identity']->username,
             ]
         );
 
         UITools::$IsAdmin = $session['is_admin'];
-        $identityRequest['username'] = $session['username'];
+        $identityRequest['username'] = $session['identity']->username;
     } else {
         $identityRequest['username'] = null;
         $smarty->assign('CURRENT_USER_GRAVATAR_URL_128', '<img src="/media/avatar_92.png">');


### PR DESCRIPTION
Un refactor anterior estaba causando una advertencia porque
`$session['username']` no estaba definido.