### PR TITLE
Eliminando todas las anotaciones de $r->{user,identity}

### DIFF
--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -93,6 +93,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
     private static function validateDetails(\OmegaUp\Request $r) {
+        $r->ensureIdentity();
         $r->ensureInt('clarification_id');
 
         // Check that the clarification actually exists

--- a/frontend/server/src/Controllers/Interview.php
+++ b/frontend/server/src/Controllers/Interview.php
@@ -4,6 +4,7 @@
 
 class Interview extends \OmegaUp\Controllers\Controller {
     private static function validateCreateOrUpdate(\OmegaUp\Request $r, $is_update = false) {
+        $r->ensureMainUserIdentity();
         $is_required = !$is_update;
 
         // Only site-admins and interviewers can create interviews for now
@@ -23,7 +24,7 @@ class Interview extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException('lockdown');
         }
 
-        $r->ensureIdentity();
+        $r->ensureMainUserIdentity();
 
         self::validateCreateOrUpdate($r, false);
 
@@ -227,7 +228,7 @@ class Interview extends \OmegaUp\Controllers\Controller {
     }
 
     public static function apiList(\OmegaUp\Request $r) {
-        $r->ensureIdentity();
+        $r->ensureMainUserIdentity();
 
         $interviews = null;
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -38,6 +38,7 @@ class Run extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
     private static function validateCreateRequest(\OmegaUp\Request $r) {
+        $r->ensureIdentity();
         // https://github.com/omegaup/omegaup/issues/739
         if ($r->identity->username == 'omi') {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -156,8 +156,12 @@ class Request extends \ArrayObject {
      * @throws \OmegaUp\Exceptions\UnauthorizedException
      * @psalm-assert !null $this->identity
      * @psalm-assert !null $this->identity->identity_id
+     * @psalm-assert !null $this->identity->username
      */
     public function ensureIdentity() : void {
+        if (!is_null($this->user) || !is_null($this->identity)) {
+            return;
+        }
         $this->user = null;
         $this->identity = null;
         $session = \OmegaUp\Controllers\Session::apiCurrentSession($this)['session'];
@@ -178,11 +182,16 @@ class Request extends \ArrayObject {
      * @psalm-assert !null $this->identity
      * @psalm-assert !null $this->identity->identity_id
      * @psalm-assert !null $this->identity->user_id
+     * @psalm-assert !null $this->identity->username
      * @psalm-assert !null $this->user
-     * @psalm-assert !null $this->user->user_id
      * @psalm-assert !null $this->user->main_identity_id
+     * @psalm-assert !null $this->user->user_id
+     * @psalm-assert !null $this->user->username
      */
     public function ensureMainUserIdentity() : void {
+        if (!is_null($this->user) && !is_null($this->identity)) {
+            return;
+        }
         $this->ensureIdentity();
         if (is_null($this->user)
             || $this->user->main_identity_id != $this->identity->identity_id

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -130,9 +130,7 @@
     <MixedReturnStatement occurrences="1">
       <code>$response</code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="4">
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
+    <PossiblyNullArgument occurrences="3">
       <code>$clarification-&gt;problem_id</code>
       <code>$clarification-&gt;author_id</code>
     </PossiblyNullArgument>
@@ -439,62 +437,26 @@
       <code>$result['requestsUserInformation']</code>
     </PossiblyFalseArgument>
     <PossiblyNullArgument occurrences="28">
-      <code>$r-&gt;identity</code>
       <code>$session['identity']</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;acl_id</code>
       <code>$acl-&gt;owner_id</code>
       <code>$contest-&gt;problemset_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$originalContest-&gt;problemset_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;problemset_id</code>
       <code>$problemset-&gt;problemset_id</code>
       <code>$problemset</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;problemset_id</code>
       <code>$problemset</code>
-      <code>$r-&gt;identity</code>
       <code>$problemsetProblem-&gt;version</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;problemset_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;problemset_id</code>
       <code>$problemset</code>
       <code>$contest-&gt;contest_id</code>
       <code>$originalContest</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;problemset_id</code>
       <code>$problemset</code>
-      <code>$r-&gt;identity</code>
       <code>$problemsetIdentity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$contest-&gt;problemset_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="7">
       <code>$session['user']</code>
@@ -525,26 +487,19 @@
       <code>$problemsetIdentity</code>
     </PossiblyNullPropertyAssignment>
     <PossiblyNullPropertyFetch occurrences="17">
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
       <code>$identity-&gt;country_id</code>
       <code>$identity-&gt;state_id</code>
       <code>$identity-&gt;school_id</code>
       <code>$identity-&gt;language_id</code>
       <code>$current_ses['identity']-&gt;identity_id</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
       <code>$original_contest-&gt;alias</code>
       <code>$original_contest-&gt;problemset_id</code>
       <code>$acl-&gt;owner_id</code>
       <code>\OmegaUp\DAO\Users::getByPK($acl-&gt;owner_id)-&gt;username</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
       <code>$contest-&gt;start_time</code>
       <code>$contest-&gt;finish_time</code>
       <code>$problemset-&gt;problemset_id</code>
       <code>$targetIdentity-&gt;identity_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
       <code>$targetIdentity-&gt;username</code>
     </PossiblyNullPropertyFetch>
     <TypeDoesNotContainNull occurrences="1">
@@ -846,47 +801,15 @@
       <code>$result</code>
     </MixedReturnStatement>
     <PossiblyNullArgument occurrences="12">
-      <code>$r-&gt;identity</code>
       <code>$course-&gt;group_id</code>
       <code>$problemset-&gt;problemset_id</code>
-      <code>$r-&gt;identity</code>
       <code>$points</code>
       <code>$order</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$course-&gt;course_id</code>
       <code>$course-&gt;group_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$course-&gt;course_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$course-&gt;group_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$acl-&gt;owner_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="1">
       <code>\OmegaUp\Controllers\Session::apiCurrentSession($r)['session']['identity']</code>
@@ -895,7 +818,6 @@
       <code>$resolvedUser-&gt;user_id</code>
       <code>$acl-&gt;owner_id</code>
       <code>\OmegaUp\DAO\Users::getByPK($acl-&gt;owner_id)-&gt;username</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
     </PossiblyNullPropertyFetch>
     <RedundantCondition occurrences="1"/>
     <TypeDoesNotContainNull occurrences="1">
@@ -1116,7 +1038,6 @@
     <MixedArgument occurrences="7">
       <code>$r</code>
       <code>\OmegaUp\Controllers\User::makeUsernameFromEmail($r['usernameOrEmail'])</code>
-      <code>$r-&gt;identity</code>
       <code>$r['interview']</code>
       <code>$r['user']-&gt;main_email_id</code>
       <code>$interview</code>
@@ -1176,15 +1097,10 @@
       <code>$r['interview']-&gt;alias</code>
       <code>$r['interview']-&gt;alias</code>
       <code>$r['interview']-&gt;alias</code>
-      <code>$r-&gt;identity</code>
       <code>$r['interview']-&gt;problemset_id</code>
       <code>$r['user']-&gt;main_identity_id</code>
       <code>$r['user']-&gt;main_email_id</code>
     </MixedPropertyFetch>
-    <PossiblyNullArgument occurrences="1">
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-    </PossiblyNullArgument>
     <PossiblyNullOperand occurrences="5">
       <code>\OmegaUp\Translations::getInstance()-&gt;get('interviewInvitationEmailBodyIntro')</code>
       <code>\OmegaUp\Translations::getInstance()-&gt;get('interviewEmailDraft')</code>
@@ -1192,11 +1108,6 @@
       <code>\OmegaUp\Translations::getInstance()-&gt;get('loginPassword')</code>
       <code>\OmegaUp\Translations::getInstance()-&gt;get('interviewInvitationEmailBodyIntro')</code>
     </PossiblyNullOperand>
-    <PossiblyNullPropertyFetch occurrences="3">
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-    </PossiblyNullPropertyFetch>
   </file>
   <file src="frontend/server/src/Controllers/Notification.php">
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -1554,47 +1465,15 @@
       <code>null</code>
     </NullableReturnStatement>
     <PossiblyNullArgument occurrences="22">
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user</code>
       <code>$problem-&gt;alias</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$response['contest']-&gt;problemset_id</code>
-      <code>$r-&gt;identity-&gt;username</code>
-      <code>$r-&gt;identity</code>
       <code>$problem-&gt;acl_id</code>
       <code>$acl-&gt;owner_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;identity</code>
       <code>$problem-&gt;alias</code>
-      <code>$r-&gt;identity</code>
       <code>$problem-&gt;alias</code>
       <code>((new \OmegaUp\ProblemArtifacts($problem-&gt;alias, 'published'))-&gt;commit())['commit']</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;identity</code>
       <code>$problem-&gt;current_version</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
       <code>$problem-&gt;alias</code>
-      <code>$r-&gt;identity</code>
       <code>$problem-&gt;alias</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="2">
@@ -1605,7 +1484,6 @@
       <code>$problemDeployer-&gt;publishedCommit</code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullPropertyFetch occurrences="4">
-      <code>$r-&gt;user-&gt;username</code>
       <code>$acl-&gt;owner_id</code>
       <code>$problemsetter-&gt;username</code>
       <code>$problemsetter-&gt;name</code>
@@ -1763,18 +1641,8 @@
     <PossiblyNullArgument occurrences="4">
       <code>$qualityReviewerGroup</code>
       <code>$qualitynominationlog-&gt;rationale</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;identity</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyFetch occurrences="4">
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;username</code>
-    </PossiblyNullPropertyFetch>
+    <PossiblyNullPropertyFetch occurrences="4"/>
     <RedundantCondition occurrences="1">
       <code>is_array($contents['tags'])</code>
     </RedundantCondition>
@@ -1798,7 +1666,6 @@
       <code>$r['password']</code>
       <code>$user-&gt;main_identity_id</code>
       <code>$user</code>
-      <code>$r-&gt;identity</code>
       <code>$reset_token</code>
       <code>$password</code>
     </MixedArgument>
@@ -1842,7 +1709,6 @@
       <code>$user-&gt;main_identity_id</code>
       <code>$user-&gt;password</code>
       <code>$user-&gt;verified</code>
-      <code>$r-&gt;identity</code>
       <code>$user-&gt;reset_sent_at</code>
       <code>$user-&gt;reset_digest</code>
       <code>$user-&gt;reset_sent_at</code>
@@ -2015,32 +1881,14 @@
       <code>$filtered</code>
       <code>$response</code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="10">
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
+    <PossiblyNullArgument occurrences="7">
       <code>$run-&gt;submission_id</code>
       <code>$submission-&gt;problem_id</code>
       <code>$problem-&gt;alias</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$submission-&gt;guid</code>
-      <code>$r-&gt;identity</code>
       <code>$submission-&gt;current_run_id</code>
       <code>$submission-&gt;problem_id</code>
-      <code>$r-&gt;identity</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyFetch occurrences="3">
-      <code>$r-&gt;identity-&gt;username</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-    </PossiblyNullPropertyFetch>
   </file>
   <file src="frontend/server/src/Controllers/School.php">
     <DocblockTypeContradiction occurrences="1">
@@ -2212,12 +2060,6 @@
     </MixedPropertyFetch>
   </file>
   <file src="frontend/server/src/Controllers/User.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_null($r-&gt;identity)</code>
-    </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>$r-&gt;identity-&gt;identity_id</code>
-    </InvalidArgument>
     <InvalidNullableReturnType occurrences="1">
       <code>Array</code>
     </InvalidNullableReturnType>
@@ -2496,28 +2338,10 @@
       <code>$user-&gt;main_identity_id</code>
       <code>$user</code>
       <code>$identity</code>
-      <code>$r-&gt;identity</code>
       <code>$user-&gt;username</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
       <code>$user</code>
       <code>$identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;main_email_id</code>
       <code>$email</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;identity</code>
-      <code>$r-&gt;user</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="6">
       <code>$session['identity']</code>
@@ -2536,56 +2360,15 @@
     </PossiblyNullOperand>
     <PossiblyNullPropertyAssignment occurrences="5">
       <code>$identity</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;user</code>
       <code>$email</code>
-      <code>$r-&gt;user</code>
-      <code>$r-&gt;user</code>
     </PossiblyNullPropertyAssignment>
-    <PossiblyNullPropertyFetch occurrences="39">
+    <PossiblyNullPropertyFetch occurrences="37">
       <code>$email-&gt;email</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;user-&gt;main_email_id</code>
-      <code>$r-&gt;user-&gt;verified</code>
-      <code>$r-&gt;user-&gt;verification_id</code>
-      <code>$r-&gt;user-&gt;username</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
-      <code>$r-&gt;identity-&gt;identity_id</code>
       <code>$identity-&gt;country_id</code>
       <code>$identity-&gt;country_id</code>
       <code>$identity-&gt;state_id</code>
       <code>$identity-&gt;school_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
     </PossiblyNullPropertyFetch>
-    <RedundantConditionGivenDocblockType occurrences="1"/>
     <UndefinedDocblockClass occurrences="11">
       <code>type</code>
       <code>$response</code>


### PR DESCRIPTION
Este cambio termina la migración de todas las anotaciones de
$r->{user,identity}. A partir de ahora, ya no se necesitarán anotaciones
porque puedes usar $r->ensure*Identity() para asegurar que estos objetos
sean no-nulos.