### PR TITLE
Regresando los objetos Users e Identities en el método createUser

### DIFF
--- a/frontend/tests/badges/100solvedProblemsTest.php
+++ b/frontend/tests/badges/100solvedProblemsTest.php
@@ -8,8 +8,8 @@
 class OneHundredSolvedProblems extends BadgesTestCase {
     public function test100SolvedProblems() {
         // Creates two users, one solves 99 problems the other 101.
-        $user99 = UserFactory::createUser();
-        $user101 = UserFactory::createUser();
+        ['user' => $user99, 'identity' => $identity99] = UserFactory::createUser();
+        ['user' => $user101, 'identity' => $identity101] = UserFactory::createUser();
         $problems = [];
         for ($i = 0; $i < 101; $i++) {
             $newProblem = ProblemsFactory::createProblem();
@@ -29,7 +29,7 @@ class OneHundredSolvedProblems extends BadgesTestCase {
 
     public function test100RunsToSameProblem() {
         $problem = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         for ($i = 0; $i < 101; $i++) {
             $run = RunsFactory::createRunToProblem($problem, $user);
             RunsFactory::gradeRun($run);

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -218,8 +218,8 @@ class BadgesTest extends BadgesTestCase {
         // Create two badge receivers:
         // - User 1 will receive: Problem Setter badge
         // - User 2 will receive: Problem Setter and Contest Manager badges
-        $userOne = UserFactory::createUser();
-        $userTwo = UserFactory::createUser();
+        ['user' => $userOne, 'identity' => $identityOne] = UserFactory::createUser();
+        ['user' => $userTwo, 'identity' => $identityTwo] = UserFactory::createUser();
         ProblemsFactory::createProblemWithAuthor($userOne);
         ProblemsFactory::createProblemWithAuthor($userTwo);
         ContestsFactory::createContest(
@@ -295,7 +295,7 @@ class BadgesTest extends BadgesTestCase {
     }
 
     public function testGetAssignationTime() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         ProblemsFactory::createProblemWithAuthor($user);
 
         $previousTime = \OmegaUp\Time::get();
@@ -327,7 +327,7 @@ class BadgesTest extends BadgesTestCase {
     public function testBadgeDetails() {
         // Creates one owner for ContestManager Badge and no owner for
         // ContestManager, then checks badge details results.
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // For some reason, this method creates a new user also.
         ProblemsFactory::createProblemWithAuthor($user);

--- a/frontend/tests/common/Utils.php
+++ b/frontend/tests/common/Utils.php
@@ -162,7 +162,7 @@ class Utils {
     public static function setUpDefaultDataConfig() {
         // Create a test default user for manual UI operations
         \OmegaUp\Controllers\User::$sendEmailOnVerify = false;
-        $admin = UserFactory::createUser(new UserParams([
+        ['user' => $admin, 'identity' => $identity] = UserFactory::createUser(new UserParams([
             'username' => 'admintest',
             'password' => 'testtesttest',
         ]));

--- a/frontend/tests/controllers/AdminTest.php
+++ b/frontend/tests/controllers/AdminTest.php
@@ -3,7 +3,7 @@
 /** @psalm-suppress MissingDependency we need to add PHPUnit */
 class AdminTest extends OmegaupTestCase {
     public function testPlatformReportStatsRequiresAdmin() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = OmegaupTestCase::login($user);
 
         try {

--- a/frontend/tests/controllers/AssignmentProblemsTest.php
+++ b/frontend/tests/controllers/AssignmentProblemsTest.php
@@ -2,7 +2,7 @@
 
 class AssignmentProblemsTest extends OmegaupTestCase {
     public function testAddProblemToAssignment() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create a course with an assignment
@@ -49,7 +49,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
     }
 
     public function testDeleteProblemFromAssignment() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create a course with an assignment
@@ -91,7 +91,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
     }
 
     public function testAddRemoveProblems() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create a course with an assignment
@@ -170,7 +170,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddProblemForbiddenAccess() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $problem = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => 1,
@@ -186,7 +186,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
         $assignmentAlias = $courseData['assignment_alias'];
 
         // Add one problem to the assignment with a normal user
-        $forbiddenUser = UserFactory::createUser();
+        ['user' => $forbiddenUser, 'identity' => $forbiddenIdentity] = UserFactory::createUser();
         $forbiddenUserLogin = self::login($forbiddenUser);
         CoursesFactory::addProblemsToAssignment(
             $forbiddenUserLogin,
@@ -202,7 +202,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddProblemForbiddenAccessStudent() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $problem = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => 1,
@@ -234,7 +234,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testDeleteProblemForbiddenAccess() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create a course with an assignment
@@ -258,7 +258,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
         );
 
         // Remove a problem from the assignment with a normal user
-        $forbiddenUser = UserFactory::createUser();
+        ['user' => $forbiddenUser, 'identity' => $forbiddenIdentity] = UserFactory::createUser();
         $forbiddenUserLogin = self::login($forbiddenUser);
         $removeProblemResponse = \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
             'auth_token' => $forbiddenUserLogin->auth_token,
@@ -274,7 +274,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testDeleteProblemForbiddenAccessStudent() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create a course with an assignment
@@ -314,7 +314,7 @@ class AssignmentProblemsTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\NotFoundException
      */
     public function testDeleteNonExistingProblem() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create a course with an assignment

--- a/frontend/tests/controllers/AssignmentUpdateTest.php
+++ b/frontend/tests/controllers/AssignmentUpdateTest.php
@@ -5,7 +5,7 @@
  */
 class AssignmentUpdateTest extends OmegaupTestCase {
     public function testAssignmentUpdate() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $courseData = CoursesFactory::createCourseWithOneAssignment(
@@ -50,7 +50,7 @@ class AssignmentUpdateTest extends OmegaupTestCase {
      * alias and course alias
      */
     public function testMissingDataOnAssignmentUpdate() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $courseData = CoursesFactory::createCourseWithOneAssignment(
@@ -77,7 +77,7 @@ class AssignmentUpdateTest extends OmegaupTestCase {
      * Can't update the start time to be after the finish time.
      */
     public function testAssignmentUpdateWithInvertedTimes() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $courseData = CoursesFactory::createCourseWithOneAssignment(
@@ -106,14 +106,14 @@ class AssignmentUpdateTest extends OmegaupTestCase {
      * Students should not be able to update the assignment.
      */
     public function testAssignmentUpdateByStudent() {
-        $admin = UserFactory::createUser();
+        ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
         $adminLogin = OmegaupTestCase::login($admin);
         $courseData = CoursesFactory::createCourseWithOneAssignment(
             $admin,
             $adminLogin
         );
 
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
         $response = \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
             'auth_token' => $adminLogin->auth_token,
             'usernameOrEmail' => $student->username,

--- a/frontend/tests/controllers/ClarificationCreateTest.php
+++ b/frontend/tests/controllers/ClarificationCreateTest.php
@@ -26,7 +26,7 @@ class CreateClarificationTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Call the API avoiding the broadcaster logic
         if ($isGraderExpectedToBeCalled) {
@@ -134,9 +134,10 @@ class CreateClarificationTest extends OmegaupTestCase {
         // Create 5 users
         $n = 5;
         $users = [];
+        $identities = [];
         for ($i = 0; $i < $n; $i++) {
             // Create a user
-            $users[$i] = UserFactory::createUser();
+            ['user' => $users[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
 
             // Add it to the contest
             ContestsFactory::addUser($contestData, $users[$i]);

--- a/frontend/tests/controllers/ClarificationDetailsTest.php
+++ b/frontend/tests/controllers/ClarificationDetailsTest.php
@@ -48,7 +48,7 @@ class DetailsClarificationTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create the clarification, note that contestant will create it
         $this->detourBroadcasterCalls();
@@ -88,7 +88,7 @@ class DetailsClarificationTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create the clarification, note that contestant will create it
         $this->detourBroadcasterCalls();
@@ -129,10 +129,10 @@ class DetailsClarificationTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create our contestant who will try to view the clarification
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Create the clarification, note that contestant will create it
         $this->detourBroadcasterCalls();
@@ -165,10 +165,10 @@ class DetailsClarificationTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create our contestant who will try to view the clarification
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Create the clarification, note that contestant will create it
         $this->detourBroadcasterCalls();

--- a/frontend/tests/controllers/ClarificationUpdateTest.php
+++ b/frontend/tests/controllers/ClarificationUpdateTest.php
@@ -22,7 +22,7 @@ class UpdateClarificationTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create clarification
         $this->detourBroadcasterCalls($this->exactly(2));

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -7,7 +7,7 @@
  */
 class CoderOfTheMonthTest extends OmegaupTestCase {
     public function testCoderOfTheMonthCalc() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         // Creating 10 AC runs for our user in the last month
         $runCreationDate = new DateTimeImmutable(date('Y-m-d'));
         $runCreationDate = $runCreationDate->modify('first day of last month');
@@ -31,7 +31,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
     }
 
     public function testCoderOfTheMonthList() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $auth_token = self::login($user);
 
         $r = new \OmegaUp\Request([
@@ -64,7 +64,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
 
         // Test coder of the month details when common user is logged, it's the
         // same that not logged user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
         $login = self::login($user);
         $r['auth_token'] = $login->auth_token;
@@ -92,7 +92,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
     }
 
     public function testCoderOfTheMonthAfterYear() {
-        $userLastYear = UserFactory::createUser();
+        ['user' => $userLastYear, 'identity' => $identity] = UserFactory::createUser();
 
         // Using the first day of the month as "today" to avoid failures near
         // certain dates.
@@ -142,7 +142,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
 
     private function createRuns($user = null, $runCreationDate = null, $n = 5) {
         if (!$user) {
-            $user = UserFactory::createUser();
+            ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         }
         if (!$runCreationDate) {
             $runCreationDate = date('Y-m-d', \OmegaUp\Time::get());
@@ -219,7 +219,7 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
             }
         }
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $user_login = self::login($user);
 
         foreach ($coders as $index => $coder) {
@@ -262,9 +262,9 @@ class CoderOfTheMonthTest extends OmegaupTestCase {
         );
 
         // Submitting some runs with new users
-        $user1 = UserFactory::createUser();
-        $user2 = UserFactory::createUser();
-        $user3 = UserFactory::createUser();
+        ['user' => $user1, 'identity' => $identity1] = UserFactory::createUser();
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser();
+        ['user' => $user3, 'identity' => $identity3] = UserFactory::createUser();
         $this->createRuns($user1, $runCreationDate->format('Y-m-d'), 2);
         $this->createRuns($user1, $runCreationDate->format('Y-m-d'), 3);
         $this->createRuns($user2, $runCreationDate->format('Y-m-d'), 4);

--- a/frontend/tests/controllers/ContestAddAdminTest.php
+++ b/frontend/tests/controllers/ContestAddAdminTest.php
@@ -11,7 +11,7 @@ class ContestAddAdminTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare request
         $login = self::login($contestData['director']);
@@ -40,7 +40,7 @@ class ContestAddAdminTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare request
         $login = self::login($contestData['director']);
@@ -83,10 +83,8 @@ class ContestAddAdminTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get users
-        $user = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
-        $user2 = UserFactory::createUser();
-        $identity2 = \OmegaUp\DAO\Identities::getByPK($user2->main_identity_id);
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $user);
         ContestsFactory::addAdminUser($contestData, $user2);
 
@@ -123,7 +121,7 @@ class ContestAddAdminTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Get a group
         $groupData = GroupsFactory::createGroup();
@@ -155,7 +153,7 @@ class ContestAddAdminTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Get a group
         $groupData = GroupsFactory::createGroup();
@@ -202,10 +200,8 @@ class ContestAddAdminTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get users
-        $user = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
-        $user2 = UserFactory::createUser();
-        $identity2 = \OmegaUp\DAO\Identities::getByPK($user2->main_identity_id);
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Get a group
         $groupData = GroupsFactory::createGroup();

--- a/frontend/tests/controllers/ContestAddProblemTest.php
+++ b/frontend/tests/controllers/ContestAddProblemTest.php
@@ -130,7 +130,7 @@ class AddProblemToContestTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Log in as another random user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Build request
         $userLogin = self::login($user);

--- a/frontend/tests/controllers/ContestCloneTest.php
+++ b/frontend/tests/controllers/ContestCloneTest.php
@@ -99,7 +99,7 @@ class ContestCloneTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create new user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
             'usernameOrEmail' => $user->username,
             'password' => $user->password

--- a/frontend/tests/controllers/ContestCreateTest.php
+++ b/frontend/tests/controllers/ContestCreateTest.php
@@ -234,7 +234,7 @@ class CreateContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problem, $contest);
 
         // Create a contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add contestant to contest
         ContestsFactory::addUser($contest, $contestant);

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -105,7 +105,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         $problems = ContestsFactory::insertProblemsInContest($contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Assert the log is empty.
         $this->assertEquals(0, count(\OmegaUp\DAO\ProblemsetAccessLog::getByProblemsetIdentityId(
@@ -154,7 +154,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare our request
         $login = self::login($contestant);
@@ -190,7 +190,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         $problems = ContestsFactory::insertProblemsInContest($contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to our private contest
         ContestsFactory::addUser($contestData, $contestant);
@@ -225,7 +225,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         $problems = ContestsFactory::insertProblemsInContest($contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare our request
         $login = self::login($contestant);
@@ -248,7 +248,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         ]));
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare our request
         $login = self::login($contestant);
@@ -295,7 +295,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare our request
         $login = self::login($contestant);
@@ -345,7 +345,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         );
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to our private contest
         ContestsFactory::addUser($contestData, $contestant);
@@ -393,7 +393,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Set contest to not started yet
         $contest = \OmegaUp\DAO\Contests::getByAlias(
@@ -427,7 +427,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         );
 
         // Create our user not added to the contest
-        $externalUser = UserFactory::createUser();
+        ['user' => $externalUser, 'identity' => $identity] = UserFactory::createUser();
 
         $originalContestAccessLog = \OmegaUp\DAO\ProblemsetAccessLog::getAll();
 
@@ -526,7 +526,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         );
 
         // Create our user not added to the contest
-        $externalUser = UserFactory::createUser();
+        ['user' => $externalUser, 'identity' => $identity] = UserFactory::createUser();
 
         // Call details using token
         $login = self::login($externalUser);
@@ -605,11 +605,12 @@ class ContestDetailsTest extends OmegaupTestCase {
 
         // Create our contestants
         $contestants = [];
-        array_push($contestants, UserFactory::createUser());
-        array_push($contestants, UserFactory::createUser());
-        array_push($contestants, UserFactory::createUser());
+        $identities = [];
+        for ($i = 0; $i < 3; $i++) {
+            ['user' => $contestants[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
+        }
 
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $identity] = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
 
         $detourGrader = new ScopedGraderDetour();
@@ -701,7 +702,7 @@ class ContestDetailsTest extends OmegaupTestCase {
         $problems = ContestsFactory::insertProblemsInContest($contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare our request
         $login = self::login($contestant);
@@ -770,8 +771,10 @@ class ContestDetailsTest extends OmegaupTestCase {
 
         // Create our contestants
         $contestants = [];
-        array_push($contestants, UserFactory::createUser());
-        array_push($contestants, UserFactory::createUser());
+        $identities = [];
+        for ($i = 0; $i < 2; $i++) {
+            ['user' => $contestants[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
+        }
 
         $detourGrader = new ScopedGraderDetour();
 

--- a/frontend/tests/controllers/ContestListClarificationsTest.php
+++ b/frontend/tests/controllers/ContestListClarificationsTest.php
@@ -24,7 +24,7 @@ class ListClarificationsContest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant who will submit the clarification
-        $contestant1 = UserFactory::createUser();
+        ['user' => $contestant1, 'identity' => $identity1] = UserFactory::createUser();
 
         // Create 4 clarifications with this contestant
         $clarificationData1 = [];
@@ -43,7 +43,7 @@ class ListClarificationsContest extends OmegaupTestCase {
         ClarificationsFactory::answer($clarificationData1[2], $contestData);
 
         // Create another contestant
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Create 3 clarifications with this contestant
         $clarificationData2 = [];

--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -39,7 +39,7 @@ class ContestListTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Log as a random contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         $r = new \OmegaUp\Request([
@@ -94,7 +94,7 @@ class ContestListTest extends OmegaupTestCase {
         );
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to our private contest
         ContestsFactory::addUser($contestData, $contestant);
@@ -131,12 +131,13 @@ class ContestListTest extends OmegaupTestCase {
         );
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to our private contest
         ContestsFactory::addUser($contestData, $contestant);
 
-        $login = self::login(UserFactory::createUser());
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        $login = self::login($user);
 
         $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
@@ -194,7 +195,7 @@ class ContestListTest extends OmegaupTestCase {
         );
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to our private contest
         ContestsFactory::addAdminUser($contestData, $contestant);
@@ -234,8 +235,8 @@ class ContestListTest extends OmegaupTestCase {
         );
         $title = $contestData['request']['title'];
 
-        $admin1 = UserFactory::createUser();
-        $admin2 = UserFactory::createUser();
+        ['user' => $admin1, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $admin2, 'identity' => $identity2] = UserFactory::createUser();
 
         $login = self::login($admin1);
         $r = new \OmegaUp\Request([
@@ -291,8 +292,8 @@ class ContestListTest extends OmegaupTestCase {
         $author = $contestData['director'];
         $title = $contestData['request']['title'];
 
-        $admin1 = UserFactory::createUser();
-        $admin2 = UserFactory::createUser();
+        ['user' => $admin1, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $admin2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Add user to our private contest
         $group = GroupsFactory::createGroup($author);
@@ -335,7 +336,7 @@ class ContestListTest extends OmegaupTestCase {
         ));
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Turn recommended ON
         ['user' => $user, 'identity' => $identity] = UserFactory::createAdminUser();
@@ -387,7 +388,7 @@ class ContestListTest extends OmegaupTestCase {
         $recommendedContest[1] = ContestsFactory::createContest();
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Get list of contests
         $login = self::login($contestant);
@@ -458,7 +459,7 @@ class ContestListTest extends OmegaupTestCase {
         ));
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to our private contests
         ContestsFactory::addUser($currentContestData, $contestant);
@@ -496,7 +497,7 @@ class ContestListTest extends OmegaupTestCase {
         }
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to two private contest
         $numberOfPrivateContests = 2;
@@ -551,7 +552,7 @@ class ContestListTest extends OmegaupTestCase {
         ];
 
         // Log as a random contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $loginContestant = self::login($contestant);
         $response = \OmegaUp\Controllers\Contest::apiList(new \OmegaUp\Request([

--- a/frontend/tests/controllers/ContestProblemsListTest.php
+++ b/frontend/tests/controllers/ContestProblemsListTest.php
@@ -32,15 +32,16 @@ class ContestProblemsListTest extends OmegaupTestCase {
         }
 
         $contestants = [];
+        $identities = [];
         for ($i = 0; $i < $numUsers; $i++) {
             // Create our contestants
-            $contestants[] = UserFactory::createUser();
+            ['user' => $contestants[], 'identity' => $identities[]]  = UserFactory::createUser();
 
             // Add users to contest
             ContestsFactory::addUser($contestData, $contestants[$i]);
         }
         $contestDirector = $contestData['director'];
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $identity]  = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
 
         return [

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -152,7 +152,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = OmegaupTestCase::login($contestant);
 
@@ -315,7 +315,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
 
@@ -351,7 +351,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
-        $secondaryAdmin = UserFactory::createUser();
+        ['user' => $secondaryAdmin, 'identity' => $identity] = UserFactory::createUser();
 
         // Prepare request
         $login = OmegaupTestCase::login($contestData['director']);
@@ -397,7 +397,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
 
@@ -423,7 +423,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
 
@@ -453,7 +453,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
 
@@ -483,7 +483,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
 
@@ -508,7 +508,7 @@ class ContestRemoveProblemTest extends OmegaupTestCase {
         );
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
 

--- a/frontend/tests/controllers/ContestRemoveUserTest.php
+++ b/frontend/tests/controllers/ContestRemoveUserTest.php
@@ -11,7 +11,7 @@ class ContestRemoveUserTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Create a user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Add user to contest
         ContestsFactory::addUser($contestData, $user);

--- a/frontend/tests/controllers/ContestRequestsTest.php
+++ b/frontend/tests/controllers/ContestRequestsTest.php
@@ -9,7 +9,7 @@
 class ContestRequestsTest extends OmegaupTestCase {
     private function preparePublicContestWithRegistration(): array {
         // create a contest and its admin
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $identity] = UserFactory::createUser();
         $contestData = ContestsFactory::createContest(new ContestParams([
             'contestDirector' => $contestAdmin,
         ]));
@@ -98,7 +98,7 @@ class ContestRequestsTest extends OmegaupTestCase {
         ] = $this->preparePublicContestWithRegistration();
 
         // some user asks for contest
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $this->registerUserForContest($contestant, $contestData['request']);
 
@@ -121,16 +121,17 @@ class ContestRequestsTest extends OmegaupTestCase {
         ] = $this->preparePublicContestWithRegistration();
 
         // Adding secondary admin
-        $secondaryAdminLogin = UserFactory::createUser();
+        ['user' => $secondaryAdminLogin, 'identity' => $identity] = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $secondaryAdminLogin);
 
         // some users ask for contest
         $contestants = [];
+        $identities = [];
         $numberOfContestants = 4;
         $arbitratedUsers = [];
         $acceptedUsers = [];
         for ($i = 0; $i < $numberOfContestants; $i++) {
-            $contestants[$i] = UserFactory::createUser();
+            ['user' => $contestants[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
             $this->registerUserForContest(
                 $contestants[$i],
                 $contestData['request']

--- a/frontend/tests/controllers/ContestRunsTest.php
+++ b/frontend/tests/controllers/ContestRunsTest.php
@@ -21,7 +21,7 @@ class ContestRunsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -87,7 +87,7 @@ class ContestRunsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -30,11 +30,12 @@ class ContestScoreboardTest extends OmegaupTestCase {
 
         // Create our contestants
         $contestants = [];
+        $identities = [];
         for ($i = 0; $i < $nUsers; $i++) {
-            $contestants[] = UserFactory::createUser();
+            ['user' => $contestants[], 'identity' => $identities[]] = UserFactory::createUser();
         }
         $contestDirector = $contestData['director'];
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $identity] = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
 
         foreach ($runMap as $runDescription) {
@@ -238,7 +239,7 @@ class ContestScoreboardTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData2, $contestData);
 
         // Create our contestants
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create runs
         $runData = RunsFactory::createRun(
@@ -295,7 +296,7 @@ class ContestScoreboardTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -358,7 +359,7 @@ class ContestScoreboardTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -420,8 +421,8 @@ class ContestScoreboardTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData2);
 
         // Create our contestants
-        $contestant = UserFactory::createUser();
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -480,10 +481,10 @@ class ContestScoreboardTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our user not added to the contest
-        $externalUser = UserFactory::createUser();
+        ['user' => $externalUser, 'identity' => $externalIdentity] = UserFactory::createUser();
 
         // Create our contestant, will submit 1 run
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
         $runData = RunsFactory::createRun(
@@ -554,7 +555,7 @@ class ContestScoreboardTest extends OmegaupTestCase {
      */
     public function testScoreboardUrlInvalidToken() {
         // Create our user not added to the contest
-        $externalUser = UserFactory::createUser();
+        ['user' => $externalUser, 'identity' => $externalIdentity] = UserFactory::createUser();
 
         // Get a contest with 0% of scoreboard show percentage
         $contestData = ContestsFactory::createContest();
@@ -588,7 +589,7 @@ class ContestScoreboardTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant, will submit 1 run
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         ContestsFactory::addUser($contestData, $contestant);
         $runData = RunsFactory::createRun(

--- a/frontend/tests/controllers/ContestStatsTest.php
+++ b/frontend/tests/controllers/ContestStatsTest.php
@@ -21,7 +21,7 @@ class ContestStatsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run that we will wait to grade it
         $maxWaitRunData = RunsFactory::createRun(
@@ -129,7 +129,7 @@ class ContestStatsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $ACRunsCount = 2;
         $ACRunsData = [];

--- a/frontend/tests/controllers/ContestUpdateTest.php
+++ b/frontend/tests/controllers/ContestUpdateTest.php
@@ -39,7 +39,8 @@ class UpdateContestTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
         // Update title
-        $login = self::login(UserFactory::createUser());
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
+        $login = self::login($contestant);
         $r = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'contest_alias' => $contestData['request']['alias'],
@@ -199,7 +200,7 @@ class UpdateContestTest extends OmegaupTestCase {
 
         // STEP 2: Get contestant ready to create a run
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Our contestant has to open the contest before sending a run
         ContestsFactory::openContest($contestData, $contestant);
@@ -320,7 +321,7 @@ class UpdateContestTest extends OmegaupTestCase {
         // Create a run
         {
             \OmegaUp\Time::setTimeForTesting($originalTime + 5 * 60);
-            $contestant = UserFactory::createUser();
+            ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
             ContestsFactory::addUser($contestData, $contestant);
 
             // The problem is opened 5 minutes after contest starts.
@@ -431,8 +432,8 @@ class UpdateContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestants
-        $contestant = UserFactory::createUser();
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -618,7 +619,7 @@ class UpdateContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problem, $contest);
 
         // Create a contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add contestant to contest
         ContestsFactory::addUser($contest, $contestant);
@@ -674,7 +675,7 @@ class UpdateContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problem, $contest);
 
         // Create a contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add contestant to contest
         ContestsFactory::addUser($contest, $contestant);
@@ -736,7 +737,7 @@ class UpdateContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problem, $contest);
 
         // Create a contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add contestant to contest
         ContestsFactory::addUser($contest, $contestant);
@@ -793,7 +794,7 @@ class UpdateContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problem, $contest);
 
         // Create a contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add contestant to contest
         ContestsFactory::addUser($contest, $contestant);

--- a/frontend/tests/controllers/ContestUsersTest.php
+++ b/frontend/tests/controllers/ContestUsersTest.php
@@ -14,9 +14,10 @@ class ContestUsersTest extends OmegaupTestCase {
         // Create 10 users
         $n = 10;
         $users = [];
+        $identities = [];
         for ($i = 0; $i < $n; $i++) {
             // Create a user
-            $users[$i] = UserFactory::createUser();
+            ['user' => $users[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
 
             // Add it to the contest
             ContestsFactory::addUser($contestData, $users[$i]);
@@ -25,7 +26,7 @@ class ContestUsersTest extends OmegaupTestCase {
         // Create a n+1 user who will just join to the contest without being
         // added via API. For public contests, by entering to the contest, the user should be in
         // the list of contest's users.
-        $nonRegisteredUser = UserFactory::createUser();
+        ['user' => $nonRegisteredUser, 'identity' => $identity] = UserFactory::createUser();
         ContestsFactory::openContest($contestData, $nonRegisteredUser);
 
         // Log in with the admin of the contest
@@ -46,7 +47,7 @@ class ContestUsersTest extends OmegaupTestCase {
         // Get a contest
         $contestData = ContestsFactory::createContest();
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         ContestsFactory::openContest($contestData, $user);
 
         $userLogin = self::login($user);
@@ -77,10 +78,11 @@ class ContestUsersTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest(new ContestParams([
             'requests_user_information' => 'optional'
         ]));
-
+        $user = [];
+        $identity = [];
         for ($i = 0; $i < 3; $i++) {
             // Create users
-            $user[$i] = UserFactory::createUser();
+            ['user' => $user[$i], 'identity' => $identity[$i]] = UserFactory::createUser();
 
             // Add users to our private contest
             ContestsFactory::addUser($contestData, $user[$i]);
@@ -193,7 +195,7 @@ class ContestUsersTest extends OmegaupTestCase {
         ]));
 
         // Create and login a user to view the contest
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $userLogin = self::login($user);
 
         $r = new \OmegaUp\Request([

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -2,6 +2,7 @@
 
 class CourseCreateTest extends OmegaupTestCase {
     private static $curator = null;
+    private static $curatorIdentity = null;
 
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -10,13 +11,10 @@ class CourseCreateTest extends OmegaupTestCase {
             \OmegaUp\Authorization::COURSE_CURATOR_GROUP_ALIAS
         );
 
-        self::$curator = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK(
-            self::$curator->main_identity_id
-        );
+        ['user' => self::$curator, 'identity' => self::$curatorIdentity] = UserFactory::createUser();
         \OmegaUp\DAO\GroupsIdentities::create(new \OmegaUp\DAO\VO\GroupsIdentities([
             'group_id' => $curatorGroup->group_id,
-            'identity_id' => $identity->identity_id,
+            'identity_id' => self::$curatorIdentity->identity_id,
         ]));
     }
 
@@ -24,7 +22,7 @@ class CourseCreateTest extends OmegaupTestCase {
      * Create course hot path
      */
     public function testCreateSchoolCourse() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -58,7 +56,7 @@ class CourseCreateTest extends OmegaupTestCase {
         $sameAlias = Utils::CreateRandomString();
         $sameName = Utils::CreateRandomString();
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -83,7 +81,7 @@ class CourseCreateTest extends OmegaupTestCase {
         );
 
         // Create a new Course with different alias and name
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -100,7 +98,7 @@ class CourseCreateTest extends OmegaupTestCase {
 
     public function testCreateSchoolAssignment() {
         // Create a test course
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $courseAlias = Utils::CreateRandomString();
 
@@ -190,7 +188,7 @@ class CourseCreateTest extends OmegaupTestCase {
     }
 
     public function testDuplicateAssignmentAliases() {
-        $admin = UserFactory::createUser();
+        ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
         $adminLogin = OmegaupTestCase::login($admin);
 
         $assignmentAlias = Utils::CreateRandomString();
@@ -239,7 +237,7 @@ class CourseCreateTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testCreateAssignmentWithInvertedTimes() {
-        $admin = UserFactory::createUser();
+        ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
         $adminLogin = OmegaupTestCase::login($admin);
         $courseData = CoursesFactory::createCourse($admin, $adminLogin);
 
@@ -260,7 +258,7 @@ class CourseCreateTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testCreatePublicCourseFailForNonCurator() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -316,7 +314,7 @@ class CourseCreateTest extends OmegaupTestCase {
      * Test updating show_scoreboard attribute in the Course object
      */
     public function testUpdateCourseShowScoreboard() {
-        $admin = UserFactory::createUser();
+        ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
         $adminLogin = OmegaupTestCase::login($admin);
 
         // Creating a course with one assignment and turning on show_scoreboard flag
@@ -331,15 +329,12 @@ class CourseCreateTest extends OmegaupTestCase {
             $courseData['request']['course']->group_id
         );
         // User not linked to course
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $identityUser = \OmegaUp\DAO\Identities::getByPK(
             $user->main_identity_id
         );
         // User linked to course
-        $student = UserFactory::createUser();
-        $identityStudent = \OmegaUp\DAO\Identities::getByPK(
-            $student->main_identity_id
-        );
+        ['user' => $student, 'identity' => $identityStudent] = UserFactory::createUser();
         $response = \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
             'auth_token' => $adminLogin->auth_token,
             'usernameOrEmail' => $student->username,

--- a/frontend/tests/controllers/CourseDetailsTest.php
+++ b/frontend/tests/controllers/CourseDetailsTest.php
@@ -115,7 +115,7 @@ class CourseDetailsTest extends OmegaupTestCase {
      */
     public function testGetCourseDetailsNoCourseMember() {
         $courseData = CoursesFactory::createCourseWithOneAssignment();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $userLogin = self::login($user);
 
         $response = \OmegaUp\Controllers\Course::apiDetails(new \OmegaUp\Request([
@@ -130,7 +130,7 @@ class CourseDetailsTest extends OmegaupTestCase {
      */
     public function testGetCourseDetailsNoCourseMemberPublic() {
         $courseData = CoursesFactory::createCourse(null, null, true);
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $userLogin = self::login($user);
         $response = \OmegaUp\Controllers\Course::apiDetails(new \OmegaUp\Request([
@@ -141,7 +141,7 @@ class CourseDetailsTest extends OmegaupTestCase {
 
     public function testGetCourseIntroDetailsNoCourseMemberPublic() {
         $courseData = CoursesFactory::createCourse(null, null, true);
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $userLogin = self::login($user);
         $response = \OmegaUp\Controllers\Course::apiIntroDetails(new \OmegaUp\Request([
@@ -185,7 +185,7 @@ class CourseDetailsTest extends OmegaupTestCase {
             'assignment_type' => 'homework',
         ]));
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $userLogin = self::login($user);
 
         // Try to get details before being added to the course;

--- a/frontend/tests/controllers/CourseListTest.php
+++ b/frontend/tests/controllers/CourseListTest.php
@@ -13,7 +13,7 @@ class CourseListTest extends OmegaupTestCase {
         );
         $this->admin_user = $courseData['admin'];
         $this->course_alias = $courseData['course_alias'];
-        $this->other_user = UserFactory::createUser();
+        ['user' => $this->other_user, 'identity' => $this->other_identity] = UserFactory::createUser();
 
         CoursesFactory::addStudentToCourse($courseData, $this->other_user);
     }
@@ -21,6 +21,8 @@ class CourseListTest extends OmegaupTestCase {
     protected $admin_user;
     protected $course_user;
     protected $other_user;
+    protected $identity_user;
+    protected $other_identity;
     protected $course_alias;
 
     public function testGetCourseForAdminUser() {

--- a/frontend/tests/controllers/CourseProblemsTest.php
+++ b/frontend/tests/controllers/CourseProblemsTest.php
@@ -3,7 +3,7 @@
 class CourseProblemsTest extends OmegaupTestCase {
     public function testOrderProblems() {
         // Create a test course
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
 
@@ -89,8 +89,8 @@ class CourseProblemsTest extends OmegaupTestCase {
     }
 
     public function testCourseProblemUsers() {
-        $admin = UserFactory::createUser();
-        $student = UserFactory::createUser();
+        ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identityStudent] = UserFactory::createUser();
 
         // Create a course with an assignment
         $adminLogin = self::login($admin);

--- a/frontend/tests/controllers/CourseRunsTest.php
+++ b/frontend/tests/controllers/CourseRunsTest.php
@@ -31,7 +31,7 @@ class CourseRunsTest extends OmegaupTestCase {
         );
 
         // Create our participant
-        $participant = UserFactory::createUser();
+        ['user' => $participant, 'identity' => $identity] = UserFactory::createUser();
 
         // Add student to course
         CoursesFactory::addStudentToCourse($courseData, $participant);

--- a/frontend/tests/controllers/CourseStudentAddTest.php
+++ b/frontend/tests/controllers/CourseStudentAddTest.php
@@ -11,10 +11,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
      */
     public function testAddStudentToCourse() {
         $courseData = CoursesFactory::createCourse();
-        $student = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK(
-            $student->main_identity_id
-        );
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
 
         $adminLogin = OmegaupTestCase::login($courseData['admin']);
         $response = \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
@@ -47,7 +44,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
             true,
             'optional'
         );
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
         UserFactory::createPrivacyStatement('course_optional_consent');
         UserFactory::createPrivacyStatement('course_required_consent');
 
@@ -121,7 +118,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
      */
     public function testRemoveStudentFromCourse() {
         $courseData = CoursesFactory::createCourse();
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
 
         $adminLogin = OmegaupTestCase::login($courseData['admin']);
         $response = \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
@@ -157,8 +154,8 @@ class CourseStudentAddTest extends OmegaupTestCase {
      */
     public function testAddStudentNonAdmin() {
         $courseData = CoursesFactory::createCourse();
-        $student = UserFactory::createUser();
-        $nonAdminUser = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $nonAdminUser, 'identity' => $identity] = UserFactory::createUser();
 
         $nonAdminLogin = OmegaupTestCase::login($nonAdminUser);
         \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
@@ -174,7 +171,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
      */
     public function testSelfAddStudentNoPublic() {
         $courseData = CoursesFactory::createCourse();
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
 
         $login = OmegaupTestCase::login($student);
         \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
@@ -189,7 +186,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
      */
     public function testSelfAddStudentPublic() {
         $courseData = CoursesFactory::createCourse(null, null, true /*public*/);
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
         $identity = \OmegaUp\DAO\Identities::getByPK(
             $student->main_identity_id
         );
@@ -221,7 +218,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
     public function testShouldShowIntro() {
         $courseDataPrivate = CoursesFactory::createCourse();
         $courseDataPublic = CoursesFactory::createCourse(null, null, true);
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
 
         // Before or after adding student to private course, intro should not show
         $studentLogin = OmegaupTestCase::login($student);
@@ -276,7 +273,7 @@ class CourseStudentAddTest extends OmegaupTestCase {
      */
     public function testUserAcceptsTeacher() {
         $courseData = CoursesFactory::createCourse();
-        $student = UserFactory::createUser();
+        ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
 
         // Admin adds user into the course
         $adminLogin = OmegaupTestCase::login($courseData['admin']);

--- a/frontend/tests/controllers/CourseStudentListTest.php
+++ b/frontend/tests/controllers/CourseStudentListTest.php
@@ -42,7 +42,8 @@ class CourseStudentListTest extends OmegaupTestCase {
         $courseData = CoursesFactory::createCourse();
 
         // Call apiStudentList by another random user
-        $userLogin = self::login(UserFactory::createUser());
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        $userLogin = self::login($user);
         $response = \OmegaUp\Controllers\Course::apiListStudents(new \OmegaUp\Request([
             'auth_token' => $userLogin->auth_token,
             'course_alias' => $courseData['course_alias']
@@ -55,7 +56,8 @@ class CourseStudentListTest extends OmegaupTestCase {
      */
     public function testCourseStudentListInvalidCourse() {
         // Call apiStudentList by another random user
-        $userLogin = self::login(UserFactory::createUser());
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        $userLogin = self::login($user);
         $response = \OmegaUp\Controllers\Course::apiListStudents(new \OmegaUp\Request([
             'auth_token' => $userLogin->auth_token,
             'course_alias' => 'foo'

--- a/frontend/tests/controllers/CourseUsersTest.php
+++ b/frontend/tests/controllers/CourseUsersTest.php
@@ -11,7 +11,7 @@ class CourseUsersTest extends OmegaupTestCase {
         // Create a course with 5 assignments
         $courseData = CoursesFactory::createCourseWithAssignments(5);
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         CoursesFactory::addStudentToCourse($courseData, $user);
 

--- a/frontend/tests/controllers/ExperimentTest.php
+++ b/frontend/tests/controllers/ExperimentTest.php
@@ -81,7 +81,7 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase {
     }
 
     public function testUserExperiments() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $experiments = new
             \OmegaUp\Experiments(
                 null,

--- a/frontend/tests/controllers/GroupsTest.php
+++ b/frontend/tests/controllers/GroupsTest.php
@@ -11,8 +11,7 @@ class GroupsTest extends OmegaupTestCase {
      * Basic create group test
      */
     public function testCreateGroup() {
-        $owner = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK($owner->main_identity_id);
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $name = Utils::CreateRandomString();
         $description = Utils::CreateRandomString();
         $alias = Utils::CreateRandomString();
@@ -42,7 +41,7 @@ class GroupsTest extends OmegaupTestCase {
      * Attempts to create groups with a restricted alias should fail.
      */
     public function testCreateGroupRestrictedAlias() {
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
 
         try {
             $login = self::login($owner);
@@ -63,8 +62,7 @@ class GroupsTest extends OmegaupTestCase {
      */
     public function testAddUserToGroup() {
         $group = GroupsFactory::createGroup();
-        $user = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($group['owner']);
         $response = \OmegaUp\Controllers\Group::apiAddUser(new \OmegaUp\Request([
@@ -88,8 +86,8 @@ class GroupsTest extends OmegaupTestCase {
      */
     public function testAddUserToGroupNotOwned() {
         $group = GroupsFactory::createGroup();
-        $user = UserFactory::createUser();
-        $userCalling = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $userCalling, 'identity' => $identityCalling] = UserFactory::createUser();
 
         $login = self::login($userCalling);
         $response = \OmegaUp\Controllers\Group::apiAddUser(new \OmegaUp\Request([
@@ -104,7 +102,7 @@ class GroupsTest extends OmegaupTestCase {
      */
     public function testRemoveUserFromGroup() {
         $groupData = GroupsFactory::createGroup();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         GroupsFactory::addUserToGroup($groupData, $user);
 
         $login = self::login($groupData['owner']);
@@ -130,7 +128,7 @@ class GroupsTest extends OmegaupTestCase {
      */
     public function testRemoveUserFromGroupUserNotInGroup() {
         $groupData = GroupsFactory::createGroup();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($groupData['owner']);
         \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
@@ -147,7 +145,7 @@ class GroupsTest extends OmegaupTestCase {
      */
     public function testRemoveUserFromGroupUserNotOwner() {
         $groupData = GroupsFactory::createGroup();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
@@ -162,7 +160,7 @@ class GroupsTest extends OmegaupTestCase {
      */
     public function testGroupsMyList() {
         // Create 5 groups for the same owner
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $groups = [];
         $n = 5;
         for ($i = 0; $i < $n; $i++) {
@@ -188,9 +186,10 @@ class GroupsTest extends OmegaupTestCase {
         // Create a group with 5 users
         $groupData = GroupsFactory::createGroup();
         $users = [];
+        $identities = [];
         $nUsers = 5;
         for ($i = 0; $i < $nUsers; $i++) {
-            $users[] = UserFactory::createUser();
+            ['user' => $users[], 'identity' => $identities[]] = UserFactory::createUser();
             GroupsFactory::addUserToGroup($groupData, $users[$i]);
         }
 
@@ -336,9 +335,9 @@ class GroupsTest extends OmegaupTestCase {
         $contestsData = [];
 
         // Create contestants to submit runs
-        $contestantInGroup = UserFactory::createUser();
+        ['user' => $contestantInGroup, 'identity' => $identityInGroup] = UserFactory::createUser();
         GroupsFactory::addUserToGroup($groupData, $contestantInGroup);
-        $contestantNotInGroup = UserFactory::createUser();
+        ['user' => $contestantNotInGroup, 'identity' => $identityNotInGroup] = UserFactory::createUser();
 
         $n = 5;
 
@@ -425,9 +424,9 @@ class GroupsTest extends OmegaupTestCase {
         $contestsData = [];
 
         // Create contestants to submit runs
-        $contestantInGroup = UserFactory::createUser();
+        ['user' => $contestantInGroup, 'identity' => $identityInGroup] = UserFactory::createUser();
         GroupsFactory::addUserToGroup($groupData, $contestantInGroup);
-        $contestantInGroupNoAc = UserFactory::createUser();
+        ['user' => $contestantInGroupNoAc, 'identity' => $identityInGroupNoAc] = UserFactory::createUser();
         GroupsFactory::addUserToGroup($groupData, $contestantInGroupNoAc);
 
         $n = 5;

--- a/frontend/tests/controllers/IdentityRestrictionsTest.php
+++ b/frontend/tests/controllers/IdentityRestrictionsTest.php
@@ -19,7 +19,7 @@ class IdentityRestrictionsTest extends OmegaupTestCase {
         ] = self::createGroupIdentityCreatorAndGroup($password);
 
         // Create a new user to associate with identity
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Associate identity with user
@@ -56,7 +56,7 @@ class IdentityRestrictionsTest extends OmegaupTestCase {
         ] = self::createGroupIdentityCreatorAndGroup($password);
 
         // Create a new user to associate with identity
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Associate identity with user
@@ -90,7 +90,7 @@ class IdentityRestrictionsTest extends OmegaupTestCase {
         ] = self::createGroupIdentityCreatorAndGroup($password);
 
         // Create a new user to associate with identity
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Associate identity with user
@@ -122,7 +122,7 @@ class IdentityRestrictionsTest extends OmegaupTestCase {
         ] = self::createGroupIdentityCreatorAndGroup($password);
 
         // Create a new user to associate with identity
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Associate identity with user

--- a/frontend/tests/controllers/IdentityUpdateTest.php
+++ b/frontend/tests/controllers/IdentityUpdateTest.php
@@ -265,7 +265,7 @@ class IdentityUpdateTest extends OmegaupTestCase {
         $identityLogin = self::login($identity);
 
         // Normal user will try change the passowrd of an identity
-        $normalUser = UserFactory::createUser();
+        ['user' => $normalUser, 'identity' => $identity] = UserFactory::createUser();
         $userLogin = self::login($normalUser);
 
         try {

--- a/frontend/tests/controllers/InterviewCreateTest.php
+++ b/frontend/tests/controllers/InterviewCreateTest.php
@@ -5,7 +5,7 @@
  */
 class InterviewCreateTest extends OmegaupTestCase {
     public function testCreateAndListInterview() {
-        $interviewer = UserFactory::createUser();
+        ['user' => $interviewer, 'identity' => $identity] = UserFactory::createUser();
         UserFactory::addSystemRole(
             $interviewer,
             \OmegaUp\Authorization::INTERVIEWER_ROLE
@@ -36,7 +36,7 @@ class InterviewCreateTest extends OmegaupTestCase {
     }
 
     public function testInterviewsMustBePrivate() {
-        $interviewer = UserFactory::createUser();
+        ['user' => $interviewer, 'identity' => $identity] = UserFactory::createUser();
         UserFactory::addSystemRole(
             $interviewer,
             \OmegaUp\Authorization::INTERVIEWER_ROLE
@@ -56,7 +56,7 @@ class InterviewCreateTest extends OmegaupTestCase {
     }
 
     public function testAddUsersToInterview() {
-        $interviewer = UserFactory::createUser();
+        ['user' => $interviewer, 'identity' => $identity] = UserFactory::createUser();
         UserFactory::addSystemRole(
             $interviewer,
             \OmegaUp\Authorization::INTERVIEWER_ROLE
@@ -105,14 +105,14 @@ class InterviewCreateTest extends OmegaupTestCase {
 
         // add 2 users that are already omegaup users (using registered email)
         $emailFor1 = Utils::CreateRandomString() . '@mail.com';
-        $interviewee1 = UserFactory::createUser(
+        ['user' => $interviewee1, 'identity' => $identity1] = UserFactory::createUser(
             new UserParams(
                 ['email' => $emailFor1]
             )
         );
 
         $emailFor2 = Utils::CreateRandomString() . '@mail.com';
-        $interviewee2 = UserFactory::createUser(
+        ['user' => $interviewee2, 'identity' => $identity2] = UserFactory::createUser(
             new UserParams(
                 ['email' => $emailFor2]
             )
@@ -126,8 +126,8 @@ class InterviewCreateTest extends OmegaupTestCase {
         $this->assertEquals('ok', $response['status']);
 
         // add 2 users that are already omegaup users (using registered username)
-        $interviewee3 = UserFactory::createUser();
-        $interviewee4 = UserFactory::createUser();
+        ['user' => $interviewee3, 'identity' => $identity3] = UserFactory::createUser();
+        ['user' => $interviewee4, 'identity' => $identity4] = UserFactory::createUser();
 
         $response = \OmegaUp\Controllers\Interview::apiAddUsers(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
@@ -147,7 +147,7 @@ class InterviewCreateTest extends OmegaupTestCase {
         $r = new \OmegaUp\Request();
 
         // Create an interview
-        $interviewer = UserFactory::createUser();
+        ['user' => $interviewer, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($interviewer);
         $response = \OmegaUp\Controllers\Interview::apiCreate(new \OmegaUp\Request([

--- a/frontend/tests/controllers/LoginTest.php
+++ b/frontend/tests/controllers/LoginTest.php
@@ -12,8 +12,7 @@ class LoginTest extends OmegaupTestCase {
      */
     public function testNativeLoginByUserPositive() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Assert the log is empty.
         $this->assertEquals(
@@ -54,8 +53,9 @@ class LoginTest extends OmegaupTestCase {
      */
     public function testNativeLoginByEmailPositive() {
         $email = Utils::CreateRandomString() . '@mail.com';
-        $user = UserFactory::createUser(new UserParams(['email' => $email]));
-        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(['email' => $email])
+        );
 
         // Inflate request with user data
         $r = new \OmegaUp\Request([
@@ -76,7 +76,7 @@ class LoginTest extends OmegaupTestCase {
      */
     public function testNativeLoginByUserInvalidPassword() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Inflate request with user data
         $r = new \OmegaUp\Request([
@@ -112,7 +112,9 @@ class LoginTest extends OmegaupTestCase {
     public function testNativeLoginByEmailInvalidPassword() {
         // Create an user in omegaup
         $email = Utils::CreateRandomString() . '@mail.com';
-        $user = UserFactory::createUser(new UserParams(['email' => $email]));
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(['email' => $email])
+        );
 
         // Inflate request with user data
         $r = new \OmegaUp\Request([
@@ -131,7 +133,7 @@ class LoginTest extends OmegaupTestCase {
      */
     public function testNativeLoginPositiveViaHttp() {
         // Create an user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
 
         // Set required context
@@ -159,7 +161,7 @@ class LoginTest extends OmegaupTestCase {
      */
     public function test2ConsecutiveLogins() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
 
         // Inflate request with user data
@@ -191,7 +193,7 @@ class LoginTest extends OmegaupTestCase {
      */
     public function testNativeLoginWithOldPassword() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $plainPassword = $user->password;
         // Set old password
@@ -216,7 +218,7 @@ class LoginTest extends OmegaupTestCase {
 
     public function testDeleteTokenExpired() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
 
@@ -236,7 +238,7 @@ class LoginTest extends OmegaupTestCase {
      */
     public function testLoginDisabled() {
         // User to be verified
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Force empty password
         $user->password = '';

--- a/frontend/tests/controllers/NotificationTest.php
+++ b/frontend/tests/controllers/NotificationTest.php
@@ -8,7 +8,7 @@
 
 class NotificationTest extends OmegaupTestCase {
     public function testListUnreadNotifications() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         \OmegaUp\DAO\Notifications::create(new \OmegaUp\DAO\VO\Notifications([
             'user_id' => $user->user_id,
             'read' => true,
@@ -40,7 +40,7 @@ class NotificationTest extends OmegaupTestCase {
     }
 
     public function testReadNotifications() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         \OmegaUp\DAO\Notifications::create(new \OmegaUp\DAO\VO\Notifications([
             'user_id' => $user->user_id,
             'contents' => json_encode(
@@ -91,7 +91,7 @@ class NotificationTest extends OmegaupTestCase {
     }
 
     public function testReadNotificationsExceptions() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         try {
             \OmegaUp\Controllers\Notification::apiReadNotifications(new \OmegaUp\Request([
@@ -116,7 +116,7 @@ class NotificationTest extends OmegaupTestCase {
     }
 
     public function testReadNotificationsForbbidenAccessException() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $notification = new \OmegaUp\DAO\VO\Notifications([
             'user_id' => $user->user_id,
             'contents' => json_encode(
@@ -125,7 +125,7 @@ class NotificationTest extends OmegaupTestCase {
         ]);
         \OmegaUp\DAO\Notifications::create($notification);
 
-        $maliciousUser = UserFactory::createUser();
+        ['user' => $maliciousUser, 'identity' => $maliciousIdentity] = UserFactory::createUser();
         $login = self::login($maliciousUser);
 
         try {

--- a/frontend/tests/controllers/ProblemBestScoreTest.php
+++ b/frontend/tests/controllers/ProblemBestScoreTest.php
@@ -13,7 +13,7 @@ class ProblemBestScoreTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create 2 runs, 100 and 50.
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
@@ -41,7 +41,7 @@ class ProblemBestScoreTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create 2 runs, 100 and 50.
         $runDataOutsideContest = RunsFactory::createRunToProblem(
@@ -75,10 +75,10 @@ class ProblemBestScoreTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $contestantIdentity] = UserFactory::createUser();
 
         // Create user who will use the API
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         // Create 2 runs, 100 and 50.
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);

--- a/frontend/tests/controllers/ProblemDeleteTest.php
+++ b/frontend/tests/controllers/ProblemDeleteTest.php
@@ -14,7 +14,7 @@ class ProblemDeleteTest extends OmegaupTestCase {
      */
     public function testProblemCanNotBeDeletedAfterSubmissionsInACourseOrContest() {
         // Get a user
-        $userLogin = UserFactory::createUser();
+        ['user' => $userLogin, 'identity' => $identity] = UserFactory::createUser();
 
         // Get a problem
         $problemData = ProblemsFactory::createProblem(new ProblemParams([
@@ -29,7 +29,7 @@ class ProblemDeleteTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -55,7 +55,7 @@ class ProblemDeleteTest extends OmegaupTestCase {
      */
     public function testAnonymousUserCannotSeeDeletedProblems() {
         // Get a user
-        $userLogin = UserFactory::createUser();
+        ['user' => $userLogin, 'identity' => $identity] = UserFactory::createUser();
 
         // Get problems
         $deletedProblemData = ProblemsFactory::createProblem(new ProblemParams([
@@ -107,7 +107,7 @@ class ProblemDeleteTest extends OmegaupTestCase {
      */
     public function testLoggedUserCannotSeeDeletedProblems() {
         // Get a user
-        $userLogin = UserFactory::createUser();
+        ['user' => $userLogin, 'identity' => $identity] = UserFactory::createUser();
 
         // Get problems
         $deletedProblemData = ProblemsFactory::createProblem(new ProblemParams([
@@ -179,7 +179,7 @@ class ProblemDeleteTest extends OmegaupTestCase {
      */
     public function testSysadminCanSeeDeletedProblemsOnlyInAdminList() {
         // Get a user
-        $userLogin = UserFactory::createUser();
+        ['user' => $userLogin, 'identity' => $identity] = UserFactory::createUser();
 
         // Get problems
         $deletedProblemData = ProblemsFactory::createProblem(

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -15,10 +15,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Get a user to be the author
-        $authorUser = UserFactory::createUser();
-        $authorIdentity = \OmegaUp\DAO\Identities::getByPK(
-            $authorUser->main_identity_id
-        );
+        ['user' => $authorUser, 'identity' => $authorIdentity] = UserFactory::createUser();
 
         // Get a problem
         $problemData = ProblemsFactory::createProblem(new ProblemParams([
@@ -30,7 +27,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Explicitly join contest
         $login = self::login($contestant);
@@ -107,7 +104,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Call api
         $login = self::login($contestant);
@@ -145,7 +142,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ]));
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Call api
         $login = self::login($contestant);
@@ -180,7 +177,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ]));
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Call api
         $login = self::login($contestant);
@@ -215,7 +212,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create 2 runs, 100 and 50.
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
@@ -243,7 +240,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create 2 runs, 100 and 50.
         $runDataOutsideContest = RunsFactory::createRunToProblem(
@@ -283,7 +280,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Get a user for our scenario
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $runDataOutOfContest = RunsFactory::createRunToProblem(
             $problemData,
@@ -324,7 +321,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create an accepted run.
         $runDataInsideContest = RunsFactory::createRun(
@@ -400,7 +397,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
     public function testShowSolutionBySolver() {
         $problemData = ProblemsFactory::createProblem();
 
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         try {
             $login = self::login($contestant);
@@ -435,7 +432,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
 
     public function testAuthorizationController() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);

--- a/frontend/tests/controllers/ProblemExtraInformationTest.php
+++ b/frontend/tests/controllers/ProblemExtraInformationTest.php
@@ -26,7 +26,7 @@ class ProblemExtraInformationTest extends OmegaupTestCase {
         $this->assertFalse($result['problem_admin']);
 
         // Normal user is able to see the problem.
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $r['auth_token'] = $login->auth_token;
         $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty($r);
@@ -38,7 +38,7 @@ class ProblemExtraInformationTest extends OmegaupTestCase {
 
     public function testQualityPayload() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
 
@@ -150,7 +150,7 @@ class ProblemExtraInformationTest extends OmegaupTestCase {
         );
 
         // Normal user should see the problem as locked
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(new \OmegaUp\Request([
             'problem_alias' => $problemData['request']['problem_alias'],

--- a/frontend/tests/controllers/ProblemListCourseTest.php
+++ b/frontend/tests/controllers/ProblemListCourseTest.php
@@ -22,8 +22,10 @@ class ProblemListCourseTest extends OmegaupTestCase {
             $problem
         );
         // Create users and add to course
+        $user = [];
+        $identity = [];
         for ($i = 0; $i < $num_users; $i++) {
-            $user[$i] = UserFactory::createUser();
+            ['user' => $user[$i], 'identity' => $identity[$i]] = UserFactory::createUser();
             CoursesFactory::addStudentToCourse($courseData, $user[$i]);
         }
         // Create runs to problems directly
@@ -140,9 +142,11 @@ class ProblemListCourseTest extends OmegaupTestCase {
             $courseData['assignment_alias'],
             $problem
         );
-        // Create users and add to course
+        // Create users and add to course$user = [];
+        $user = [];
+        $identity = [];
         for ($i = 0; $i < $num_users; $i++) {
-            $user[$i] = UserFactory::createUser();
+            ['user' => $user[$i], 'identity' => $identity[$i]] = UserFactory::createUser();
             CoursesFactory::addStudentToCourse($courseData, $user[$i]);
         }
         // Create runs to problems directly

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -22,7 +22,8 @@ class ProblemList extends OmegaupTestCase {
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PRIVATE
         ]));
 
-        $login = self::login(UserFactory::createUser());
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        $login = self::login($user);
         $response = \OmegaUp\Controllers\Problem::apiList(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
         ]));
@@ -106,7 +107,8 @@ class ProblemList extends OmegaupTestCase {
             );
         }
 
-        $login = self::login(UserFactory::createUser());
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        $login = self::login($user);
 
         // Test one tag at a time
         for ($j = 0; $j < $n; $j++) {
@@ -165,8 +167,10 @@ class ProblemList extends OmegaupTestCase {
 
         // 5 users are going to be created, each i user will solve i problems
         // and all users are going to send their feedback to the first problem
+        $users = [];
+        $identities = [];
         for ($i = 0; $i < 5; $i++) {
-            $users[$i] = UserFactory::createUser();
+            ['user' => $users[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
             for ($j = 0; $j <= $i; $j++) {
                 $runData = RunsFactory::createRunToProblem(
                     $problemData[$j],
@@ -285,17 +289,17 @@ class ProblemList extends OmegaupTestCase {
                 ['username' => 'admin']
             )
         );
-        $userA = UserFactory::createUser(
+        ['user' => $userA, 'identity' => $identityA] = UserFactory::createUser(
             new UserParams(
                 ['username' => 'user_a']
             )
         );
-        $userB = UserFactory::createUser(
+        ['user' => $userB, 'identity' => $identityB] = UserFactory::createUser(
             new UserParams(
                 ['username' => 'user_b']
             )
         );
-        $otherUser = UserFactory::createUser(
+        ['user' => $otherUser, 'identity' => $otherIdentity] = UserFactory::createUser(
             new UserParams(
                 ['username' => 'other']
             )
@@ -388,7 +392,9 @@ class ProblemList extends OmegaupTestCase {
                 'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PROMOTED
             ]));
         }
-        $login = self::login(UserFactory::createUser());
+
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        $login = self::login($user);
         $response = \OmegaUp\Controllers\Problem::apiList(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'rowcount' => 1,
@@ -406,8 +412,8 @@ class ProblemList extends OmegaupTestCase {
      *
      */
     public function testPrivateProblemsShowToAuthor() {
-        $author = UserFactory::createUser();
-        $anotherAuthor = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
+        ['user' => $anotherAuthor, 'identity' => $anotherIdentity] = UserFactory::createUser();
 
         $problemDataPublic = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PROMOTED,
@@ -439,7 +445,7 @@ class ProblemList extends OmegaupTestCase {
      *
      */
     public function testAllPrivateProblemsShowToAdmin() {
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
 
         $problemDataPublic = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PROMOTED,
@@ -468,14 +474,14 @@ class ProblemList extends OmegaupTestCase {
      * An added admin should see those problems as well
      */
     public function testAllPrivateProblemsShowToAddedAdmin() {
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
 
         $problemDataPrivate = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PRIVATE,
             'author' => $author
         ]));
 
-        $addedAdmin = UserFactory::createUser();
+        ['user' => $addedAdmin, 'identity' => $addedIdentityAdmin] = UserFactory::createUser();
 
         $adminLogin = self::login($addedAdmin);
         $r = new \OmegaUp\Request([
@@ -512,7 +518,7 @@ class ProblemList extends OmegaupTestCase {
      * An added admin group should see those problems as well
      */
     public function testAllPrivateProblemsShowToAddedAdminGroup() {
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
 
         $problemDataPrivate = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PRIVATE,
@@ -520,7 +526,7 @@ class ProblemList extends OmegaupTestCase {
         ]));
         $alias = $problemDataPrivate['request']['problem_alias'];
 
-        $addedAdmin = UserFactory::createUser();
+        ['user' => $addedAdmin, 'identity' => $addedIdentityAdmin] = UserFactory::createUser();
 
         $login = self::login($addedAdmin);
         $r = new \OmegaUp\Request([
@@ -581,7 +587,7 @@ class ProblemList extends OmegaupTestCase {
      * Authors with admin groups should only see each problem once.
      */
     public function testAuthorOnlySeesProblemsOnce() {
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
 
         $problemDataPrivate = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PRIVATE,
@@ -597,9 +603,10 @@ class ProblemList extends OmegaupTestCase {
             null,
             $authorLogin
         );
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         GroupsFactory::addUserToGroup(
             $group,
-            UserFactory::createUser(),
+            $user,
             $authorLogin
         );
         GroupsFactory::addUserToGroup($group, $author, $authorLogin);
@@ -635,8 +642,8 @@ class ProblemList extends OmegaupTestCase {
      * An author that belongs to an admin group should not see repeated problems.
      */
     public function testPublicProblemsPlusAddedAdminGroup() {
-        $author = UserFactory::createUser();
-        $helper = UserFactory::createUser();
+        ['user' => $author, 'identity' => $authorIdentity] = UserFactory::createUser();
+        ['user' => $helper, 'identity' => $helperIdentity] = UserFactory::createUser();
 
         $problemDataPrivate = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PROMOTED,
@@ -671,7 +678,7 @@ class ProblemList extends OmegaupTestCase {
      */
     public function testMyList() {
         // Get 3 problems
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
         $n = 3;
         for ($i = 0; $i < $n; $i++) {
             $problemData[$i] = ProblemsFactory::createProblem(new ProblemParams([
@@ -695,7 +702,7 @@ class ProblemList extends OmegaupTestCase {
      * Logged-in users will have their best scores for all problems
      */
     public function testListContainsScores() {
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $problemData = ProblemsFactory::createProblem();
         $problemDataNoRun = ProblemsFactory::createProblem();
@@ -764,7 +771,7 @@ class ProblemList extends OmegaupTestCase {
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PRIVATE
         ]));
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $userLogin = self::login($user);
 
         // Expect public problem only
@@ -820,7 +827,7 @@ class ProblemList extends OmegaupTestCase {
      */
     public function testProblemListPager() {
         // Create a user and some problems with submissions for the tests.
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         for ($i = 0; $i < 6; $i++) {
             $problemData[$i] = ProblemsFactory::createProblem(new ProblemParams([
                 'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PROMOTED
@@ -937,7 +944,7 @@ class ProblemList extends OmegaupTestCase {
      * Test getting the list of Problems unsolved by some user.
      */
     public function testListUnsolvedProblemsByUser() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         /* Five different problems, each variable has its expected final verdict as suffix */
         $problemDataAC = ProblemsFactory::createProblem();
         $problemDataAC2 = ProblemsFactory::createProblem();

--- a/frontend/tests/controllers/ProblemRunsTest.php
+++ b/frontend/tests/controllers/ProblemRunsTest.php
@@ -12,7 +12,7 @@ class ProblemRunsTest extends OmegaupTestCase {
         $contestants = [];
         $runs = [];
         for ($i = 0; $i < 2; ++$i) {
-            $user = UserFactory::createUser();
+            ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
             $runData = RunsFactory::createRunToProblem($problemData, $user);
             RunsFactory::gradeRun($runData);
             $contestants[] = $user;
@@ -80,7 +80,7 @@ class ProblemRunsTest extends OmegaupTestCase {
 
     public function testUserHasTriedToSolvedProblem() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         // Never tried, never solved
         $this->assertFalse(\OmegaUp\DAO\Problems::hasTriedToSolveProblem(
             $problemData['problem'],

--- a/frontend/tests/controllers/ProblemStatsTest.php
+++ b/frontend/tests/controllers/ProblemStatsTest.php
@@ -21,7 +21,7 @@ class ProblemStatsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create some runs to be pending
         $pendingRunsCount = 5;

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -49,7 +49,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData[0] = RunsFactory::createRun(
@@ -184,7 +184,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         // Get a problem with a run.
         $problemData = ProblemsFactory::createProblem();
         $problemAlias = $problemData['request']['problem_alias'];
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData[0] = RunsFactory::createRunToProblem(
             $problemData,
             $contestant
@@ -465,7 +465,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create our new admin
-        $problemAdmin = UserFactory::createUser();
+        ['user' => $problemAdmin, 'identity' => $identity] = UserFactory::createUser();
 
         // Add admin to the problem
         $adminLogin = self::login($problemData['author']);
@@ -503,7 +503,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create our new admin
-        $problemAdmin = UserFactory::createUser();
+        ['user' => $problemAdmin, 'identity' => $identity] = UserFactory::createUser();
 
         // Add admin to the problem
         $adminLogin = self::login($problemData['author']);
@@ -545,7 +545,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create our new admin
-        $problemAdmin = UserFactory::createUser();
+        ['user' => $problemAdmin, 'identity' => $identity] = UserFactory::createUser();
 
         // Add admin to the problem
         $login = self::login($problemData['author']);
@@ -589,7 +589,7 @@ class UpdateProblemTest extends OmegaupTestCase {
         ]));
 
         // Normal user shouldn't even be able to see the problem.
-        $reviewer = UserFactory::createUser();
+        ['user' => $reviewer, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($reviewer);
         try {
             \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([
@@ -878,7 +878,7 @@ class UpdateProblemTest extends OmegaupTestCase {
     public function testProblemVersionUpdate() {
         $problemData = ProblemsFactory::createProblem();
         $problem = $problemData['problem'];
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData, 1.0, 'AC');
 
@@ -1068,7 +1068,7 @@ class UpdateProblemTest extends OmegaupTestCase {
                 'author' => $problemAuthor,
             ]));
             $problem = $problemData['problem'];
-            $contestant = UserFactory::createUser();
+            ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
             \OmegaUp\Time::setTimeForTesting($originalTime - 30 * 60);
 
@@ -1190,7 +1190,7 @@ class UpdateProblemTest extends OmegaupTestCase {
             )->verdict
         );
 
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $result = $this->updateProblemsetProblemWithRuns(
             \OmegaUp\Controllers\Problem::UPDATE_PUBLISHED_NONE,
             $owner,
@@ -1239,7 +1239,7 @@ class UpdateProblemTest extends OmegaupTestCase {
             )->verdict
         );
 
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $result = $this->updateProblemsetProblemWithRuns(
             \OmegaUp\Controllers\Problem::UPDATE_PUBLISHED_NON_PROBLEMSET,
             $owner,
@@ -1304,7 +1304,7 @@ class UpdateProblemTest extends OmegaupTestCase {
             )->verdict
         );
 
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $result = $this->updateProblemsetProblemWithRuns(
             \OmegaUp\Controllers\Problem::UPDATE_PUBLISHED_OWNED_PROBLEMSETS,
             $owner,
@@ -1410,7 +1410,7 @@ class UpdateProblemTest extends OmegaupTestCase {
             )->verdict
         );
 
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $result = $this->updateProblemsetProblemWithRuns(
             \OmegaUp\Controllers\Problem::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS,
             $owner,
@@ -1434,7 +1434,7 @@ class UpdateProblemTest extends OmegaupTestCase {
             )->verdict
         );
 
-        $owner = UserFactory::createUser();
+        ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         $result = $this->updateProblemsetProblemWithRuns(
             \OmegaUp\Controllers\Problem::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS,
             $owner,

--- a/frontend/tests/controllers/ProblemsForfeitedTest.php
+++ b/frontend/tests/controllers/ProblemsForfeitedTest.php
@@ -8,7 +8,7 @@
 
 class ProblemsForfeitedTest extends OmegaupTestCase {
     public function testGetCounts() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         for (
@@ -34,7 +34,7 @@ class ProblemsForfeitedTest extends OmegaupTestCase {
     }
 
     public function testGetSolution() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $problems = [];
         for (
@@ -76,7 +76,7 @@ class ProblemsForfeitedTest extends OmegaupTestCase {
     }
 
     public function testGetSolutionForbiddenAccessException() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $problem = ProblemsFactory::createProblem()['problem'];
         try {

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -3,7 +3,7 @@
 class QualityNominationTest extends OmegaupTestCase {
     public function testGetNominationsHasAuthorAndNominatorSet() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -26,7 +26,7 @@ class QualityNominationTest extends OmegaupTestCase {
 
     public function testGetByIdHasAuthorAndNominatorSet() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         $result = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -52,7 +52,7 @@ class QualityNominationTest extends OmegaupTestCase {
 
     public function testApiDetailsReturnsFieldsRequiredByUI() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $contents = json_encode([
                  'statements' => [
@@ -123,7 +123,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testMustSolveBeforeNominatingItForPromotion() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
 
         $login = self::login($contestant);
@@ -188,7 +188,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testMustSolveBeforeSuggesting() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
 
         $login = self::login($contestant);
@@ -230,7 +230,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testNominatingForDemotion() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -272,7 +272,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testDemotionCannotBeResolvedByRegularUser() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -306,7 +306,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testDemotionCanBeApprovedAndLaterRevertedByReviewer() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -383,7 +383,7 @@ class QualityNominationTest extends OmegaupTestCase {
     public function testDemotionApprovedByReviewerAndSendMail() {
         $emailSender = new ScopedEmailSender();
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -436,7 +436,7 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PUBLIC
         ]));
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -486,7 +486,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testDemotionCanBeApprovedAndThenReopenedByReviewer() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -565,7 +565,7 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => \OmegaUp\Controllers\Problem::VISIBILITY_PRIVATE
         ]));
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
@@ -643,7 +643,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testBeforeACNomination() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
 
@@ -724,7 +724,7 @@ class QualityNominationTest extends OmegaupTestCase {
     public function testNominatingForDuplicate() {
         $originalProblemData = ProblemsFactory::createProblem();
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
 
@@ -787,7 +787,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testNominationList() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);
 
@@ -850,7 +850,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testTagsForDuplicate() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);
 
@@ -926,7 +926,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testNominationListDoesntShowSuggestionsOrDismisssal() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);
 
@@ -1008,7 +1008,7 @@ class QualityNominationTest extends OmegaupTestCase {
      */
     public function testMustSolveBeforeDismissed() {
         $problemData = ProblemsFactory::createProblem();
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         $login = self::login($contestant);
         $r = new \OmegaUp\Request([
@@ -1141,8 +1141,10 @@ class QualityNominationTest extends OmegaupTestCase {
         for ($i = 0; $i < 5; $i++) {
             $problemData[$i] = ProblemsFactory::createProblem();
         }
+        $userData = [];
+        $identityData = [];
         for ($i = 0; $i < 5; $i++) {
-            $userData[$i] = UserFactory::createUser();
+            ['user' => $userData[$i], 'identity' => $identityData[$i]] = UserFactory::createUser();
         }
         self::setUpRankForUsers($problemData, $userData, true);
 
@@ -1461,7 +1463,7 @@ class QualityNominationTest extends OmegaupTestCase {
         }
         $login = [];
         for ($i = 0; $i < 10; $i++) {
-            $contestant = UserFactory::createUser();
+            ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
             for ($j = 0; $j < $numberOfProblems; $j++) {
                 $runData = RunsFactory::createRunToProblem(
                     $problemData[$j],
@@ -1548,7 +1550,7 @@ class QualityNominationTest extends OmegaupTestCase {
         // Setup synthetic data.
         $login = [];
         for ($i = 0; $i < 10; $i++) {
-            $contestant = UserFactory::createUser();
+            ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
             for ($j = 0; $j < 2; $j++) {
                 $runData = RunsFactory::createRunToProblem(
                     $problemData[$j],

--- a/frontend/tests/controllers/RegisterToContestTest.php
+++ b/frontend/tests/controllers/RegisterToContestTest.php
@@ -11,7 +11,7 @@ class RegisterToContestTest extends OmegaupTestCase {
     public function testIntro() {
         // Create contest
         $contestData = ContestsFactory::createContest();
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $contestIdentityAdmin] = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
 
         // Contest will start in the future:
@@ -25,7 +25,7 @@ class RegisterToContestTest extends OmegaupTestCase {
         \OmegaUp\Controllers\Contest::apiUpdate($request);
 
         // Contestant will try to open the contes, this should fail
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $contestantLogin = self::login($contestant);
         $request2 = new \OmegaUp\Request([
@@ -95,7 +95,7 @@ class RegisterToContestTest extends OmegaupTestCase {
      * Testing if intro must be shown
      */
     public function testShowIntro() {
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestData = ContestsFactory::createContest(
             new ContestParams(
                 ['admission_mode' => 'private']
@@ -123,7 +123,7 @@ class RegisterToContestTest extends OmegaupTestCase {
     //pruebas extra para distinguir entre invitado y ya entrado al concurso
     public function testSimpleRegistrationActions() {
         // create a contest and its admin
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $contestIdentityAdmin] = UserFactory::createUser();
         $contestData = ContestsFactory::createContest(
             new ContestParams(
                 ['contestDirector' => $contestAdmin]
@@ -143,7 +143,7 @@ class RegisterToContestTest extends OmegaupTestCase {
         \OmegaUp\Controllers\Contest::apiUpdate($r1);
 
         // some user asks for contest
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestantLogin = self::login($contestant);
         $r2 = new \OmegaUp\Request([
             'contest_alias' => $contestData['request']['alias'],
@@ -211,7 +211,7 @@ class RegisterToContestTest extends OmegaupTestCase {
     public function testUserCannotSelfApprove() {
         // create a contest and its admin
         $contestData = ContestsFactory::createContest();
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $contestIdentityAdmin] = UserFactory::createUser();
         ContestsFactory::addAdminUser($contestData, $contestAdmin);
         $problemData = ProblemsFactory::createProblem();
         ContestsFactory::addProblemToContest($problemData, $contestData);
@@ -226,7 +226,7 @@ class RegisterToContestTest extends OmegaupTestCase {
         \OmegaUp\Controllers\Contest::apiUpdate($r1);
 
         // some user asks for contest
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestantLogin = self::login($contestant);
         $r2 = new \OmegaUp\Request([
             'contest_alias' => $contestData['request']['alias'],
@@ -257,7 +257,7 @@ class RegisterToContestTest extends OmegaupTestCase {
      */
     public function testUserNotAllowedJoinTheContest() {
         // create a contest and its admin
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $contestIdentityAdmin] = UserFactory::createUser();
         $contestData = ContestsFactory::createContest(new ContestParams([
             'contestDirector' => $contestAdmin,
         ]));
@@ -270,7 +270,7 @@ class RegisterToContestTest extends OmegaupTestCase {
         ]));
 
         // Contestant will try to open the contest, it should fail
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $contestantLogin = self::login($contestant);
 
@@ -288,7 +288,7 @@ class RegisterToContestTest extends OmegaupTestCase {
         $school = SchoolsFactory::createSchool();
 
         // create a contest and its admin
-        $contestAdmin = UserFactory::createUser();
+        ['user' => $contestAdmin, 'identity' => $contestIdentityAdmin] = UserFactory::createUser();
         $contestData = ContestsFactory::createContest(new ContestParams([
             'contestDirector' => $contestAdmin,
         ]));
@@ -302,7 +302,7 @@ class RegisterToContestTest extends OmegaupTestCase {
         ]));
 
         // Contestant will try to open the contes, this should fail
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Updates contestant, with basic information
         $contestantLogin = self::login($contestant);
@@ -330,8 +330,12 @@ class RegisterToContestTest extends OmegaupTestCase {
         // Creating 5 identities, and inviting them to the contest
         $numberOfInvitedContestants = 5;
         $invitedContestants = [];
+        $invitedContestantIdentities = [];
         for ($i = 0; $i < $numberOfInvitedContestants; $i++) {
-            $invitedContestants[] = UserFactory::createUser();
+            [
+                'user' => $invitedContestants[],
+                'identity' => $invitedContestantIdentities[],
+            ] = UserFactory::createUser();
         }
         $contestData = ContestsFactory::createContest(
             new ContestParams(
@@ -344,8 +348,12 @@ class RegisterToContestTest extends OmegaupTestCase {
         // Creating 3 identities without an invitation to join the contest
         $numberOfNotInvitedContestants = 3;
         $uninvitedContestants = [];
+        $uninvitedContestantIdentities = [];
         for ($i = 0; $i < $numberOfNotInvitedContestants; $i++) {
-            $uninvitedContestants[] = UserFactory::createUser();
+            [
+                'user' => $uninvitedContestants[],
+                'identity' => $uninvitedContestantIdentities[],
+            ] = UserFactory::createUser();
         }
 
         // All identities join the contest

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -9,6 +9,11 @@
 class RunCreateTest extends OmegaupTestCase {
     private $contestData;
     private $contestant;
+    private $contestantIdentity;
+    private $student;
+    private $studentIdentity;
+    private $non_student;
+    private $non_student_identity;
 
     /**
      * Prepares the context to submit a run to a problem. Creates the contest,
@@ -32,7 +37,7 @@ class RunCreateTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $this->contestData);
 
         // Create our contestant
-        $this->contestant = UserFactory::createUser();
+        ['user' => $this->contestant, 'identity' => $this->contestantIdentity] = UserFactory::createUser();
 
         // If the contest is private, add the user
         if ($contestParams['admission_mode'] === 'private') {
@@ -80,11 +85,11 @@ class RunCreateTest extends OmegaupTestCase {
         );
 
         // Student user
-        $this->student = UserFactory::createUser();
+        ['user' => $this->student, 'identity' => $this->studentIdentity] = UserFactory::createUser();
         CoursesFactory::addStudentToCourse($this->courseData, $this->student);
 
         // Non-student user
-        $this->non_student = UserFactory::createUser();
+        ['user' => $this->non_student, 'identity' => $this->non_student_identity] = UserFactory::createUser();
 
         // Get the actual DB entries for later
         $this->course = \OmegaUp\DAO\Courses::getByAlias(
@@ -247,7 +252,7 @@ class RunCreateTest extends OmegaupTestCase {
         ]));
 
         // Create a second user not regitered to private contest
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity] = UserFactory::createUser();
 
         // Log in this second user
         $login = self::login($contestant2);
@@ -525,7 +530,7 @@ class RunCreateTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $this->contestant = UserFactory::createUser();
+        ['user' => $this->contestant, 'identity' => $contestantIdentity] = UserFactory::createUser();
 
         // Create an empty request
         $login = self::login($this->contestant);
@@ -558,7 +563,7 @@ class RunCreateTest extends OmegaupTestCase {
         ]));
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create an empty request
         $login = self::login($contestant);
@@ -592,7 +597,7 @@ class RunCreateTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Our contestant has to open the contest before sending a run
         ContestsFactory::openContest($contestData, $contestant);
@@ -637,7 +642,7 @@ class RunCreateTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $this->contestant = UserFactory::createUser();
+        ['user' => $this->contestant, 'identity' => $this->contestantIdentity] = UserFactory::createUser();
 
         $login = self::login($this->contestant);
         $r = new \OmegaUp\Request([
@@ -665,7 +670,7 @@ class RunCreateTest extends OmegaupTestCase {
             $problemData = ProblemsFactory::createProblem();
 
             // Create our contestant
-            $this->contestant = UserFactory::createUser();
+            ['user' => $this->contestant, 'identity' => $this->contestantIdentity] = UserFactory::createUser();
 
             // Create an empty request
             $r = new \OmegaUp\Request();
@@ -850,7 +855,7 @@ class RunCreateTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $contestantIdentity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         $waRunData = RunsFactory::createRunToProblem(
@@ -861,9 +866,6 @@ class RunCreateTest extends OmegaupTestCase {
         RunsFactory::gradeRun($waRunData, 0, 'WA', 60);
 
         // Contestant should be able to view run (but not the run details).
-        $contestantIdentity = \OmegaUp\Controllers\Identity::resolveIdentity(
-            $contestant->username
-        );
         $this->assertFalse(\OmegaUp\Authorization::isProblemAdmin(
             $contestantIdentity,
             $problemData['problem']
@@ -896,7 +898,7 @@ class RunCreateTest extends OmegaupTestCase {
         // But having solved a problem does not grant permission to view
         // details to runs that the user would otherwise not had permission to
         // view.
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $contestantIdentity2] = UserFactory::createUser();
         $login2 = self::login($contestant2);
         $runData = RunsFactory::createRunToProblem(
             $problemData,

--- a/frontend/tests/controllers/RunDisqualifyTest.php
+++ b/frontend/tests/controllers/RunDisqualifyTest.php
@@ -17,7 +17,7 @@ class RunDisqualifyTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a new run
         $runData = RunsFactory::createRun(
@@ -51,8 +51,8 @@ class RunDisqualifyTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestants
-        $contestant1 = UserFactory::createUser();
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant1, 'identity' => $identity1] = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Create new runs
         $runData1 = RunsFactory::createRun(

--- a/frontend/tests/controllers/RunRejudgeTest.php
+++ b/frontend/tests/controllers/RunRejudgeTest.php
@@ -21,7 +21,7 @@ class RunRejudgeTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(

--- a/frontend/tests/controllers/RunStatusTest.php
+++ b/frontend/tests/controllers/RunStatusTest.php
@@ -18,7 +18,7 @@ class RunStatusTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run
         $runData = RunsFactory::createRun(
@@ -43,10 +43,8 @@ class RunStatusTest extends OmegaupTestCase {
      */
     public function testDownload() {
         $problemData = ProblemsFactory::createProblem();
-        $user = UserFactory::createUser();
-        $contestantIdentity = \OmegaUp\Controllers\Identity::resolveIdentity(
-            $user->username
-        );
+        ['user' => $user, 'identity' => $contestantIdentity] = UserFactory::createUser();
+
         $authorIdentity = \OmegaUp\Controllers\Identity::resolveIdentity(
             $problemData['author']->username
         );

--- a/frontend/tests/controllers/RunsTotalsTest.php
+++ b/frontend/tests/controllers/RunsTotalsTest.php
@@ -17,7 +17,7 @@ class RunsTotalsTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create our contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Create a run. Submission gap must be 60 seconds
         $runData = RunsFactory::createRun(

--- a/frontend/tests/controllers/SchoolCreateTest.php
+++ b/frontend/tests/controllers/SchoolCreateTest.php
@@ -10,7 +10,7 @@ class SchoolCreateTest extends OmegaupTestCase {
      * Create school happy path
      */
     public function testCreateSchool() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -36,7 +36,7 @@ class SchoolCreateTest extends OmegaupTestCase {
      *
      */
     public function testCreateSchoolDuplicatedName() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([

--- a/frontend/tests/controllers/SchoolRankTest.php
+++ b/frontend/tests/controllers/SchoolRankTest.php
@@ -12,8 +12,9 @@ class SchoolRankTest extends OmegaupTestCase {
      */
     private function createRunsWithSchool(&$schoolsData) {
         $users = [];
+        $identities = [];
         for ($i = 0; $i < 5; $i++) {
-            $users[] = UserFactory::createUser();
+            ['user' => $users[], 'identity' => $identities[]] = UserFactory::createUser();
         }
 
         SchoolsFactory::addUserToSchool($schoolsData[0], $users[0]);
@@ -72,7 +73,7 @@ class SchoolRankTest extends OmegaupTestCase {
         $this->createRunsWithSchool($schoolsData);
 
         // Call API
-        $rankViewer = UserFactory::createUser();
+        ['user' => $rankViewer, 'identity' => $identity] = UserFactory::createUser();
         $rankViewerLogin = self::login($rankViewer);
         $response = \OmegaUp\Controllers\School::apiRank(new \OmegaUp\Request([
             'auth_token' => $rankViewerLogin->auth_token
@@ -108,7 +109,7 @@ class SchoolRankTest extends OmegaupTestCase {
         // 1 in school #2 but PA, 1 with no school.
         $schoolsData = [SchoolsFactory::createSchool(), SchoolsFactory::createSchool()];
 
-        $rankViewer = UserFactory::createUser();
+        ['user' => $rankViewer, 'identity' => $identity] = UserFactory::createUser();
         $rankViewerLogin = self::login($rankViewer);
         $originalResponse = \OmegaUp\Controllers\School::apiRank(new \OmegaUp\Request([
             'auth_token' => $rankViewerLogin->auth_token,

--- a/frontend/tests/controllers/UserContestsTest.php
+++ b/frontend/tests/controllers/UserContestsTest.php
@@ -11,7 +11,7 @@ class UserContestsTest extends OmegaupTestCase {
      */
     public function testDirectorList() {
         // Our director
-        $director = UserFactory::createUser();
+        ['user' => $director, 'identity' => $identity] = UserFactory::createUser();
 
         $contestData[0] = ContestsFactory::createContest(
             new ContestParams(
@@ -48,13 +48,17 @@ class UserContestsTest extends OmegaupTestCase {
      */
     public function testAdminList() {
         // Our director
-        $director = UserFactory::createUser();
+        ['user' => $director, 'identity' => $identity] = UserFactory::createUser();
         $contestAdminData = [];
 
         // Create a group with two arbitrary users.
         $helperGroup = GroupsFactory::createGroup($director);
-        GroupsFactory::addUserToGroup($helperGroup, UserFactory::createUser());
-        GroupsFactory::addUserToGroup($helperGroup, UserFactory::createUser());
+        $users = [];
+        $identities = [];
+        for ($i = 0; $i < 2; $i++) {
+            ['user' => $users[$i], 'identity' => $identities[$i]] = UserFactory::createUser();
+            GroupsFactory::addUserToGroup($helperGroup, $users[$i]);
+        }
 
         // Get two contests with another director, add $director to their
         // admin list
@@ -70,7 +74,8 @@ class UserContestsTest extends OmegaupTestCase {
         $contestAdminData[1] = ContestsFactory::createContest();
         $group = GroupsFactory::createGroup($contestAdminData[1]['director']);
         GroupsFactory::addUserToGroup($group, $director);
-        GroupsFactory::addUserToGroup($group, UserFactory::createUser());
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
+        GroupsFactory::addUserToGroup($group, $user);
         ContestsFactory::addGroupAdmin($contestAdminData[1], $group['group']);
         ContestsFactory::addGroupAdmin(
             $contestAdminData[1],
@@ -174,7 +179,7 @@ class UserContestsTest extends OmegaupTestCase {
      * created
      */
     public function testPrivateContestsCountWithNoContests() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $this->assertEquals(
             0,

--- a/frontend/tests/controllers/UserCreateTest.php
+++ b/frontend/tests/controllers/UserCreateTest.php
@@ -248,7 +248,9 @@ class CreateUserTest extends OmegaupTestCase {
      */
     public function testUsernameVerificationByAdmin() {
         // User to be verified
-        $user = UserFactory::createUser(new UserParams(['verify' => false]));
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(['verify' => false])
+        );
 
         // Admin will verify $user
         ['user' => $admin, 'identity' => $identityAdmin] = UserFactory::createAdminUser();
@@ -292,10 +294,12 @@ class CreateUserTest extends OmegaupTestCase {
      */
     public function testUsernameVerificationByAdminNotAdmin() {
         // User to be verified
-        $user = UserFactory::createUser(new UserParams(['verify' => false]));
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(['verify' => false])
+        );
 
         // Another user will try to verify $user
-        $user2 = UserFactory::createUser();
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser();
 
         // Call api using admin
         $login = self::login($user2);
@@ -311,7 +315,7 @@ class CreateUserTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testMailingListBackfillNotAdmin() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $response = \OmegaUp\Controllers\User::apiMailingListBackfill(new \OmegaUp\Request([
@@ -324,7 +328,7 @@ class CreateUserTest extends OmegaupTestCase {
      * into Sendy.
      */
     public function testMailingtListBackfill() {
-        $userUnregistered = UserFactory::createUser();
+        ['user' => $unregisteredUser, 'identity' => $unregisteredIdentity] = UserFactory::createUser();
 
         $urlHelperMock = $this
             ->getMockBuilder('\\OmegaUp\\UrlHelper')
@@ -347,7 +351,7 @@ class CreateUserTest extends OmegaupTestCase {
         $this->assertEquals('ok', $response['status']);
         $this->assertEquals(
             true,
-            $response['users'][$userUnregistered->username]
+            $response['users'][$unregisteredUser->username]
         );
     }
 
@@ -355,7 +359,7 @@ class CreateUserTest extends OmegaupTestCase {
      * Test only verified users are backfilled into Sendy
      */
     public function testMailingListBackfillOnlyVerified() {
-        $userNotVerified = UserFactory::createUser(
+        ['user' => $userNotVerified, 'identity' => $identityNotVerified] = UserFactory::createUser(
             new UserParams(
                 ['verify' => false]
             )

--- a/frontend/tests/controllers/UserFilterTest.php
+++ b/frontend/tests/controllers/UserFilterTest.php
@@ -26,7 +26,7 @@ class UserFilterTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testInsufficientPrivileges() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([
@@ -47,7 +47,7 @@ class UserFilterTest extends OmegaupTestCase {
     }
 
     public function testMyEvents() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $response = \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([
@@ -65,8 +65,8 @@ class UserFilterTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testOtherUsersEvents() {
-        $user1 = UserFactory::createUser();
-        $user2 = UserFactory::createUser();
+        ['user' => $user1, 'identity' => $identity1] = UserFactory::createUser();
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser();
 
         $login = self::login($user1);
         \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([
@@ -77,7 +77,7 @@ class UserFilterTest extends OmegaupTestCase {
 
     public function testOtherUsersEventsWithAdmin() {
         ['user' => $admin, 'identity' => $identityAdmin] = UserFactory::createAdminUser();
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($admin);
         $response = \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([
@@ -89,7 +89,7 @@ class UserFilterTest extends OmegaupTestCase {
 
     public function testPublicProblemsetAccess() {
         $contest = ContestsFactory::createContest()['contest'];
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([
@@ -100,7 +100,7 @@ class UserFilterTest extends OmegaupTestCase {
 
     public function testPublicContestAccess() {
         $contest = ContestsFactory::createContest()['contest'];
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([
@@ -233,7 +233,7 @@ class UserFilterTest extends OmegaupTestCase {
 
     public function testPublicProblemAccess() {
         $problem = ProblemsFactory::createProblem()['problem'];
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $response = \OmegaUp\Controllers\User::apiValidateFilter(new \OmegaUp\Request([

--- a/frontend/tests/controllers/UserIdentityAssociationTest.php
+++ b/frontend/tests/controllers/UserIdentityAssociationTest.php
@@ -48,7 +48,7 @@ class UserIdentityAssociationTest extends OmegaupTestCase {
         ]));
 
         // Create the user to associate
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $associatedIdentities = \OmegaUp\Controllers\User::apiListAssociatedIdentities(new \OmegaUp\Request([
@@ -127,7 +127,7 @@ class UserIdentityAssociationTest extends OmegaupTestCase {
         ]));
 
         // Create the user to associate
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         try {
@@ -177,7 +177,7 @@ class UserIdentityAssociationTest extends OmegaupTestCase {
         ]));
 
         // Create the user to associate
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         try {
@@ -229,7 +229,7 @@ class UserIdentityAssociationTest extends OmegaupTestCase {
         ]));
 
         // Create the user to associate
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Trying to associate first identity to the logged user

--- a/frontend/tests/controllers/UserIdentitySynchronizeTest.php
+++ b/frontend/tests/controllers/UserIdentitySynchronizeTest.php
@@ -37,7 +37,7 @@ class UserIdentitySynchronizeTest extends OmegaupTestCase {
      */
     public function testResetMyPassword() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -72,7 +72,7 @@ class UserIdentitySynchronizeTest extends OmegaupTestCase {
      */
     public function testUserUpdate() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $locale = \OmegaUp\DAO\Languages::getByName('pt');
@@ -177,7 +177,7 @@ class UserIdentitySynchronizeTest extends OmegaupTestCase {
      */
     public function testUserUpdateBasicInfo() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $newUsername = 'new_username_basic_info';

--- a/frontend/tests/controllers/UserPrivacyPolicyTest.php
+++ b/frontend/tests/controllers/UserPrivacyPolicyTest.php
@@ -13,7 +13,7 @@ class UserPrivacyPolicyTest extends OmegaupTestCase {
         $privacy_poilcy = UserFactory::createPrivacyStatement();
 
         // Create the user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $response = \OmegaUp\Controllers\User::apiLastPrivacyPolicyAccepted(new \OmegaUp\Request([
@@ -31,7 +31,7 @@ class UserPrivacyPolicyTest extends OmegaupTestCase {
      */
     public function testUserAcceptsPrivacyPolicy() {
         // Create the user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create privacy policy
@@ -63,7 +63,7 @@ class UserPrivacyPolicyTest extends OmegaupTestCase {
      */
     public function testUserTriesToAcceptPolicyPreviouslyAccepted() {
         // Create the user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create privacy policy
@@ -99,7 +99,7 @@ class UserPrivacyPolicyTest extends OmegaupTestCase {
      */
     public function testAcceptsPreviousPolicyButNotLatestOne() {
         // Create the user
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Create privacy policy

--- a/frontend/tests/controllers/UserPrivilegesTest.php
+++ b/frontend/tests/controllers/UserPrivilegesTest.php
@@ -11,7 +11,7 @@ class UserPrivilegesTest extends OmegaupTestCase {
      */
     public function testAddRemoveRoles() {
         $username = 'testuserrole';
-        $user = UserFactory::createUser(
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
             new UserParams(
                 ['username' => $username]
             )
@@ -55,7 +55,7 @@ class UserPrivilegesTest extends OmegaupTestCase {
      */
     public function testAddRemoveGroups() {
         $username = 'testusergroup';
-        $user = UserFactory::createUser(
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
             new UserParams(
                 ['username' => $username]
             )

--- a/frontend/tests/controllers/UserProblemsTest.php
+++ b/frontend/tests/controllers/UserProblemsTest.php
@@ -7,7 +7,7 @@
  */
 class UserProblemsTest extends OmegaupTestCase {
     public function testEditableProblems() {
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
 
         $problemData[0] = ProblemsFactory::createProblemWithAuthor($author);
         $problemData[1] = ProblemsFactory::createProblemWithAuthor($author);
@@ -36,7 +36,7 @@ class UserProblemsTest extends OmegaupTestCase {
     }
 
     public function testNoProblems() {
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
 
         // Call API
         $login = self::login($author);
@@ -53,7 +53,7 @@ class UserProblemsTest extends OmegaupTestCase {
      */
     public function testAdminList() {
         // Our author
-        $author = UserFactory::createUser();
+        ['user' => $author, 'identity' => $identity] = UserFactory::createUser();
         $problemAdminData = [];
 
         // Get two problems with another author, add $author to their
@@ -143,7 +143,7 @@ class UserProblemsTest extends OmegaupTestCase {
      * Test \OmegaUp\DAO\Problems::getPrivateCount when there's 0 problems
      */
     public function testPrivateProblemsCountWithNoProblems() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $this->assertEquals(0, \OmegaUp\DAO\Problems::getPrivateCount($user));
     }

--- a/frontend/tests/controllers/UserProfileTest.php
+++ b/frontend/tests/controllers/UserProfileTest.php
@@ -10,7 +10,7 @@ class UserProfileTest extends OmegaupTestCase {
      * Test for the function which returns the general user info
      */
     public function testUserData() {
-        $user = UserFactory::createUser(
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
             new UserParams(
                 ['username' => 'testuser1']
             )
@@ -30,12 +30,12 @@ class UserProfileTest extends OmegaupTestCase {
      * Test for the function which returns the general user info
      */
     public function testUserDataAnotherUser() {
-        $user = UserFactory::createUser(
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
             new UserParams(
                 ['username' => 'testuser2']
             )
         );
-        $user2 = UserFactory::createUser(
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser(
             new UserParams(
                 ['username' => 'testuser3']
             )
@@ -60,9 +60,9 @@ class UserProfileTest extends OmegaupTestCase {
      * Test apiProfile with is_private enabled
      */
     public function testUserPrivateDataAnotherUser() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         // Mark user2's profile as private (5th argument)
-        $user2 = UserFactory::createUser(
+        ['user' => $user2, 'identity' => $identity2] = UserFactory::createUser(
             new UserParams(
                 ['is_private' => true]
             )
@@ -98,7 +98,7 @@ class UserProfileTest extends OmegaupTestCase {
      * Test admin can see emails for all non-private profiles
      */
     public function testAdminCanSeeEmails() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         ['user' => $admin, 'identity' => $identityAdmin] = UserFactory::createAdminUser();
 
         $login = self::login($admin);
@@ -115,7 +115,9 @@ class UserProfileTest extends OmegaupTestCase {
      * Test admin can see all details for private profiles
      */
     public function testAdminCanSeePrivateProfile() {
-        $user = UserFactory::createUser(new UserParams(['is_private' => true]));
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(['is_private' => true])
+        );
         ['user' => $admin, 'identity' => $identityAdmin] = UserFactory::createAdminUser();
 
         $login = self::login($admin);
@@ -141,7 +143,7 @@ class UserProfileTest extends OmegaupTestCase {
      * User can see his own email
      */
     public function testUserCanSeeSelfEmail() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -157,7 +159,7 @@ class UserProfileTest extends OmegaupTestCase {
      * Test the contest which a certain user has participated
      */
     public function testUserContests() {
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $contests = [];
         $contests[0] = ContestsFactory::createContest();
@@ -193,7 +195,7 @@ class UserProfileTest extends OmegaupTestCase {
      * API can be accessed by a user who cannot see the contest (contest is private)
      */
     public function testUserContestsPrivateContestOutsider() {
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $contests = [];
         $contests[0] = ContestsFactory::createContest(
@@ -216,7 +218,7 @@ class UserProfileTest extends OmegaupTestCase {
         );
         RunsFactory::gradeRun($runData);
 
-        $externalUser = UserFactory::createUser();
+        ['user' => $externalUser, 'identity' => $externalIdentity] = UserFactory::createUser();
 
         $login = self::login($externalUser);
         // Get ContestStats
@@ -235,7 +237,7 @@ class UserProfileTest extends OmegaupTestCase {
      * Test the problems solved by user
      */
     public function testProblemsSolved() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $contest = ContestsFactory::createContest();
 
@@ -273,7 +275,7 @@ class UserProfileTest extends OmegaupTestCase {
      * Test update main email api
      */
     public function testUpdateMainEmail() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -291,7 +293,7 @@ class UserProfileTest extends OmegaupTestCase {
      * Test update main email api
      */
     public function testStats() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $problem = ProblemsFactory::createProblem();
 
         $login = self::login($user);

--- a/frontend/tests/controllers/UserRankTest.php
+++ b/frontend/tests/controllers/UserRankTest.php
@@ -6,7 +6,7 @@ class UserRankTest extends OmegaupTestCase {
      */
     public function testFullRankByProblemSolved() {
         // Create a user and sumbit a run with him
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestantIdentity = \OmegaUp\DAO\Identities::getByPK(
             $contestant->main_identity_id
         );
@@ -40,7 +40,7 @@ class UserRankTest extends OmegaupTestCase {
      */
     public function testPrivateUserInRanking() {
         // Create a private user
-        $contestantPrivate = UserFactory::createUser(
+        ['user' => $contestantPrivate, 'identity' => $identityPrivate] = UserFactory::createUser(
             new UserParams(
                 ['is_private' => true]
             )
@@ -77,7 +77,7 @@ class UserRankTest extends OmegaupTestCase {
      */
     public function testFullRankByProblemSolvedNoPrivateProblems() {
         // Create a user and sumbit a run with him
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestantIdentity = \OmegaUp\DAO\Identities::getByPK(
             $contestant->main_identity_id
         );
@@ -86,7 +86,7 @@ class UserRankTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runData);
 
         // Create a user and sumbit a run with him
-        $contestant2 = UserFactory::createUser();
+        ['user' => $contestant2, 'identity' => $identity2] = UserFactory::createUser();
         $problemDataPrivate = ProblemsFactory::createProblem(new ProblemParams([
             'visibility' => 0
         ]));
@@ -126,7 +126,7 @@ class UserRankTest extends OmegaupTestCase {
      */
     public function testUserRankByProblemsSolved() {
         // Create a user and sumbit a run with him
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestantIdentity = \OmegaUp\DAO\Identities::getByPK(
             $contestant->main_identity_id
         );
@@ -151,7 +151,7 @@ class UserRankTest extends OmegaupTestCase {
      */
     public function testUserRankByProblemsSolvedWith0Runs() {
         // Create a user with no runs
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $contestantIdentity = \OmegaUp\DAO\Identities::getByPK(
             $contestant->main_identity_id
         );
@@ -176,7 +176,7 @@ class UserRankTest extends OmegaupTestCase {
         // Create a school
         $school = SchoolsFactory::createSchool();
         // Create a user with no country, state and school
-        $contestantWithNoCountry = UserFactory::createUser();
+        ['user' => $contestantWithNoCountry, 'identity' => $identityWithNoCountry] = UserFactory::createUser();
         $problemData = ProblemsFactory::createProblem();
         $runDataContestantWithNoCountry = RunsFactory::createRunToProblem(
             $problemData,
@@ -185,7 +185,7 @@ class UserRankTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataContestantWithNoCountry);
 
         // Create a user with country, state and school
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($contestant);
 
         $states = \OmegaUp\DAO\States::getByCountry('MX');
@@ -234,7 +234,10 @@ class UserRankTest extends OmegaupTestCase {
         $problemData[] = ProblemsFactory::createProblem();
 
         // Create two users from Maranhao, Brasil
-        $contestantFromMaranhao1 = UserFactory::createUser();
+        [
+            'user' => $contestantFromMaranhao1,
+            'identity' => $identityFromMaranhao1
+        ] = UserFactory::createUser();
         $maranhao1Login = self::login($contestantFromMaranhao1);
 
         \OmegaUp\Controllers\User::apiUpdate(new \OmegaUp\Request([
@@ -257,7 +260,10 @@ class UserRankTest extends OmegaupTestCase {
         );
         RunsFactory::gradeRun($runDataContestantFromMaranhao1);
 
-        $contestantFromMaranhao2 = UserFactory::createUser();
+        [
+            'user' => $contestantFromMaranhao2,
+            'identity' => $identityFromMaranhao2
+        ] = UserFactory::createUser();
         $maranhao2Login = self::login($contestantFromMaranhao2);
 
         \OmegaUp\Controllers\User::apiUpdate(new \OmegaUp\Request([
@@ -275,7 +281,10 @@ class UserRankTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runDataContestantFromMaranhao2);
 
         // Create a user from Massachusetts, USA
-        $contestantFromMassachusetts = UserFactory::createUser();
+        [
+            'user' => $contestantFromMassachusetts,
+            'identity' => $identityFromMassachusetts
+        ] = UserFactory::createUser();
         $massachusettsLogin = self::login($contestantFromMassachusetts);
 
         \OmegaUp\Controllers\User::apiUpdate(new \OmegaUp\Request([
@@ -319,7 +328,7 @@ class UserRankTest extends OmegaupTestCase {
 
     public function testUserRankingClassName() {
         // Create a user and sumbit a run with them
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $problemData = ProblemsFactory::createProblem();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);
@@ -339,7 +348,7 @@ class UserRankTest extends OmegaupTestCase {
     }
 
     public function testUserRankWithForfeitedProblem() {
-        $firstPlaceUser = UserFactory::createUser();
+        ['user' => $firstPlaceUser, 'identity' => $firstPlaceIdentity] = UserFactory::createUser();
         $login = self::login($firstPlaceUser);
         $problems = [];
         $extraProblem = ProblemsFactory::createProblem();
@@ -361,7 +370,7 @@ class UserRankTest extends OmegaupTestCase {
         );
         RunsFactory::gradeRun($run);
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         for (
             $i = 0; $i < \OmegaUp\Controllers\ProblemForfeited::SOLVED_PROBLEMS_PER_ALLOWED_SOLUTION; $i++

--- a/frontend/tests/controllers/UserResetPasswordTest.php
+++ b/frontend/tests/controllers/UserResetPasswordTest.php
@@ -11,7 +11,7 @@ class UserResetPasswordTest extends OmegaupTestCase {
      */
     public function testResetMyPassword() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -44,7 +44,7 @@ class UserResetPasswordTest extends OmegaupTestCase {
      */
     public function testResetMyPasswordBadOldPassword() {
         // Create an user in omegaup
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([

--- a/frontend/tests/controllers/UserSupportTest.php
+++ b/frontend/tests/controllers/UserSupportTest.php
@@ -37,7 +37,7 @@ class UserSupportTest extends OmegaupTestCase {
 
         // Creates a user
         $email = Utils::CreateRandomString() . '@mail.com';
-        $user = UserFactory::createUser(new UserParams([
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(new UserParams([
             'email' => $email,
             'verify' => false
         ]));
@@ -77,7 +77,11 @@ class UserSupportTest extends OmegaupTestCase {
 
         // Creates a user
         $email = Utils::CreateRandomString() . '@mail.com';
-        $user = UserFactory::createUser(new UserParams(['email' => $email]));
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(
+                ['email' => $email]
+            )
+        );
 
         // Call api using support team member
         $supportLogin = self::login($supportUser);
@@ -127,7 +131,11 @@ class UserSupportTest extends OmegaupTestCase {
 
         // Creates a user
         $email = Utils::CreateRandomString() . '@mail.com';
-        $user = UserFactory::createUser(new UserParams(['email' => $email]));
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser(
+            new UserParams(
+                ['email' => $email]
+            )
+        );
 
         // Call api using support team member
         $supportLogin = self::login($supportUser);

--- a/frontend/tests/controllers/UserUpdateTest.php
+++ b/frontend/tests/controllers/UserUpdateTest.php
@@ -10,7 +10,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testUserUpdate() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $locale = \OmegaUp\DAO\Languages::getByName('pt');
@@ -108,7 +108,7 @@ class UserUpdateTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testNegativeStateUpdate() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -125,7 +125,7 @@ class UserUpdateTest extends OmegaupTestCase {
      * Update profile username with non-existence username
      */
     public function testUsernameUpdate() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $new_username = Utils::CreateRandomString();
         $r = new \OmegaUp\Request([
@@ -144,13 +144,13 @@ class UserUpdateTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
     public function testDuplicateUsernameUpdate() {
-        $old_user = UserFactory::createUser();
-        $user = UserFactory::createUser();
+        ['user' => $oldUser, 'identity' => $oldIdentity] = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
         $r = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             //update username with existed username
-            'username' => $old_user->username
+            'username' => $oldUser->username
         ]);
         \OmegaUp\Controllers\User::apiUpdate($r);
     }
@@ -160,7 +160,7 @@ class UserUpdateTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testNameUpdateTooLong() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -178,7 +178,7 @@ class UserUpdateTest extends OmegaupTestCase {
      * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testEmptyNameUpdate() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($user);
         $r = new \OmegaUp\Request([
@@ -195,7 +195,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testFutureBirthday() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $r = new \OmegaUp\Request([
@@ -212,7 +212,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testUpdateCountryWithNoStateData() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         // Omit state.
@@ -238,7 +238,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testGenderWithInvalidOption() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         //generate wrong gender option
@@ -261,7 +261,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testGenderWithValidOption() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $r = new \OmegaUp\Request([
@@ -278,7 +278,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testGenderWithNull() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         $r = new \OmegaUp\Request([
@@ -295,7 +295,7 @@ class UserUpdateTest extends OmegaupTestCase {
      */
     public function testGenderWithEmptyString() {
         // Create the user to edit
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = self::login($user);
 
         //generate wrong gender option
@@ -316,7 +316,7 @@ class UserUpdateTest extends OmegaupTestCase {
      * Tests that the user can generate a git token.
      */
     public function testGenerateGitToken() {
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $this->assertNull($user->git_token);
         $login = self::login($user);
         $response = \OmegaUp\Controllers\User::apiGenerateGitToken(new \OmegaUp\Request([
@@ -341,8 +341,7 @@ class UserUpdateTest extends OmegaupTestCase {
     public function testOldHashTransparentMigration() {
         // Create the user and manually set its password to the well-known
         // 'omegaup' hash.
-        $user = UserFactory::createUser();
-        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $identity->password = '$2a$08$tyE7x/yxOZ1ltM7YAuFZ8OK/56c9Fsr/XDqgPe22IkOORY2kAAg2a';
         \OmegaUp\DAO\Identities::update($identity);
         $user->password = $identity->password;

--- a/frontend/tests/controllers/VirtualContestTest.php
+++ b/frontend/tests/controllers/VirtualContestTest.php
@@ -21,7 +21,7 @@ class VirtualContestTest extends OmegaupTestCase {
         \OmegaUp\Time::setTimeForTesting(\OmegaUp\Time::get() + 3600);
 
         // Create a new contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         $r = new \OmegaUp\Request([
@@ -109,7 +109,7 @@ class VirtualContestTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Create a new contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         $login = self::login($contestant);
         $r = new \OmegaUp\Request([
@@ -135,7 +135,7 @@ class VirtualContestTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
 
         // Create a new contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Lets assume the original contest has been finished
         \OmegaUp\Time::setTimeForTesting(\OmegaUp\Time::get() + 3600);
@@ -173,7 +173,7 @@ class VirtualContestTest extends OmegaupTestCase {
         ContestsFactory::addProblemToContest($problemData, $contestData);
 
         // Create a new contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Lets assume the original contest has been finished
         \OmegaUp\Time::setTimeForTesting(\OmegaUp\Time::get() + 3600);
@@ -204,7 +204,7 @@ class VirtualContestTest extends OmegaupTestCase {
         $contestData = ContestsFactory::createContest();
 
         // Create a new contestant
-        $contestant = UserFactory::createUser();
+        ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
         // Lets assume the original contest has been finished
         \OmegaUp\Time::setTimeForTesting(\OmegaUp\Time::get() + 3600);

--- a/frontend/tests/factories/ContestsFactory.php
+++ b/frontend/tests/factories/ContestsFactory.php
@@ -39,11 +39,12 @@ class ContestParams implements ArrayAccess {
             false,
             'no'
         );
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         ContestParams::validateParameter(
             'contestDirector',
             $this->params,
             false,
-            UserFactory::createUser()
+            $user
         );
         ContestParams::validateParameter('window_length', $this->params, false);
         ContestParams::validateParameter('languages', $this->params, false);

--- a/frontend/tests/factories/CoursesFactory.php
+++ b/frontend/tests/factories/CoursesFactory.php
@@ -9,7 +9,7 @@ class CoursesFactory {
         $showScoreboard = 'false'
     ) {
         if (is_null($admin)) {
-            $admin = UserFactory::createUser();
+            ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
             $adminLogin = OmegaupTestCase::login($admin);
         }
         $identity = \OmegaUp\DAO\Identities::getByPK($admin->main_identity_id);
@@ -56,7 +56,7 @@ class CoursesFactory {
         $startTimeDelay = 0
     ) {
         if (is_null($admin)) {
-            $admin = UserFactory::createUser();
+            ['user' => $admin, 'identity' => $identity] = UserFactory::createUser();
             $adminLogin = OmegaupTestCase::login($admin);
         }
 
@@ -152,7 +152,7 @@ class CoursesFactory {
         ?ScopedLoginToken $login = null
     ) {
         if (is_null($student)) {
-            $student = UserFactory::createUser();
+            ['user' => $student, 'identity' => $identity] = UserFactory::createUser();
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseData['course_alias']);

--- a/frontend/tests/factories/GroupsFactory.php
+++ b/frontend/tests/factories/GroupsFactory.php
@@ -16,7 +16,7 @@ class GroupsFactory {
         ScopedLoginToken $login = null
     ) {
         if (is_null($owner)) {
-            $owner = UserFactory::createUser();
+            ['user' => $owner, 'identity' => $identity] = UserFactory::createUser();
         }
 
         if (is_null($name)) {

--- a/frontend/tests/factories/ProblemsFactory.php
+++ b/frontend/tests/factories/ProblemsFactory.php
@@ -34,11 +34,12 @@ class ProblemParams implements ArrayAccess {
             false,
             \OmegaUp\Controllers\Problem::VISIBILITY_PUBLIC
         );
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         ProblemParams::validateParameter(
             'author',
             $this->params,
             false,
-            UserFactory::createUser()
+            $user
         );
         ProblemParams::validateParameter(
             'languages',

--- a/frontend/tests/factories/QualityNominationFactory.php
+++ b/frontend/tests/factories/QualityNominationFactory.php
@@ -13,13 +13,10 @@ class QualityNominationFactory {
             \OmegaUp\Authorization::QUALITY_REVIEWER_GROUP_ALIAS
         );
         for ($i = 0; $i < 5; $i++) {
-            $reviewer = UserFactory::createUser();
+            ['user' => $reviewer, 'identity' => $identity] = UserFactory::createUser();
             if (is_null($reviewer->main_identity_id)) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotFound');
             }
-            $identity = \OmegaUp\DAO\Identities::getByPK(
-                $reviewer->main_identity_id
-            );
             \OmegaUp\DAO\GroupsIdentities::create(new \OmegaUp\DAO\VO\GroupsIdentities([
                 'group_id' => $qualityReviewerGroup->group_id,
                 'identity_id' => $identity->identity_id,

--- a/frontend/tests/factories/SchoolsFactory.php
+++ b/frontend/tests/factories/SchoolsFactory.php
@@ -18,7 +18,7 @@ class SchoolsFactory {
             $name = Utils::CreateRandomString();
         }
 
-        $user = UserFactory::createUser();
+        ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
         $login = OmegaupTestCase::login($user);
         $r = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -3784,9 +3784,8 @@
     <MixedPropertyFetch occurrences="1">
       <code>$login-&gt;auth_token</code>
     </MixedPropertyFetch>
-    <PossiblyNullPropertyFetch occurrences="2">
+    <PossiblyNullPropertyFetch occurrences="1">
       <code>$qualityReviewerGroup-&gt;group_id</code>
-      <code>$identity-&gt;identity_id</code>
     </PossiblyNullPropertyFetch>
   </file>
   <file src="frontend/tests/factories/RunsFactory.php">
@@ -3872,9 +3871,8 @@
       <code>$this-&gt;params[$offset]</code>
       <code>$this-&gt;params[$offset]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$array[$parameter]</code>
-      <code>$user-&gt;password</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;params</code>


### PR DESCRIPTION
# Descripción

Se realiza un ajuste en la función `UserFactory::createUser` para que ahora regrese los
objetos `Users` e `Identities`. A su vez, se arreglan todas las llamadas a esta función.

Part of: #2910 

# Comentarios

El siguiente cambio a realizar es modificar el método de `OmegaupTestCase::login`
para que ahora este reciba realmente el objeto `Identities`.

# Checklist:

- [X] El código sigue la [guía de  estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de  omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
