### PR TITLE
Aplicando corrección al editar concurso

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -44,7 +44,7 @@
         <omegaup-contest-new-form v-bind:data="contest"
              v-bind:update="true"
              v-on:emit-update-contest=
-             "$emit('update-contest', newFormComponent)"></omegaup-contest-new-form>
+             "newFormComponent =&gt; $emit('update-contest', newFormComponent)"></omegaup-contest-new-form>
       </div>
       <div class="tab-pane active problems"
            v-if="showTab === 'problems'">


### PR DESCRIPTION
# Descripción

Se agrega la definición de un componente faltante para que no mande error al editar concurso.

Fixes: #2885 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
