### PR TITLE
Ocultando la pestaña de Clarificaciones en la vista de Sólo Problema

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2490,6 +2490,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'memory_limit' => "{$memoryLimit} MiB",
             'input_limit' => ($details['input_limit'] / 1024) . ' KiB',
             'solvers' => $details['solvers'],
+            'only_problem_clarifications_enabled' => false,
             'quality_payload' => [
                 'solved' => false,
                 'nominated' => false,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2490,7 +2490,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'memory_limit' => "{$memoryLimit} MiB",
             'input_limit' => ($details['input_limit'] / 1024) . ' KiB',
             'solvers' => $details['solvers'],
-            'only_problem_clarifications_enabled' => false,
             'quality_payload' => [
                 'solved' => false,
                 'nominated' => false,

--- a/frontend/templates/arena.clarification_list.tpl
+++ b/frontend/templates/arena.clarification_list.tpl
@@ -21,9 +21,11 @@
 						</tr>
 					</thead>
 					<tfoot>
+						{if $contest}
 						<tr>
 							<td colspan="6"><a href="#clarifications/new">{#wordsNewClarification#}</a></td>
 						</tr>
+						{/if}
 					</tfoot>
 					<tbody class="clarification-list">
 						<tr class="template">

--- a/frontend/templates/arena.problem.tpl
+++ b/frontend/templates/arena.problem.tpl
@@ -5,8 +5,8 @@
     {if $payload['user']['logged_in']}
       <li><a href="#solution">{#wordsSolution#}</a></li>
     {/if}
-    {if $problem_admin}<li><a href="#runs">{#wordsRuns#}</a></li>{/if}
     {if $problem_admin}
+      <li><a href="#runs">{#wordsRuns#}</a></li>
       <li><a href="#clarifications">{#wordsClarifications#}<span id="clarifications-count"></span></a></li>
     {/if}
   </ul>

--- a/frontend/templates/arena.problem.tpl
+++ b/frontend/templates/arena.problem.tpl
@@ -2,9 +2,13 @@
 <script type="text/json" id="payload">{$payload|json_encode}</script>
   <ul class="tabs">
     <li><a href="#problems" class="active">{#wordsProblem#}</a></li>
-    <li><a href="#solution">{#wordsSolution#}</a></li>
+    {if $payload['user']['logged_in']}
+      <li><a href="#solution">{#wordsSolution#}</a></li>
+    {/if}
     {if $problem_admin}<li><a href="#runs">{#wordsRuns#}</a></li>{/if}
-    <li><a href="#clarifications">{#wordsClarifications#}<span id="clarifications-count"></span></a></li>
+    {if $only_problem_clarifications_enabled}
+      <li><a href="#clarifications">{#wordsClarifications#}<span id="clarifications-count"></span></a></li>
+    {/if}
   </ul>
   <div id="problems" class="tab">
     <div id="problem" class="main">

--- a/frontend/templates/arena.problem.tpl
+++ b/frontend/templates/arena.problem.tpl
@@ -6,7 +6,7 @@
       <li><a href="#solution">{#wordsSolution#}</a></li>
     {/if}
     {if $problem_admin}<li><a href="#runs">{#wordsRuns#}</a></li>{/if}
-    {if $only_problem_clarifications_enabled}
+    {if $problem_admin}
       <li><a href="#clarifications">{#wordsClarifications#}<span id="clarifications-count"></span></a></li>
     {/if}
   </ul>


### PR DESCRIPTION
# Descripción

Se oculta la pestaña de `Clarificaciones` en la vista de Arena Sólo Problema a menos que sea administrador, ya que los no-administradores no pueden interactuar con ella.

Fixes: #2890 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
