### PR TITLE
Migrando componente de GroupMembers a TypeScript

### DIFF
--- a/frontend/server/controllers/GroupController.php
+++ b/frontend/server/controllers/GroupController.php
@@ -111,6 +111,13 @@ class GroupController extends Controller {
         $group = self::validateGroupAndOwner($r['group_alias'], $r->identity);
         $resolvedIdentity = IdentityController::resolveIdentity($r['usernameOrEmail']);
 
+        if (!is_null(GroupsIdentitiesDAO::getByPK(
+            $group->group_id,
+            $resolvedIdentity->identity_id
+        ))) {
+            throw new DuplicatedEntryInDatabaseException('identityAlreadyAssociated');
+        }
+
         GroupsIdentitiesDAO::create(new GroupsIdentities([
             'group_id' => $group->group_id,
             'identity_id' => $resolvedIdentity->identity_id

--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -371,6 +371,7 @@ groupsIdentityWarning = "Save the passwords in a safe place, because once you cr
 groupsInvalidCsv = "Please upload a valid CSV file."
 groupsUploadCsvFile = "Upload CSV file"
 identityAlreadyAssociated = "You already have one identity associated with the same group."
+identityInGroup = "Identity is already associated to the group."
 incompatibleArgs = "Arguments can't be set simultaneously"
 index = "Coder of the month"
 interviewCreateNew = "Create a new interview"

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -371,6 +371,7 @@ groupsIdentityWarning = "Guarda las contraseñas en un lugar seguro, porque una 
 groupsInvalidCsv = "Favor de cargar un archivo CSV válido."
 groupsUploadCsvFile = "Carga el archivo CSV"
 identityAlreadyAssociated = "Ya cuentas con una identidad asociada con el mimso grupo."
+identityInGroup = "La identidad ya está asociada al grupo."
 incompatibleArgs = "Parametros no se pueden utilizar al mismo tiempo"
 index = "Coder del mes"
 interviewCreateNew = "Crear nueva entrevista"

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -371,6 +371,7 @@ groupsIdentityWarning = "(Sav3 7h3 pa55w0rd5 in a 5af3 p1ac3, b3cau53 0nc3 y0u c
 groupsInvalidCsv = "(P13a53 up10ad a va1id CSV fi13.)"
 groupsUploadCsvFile = "(Up10ad CSV fi13)"
 identityAlreadyAssociated = "(Y0u a1r3ady hav3 0n3 id3n7i7y a550cia73d wi7h 7h3 5am3 gr0up.)"
+identityInGroup = "(Id3n7i7y i5 a1r3ady a550cia73d 70 7h3 gr0up.)"
 incompatibleArgs = "(Argum3n75 can'7 b3 537 5imu17an30u51y)"
 index = "(C0d3r 0f 7h3 m0n7h)"
 interviewCreateNew = "(Cr3a73 a n3w in73rvi3w)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -371,6 +371,7 @@ groupsIdentityWarning = "Salve as senhas em um local seguro, porque depois de cr
 groupsInvalidCsv = "Faça o upload de um arquivo CSV válido."
 groupsUploadCsvFile = "Subir CSV arquivo"
 identityAlreadyAssociated = "Você já tem uma identidade associada ao mesmo grupo."
+identityInGroup = "A identidade já está associada ao grupo"
 incompatibleArgs = "Argumentos não podem ser definidos simultaneamente"
 index = "Programador do mês"
 interviewCreateNew = "Criar uma nova entrevista"

--- a/frontend/www/js/omegaup/api.d.ts
+++ b/frontend/www/js/omegaup/api.d.ts
@@ -47,7 +47,6 @@ declare namespace omegaup {
     version: string;
   }
 
-
   export interface Contest {
     alias: string;
     title: string;
@@ -55,10 +54,44 @@ declare namespace omegaup {
     start_time?: Date;
     finish_time?: Date;
     admission_mode?: string;
+    contestant_must_register?: boolean;
+    admin?: boolean;
+    available_languages?: omegaup.Languages;
+    description?: string;
+    director?: string;
+    feedback?: string;
+    languages?: Array<string>;
+    needs_basic_information?: boolean;
+    opened?: boolean;
+    original_contest_alias?: string;
+    original_problemset_id?: string;
+    partial_score?: boolean;
+    penalty?: number;
+    penalty_calc_policy?: string;
+    penalty_type?: string;
+    points_decay_factor?: number;
+    problems?: omegaup.Problem[];
+    problemset_id?: number;
+    requests_user_information?: string;
+    rerun_id?: number;
+    scoreboard?: number;
+    scoreboard_url?: string;
+    scoreboard_url_admin?: string;
+    show_penalty?: boolean;
+    show_scoreboard_after?: boolean;
+    submission_deadline?: Date;
+    submissions_gap?: number;
   }
 
   interface ContestAdmin {
     username: string;
+    role: string;
+  }
+
+  export interface ContestGroupAdmin {
+    role: string;
+    name: string;
+    alias: string;
   }
 
   interface ContestResult {
@@ -102,14 +135,20 @@ declare namespace omegaup {
 
   export interface Identity extends User {
     school: string;
+    school_name?: string;
+    gender?: string;
+    password?: string;
     school_id: number;
     country_id: string;
     state_id: string;
+    classname: string;
   }
 
   export interface IdentityContest {
     username: string;
     end_time: Date;
+    access_time?: Date;
+    country_id?: string;
   }
 
   export interface IdentityContestRequest {
@@ -119,7 +158,10 @@ declare namespace omegaup {
     last_update: Date;
     accepted: boolean;
     admin?: ContestAdmin;
+  }
 
+  interface Languages {
+    [language: string]: string;
   }
 
   interface Meta {

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -4,11 +4,9 @@
       <form class="form"
             v-on:submit.prevent="onAddMember">
         <div class="form-group">
-          <label>{{ T.wordsMember }} <input autocomplete="off"
-                 class="form-control typeahead"
-                 name="username"
-                 size="20"
-                 type="text"></label>
+          <label>{{ T.wordsMember }} <omegaup-autocomplete class="form-control"
+                                v-bind:init="el =&gt; UI.userTypeahead(el)"
+                                v-model="searchedUsername"></omegaup-autocomplete></label>
         </div><button class="btn btn-primary"
               type="submit">{{ T.wordsAddMember }}</button>
       </form>
@@ -75,68 +73,9 @@
          v-bind:selected-country="identity.country_id"
          v-bind:selected-state="identity.state_id"
          v-bind:username="username"
-         v-if="show"></omegaup-identity-edit><!-- Modal Change Password-->
-    <div class="modal fade modal-change-password"
-         role="dialog">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <form class="form-horizontal"
-                role="form"
-                v-on:submit.prevent="onChangePasswordMember">
-            <div class="modal-header">
-              <button class="close"
-                   data-dismiss="modal"
-                   type="button">×</button>
-              <h4 class="modal-title">{{ T.userEditChangePassword }}</h4>
-            </div>
-            <div class="modal-body">
-              <div class="panel-body">
-                <div class="form-group">
-                  <label class="col-md-4 col-sm-4 control-label"
-                       for="username">{{ T.username }}</label>
-                  <div class="col-md-7 col-sm-7">
-                    <input class="form-control"
-                         disabled="disabled"
-                         name="username"
-                         size="30"
-                         type="text"
-                         v-bind:value="username">
-                  </div>
-                </div>
-                <div class="form-group">
-                  <label class="col-md-4 col-sm-4 control-label"
-                       for="new-password-1">{{ T.userEditChangePasswordNewPassword }}</label>
-                  <div class="col-md-7 col-sm-7">
-                    <input class="form-control"
-                         name="new-password-1"
-                         size="30"
-                         type="password"
-                         v-model="newPassword">
-                  </div>
-                </div>
-                <div class="form-group">
-                  <label class="col-md-4 col-sm-4 control-label"
-                       for="new-password-2">{{ T.userEditChangePasswordRepeatNewPassword }}</label>
-                  <div class="col-md-7 col-sm-7">
-                    <input class="form-control"
-                         name="new-password-2"
-                         size="30"
-                         type="password"
-                         v-model="newPasswordRepeat">
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button class="btn btn-default"
-                   data-dismiss="modal"
-                   type="button">{{ T.wordsCancel }}</button> <button class="btn btn-primary"
-                   type="submit">{{ T.wordsSaveChanges }}</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
+         v-if="showEditForm"></omegaup-identity-edit>
+         <omegaup-identity-change-password v-bind:username="username"
+         v-if="showChangePasswordForm"></omegaup-identity-change-password>
   </div>
 </template>
 
@@ -146,70 +85,58 @@ label {
 }
 </style>
 
-<script>
-import {T, UI} from '../../omegaup.js';
+<script lang="ts">
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { T } from '../../omegaup.js';
+import UI from '../../ui.js';
+import omegaup from '../../api.js';
 import user_Username from '../user/Username.vue';
 import identity_Edit from '../identity/Edit.vue';
-export default {
-  props: {
-    identities: Array,
-    identitiesCsv: Array,
-    groupAlias: String,
-    countries: {
-      type: Array,
-    },
-  },
-  data: function() {
-    return {
-      T: T,
-      identity: {},
-      memberUsername: '',
-      username: '',
-      newPassword: '',
-      newPasswordRepeat: '',
-      show: false,
-    };
-  },
-  mounted: function() {
-    let self = this;
-    UI.userTypeahead($('input.typeahead', self.$el), function(event, item) {
-      self.memberUsername = item.value;
-    });
-  },
-  methods: {
-    onAddMember: function() {
-      let hintElem = $('input.typeahead.tt-hint', this.$el);
-      let hint = hintElem.val();
-      if (hint) {
-        // There is a hint currently visible in the UI, the user likely
-        // expects that hint to be used when trying to add someone, instead
-        // of what they've actually typed so far.
-        this.memberUsername = hint;
-      } else {
-        this.memberUsername = $('input.typeahead.tt-input', this.$el).val();
-      }
-      this.$emit('add-member', this, this.memberUsername);
-    },
-    onEdit: function(identity) { this.$emit('edit-identity', this, identity);},
-    onChangePass: function(username) {
-      this.username = username;
-      $('.modal-change-password').modal();
-    },
-    onChangePasswordMember: function() {
-      this.$emit('change-password-identity-member', this, this.username,
-                 this.newPassword, this.newPasswordRepeat);
-    },
-    onRemove: function(username) { this.$emit('remove', username);},
-    reset: function() {
-      this.memberUsername = '';
-      let inputElem = $('input.typeahead', this.$el);
-      inputElem.typeahead('close');
-      inputElem.val('');
-    },
-  },
+import identity_ChangePassword from '../identity/ChangePassword.vue';
+import Autocomplete from '../Autocomplete.vue';
+
+@Component({
   components: {
+    'omegaup-autocomplete': Autocomplete,
     'omegaup-user-username': user_Username,
     'omegaup-identity-edit': identity_Edit,
+    'omegaup-identity-change-password': identity_ChangePassword,
   },
-};
+})
+export default class UserProfile extends Vue {
+  @Prop() identities!: omegaup.Identity[];
+  @Prop() identitiesCsv!: omegaup.Identity[];
+  @Prop() groupAlias!: string;
+  @Prop() countries!: Array<string>;
+
+  T = T;
+  UI = UI;
+  identity = {};
+  username = '';
+  showEditForm = false;
+  showChangePasswordForm = false;
+  searchedUsername = '';
+
+  onAddMember(): void {
+    this.$emit('add-member', this, this.searchedUsername);
+  }
+
+  onEdit(identity: omegaup.Identity): void {
+    this.$emit('edit-identity', this, identity);
+  }
+
+  onChangePass(username: string): void {
+    this.$emit('change-password-identity', this, username);
+  }
+
+  @Emit('remove')
+  onRemove(username: string): string {
+    return username;
+  }
+
+  reset(): void {
+    this.searchedUsername = '';
+  }
+}
+
 </script>

--- a/frontend/www/js/omegaup/components/identity/ChangePassword.vue
+++ b/frontend/www/js/omegaup/components/identity/ChangePassword.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="panel">
+    <div>
+      <h1><span><a class="header">{{ T.userEditChangePassword }}: {{ username }}</a></span></h1>
+    </div>
+    <div class="panel-body">
+      <form class="form-horizontal"
+            role="form"
+            v-on:submit.prevent="onChangePasswordMember">
+        <div class="row">
+          <div class="form-group">
+            <label class="col-md-4 col-sm-4 control-label">{{ T.username }}</label>
+            <div class="col-md-7 col-sm-7">
+              <input class="form-control"
+                   disabled="disabled"
+                   size="30"
+                   type="text"
+                   v-bind:value="username">
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-md-4 col-sm-4 control-label">{{ T.userEditChangePasswordNewPassword
+            }}</label>
+            <div class="col-md-7 col-sm-7">
+              <input class="form-control"
+                   size="30"
+                   type="password"
+                   v-model="newPassword">
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-md-4 col-sm-4 control-label">{{
+            T.userEditChangePasswordRepeatNewPassword }}</label>
+            <div class="col-md-7 col-sm-7">
+              <input class="form-control"
+                   size="30"
+                   type="password"
+                   v-model="newPasswordRepeat">
+            </div>
+          </div>
+        </div>
+        <div class="form-group pull-right">
+          <button class="btn btn-primary"
+               type="submit">{{ T.wordsSaveChanges }}</button> <button class="btn btn-secundary"
+               type="reset"
+               v-on:click="onCancel">{{ T.wordsCancel }}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { T } from '../../omegaup.js';
+import omegaup from '../../api.js';
+
+@Component({})
+export default class IdentityEdit extends Vue {
+  @Prop() username!: string;
+
+  T = T;
+  newPassword = '';
+  newPasswordRepeat = '';
+
+  onChangePasswordMember() {
+    this.$parent.$emit(
+      'change-password-identity-member',
+      this.$parent,
+      this.username,
+      this.newPassword,
+      this.newPasswordRepeat,
+    );
+  }
+
+  onCancel(): void {
+    this.$parent.$emit('cancel', this.$parent);
+  }
+}
+
+</script>

--- a/frontend/www/js/omegaup/group/members.js
+++ b/frontend/www/js/omegaup/group/members.js
@@ -16,7 +16,8 @@ OmegaUp.on('ready', function() {
           identitiesCsv: this.identitiesCsv,
           groupAlias: this.groupAlias,
           countries: this.countries,
-          show: this.show,
+          showEditForm: this.showEditForm,
+          showChangePasswordForm: this.showChangePasswordForm,
         },
         on: {
           'add-member': function(groupMembersInstance, username) {
@@ -32,7 +33,8 @@ OmegaUp.on('ready', function() {
                 .fail(UI.apiError);
           },
           'edit-identity': function(groupMembersInstance, identity) {
-            groupMembersInstance.show = true;
+            groupMembersInstance.showEditForm = true;
+            groupMembersInstance.showChangePasswordForm = false;
             groupMembersInstance.identity = identity;
             groupMembersInstance.username = identity.username;
           },
@@ -50,10 +52,15 @@ OmegaUp.on('ready', function() {
                         })
                 .then(function(data) {
                   UI.success(T.groupEditMemberUpdated);
-                  groupMembersInstance.show = false;
+                  groupMembersInstance.showEditForm = false;
                   refreshMemberList();
                 })
                 .fail(function(response) { UI.apiError(response); });
+          },
+          'change-password-identity': function(groupMembersInstance, username) {
+            groupMembersInstance.showEditForm = false;
+            groupMembersInstance.showChangePasswordForm = true;
+            groupMembersInstance.username = username;
           },
           'change-password-identity-member': function(
               groupMembersInstance, username, newPassword, newPasswordRepeat) {
@@ -71,6 +78,7 @@ OmegaUp.on('ready', function() {
                 .then(function(data) {
                   refreshMemberList();
                   UI.success(T.groupEditMemberPasswordUpdated);
+                  groupMembersInstance.showChangePasswordForm = false;
                   groupMembersInstance.reset();
                 })
                 .fail(function(response) {
@@ -89,7 +97,8 @@ OmegaUp.on('ready', function() {
           },
           cancel: function(groupMembersInstance) {
             refreshMemberList();
-            groupMembersInstance.show = false;
+            groupMembersInstance.showEditForm = false;
+            groupMembersInstance.showChangePasswordForm = false;
             groupMembersInstance.$el.scrollIntoView();
           },
         },
@@ -100,7 +109,8 @@ OmegaUp.on('ready', function() {
       identitiesCsv: [],
       groupAlias: groupAlias,
       countries: payload.countries,
-      show: false,
+      showEditForm: false,
+      showChangePasswordForm: false,
     },
     components: {
       'omegaup-group-members': group_Members,

--- a/frontend/www/js/omegaup/lang.en.js
+++ b/frontend/www/js/omegaup/lang.en.js
@@ -373,6 +373,7 @@ const translations = {
 	groupsInvalidCsv: "Please upload a valid CSV file.",
 	groupsUploadCsvFile: "Upload CSV file",
 	identityAlreadyAssociated: "You already have one identity associated with the same group.",
+	identityInGroup: "Identity is already associated to the group.",
 	incompatibleArgs: "Arguments can't be set simultaneously",
 	index: "Coder of the month",
 	interviewCreateNew: "Create a new interview",

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -372,6 +372,7 @@
 	"groupsInvalidCsv": "Please upload a valid CSV file.",
 	"groupsUploadCsvFile": "Upload CSV file",
 	"identityAlreadyAssociated": "You already have one identity associated with the same group.",
+	"identityInGroup": "Identity is already associated to the group.",
 	"incompatibleArgs": "Arguments can't be set simultaneously",
 	"index": "Coder of the month",
 	"interviewCreateNew": "Create a new interview",

--- a/frontend/www/js/omegaup/lang.es.js
+++ b/frontend/www/js/omegaup/lang.es.js
@@ -373,6 +373,7 @@ const translations = {
 	groupsInvalidCsv: "Favor de cargar un archivo CSV v\u00e1lido.",
 	groupsUploadCsvFile: "Carga el archivo CSV",
 	identityAlreadyAssociated: "Ya cuentas con una identidad asociada con el mimso grupo.",
+	identityInGroup: "La identidad ya est\u00e1 asociada al grupo.",
 	incompatibleArgs: "Parametros no se pueden utilizar al mismo tiempo",
 	index: "Coder del mes",
 	interviewCreateNew: "Crear nueva entrevista",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -372,6 +372,7 @@
 	"groupsInvalidCsv": "Favor de cargar un archivo CSV v\u00e1lido.",
 	"groupsUploadCsvFile": "Carga el archivo CSV",
 	"identityAlreadyAssociated": "Ya cuentas con una identidad asociada con el mimso grupo.",
+	"identityInGroup": "La identidad ya est\u00e1 asociada al grupo.",
 	"incompatibleArgs": "Parametros no se pueden utilizar al mismo tiempo",
 	"index": "Coder del mes",
 	"interviewCreateNew": "Crear nueva entrevista",

--- a/frontend/www/js/omegaup/lang.pseudo.js
+++ b/frontend/www/js/omegaup/lang.pseudo.js
@@ -373,6 +373,7 @@ const translations = {
 	groupsInvalidCsv: "(P13a53 up10ad a va1id CSV fi13.)",
 	groupsUploadCsvFile: "(Up10ad CSV fi13)",
 	identityAlreadyAssociated: "(Y0u a1r3ady hav3 0n3 id3n7i7y a550cia73d wi7h 7h3 5am3 gr0up.)",
+	identityInGroup: "(Id3n7i7y i5 a1r3ady a550cia73d 70 7h3 gr0up.)",
 	incompatibleArgs: "(Argum3n75 can'7 b3 537 5imu17an30u51y)",
 	index: "(C0d3r 0f 7h3 m0n7h)",
 	interviewCreateNew: "(Cr3a73 a n3w in73rvi3w)",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -372,6 +372,7 @@
 	"groupsInvalidCsv": "(P13a53 up10ad a va1id CSV fi13.)",
 	"groupsUploadCsvFile": "(Up10ad CSV fi13)",
 	"identityAlreadyAssociated": "(Y0u a1r3ady hav3 0n3 id3n7i7y a550cia73d wi7h 7h3 5am3 gr0up.)",
+	"identityInGroup": "(Id3n7i7y i5 a1r3ady a550cia73d 70 7h3 gr0up.)",
 	"incompatibleArgs": "(Argum3n75 can'7 b3 537 5imu17an30u51y)",
 	"index": "(C0d3r 0f 7h3 m0n7h)",
 	"interviewCreateNew": "(Cr3a73 a n3w in73rvi3w)",

--- a/frontend/www/js/omegaup/lang.pt.js
+++ b/frontend/www/js/omegaup/lang.pt.js
@@ -373,6 +373,7 @@ const translations = {
 	groupsInvalidCsv: "Fa\u00e7a o upload de um arquivo CSV v\u00e1lido.",
 	groupsUploadCsvFile: "Subir CSV arquivo",
 	identityAlreadyAssociated: "Voc\u00ea j\u00e1 tem uma identidade associada ao mesmo grupo.",
+	identityInGroup: "A identidade j\u00e1 est\u00e1 associada ao grupo",
 	incompatibleArgs: "Argumentos n\u00e3o podem ser definidos simultaneamente",
 	index: "Programador do m\u00eas",
 	interviewCreateNew: "Criar uma nova entrevista",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -372,6 +372,7 @@
 	"groupsInvalidCsv": "Fa\u00e7a o upload de um arquivo CSV v\u00e1lido.",
 	"groupsUploadCsvFile": "Subir CSV arquivo",
 	"identityAlreadyAssociated": "Voc\u00ea j\u00e1 tem uma identidade associada ao mesmo grupo.",
+	"identityInGroup": "A identidade j\u00e1 est\u00e1 associada ao grupo",
 	"incompatibleArgs": "Argumentos n\u00e3o podem ser definidos simultaneamente",
 	"index": "Programador do m\u00eas",
 	"interviewCreateNew": "Criar uma nova entrevista",


### PR DESCRIPTION
# Descripción

Se realiza la migración del componente `GroupMembers` a `TypeScript`. 

También se aprovecha para migrar el código de cambiar contraseña de identidades, antes se mostraba en un modal, ahora se muestra cómo los demás formularios (debajo de las tablas). 

Part of: #2595 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
