### PR TITLE
Haciendo que las pruebas de Selenium sean más robustas

### DIFF
--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -401,6 +401,7 @@ def add_students_bulk(driver, users):
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CLASS_NAME, ('user-add-bulk')))).click()
+    util.dismiss_status(driver)
     for user in users:
         driver.wait.until(
             EC.visibility_of_element_located(
@@ -423,6 +424,7 @@ def add_problem_to_contest(driver, problem):
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR, '.btn.add-problem'))).click()
+    util.dismiss_status(driver)
     driver.wait.until(
         EC.visibility_of_element_located(
             (By.XPATH,
@@ -488,6 +490,7 @@ def change_contest_admission_mode(driver, contest_admission_mode):
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR, '.btn.change-admission-mode'))).click()
+    util.dismiss_status(driver)
 
 
 @util.annotate

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -260,6 +260,7 @@ def add_assignment(driver, assignment_alias):
             (By.XPATH,
              '//*[contains(@class, "omegaup-course-assignmentlist")]'
              '//a[text()="%s"]' % assignment_alias)))
+    util.dismiss_status(driver)
 
 
 @util.annotate

--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -54,6 +54,20 @@ def add_students(driver, users, *, tab_xpath,
             EC.visibility_of_element_located(
                 (By.XPATH,
                  '%s//a[text()="%s"]' % (container_xpath, user))))
+        dismiss_status(driver)
+
+
+def dismiss_status(driver):
+    '''Closes the status bar and waits for it to disappear.'''
+    driver.wait.until(
+        EC.visibility_of_element_located(
+            (By.CSS_SELECTOR, '#status:not(.animating)')))
+    driver.wait.until(
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR,
+             '#status:not(.animating) button.close'))).click()
+    driver.wait.until(
+        EC.invisibility_of_element_located((By.CSS_SELECTOR, '#status')))
 
 
 def create_run(driver, problem_alias, filename):

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -94,8 +94,11 @@ let UI = {
     $('#status .message').html(message);
     $('#status')
         .removeClass('alert-success alert-info alert-warning alert-danger')
-        .addClass(type)
-        .slideDown();
+        .addClass(type + ' animating')
+        .slideDown({
+          complete: function() { $('#status')
+                                     .removeClass('animating'); },
+        });
     if (type == 'alert-success') {
       setTimeout(UI.dismissNotifications, 5000);
     }
@@ -115,8 +118,14 @@ let UI = {
 
   ignoreError: function(response) {},
 
-  dismissNotifications: function() { $('#status')
-                                         .slideUp(); },
+  dismissNotifications: function() {
+    $('#status')
+        .addClass('animating')
+        .slideUp({
+          complete: function() { $('#status')
+                                     .removeClass('animating'); },
+        });
+  },
 
   bulkOperation: function(operation, onOperationFinished, options) {
     var isStopExecuted = false;

--- a/frontend/www/js/status.dismiss.js
+++ b/frontend/www/js/status.dismiss.js
@@ -1,4 +1,4 @@
-$('#alert-close').on('click', function() { $('#status').slideUp(); });
+$('#alert-close').on('click', omegaup.UI.dismissNotifications);
 
 $('#email-verification-alert-close')
     .on('click', function() { $('#email-verification-alert')


### PR DESCRIPTION
Este cambio hace que Selenium se espere a que aparezca la barra de
notificaciones después de hacer algunas acciones que la muestran, la
cierra y espera a que desaparezca. Esto hace que las pruebas fallen
menos seguido.

Fixes: #2722