### PR TITLE
Haciendo que Travis imprima el diff de psalm.baseline.xml

### DIFF
--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -47,9 +47,10 @@ stage_script() {
 	./vendor/bin/psalm --update-baseline --show-info=false
 
 	if [[ "$(/usr/bin/git status --porcelain psalm.baseline.xml)" != "" ]]; then
+		/usr/bin/git diff -- psalm.baseline.xml
 		>&2 echo "Some psalm errors have been fixed! Please run:"
 		>&2 echo ""
-		>&2 echo "    ./vendor/bin/psalm --update-baseline"
+		>&2 echo "    ./vendor/bin/psalm --show-info=false --update-baseline"
 		exit 1
 	fi
 }


### PR DESCRIPTION
Este cambio hace que Travis nos diga qué parte del archivo
psalm.baseline.xml no le gustó para no andar adivinando.