### PR TITLE
Arreglando bug que ocasionaba un error en arena modo práctica

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1865,7 +1865,8 @@ export class Arena {
   updateProblemScore(alias, maxScore, previousScore) {
     let self = this;
     // It only works for contests
-    if (self.options.contestAlias != null) {
+    if (self.options.contestAlias != null &&
+        typeof(self.elements.rankingTable) !== 'undefined') {
       self.elements.rankingTable.ranking =
           self.elements.rankingTable.ranking.map(rank => {
             let ranking = rank;


### PR DESCRIPTION
# Descripción

Se agrega la condición de que exista el elemento `ranking` dentro del DOM para poder mostrar la gráfica y la tabla de rankeo. Al no existir esta en Modo Práctica, mandaba el error mencionado en el issue.

Fixes: #2796 


# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
