### PR TITLE
Moviendo de posición el script de twitter para evitar error

### DIFF
--- a/frontend/templates/footer.tpl
+++ b/frontend/templates/footer.tpl
@@ -42,6 +42,7 @@
 		<!-- #content -->
 	</div>
 </div>
+<script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 {include file='common.analytics.tpl'}
 <!-- #root -->
 </body>

--- a/frontend/templates/footer.tpl
+++ b/frontend/templates/footer.tpl
@@ -15,6 +15,7 @@
 						<div class="col-md-4">
 							<!-- Twitter follow -->
 							<a href="https://twitter.com/omegaup?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-width="300px" data-height="20" data-show-screen-name="false" data-dnt="true" data-show-count="true">Follow @omegaup</a>
+							<script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 						</div>
 					</div>
 				</div>
@@ -42,7 +43,6 @@
 		<!-- #content -->
 	</div>
 </div>
-<script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 {include file='common.analytics.tpl'}
 <!-- #root -->
 </body>

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -44,7 +44,6 @@
 		<script type="text/javascript" src="{version_hash src="/js/head.sugar_locale.js"}"></script>
         <!-- Social media button -->
         <script async defer src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12" charset="utf-8"></script>
-        <script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 		<!-- Bootstrap from CDN -->
 		<!-- Latest compiled and minified CSS -->
 		<link rel="stylesheet" href="/third_party/css/bootstrap.min.css">


### PR DESCRIPTION
# Descripción

Se mueve de posición de script de twitter para evitar un error que estaba apareciendo en la consola de JavaScript

Fixes: #2878 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.