### PR TITLE
Arreglando los nombres de las excepciones

### DIFF
--- a/frontend/www/contestedit.php
+++ b/frontend/www/contestedit.php
@@ -9,7 +9,7 @@ $smarty->assign('LANGUAGES', array_keys(RunController::$kSupportedLanguages));
 $smarty->assign('IS_UPDATE', 1);
 try {
     $smarty->display('../templates/contest.edit.tpl');
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     header('HTTP/1.1 404 Not Found');
     die();
 }

--- a/frontend/www/contestmine.php
+++ b/frontend/www/contestmine.php
@@ -20,7 +20,7 @@ try {
     $smarty->assign('privateContestsAlert', $privateContestsAlert);
     $smarty->assign('payload', $payload);
     $smarty->display('../templates/contest.mine.tpl');
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     Logger::getLogger('contestlist')->error('APIException ' . $e);
     header('HTTP/1.1 404 Not Found');
     die(file_get_contents('404.html'));

--- a/frontend/www/coursestudent.php
+++ b/frontend/www/coursestudent.php
@@ -17,7 +17,7 @@ try {
 
     $smarty->assign('payload', $payload);
     $smarty->display('../templates/course.student.tpl');
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     Logger::getLogger('coursestudents')->error('APIException ' . $e);
     header('HTTP/1.1 404 Not Found');
     die();

--- a/frontend/www/coursestudents.php
+++ b/frontend/www/coursestudents.php
@@ -15,7 +15,7 @@ try {
 
     $smarty->assign('payload', $payload);
     $smarty->display('../templates/course.students.tpl');
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     Logger::getLogger('coursestudents')->error('APIException ' . $e);
     header('HTTP/1.1 404 Not Found');
     die();

--- a/frontend/www/grouplist.php
+++ b/frontend/www/grouplist.php
@@ -6,7 +6,7 @@ try {
     $payload = GroupController::apiMyList(new \OmegaUp\Request([]));
     $smarty->assign('payload', $payload);
     $smarty->display('../templates/group.list.tpl');
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     Logger::getLogger('grouplist')->error('APIException ' . $e);
     header('HTTP/1.1 404 Not Found');
     die(file_get_contents('404.html'));

--- a/frontend/www/qualitynomination.php
+++ b/frontend/www/qualitynomination.php
@@ -21,7 +21,7 @@ try {
     }
     $smarty->assign('payload', $payload);
     $smarty->display($template);
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     Logger::getLogger('qualitynomination')->error('APIException ' . $e);
     header('HTTP/1.1 404 Not Found');
     die();

--- a/frontend/www/qualitynomination_mine.php
+++ b/frontend/www/qualitynomination_mine.php
@@ -11,7 +11,7 @@ try {
     ];
     $smarty->assign('payload', $payload);
     $smarty->display('../templates/quality.nomination.list.tpl');
-} catch (APIException $e) {
+} catch (\OmegaUp\Exceptions\ApiException $e) {
     Logger::getLogger('qualitynomination')->error('APIException ' . $e);
     header('HTTP/1.1 404 Not Found');
     die(file_get_contents('404.html'));


### PR DESCRIPTION
Algunas excepciones no se estaban atrapando correctamente porque estaban
usando el nombre de clase incorrecto.