### PR TITLE
Corrigiendo error en las nominaciones de calidad

### DIFF
--- a/frontend/www/js/omegaup/arena/qualitynomination_popup.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_popup.js
@@ -22,13 +22,13 @@ OmegaUp.on('ready', function() {
           submit: function(ev) {
             let contents = {};
 
-            if (!!ev.difficulty) {
+            if (ev.difficulty !== '') {
               contents.difficulty = Number.parseInt(ev.difficulty, 10);
             }
             if (ev.tags.length > 0) {
               contents.tags = ev.tags;
             }
-            if (!!ev.quality) {
+            if (ev.quality !== '') {
               contents.quality = Number.parseInt(ev.quality, 10);
             }
             API.QualityNomination.create({

--- a/frontend/www/js/omegaup/arena/qualitynomination_popup.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_popup.js
@@ -22,13 +22,13 @@ OmegaUp.on('ready', function() {
           submit: function(ev) {
             let contents = {};
 
-            if (typeof(ev.difficulty) !== 'undefined') {
+            if (!!ev.difficulty) {
               contents.difficulty = Number.parseInt(ev.difficulty, 10);
             }
             if (ev.tags.length > 0) {
               contents.tags = ev.tags;
             }
-            if (typeof(ev.quality) !== 'undefined') {
+            if (!!ev.quality) {
               contents.quality = Number.parseInt(ev.quality, 10);
             }
             API.QualityNomination.create({

--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -110,10 +110,11 @@ def get_global_quality_and_difficulty_average(dbconn, rank_cutoffs):
 
             user_score = row[1]
             weighting_factor = get_weighting_factor(user_score, rank_cutoffs)
-            if 'quality' in contents:
+            if 'quality' in contents and contents['quality'] is not None:
                 quality_sum += weighting_factor * contents['quality']
                 quality_n += weighting_factor
-            if 'difficulty' in contents:
+            if ('difficulty' in contents and
+                    contents['difficulty'] is not None):
                 difficulty_sum += weighting_factor * contents['difficulty']
                 difficulty_n += weighting_factor
 
@@ -141,11 +142,12 @@ def get_problem_aggregates(dbconn, problem_id, rank_cutoffs):
             contents = json.loads(row[0])
             user_score = row[1]
             weighting_factor = get_weighting_factor(user_score, rank_cutoffs)
-            if 'quality' in contents:
+            if 'quality' in contents and contents['quality'] is not None:
                 quality_votes[contents['quality']].count += 1
                 quality_votes[contents['quality']].weighted_sum += (
                     weighting_factor)
-            if 'difficulty' in contents:
+            if ('difficulty' in contents and
+                    contents['difficulty'] is not None):
                 difficulty_votes[contents['difficulty']].count += 1
                 difficulty_votes[contents['difficulty']].weighted_sum += (
                     weighting_factor)
@@ -384,7 +386,7 @@ def update_problem_of_the_week(dbconn, difficulty):
                 logging.exception('Failed to parse contents')
                 continue
 
-            if 'quality' not in contents:
+            if 'quality' not in contents or contents['quality'] is None:
                 continue
 
             quality_map[problem_id] += contents['quality']


### PR DESCRIPTION
# Descripción

Cuando `Popup.vue` fue migrado a Typescript, los valores iniciales de `quality` y `difficulty` pasaron a ser de `undefined` a `''`, lo cual ocasionó que en la base de datos se guarden valores nulos cuando dichos valores no eran modificados al momento de enviar una nominación.

En este PR, modifico la verificación que se hacía en `arena.quality_nomination_popup` y también agrego nuevas verificaciones a `aggregate_feedback.py` para solucionar los conflictos que pueden estar ocurriendo en caso se hayan enviado nominaciones desde la fecha de migración hasta el envío de este PR.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
