### PR TITLE
Asegurando que el parámetro a DAO\Users::FindByUsername no es nulo

### DIFF
--- a/frontend/server/src/Controllers/Badge.php
+++ b/frontend/server/src/Controllers/Badge.php
@@ -1,6 +1,6 @@
 <?php
 
- namespace OmegaUp\Controllers;
+namespace OmegaUp\Controllers;
 
 /**
  * BadgesController
@@ -55,6 +55,10 @@ class Badge extends \OmegaUp\Controllers\Controller {
      * @return array
      */
     public static function apiUserList(\OmegaUp\Request $r) {
+        \OmegaUp\Validators::validateValidUsername(
+            $r['target_username'],
+            'target_username'
+        );
         $user = \OmegaUp\DAO\Users::FindByUsername($r['target_username']);
         if (is_null($user)) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -167,9 +167,6 @@ class Validators {
         $parameter,
         string $parameterName
     ) : void {
-        if (!self::isPresent($parameter, $parameterName, /*required=*/true)) {
-            return;
-        }
         self::validateStringOfLengthInRange($parameter, $parameterName, 2, null, /*required=*/true);
 
         if (preg_match('/[^a-zA-Z0-9_.-]/', $parameter)) {

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -68,7 +68,7 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Badge.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>static::OMEGAUP_BADGES_ROOT</code>
     </MixedArgument>
     <MixedAssignment occurrences="3">


### PR DESCRIPTION
Este cambio agrega validación para evitar un error al intentar pasar
`null` como parámetro a DAO\Users::FindByUsername.