### PR TITLE
Agregando más aseveraciones a Request::ensure*Identity()

### DIFF
--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -50,7 +50,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      * @param \OmegaUp\Request $r
      */
     public static function apiCreate(\OmegaUp\Request $r) {
-        $r->ensureIdentity();
+        $r->ensureMainUserIdentity();
 
         \OmegaUp\Validators::validateValidAlias($r['alias'], 'alias', true);
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
@@ -171,7 +171,6 @@ class Group extends \OmegaUp\Controllers\Controller {
     public static function apiMyList(\OmegaUp\Request $r) : array {
         $r->ensureMainUserIdentity();
 
-        /** @psalm-suppress PossiblyNullArgument */
         $groups = \OmegaUp\DAO\Groups::getAllGroupsAdminedByUser(
             $r->user->user_id,
             $r->identity->identity_id

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -155,6 +155,7 @@ class Request extends \ArrayObject {
      *
      * @throws \OmegaUp\Exceptions\UnauthorizedException
      * @psalm-assert !null $this->identity
+     * @psalm-assert !null $this->identity->identity_id
      */
     public function ensureIdentity() : void {
         $this->user = null;
@@ -175,7 +176,11 @@ class Request extends \ArrayObject {
      *
      * @throws \OmegaUp\Exceptions\UnauthorizedException
      * @psalm-assert !null $this->identity
+     * @psalm-assert !null $this->identity->identity_id
+     * @psalm-assert !null $this->identity->user_id
      * @psalm-assert !null $this->user
+     * @psalm-assert !null $this->user->user_id
+     * @psalm-assert !null $this->user->main_identity_id
      */
     public function ensureMainUserIdentity() : void {
         $this->ensureIdentity();

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -438,23 +438,18 @@
     <PossiblyFalseArgument occurrences="1">
       <code>$result['requestsUserInformation']</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="33">
-      <code>$r-&gt;identity-&gt;identity_id</code>
+    <PossiblyNullArgument occurrences="28">
       <code>$r-&gt;identity</code>
       <code>$session['identity']</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
       <code>$contest-&gt;acl_id</code>
       <code>$acl-&gt;owner_id</code>
       <code>$contest-&gt;problemset_id</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
-      <code>$r-&gt;user-&gt;user_id</code>
       <code>$originalContest-&gt;problemset_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
@@ -850,7 +845,7 @@
       <code>$course</code>
       <code>$result</code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="15">
+    <PossiblyNullArgument occurrences="12">
       <code>$r-&gt;identity</code>
       <code>$course-&gt;group_id</code>
       <code>$problemset-&gt;problemset_id</code>
@@ -874,9 +869,6 @@
       <code>$r-&gt;identity</code>
       <code>$course-&gt;course_id</code>
       <code>$r-&gt;identity</code>
-      <code>$resolvedIdentity-&gt;identity_id</code>
-      <code>$resolvedIdentity-&gt;identity_id</code>
-      <code>$resolvedIdentity-&gt;identity_id</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;identity</code>
@@ -960,10 +952,6 @@
       <code>$group-&gt;name</code>
       <code>$group-&gt;alias</code>
     </MixedPropertyFetch>
-    <PossiblyNullPropertyFetch occurrences="1">
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-    </PossiblyNullPropertyFetch>
   </file>
   <file src="frontend/server/src/Controllers/GroupScoreboard.php">
     <MissingReturnType occurrences="4">
@@ -1565,7 +1553,7 @@
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="23">
+    <PossiblyNullArgument occurrences="22">
       <code>$r-&gt;identity</code>
       <code>$r-&gt;user</code>
       <code>$r-&gt;identity</code>
@@ -1772,7 +1760,7 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
-    <PossiblyNullArgument occurrences="5">
+    <PossiblyNullArgument occurrences="4">
       <code>$qualityReviewerGroup</code>
       <code>$qualitynominationlog-&gt;rationale</code>
       <code>$r-&gt;identity</code>


### PR DESCRIPTION
Este cambio hace que tengamos más aseveraciones en
Request::ensureMainUserIdentity() y Request::ensureIdentity() para
necesitar menos anotaciones explícitas.