### PR TITLE
Arreglando la búsqueda de concursos

### DIFF
--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -64,19 +64,27 @@ class ContestListTest extends OmegaupTestCase {
         // Create new PUBLIC contest
         $contestData = ContestsFactory::createContest();
 
-        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request(['page_size' => 50]));
-
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'page_size' => 50,
+        ]));
         $this->assertArrayContainsInKeyExactlyOnce(
             $response['results'],
             'title',
             $contestData['request']['title']
         );
         $this->assertDurationIsCorrect($response, $contestData);
+
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'page_size' => 50,
+            'query' => 'thiscontestdoesnotexist',
+        ]));
+        $this->assertArrayNotContainsInKey(
+            $response['results'],
+            'title',
+            $contestData['request']['title']
+        );
     }
 
-    /**
-     *
-     */
     public function testPrivateContestForInvitedUser() {
         // Create new private contest
         $contestData = ContestsFactory::createContest(new ContestParams(['admission_mode' => 'private']));
@@ -88,22 +96,28 @@ class ContestListTest extends OmegaupTestCase {
         ContestsFactory::addUser($contestData, $contestant);
 
         $login = self::login($contestant);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-        ]);
-        $response = \OmegaUp\Controllers\Contest::apiList($r);
 
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
         $this->assertArrayContainsInKeyExactlyOnce(
             $response['results'],
             'title',
             $contestData['request']['title']
         );
         $this->assertDurationIsCorrect($response, $contestData);
+
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'query' => 'thiscontestdoesnotexist',
+        ]));
+        $this->assertArrayNotContainsInKey(
+            $response['results'],
+            'title',
+            $contestData['request']['title']
+        );
     }
 
-    /**
-     *
-     */
     public function testPrivateContestForNonInvitedUser() {
         // Create new private contest
         $contestData = ContestsFactory::createContest(new ContestParams(['admission_mode' => 'private']));
@@ -115,12 +129,10 @@ class ContestListTest extends OmegaupTestCase {
         ContestsFactory::addUser($contestData, $contestant);
 
         $login = self::login(UserFactory::createUser());
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-        ]);
-        $response = \OmegaUp\Controllers\Contest::apiList($r);
 
-        // Assert our contest is not there
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
         $this->assertArrayNotContainsInKey(
             $response['results'],
             'title',
@@ -128,27 +140,33 @@ class ContestListTest extends OmegaupTestCase {
         );
     }
 
-    /**
-     *
-     */
     public function testPrivateContestForSystemAdmin() {
         // Create new private contest
         $contestData = ContestsFactory::createContest(new ContestParams(['admission_mode' => 'private']));
 
         $login = self::login(UserFactory::createAdminUser());
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'page_size' => 100
-        ]);
-        $response = \OmegaUp\Controllers\Contest::apiList($r);
 
-        // Assert our contest is there
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'page_size' => 100,
+        ]));
         $this->assertArrayContainsInKeyExactlyOnce(
             $response['results'],
             'title',
             $contestData['request']['title']
         );
         $this->assertDurationIsCorrect($response, $contestData);
