### PR TITLE
Migrando UrlHelper a frontend/src

### DIFF
--- a/frontend/server/controllers/UserController.php
+++ b/frontend/server/controllers/UserController.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'libs/UrlHelper.php';
-
 /**
  *  UserController
  *
@@ -11,7 +9,10 @@ class UserController extends Controller {
     public static $sendEmailOnVerify = true;
     public static $redirectOnVerify = true;
     public static $permissionKey = null;
-    public static $urlHelper = null;
+
+    /** @var \OmegaUp\UrlHelper */
+    public static $urlHelper;
+
     const ALLOWED_SCHOLAR_DEGREES = [
         'none', 'early_childhood', 'pre_primary', 'primary', 'lower_secondary',
         'upper_secondary', 'post_secondary', 'tertiary', 'bachelors', 'master',
@@ -2509,4 +2510,4 @@ class UserController extends Controller {
     }
 }
 
-UserController::$urlHelper = new UrlHelper();
+UserController::$urlHelper = new \OmegaUp\UrlHelper();

--- a/frontend/server/src/UrlHelper.php
+++ b/frontend/server/src/UrlHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace OmegaUp;
+
 class UrlHelper {
     /**
      * Wrapper of file_get_contents

--- a/frontend/tests/controllers/UserCreateTest.php
+++ b/frontend/tests/controllers/UserCreateTest.php
@@ -326,7 +326,9 @@ class CreateUserTest extends OmegaupTestCase {
     public function testMailingtListBackfill() {
         $userUnregistered = UserFactory::createUser();
 
-        $urlHelperMock = $this->getMockBuilder('UrlHelper')->getMock();
+        $urlHelperMock = $this
+            ->getMockBuilder('\\OmegaUp\\UrlHelper')
+            ->getMock();
         $urlHelperMock->expects($this->atLeastOnce())
             ->method('fetchUrl')
             ->will($this->returnValue(UserController::SENDY_SUCCESS));
@@ -348,7 +350,9 @@ class CreateUserTest extends OmegaupTestCase {
     public function testMailingListBackfillOnlyVerified() {
         $userNotVerified = UserFactory::createUser(new UserParams(['verify' => false]));
 
-        $urlHelperMock = $this->getMockBuilder('UrlHelper')->getMock();
+        $urlHelperMock = $this
+            ->getMockBuilder('\\OmegaUp\\UrlHelper')
+            ->getMock();
         $urlHelperMock->expects($this->atLeastOnce())
             ->method('fetchUrl')
             ->will($this->returnValue(UserController::SENDY_SUCCESS));


### PR DESCRIPTION
Este cambio mueve \OmegaUp\UrlHelper al directorio que puede ser
autoloaded.