### PR TITLE
Arreglando bug que mostraba mensaje: Versión del problema no encontrada

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1348,6 +1348,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\PreconditionFailedException('contestAddproblemTooManyProblems');
         }
 
+        \OmegaUp\Validators::validateStringOfLengthInRange($r['commit'], 'commit', 1, 40, false);
         [$masterCommit, $currentVersion] = \OmegaUp\Controllers\Problem::resolveCommit(
             $params['problem'],
             $r['commit']

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -584,6 +584,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $points = (int)$r['points'];
         }
 
+        \OmegaUp\Validators::validateStringOfLengthInRange($r['commit'], 'commit', 1, 40, false);
         self::addProblemToAssignment(
             $r['problem_alias'],
             $problemset->problemset_id,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1810,7 +1810,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?string $commit
     ) : array {
         $masterCommit = null;
-        if (is_null($commit)) {
+        if (empty($commit)) {
             $masterCommit = (new \OmegaUp\ProblemArtifacts($problem->alias, 'published'))->commit();
         } else {
             foreach ((new \OmegaUp\ProblemArtifacts($problem->alias, 'master'))->log() as $logEntry) {

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1654,7 +1654,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $r->ensureIdentity();
 
         \OmegaUp\Validators::validateValidAlias($r['problem_alias'], 'problem_alias');
-        \OmegaUp\Validators::validateStringNonEmpty($r['commit'], 'commit');
+        \OmegaUp\Validators::validateStringOfLengthInRange($r['commit'], 'commit', 1, 40, false);
         // \OmegaUp\Controllers\Problem::UPDATE_PUBLISHED_NONE is not allowed here because
         // it would not make any sense!
         \OmegaUp\Validators::validateInEnum(
@@ -1810,7 +1810,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?string $commit
     ) : array {
         $masterCommit = null;
-        if (empty($commit)) {
+        if (is_null($commit)) {
             $masterCommit = (new \OmegaUp\ProblemArtifacts($problem->alias, 'published'))->commit();
         } else {
             foreach ((new \OmegaUp\ProblemArtifacts($problem->alias, 'master'))->log() as $logEntry) {

--- a/frontend/www/js/omegaup/components/contest/AddProblem.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblem.vue
@@ -29,7 +29,7 @@
       <div class="form-group">
         <button class="btn btn-primary add-problem"
              type="submit"
-             v-on:click="onAddProblem"
+             v-on:click.prevent="onAddProblem"
              v-show="selectedRevision.commit !== ''">{{addProblemButtonLabel}}</button>
       </div>
     </div>

--- a/frontend/www/js/omegaup/components/contest/AddProblem.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblem.vue
@@ -25,11 +25,13 @@
               v-bind:show-footer="false"
               v-model="selectedRevision"
               v-on:runs-diff="onRunsDiff"></omegaup-problem-versions>
-        <div class="form-group">
-          <button class="btn btn-primary add-problem"
-               type="submit">{{addProblemButtonLabel}}</button>
-        </div>
       </form>
+      <div class="form-group">
+        <button class="btn btn-primary add-problem"
+             type="submit"
+             v-on:click="onAddProblem"
+             v-show="selectedRevision.commit !== ''">{{addProblemButtonLabel}}</button>
+      </div>
     </div>
     <table class="table table-striped">
       <thead>
@@ -101,6 +103,10 @@ export default class AddProblem extends Vue {
   selectedRevision = emptyCommit;
 
   onSubmit(): void {
+    this.$emit('emit-change-alias', this, this.alias);
+  }
+
+  onAddProblem(): void {
     this.$emit('emit-add-problem', this);
   }
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -185,7 +185,7 @@
       <code>apiDownload</code>
       <code>isPublic</code>
     </MissingReturnType>
-    <MixedArgument occurrences="80">
+    <MixedArgument occurrences="79">
       <code>$callback_user_function</code>
       <code>$contest['start_time']</code>
       <code>$contest['finish_time']</code>
@@ -225,7 +225,6 @@
       <code>$r['contest_alias']</code>
       <code>$r['contest_alias']</code>
       <code>$r['problem_alias']</code>
-      <code>$r['commit']</code>
       <code>$masterCommit</code>
       <code>$currentVersion</code>
       <code>$r['points']</code>
@@ -602,7 +601,7 @@
       <code>apiListCourses</code>
       <code>apiStudentProgress</code>
     </MissingReturnType>
-    <MixedArgument occurrences="100">
+    <MixedArgument occurrences="99">
       <code>$r['school_id']</code>
       <code>$r['course_alias']</code>
       <code>$r['start_time']</code>
@@ -617,7 +616,6 @@
       <code>$r['course_alias']</code>
       <code>$r['problem_alias']</code>
       <code>$problemset-&gt;problemset_id</code>
-      <code>$r['commit']</code>
       <code>$r['assignment_alias']</code>
       <code>$r['course_alias']</code>
       <code>$r['course_alias']</code>


### PR DESCRIPTION
# Descripción

Se arregla bug en el que se mostraba el mensaje: **Versión del problema no encontrada**.

Este bug se reproducía aleatoriamente, no encontré alguna constante para hacerlo fallar y por ende, agregar una prueba. Sólo noté que en algunas ocasiones el parámetro `commit` que se envía como parámetro a `Problem::resolveCommit` llegaba vacío y la condición para obtener `masterCommit` si `commit` era `null`, así que en algunas ocasiones no entraba en el caso correcto.

Después de este cambio ya no me volvió a aparecer el mensaje, faltaría corroborar si en producción también funciona esta solución.

Fixes: #2873

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
