### PR TITLE
Agregando el archivo omegaup.db en .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ frontend/www/docs/pas
 
 # Ignore VS Code json
 .vscode/*
+
+# Ignore omegaup.db
+omegaup.db


### PR DESCRIPTION
# Descripción

Se agrega `omegaup.db` en el archivo `.gitignore` para que no aparezca al intentar 
subir cambios.
