### PR TITLE
Migrando LibinteractiveRefreshCmd a frontend/src

### DIFF
--- a/frontend/server/cmd/LibinteractiveRefreshCmd.php
+++ b/frontend/server/cmd/LibinteractiveRefreshCmd.php
@@ -25,6 +25,9 @@ Logger::configure([
     ],
 ]);
 
+/**
+ * @return Generator<int, string>
+ */
 function listDir(string $path) : Generator {
     $dh = opendir($path);
     if (!is_resource($dh)) {


### PR DESCRIPTION
Este cambio mueve LibinteractiveRefreshCmd a un mejor lugar.