### PR TITLE
Arreglando llamado a UsersDAO que estaba incorrecto

### DIFF
--- a/frontend/server/controllers/ProblemController.php
+++ b/frontend/server/controllers/ProblemController.php
@@ -2233,7 +2233,7 @@ class ProblemController extends Controller {
 
         $addedProblems = [];
 
-        $hiddenTags = UsersDao::getHideTags($r->identity->identity_id);
+        $hiddenTags = UsersDAO::getHideTags($r->identity->identity_id);
         foreach ($problems as $problem) {
             $problemArray = $problem->asArray();
             $problemArray['tags'] = $hiddenTags ? [] : ProblemsDAO::getTagsForProblem($problem, false);
@@ -2269,7 +2269,7 @@ class ProblemController extends Controller {
 
         $addedProblems = [];
 
-        $hiddenTags = UsersDao::getHideTags($r->identity->identity_id);
+        $hiddenTags = UsersDAO::getHideTags($r->identity->identity_id);
         foreach ($problems as $problem) {
             $problemArray = $problem->asArray();
             $problemArray['tags'] = $hiddenTags ? [] : ProblemsDAO::getTagsForProblem($problem, false);


### PR DESCRIPTION
# Descripción

Se arregla un llamado que se estaba haciendo incorrectamente, se estaba llamando `UsersDao` cuando debería mandarse llamar `UsersDAO`. 

En las pruebas de `PHPUnit` no se detectaba esta falla, por eso no nos habíamos percatado.

Fixes: #2848 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
