### PR TITLE
Usando la nueva interfaz de gitserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ frontend/tests/controllers/gitserver.pid
 frontend/tests/controllers/grade/
 frontend/tests/controllers/img/
 frontend/tests/controllers/templates/
+frontend/tests/omegaup.db
 frontend/tests/ui/results/
 omegaup_test.log
 

--- a/frontend/tests/controllers/gitserver-start.sh
+++ b/frontend/tests/controllers/gitserver-start.sh
@@ -30,5 +30,6 @@ cat > "${DIR}/gitserver.config.json" <<EOF
 EOF
 
 /usr/bin/nohup /usr/bin/omegaup-gitserver \
+	-insecure-skip-authorization \
 	-config="${DIR}/gitserver.config.json" >> "${DIR}/gitserver.log" 2>&1 &
 echo $! > "${DIR}/gitserver.pid"

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,7 +42,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.19/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.20/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.

--- a/stuff/travis/nginx/gitserver-start.sh
+++ b/stuff/travis/nginx/gitserver-start.sh
@@ -13,7 +13,8 @@ cat > "/tmp/omegaup/gitserver.config.json" <<EOF
 	},
 	"Gitserver": {
 		"AllowDirectPushToMaster": true,
-		"RootPath": "/tmp/omegaup/problems.git"
+		"RootPath": "/tmp/omegaup/problems.git",
+		"FrontendAuthorizationProblemRequestURL": "http://localhost/api/authorization/problem/"
 	}
 }
 EOF


### PR DESCRIPTION
Se hizo un cambio en la manera en la que gitserver autoriza a los
usuarios. Este cambio desactiva la autorización en las pruebas
unitarias, pero lo activa en las pruebas de Selenium.