### PR TITLE
Migrando componentes de Contest a TypeScript

### DIFF
--- a/frontend/www/js/omegaup/api.d.ts
+++ b/frontend/www/js/omegaup/api.d.ts
@@ -47,7 +47,6 @@ declare namespace omegaup {
     version: string;
   }
 
-
   export interface Contest {
     alias: string;
     title: string;
@@ -55,10 +54,44 @@ declare namespace omegaup {
     start_time?: Date;
     finish_time?: Date;
     admission_mode?: string;
+    contestant_must_register?: boolean;
+    admin?: boolean;
+    available_languages?: omegaup.Languages;
+    description?: string;
+    director?: string;
+    feedback?: string;
+    languages?: Array<string>;
+    needs_basic_information?: boolean;
+    opened?: boolean;
+    original_contest_alias?: string;
+    original_problemset_id?: string;
+    partial_score?: boolean;
+    penalty?: number;
+    penalty_calc_policy?: string;
+    penalty_type?: string;
+    points_decay_factor?: number;
+    problems?: omegaup.Problem[];
+    problemset_id?: number;
+    requests_user_information?: string;
+    rerun_id?: number;
+    scoreboard?: number;
+    scoreboard_url?: string;
+    scoreboard_url_admin?: string;
+    show_penalty?: boolean;
+    show_scoreboard_after?: boolean;
+    submission_deadline?: Date;
+    submissions_gap?: number;
   }
 
   interface ContestAdmin {
     username: string;
+    role: string;
+  }
+
+  export interface ContestGroupAdmin {
+    role: string;
+    name: string;
+    alias: string;
   }
 
   interface ContestResult {
@@ -110,6 +143,8 @@ declare namespace omegaup {
   export interface IdentityContest {
     username: string;
     end_time: Date;
+    access_time?: Date;
+    country_id?: string;
   }
 
   export interface IdentityContestRequest {
@@ -119,7 +154,10 @@ declare namespace omegaup {
     last_update: Date;
     accepted: boolean;
     admin?: ContestAdmin;
+  }
 
+  interface Languages {
+    [language: string]: string;
   }
 
   interface Meta {

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -76,8 +76,11 @@
   </div>
 </template>
 
-<script>
-import {T, UI} from '../../omegaup.js';
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { T } from '../../omegaup.js';
+import UI from '../../ui.js';
+import omegaup from '../../api.js';
 import contest_AddProblem from './AddProblem.vue';
 import contest_Admins from './Admins.vue';
 import contest_Clone from './Clone.vue';
@@ -88,23 +91,16 @@ import contest_Links from './Links.vue';
 import contest_NewForm from './NewForm.vue';
 import contest_Publish from './Publish.vue';
 
-export default {
-  props: {
-    data: Object,
-  },
-  data: function() {
-    return {
-      showTab: UI.isVirtual(this.data.contest) ? 'contestants' : 'new_form',
-      T: T, virtual: UI.isVirtual(this.data.contest),
-      UI: UI,
-      contest: this.data.contest,
-      problems: this.data.problems,
-      users: this.data.users,
-      requests: this.data.requests,
-      admins: this.data.admins,
-      groupAdmins: this.data.groupAdmins,
-    };
-  },
+interface ContestEdit {
+  admins: omegaup.ContestAdmin[];
+  contest: omegaup.Contest;
+  groupAdmins: omegaup.ContestGroupAdmin[];
+  problems: omegaup.Problem[];
+  requests: omegaup.IdentityContestRequest[];
+  users: omegaup.IdentityContest[];
+}
+
+@Component({
   components: {
     'omegaup-contest-add-problem': contest_AddProblem,
     'omegaup-contest-admins': contest_Admins,
@@ -116,5 +112,20 @@ export default {
     'omegaup-contest-new-form': contest_NewForm,
     'omegaup-contest-publish': contest_Publish,
   },
-};
+})
+export default class Edit extends Vue {
+  @Prop() data!: ContestEdit;
+
+  T = T;
+  UI = UI;
+  showTab = UI.isVirtual(this.data.contest) ? 'contestants' : 'new_form';
+  virtual = UI.isVirtual(this.data.contest);
+  contest = this.data.contest;
+  problems = this.data.problems;
+  users = this.data.users;
+  requests = this.data.requests;
+  admins = this.data.admins;
+  groupAdmins = this.data.groupAdmins;
+}
+
 </script>

--- a/frontend/www/js/omegaup/components/contest/GroupAdmins.vue
+++ b/frontend/www/js/omegaup/components/contest/GroupAdmins.vue
@@ -5,7 +5,7 @@
             v-on:submit.prevent="onSubmit">
         <div class="form-group">
           <label>{{T.wordsGroupAdmin}}</label> <omegaup-autocomplete v-bind:init=
-          "el =&gt; UI.typeahead(el, API.Group.list)"
+          "el =&gt; UI.groupTypeahead(el)"
                v-model="groupName"></omegaup-autocomplete>
         </div><button class="btn btn-primary"
               type="submit">{{T.contestAddgroupAddGroup}}</button>
@@ -35,33 +35,35 @@
   </div>
 </template>
 
-<script>
-import {T, UI, API} from '../../omegaup.js';
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { T } from '../../omegaup.js';
+import UI from '../../ui.js';
+import omegaup from '../../api.js';
 import Autocomplete from '../Autocomplete.vue';
 
-export default {
-  props: {
-    data: Array,
-  },
-  data: function() {
-    return {
-      T: T,
-      UI: UI,
-      API: API,
-      groupName: '',
-      groupAdmins: this.data,
-      selected: {},
-    };
-  },
-  methods: {
-    onSubmit: function() { this.$parent.$emit('add-group-admin', this);},
-    onRemove: function(group) {
-      this.selected = group;
-      this.$parent.$emit('remove-group-admin', this);
-    },
-  },
+@Component({
   components: {
     'omegaup-autocomplete': Autocomplete,
   },
-};
+})
+export default class GroupAdmin extends Vue {
+  @Prop() data!: omegaup.ContestGroupAdmin[];
+
+  T = T;
+  UI = UI;
+  groupName = '';
+  groupAdmins = this.data;
+  selected = {};
+
+  onSubmit(): void {
+    this.$parent.$emit('add-group-admin', this);
+  }
+
+  onRemove(group: omegaup.ContestGroupAdmin): void {
+    this.selected = group;
+    this.$parent.$emit('remove-group-admin', this);
+  }
+}
+
 </script>

--- a/frontend/www/js/omegaup/components/contest/Links.vue
+++ b/frontend/www/js/omegaup/components/contest/Links.vue
@@ -33,18 +33,17 @@
   </div>
 </template>
 
-<script>
-import {T} from '../../omegaup.js';
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { T } from '../../omegaup.js';
+import omegaup from '../../api.js';
 
-export default {
-  props: {
-    data: Object,
-  },
-  data: function() {
-    return {
-      T: T,
-      contest: this.data,
-    };
-  },
-};
+@Component({})
+export default class Links extends Vue {
+  @Prop() data!: omegaup.Contest;
+
+  T = T;
+  contest = this.data;
+}
+
 </script>

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -197,86 +197,89 @@
   </div>
 </template>
 
-<script>
-import {T} from '../../omegaup.js';
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { T } from '../../omegaup.js';
+import omegaup from '../../api.js';
 import DateTimePicker from '../DateTimePicker.vue';
 
-export default {
-  props: {
-    update: Boolean,
-    data: Object,
-  },
-  data: function() {
-    return {
-      alias: this.data.alias,
-      availableLanguages: this.data.available_languages,
-      contest: this.data,
-      contestantMustRegister: this.data.contestant_must_register,
-      description: this.data.description,
-      feedback: this.data.feedback,
-      finishTime: this.data.finish_time,
-      scoreboard: this.data.scoreboard,
-      languages: this.data.languages,
-      needsBasicInformation: this.data.needs_basic_information,
-      penalty: this.data.penalty,
-      penaltyType: this.data.penalty_type,
-      penaltyCalcPolicy: this.data.penalty_calc_policy,
-      pointsDecayFactor: this.data.points_decay_factor,
-      requestsUserInformation: this.data.requests_user_information,
-      startTime: this.data.start_time,
-      showPenalty: this.data.show_penalty,
-      showScoreboardAfter: this.data.show_scoreboard_after,
-      submissionsGap: this.data.submissions_gap,
-      title: this.data.title,
-      titlePlaceHolder: '',
-      windowLength: this.data.window_length || 0,
-      windowLengthEnabled: this.data.window_length != 0 &&
-                               this.data.window_length != '' &&
-                               this.data.window_length != null,
-      T: T,
-    };
-  },
-  methods: {
-    fillOmi: function() {
-      this.titlePlaceHolder = T.contestNewFormTitlePlaceholderOmiStyle;
-      this.windowLengthEnabled = false;
-      this.windowLength = 0;
-      this.scoreboard = 0;
-      this.pointsDecayFactor = 0;
-      this.submissionsGap = 1;
-      this.feedback = 'yes';
-      this.penalty = 0;
-      this.penaltyType = 'none';
-      this.showScoreboardAfter = true;
-    },
-    fillPreIoi: function() {
-      this.titlePlaceHolder = T.contestNewFormTitlePlaceholderIoiStyle;
-      this.windowLengthEnabled = true;
-      this.windowLength = 180;
-      this.scoreboard = 0;
-      this.pointsDecayFactor = 0;
-      this.submissionsGap = 0;
-      this.feedback = 'yes';
-      this.penalty = 0;
-      this.penaltyType = 'none';
-      this.showScoreboardAfter = true;
-    },
-    fillConacup: function() {
-      this.titlePlaceHolder = T.contestNewFormTitlePlaceholderConacupStyle;
-      this.windowLengthEnabled = false;
-      this.windowLength = '';
-      this.scoreboard = 75;
-      this.pointsDecayFactor = 0;
-      this.submissionsGap = 1;
-      this.feedback = 'yes';
-      this.penalty = 20;
-      this.penaltyType = 'none';
-      this.showScoreboardAfter = true;
-    },
-    onSubmit: function() { this.$parent.$emit('update-contest', this);},
-  },
+@Component({
   components: {
     'omegaup-datetimepicker': DateTimePicker,
   },
-};
+})
+export default class NewForm extends Vue {
+  @Prop() data!: omegaup.Contest;
+  @Prop() update!: boolean;
+
+  T = T;
+  alias = this.data.alias;
+  availableLanguages = this.data.available_languages;
+  contest = this.data;
+  contestantMustRegister = this.data.contestant_must_register;
+  description = this.data.description;
+  feedback = this.data.feedback;
+  finishTime = this.data.finish_time;
+  scoreboard = this.data.scoreboard;
+  languages = this.data.languages;
+  needsBasicInformation = this.data.needs_basic_information;
+  penalty = this.data.penalty;
+  penaltyType = this.data.penalty_type;
+  penaltyCalcPolicy = this.data.penalty_calc_policy;
+  pointsDecayFactor = this.data.points_decay_factor;
+  requestsUserInformation = this.data.requests_user_information;
+  startTime = this.data.start_time;
+  showPenalty = this.data.show_penalty;
+  showScoreboardAfter = this.data.show_scoreboard_after;
+  submissionsGap = this.data.submissions_gap;
+  title = this.data.title;
+  titlePlaceHolder = '';
+  windowLength = this.data.window_length || 0;
+  windowLengthEnabled =
+    this.data.window_length != 0 && this.data.window_length != null;
+
+  fillOmi(): void {
+    this.titlePlaceHolder = T.contestNewFormTitlePlaceholderOmiStyle;
+    this.windowLengthEnabled = false;
+    this.windowLength = 0;
+    this.scoreboard = 0;
+    this.pointsDecayFactor = 0;
+    this.submissionsGap = 1;
+    this.feedback = 'yes';
+    this.penalty = 0;
+    this.penaltyType = 'none';
+    this.showScoreboardAfter = true;
+  }
+
+  fillPreIoi(): void {
+    this.titlePlaceHolder = T.contestNewFormTitlePlaceholderIoiStyle;
+    this.windowLengthEnabled = true;
+    this.windowLength = 180;
+    this.scoreboard = 0;
+    this.pointsDecayFactor = 0;
+    this.submissionsGap = 0;
+    this.feedback = 'yes';
+    this.penalty = 0;
+    this.penaltyType = 'none';
+    this.showScoreboardAfter = true;
+  }
+
+  fillConacup(): void {
+    this.titlePlaceHolder = T.contestNewFormTitlePlaceholderConacupStyle;
+    this.windowLengthEnabled = false;
+    this.windowLength = 0;
+    this.scoreboard = 75;
+    this.pointsDecayFactor = 0;
+    this.submissionsGap = 1;
+    this.feedback = 'yes';
+    this.penalty = 20;
+    this.penaltyType = 'none';
+    this.showScoreboardAfter = true;
+  }
+
+  onSubmit() {
+    this.$parent.$emit('update-contest', this);
+  }
+}
+
 </script>

--- a/frontend/www/js/omegaup/ui.d.ts
+++ b/frontend/www/js/omegaup/ui.d.ts
@@ -9,6 +9,8 @@ declare namespace omegaup {
     markdownConverter: (options?: MarkdownConverterOptions) => Converter;
     navigateTo: (url: string) => void;
     userTypeahead: (elem: HTMLElement, cb: (event: HTMLEvent, val: any) => void) => void;
+    groupTypeahead: (elem: HTMLElement, cb: (event: HTMLEvent, val: any) => void) => void;
+    isVirtual: (contest: omegaup.Contest) => boolean,
   };
 
   interface MarkdownConverterOptions {


### PR DESCRIPTION
# Descripción

Se migran a TypeScript los últimos componentes relacionados a `Contests`

Fixes: #2590 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