+
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'page_size' => 100,
+            'query' => 'thiscontestdoesnotexist',
+        ]));
+        $this->assertArrayNotContainsInKey(
+            $response['results'],
+            'title',
+            $contestData['request']['title']
+        );
     }
 
     /**
@@ -165,18 +183,26 @@ class ContestListTest extends OmegaupTestCase {
         ContestsFactory::addAdminUser($contestData, $contestant);
 
         $login = self::login($contestant);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-        ]);
-        $response = \OmegaUp\Controllers\Contest::apiList($r);
 
-        // Assert our contest is there
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
         $this->assertArrayContainsInKeyExactlyOnce(
             $response['results'],
             'title',
             $contestData['request']['title']
         );
         $this->assertDurationIsCorrect($response, $contestData);
+
+        $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'query' => 'thiscontestdoesnotexist',
+        ]));
+        $this->assertArrayNotContainsInKey(
+            $response['results'],
+            'title',
+            $contestData['request']['title']
+        );
     }
 
     /**
@@ -279,7 +305,7 @@ class ContestListTest extends OmegaupTestCase {
         $recommendedContestData = ContestsFactory::createContest();
         $notRecommendedContestData = ContestsFactory::createContest(new ContestParams(
             [
-                'finish_time' => $recommendedContestData['request']['finish_time'] + 1
+                'finish_time' => $recommendedContestData['request']['finish_time'] + 1,
             ]
         ));
 

--- a/frontend/www/arena/index.php
+++ b/frontend/www/arena/index.php
@@ -4,9 +4,9 @@ require_once('../../server/bootstrap_smarty.php');
 // Fetch contests
 try {
     $query = '';
-    if (!empty($_REQUEST['query']) && strlen($_REQUEST['query']) > 0) {
-        $query = substr($_REQUEST['query'], 0, 256);
-        $r['query'] = $query;
+    if (!empty($_REQUEST['query'])) {
+        /** @var array<string, mixed> $_REQUEST */
+        $query = substr(strval($_REQUEST['query']), 0, 256);
     }
     $smarty->assign('query', $query);
 } catch (Exception $e) {

--- a/frontend/www/js/omegaup/arena/contest_list.js
+++ b/frontend/www/js/omegaup/arena/contest_list.js
@@ -1,10 +1,9 @@
 omegaup.arena = omegaup.arena || {};
 
 // TODO: This really should be a Knockout component.
-omegaup.arena.ContestList = function(element, apiParams, uiParams) {
+omegaup.arena.ContestList = function(domElement, apiParams, uiParams) {
   var self = this;
-  self.jQueryElement = $(element);
-  self.domElement = self.jQueryElement[0];
+  self.domElement = domElement;
 
   var actualApiParams = $.extend(
       {
@@ -23,7 +22,7 @@ omegaup.arena.ContestList = function(element, apiParams, uiParams) {
                     actualApiParams.active == 'FUTURE'),
         showPractice: (actualApiParams.active == 'PAST'),
         showVirtual: (actualApiParams.active == 'PAST'),
-        showPublicUpdated: actualApiParams.public == 'YES'
+        showPublicUpdated: actualApiParams.public == 'YES',
       },
       uiParams);
 

--- a/frontend/www/ux/arena.js
+++ b/frontend/www/ux/arena.js
@@ -9,7 +9,7 @@ omegaup.OmegaUp.on('ready', function() {
       'RECOMMENDED',
       'NO',
       'NO',
-      omegaup.T.arenaRecommendedCurrentContests
+      omegaup.T.arenaRecommendedCurrentContests,
     ],
     [
       '#current-contests',
@@ -17,7 +17,7 @@ omegaup.OmegaUp.on('ready', function() {
       'NOT_RECOMMENDED',
       'NO',
       'NO',
-      omegaup.T.arenaCurrentContests
+      omegaup.T.arenaCurrentContests,
     ],
     [
       '#list-current-public-contest',
@@ -25,7 +25,7 @@ omegaup.OmegaUp.on('ready', function() {
       'NOT_RECOMMENDED',
       'NO',
       'YES',
-      omegaup.T.arenaCurrentPublicContests
+      omegaup.T.arenaCurrentPublicContests,
     ],
     [
       '#future-contests',
@@ -33,7 +33,7 @@ omegaup.OmegaUp.on('ready', function() {
       'NOT_RECOMMENDED',
       'NO',
       'NO',
-      omegaup.T.arenaFutureContests
+      omegaup.T.arenaFutureContests,
     ],
     [
       '#recommended-past-contests',
@@ -41,7 +41,7 @@ omegaup.OmegaUp.on('ready', function() {
       'RECOMMENDED',
       'NO',
       'NO',
-      omegaup.T.arenaRecommendedOldContests
+      omegaup.T.arenaRecommendedOldContests,
     ],
     [
       '#past-contests',
@@ -49,7 +49,7 @@ omegaup.OmegaUp.on('ready', function() {
       'NOT_RECOMMENDED',
       'NO',
       'NO',
-      omegaup.T.arenaOldContests
+      omegaup.T.arenaOldContests,
     ],
     [
       '#participating-current-contests',
@@ -57,21 +57,23 @@ omegaup.OmegaUp.on('ready', function() {
       'NOT_RECOMMENDED',
       'YES',
       'NO',
-      omegaup.T.arenaMyActiveContests
+      omegaup.T.arenaMyActiveContests,
     ],
   ];
 
   var requests = [];
   var contestLists = [];
+  var query = document.querySelector('input[name=query]').value;
+
   for (var i = 0, len = contestListConfigs.length; i < len; i++) {
     var config = contestListConfigs[i];
     var contestList = new omegaup.arena.ContestList(
-        config[0],
+        document.querySelector(config[0]),
         {
           active: config[1],
           recommended: config[2],
           participating: config[3], public: config[4],
-          query: $('input[name=query]').val()
+          query: query,
         },
         {header: config[5]});
     contestLists.push(contestList);


### PR DESCRIPTION
En un par de los casos donde se permitía hacer la búsqueda de concursos,
se estaba usando incondicionalmente el cache, lo que ocasionaba que si
alguien intentaba buscar un concurso, se desplegaran todos los
concursos.

Fixes: #2886