### PR TITLE
Hotfix para arreglar errores de producción

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -266,19 +266,19 @@ class ApiCaller {
             // Even though this is forbidden, we pretend the resource did not
             // exist.
             header('HTTP/1.1 404 Not Found');
-            die(file_get_contents(__DIR__ . '/../404.html'));
+            die(file_get_contents(OMEGAUP_ROOT . '/www/404.html'));
         }
         if ($apiException->getcode() == 404) {
             self::$log->info("{$apiException}");
             header('HTTP/1.1 404 Not Found');
-            die(file_get_contents(__DIR__ . '/../404.html'));
+            die(file_get_contents(OMEGAUP_ROOT . '/www/404.html'));
         }
         self::$log->error("{$apiException}");
         if (extension_loaded('newrelic') && $apiException->getCode() == 500) {
             newrelic_notice_error(strval($apiException));
         }
         header('HTTP/1.1 500 Internal Server Error');
-        die(file_get_contents(__DIR__ . '/../500.html'));
+        die(file_get_contents(OMEGAUP_ROOT . '/www/500.html'));
     }
 }
 

--- a/frontend/www/login.php
+++ b/frontend/www/login.php
@@ -7,16 +7,21 @@ $c_Session = new \OmegaUp\Controllers\Session();
 
 if (isset($_POST['request']) && ($_POST['request'] == 'login')) {
     // user wants to login natively
-
-    $r = new \OmegaUp\Request();
-    $r['usernameOrEmail'] = $_POST['user'];
-    $r['password'] = $_POST['pass'];
-    $response = \OmegaUp\Controllers\User::apiLogin($r);
-
-    if ($response['status'] === 'error') {
-        if ($response['errorcode'] === 600 || $response['errorcode'] === 601) {
-            $emailVerified = false;
-        }
+    try {
+        $response = \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
+            'usernameOrEmail' => $_POST['user'],
+            'password' => $_POST['pass'],
+        ]));
+    } catch (\OmegaUp\Exceptions\EmailNotVerifiedException $e) {
+        $emailVerified = false;
+        $response = $e->asResponseArray();
+    } catch (\OmegaUp\Exceptions\ApiException $e) {
+        $response = $e->asResponseArray();
+    } catch (\Exception $e) {
+        self::$log->error($e);
+        $apiException = new \OmegaUp\Exceptions\InternalServerErrorException($e);
+        /** @var array<string, mixed> */
+        $response = $apiException->asResponseArray();
     }
 
     $triedToLogin = true;
@@ -29,10 +34,12 @@ if (isset($_POST['request']) && ($_POST['request'] == 'login')) {
 
 if (isset($_GET['linkedin'])) {
     if (isset($_GET['code']) && isset($_GET['state'])) {
+        /** @var array<string, mixed> */
         $response = $c_Session->LoginViaLinkedIn();
     }
     $triedToLogin = true;
 } elseif (isset($_GET['fb'])) {
+    /** @var array<string, mixed> */
     $response = $c_Session->LoginViaFacebook();
     $triedToLogin = true;
 }

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -5043,17 +5043,10 @@
     <MixedArgument occurrences="1">
       <code>$_GET['redirect']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="6">
-      <code>$_POST['user']</code>
-      <code>$_POST['pass']</code>
-      <code>$response['status']</code>
-      <code>$response['errorcode']</code>
-      <code>$response['errorcode']</code>
+    <MixedArrayAccess occurrences="1">
       <code>$response['error']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
-      <code>$r['usernameOrEmail']</code>
-      <code>$r['password']</code>
+    <MixedAssignment occurrences="3">
       <code>$response</code>
       <code>$response</code>
       <code>$response</code>


### PR DESCRIPTION
Resulta que al momento de hacer login, si hay algún error, no se está
manejando correctamente y se está desplegando sólamente `error`.
    
También cuando se intenta desplegar el 404, se estaba usando la ruta
anterior.