### PR TITLE
Agregando createNomination() como función para reemplazar a apiCreate() en QualityNominations

### DIFF
--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -377,9 +377,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         $nomination = \OmegaUp\Controllers\QualityNomination::createNomination(
             $problem,
             $r->user,
-            strval(
-                $r['nomination']
-            ),
+            strval($r['nomination']),
             $contents
         );
 

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -12,7 +12,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * @param \OmegaUp\DAO\VO\Problems $problem
      * @param \OmegaUp\DAO\VO\Users $user
      * @param string $nominationType
-     * @param array $contents
+     * @param array{tags?: mixed, before_ac?: mixed, difficulty?: mixed, quality?: mixed, statements?: mixed, source?: mixed, reason?: mixed, original?: mixed} $contents
      * @return \OmegaUp\DAO\VO\QualityNominations
      */
     public static function createNomination(

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -9,105 +9,31 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     const REVIEWERS_PER_NOMINATION = 2;
 
     /**
-     * Creates a new QualityNomination
-     *
-     * There are three ways in which users can interact with this:
-     *
-     * # Suggestion
-     *
-     * A user that has already solved a problem can make suggestions about a
-     * problem. This expects the `nomination` field to be `suggestion` and the
-     * `contents` field should be a JSON blob with at least one the following fields:
-     *
-     * * `difficulty`: (Optional) A number in the range [0-4] indicating the
-     *                 difficulty of the problem.
-     * * `quality`: (Optional) A number in the range [0-4] indicating the quality
-     *             of the problem.
-     * * `tags`: (Optional) An array of tag names that will be added to the
-     *           problem upon promotion.
-     * * `before_ac`: (Optional) Boolean indicating if the suggestion has been sent
-     *                before receiving an AC verdict for problem run.
-     *
-     * # Promotion
-     *
-     * A user that has already solved a problem can nominate it to be promoted
-     * as a Quality Problem. This expects the `nomination` field to be
-     * `promotion` and the `contents` field should be a JSON blob with the
-     * following fields:
-     *
-     * * `statements`: A dictionary of languages to objects that contain a
-     *                 `markdown` field, which is the markdown-formatted
-     *                 problem statement for that language.
-     * * `source`: A URL or string clearly documenting the source or full name
-     *             of original author of the problem.
-     * * `tags`: An array of tag names that will be added to the problem upon
-     *           promotion.
-     *
-     * # Demotion
-     *
-     * A demoted problem is banned, and cannot be un-banned or added to any new
-     * problemsets. This expects the `nomination` field to be `demotion` and
-     * the `contents` field should be a JSON blob with the following fields:
-     *
-     * * `rationale`: A small text explaining the rationale for demotion.
-     * * `reason`: One of `['duplicate', 'no-problem-statement', 'offensive', 'other', 'spam']`.
-     * * `original`: If the `reason` is `duplicate`, the alias of the original
-     *               problem.
-     * # Dismissal
-     * A user that has already solved a problem can dismiss suggestions. The
-     * `contents` field is empty.
-     *
-     * @param \OmegaUp\Request $r
-     *
-     * @return array
-     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
+     * @param \OmegaUp\DAO\VO\Problems $problem
+     * @param \OmegaUp\DAO\VO\Users $user
+     * @param string $nominationType
+     * @param array $contents
+     * @return \OmegaUp\DAO\VO\QualityNominations
      */
-    public static function apiCreate(\OmegaUp\Request $r) {
-        if (OMEGAUP_LOCKDOWN) {
-            throw new \OmegaUp\Exceptions\ForbiddenAccessException('lockdown');
-        }
-
-        // Validate request
-        $r->ensureIdentity();
-
-        \OmegaUp\Validators::validateStringNonEmpty(
-            $r['problem_alias'],
-            'problem_alias'
-        );
-        \OmegaUp\Validators::validateInEnum(
-            $r['nomination'],
-            'nomination',
-            ['suggestion', 'promotion', 'demotion', 'dismissal']
-        );
-        \OmegaUp\Validators::validateStringNonEmpty($r['contents'], 'contents');
-        /**
-         * @var null|array{tags?: mixed, before_ac?: mixed, difficulty?: mixed, quality?: mixed, statements?: mixed, source?: mixed, reason?: mixed, original?: mixed} $contents
-         */
-        $contents = json_decode($r['contents'], true /*assoc*/);
-        if (!is_array($contents)) {
-            throw new \OmegaUp\Exceptions\InvalidParameterException(
-                'parameterInvalid',
-                'contents'
-            );
-        }
-        $problem = \OmegaUp\DAO\Problems::getByAlias($r['problem_alias']);
-        if (is_null($problem)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
-        }
-
-        if ($r['nomination'] !== 'demotion') {
+    public static function createNomination(
+        \OmegaUp\DAO\VO\Problems $problem,
+        \OmegaUp\DAO\VO\Users $user,
+        string $nominationType,
+        array $contents
+    ): \OmegaUp\DAO\VO\QualityNominations {
+        if ($nominationType !== 'demotion') {
             if (
                 isset($contents['before_ac']) &&
                 boolval($contents['before_ac']) &&
-                ($r['nomination'] === 'dismissal' ||
-                 $r['nomination'] === 'suggestion')
+                ($nominationType === 'dismissal' ||
+                 $nominationType === 'suggestion')
             ) {
                 // Before AC suggestions or dismissals are only allowed
                 // for users who didn't solve a problem, but tried to.
                 if (
                     \OmegaUp\DAO\Problems::isProblemSolved(
                         $problem,
-                        intval($r->identity->identity_id)
+                        intval($user->main_identity_id)
                     )
                 ) {
                     throw new \OmegaUp\Exceptions\PreconditionFailedException(
@@ -118,7 +44,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 if (
                     !\OmegaUp\DAO\Problems::hasTriedToSolveProblem(
                         $problem,
-                        intval($r->identity->identity_id)
+                        intval($user->main_identity_id)
                     )
                 ) {
                     throw new \OmegaUp\Exceptions\PreconditionFailedException(
@@ -132,7 +58,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 if (
                     !\OmegaUp\DAO\Problems::isProblemSolved(
                         $problem,
-                        intval($r->identity->identity_id)
+                        intval($user->main_identity_id)
                     )
                 ) {
                     throw new \OmegaUp\Exceptions\PreconditionFailedException(
@@ -142,7 +68,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             }
         }
 
-        if ($r['nomination'] === 'suggestion') {
+        if ($nominationType === 'suggestion') {
             $atLeastOneFieldIsPresent = false;
             if (isset($contents['difficulty'])) {
                 if (
@@ -205,7 +131,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                     );
                 }
             }
-        } elseif ($r['nomination'] === 'promotion') {
+        } elseif ($nominationType === 'promotion') {
             if (
                 (!isset($contents['statements'])
                 || !is_array($contents['statements']))
@@ -256,7 +182,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                     );
                 }
             }
-        } elseif ($r['nomination'] === 'demotion') {
+        } elseif ($nominationType === 'demotion') {
             if (
                 !isset($contents['reason']) ||
                 !in_array(
@@ -312,7 +238,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                     }
                 }
             }
-        } elseif ($r['nomination'] === 'dismissal') {
+        } elseif ($nominationType === 'dismissal') {
             if (
                 isset($contents['origin'])
                 || isset($contents['difficulty'])
@@ -328,12 +254,11 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             }
         }
 
-        // Create object
         $nomination = new \OmegaUp\DAO\VO\QualityNominations([
-            'user_id' => $r->user->user_id,
+            'user_id' => $user->user_id,
             'problem_id' => $problem->problem_id,
-            'nomination' => $r['nomination'],
-            'contents' => json_encode($contents), // re-encoding it for normalization.
+            'nomination' => $nominationType,
+            'contents' => json_encode($contents),
             'status' => 'open',
         ]);
         \OmegaUp\DAO\QualityNominations::create($nomination);
@@ -359,6 +284,104 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 ]));
             }
         }
+        return $nomination;
+    }
+
+    /**
+     * Creates a new QualityNomination
+     *
+     * There are three ways in which users can interact with this:
+     *
+     * # Suggestion
+     *
+     * A user that has already solved a problem can make suggestions about a
+     * problem. This expects the `nomination` field to be `suggestion` and the
+     * `contents` field should be a JSON blob with at least one the following fields:
+     *
+     * * `difficulty`: (Optional) A number in the range [0-4] indicating the
+     *                 difficulty of the problem.
+     * * `quality`: (Optional) A number in the range [0-4] indicating the quality
+     *             of the problem.
+     * * `tags`: (Optional) An array of tag names that will be added to the
+     *           problem upon promotion.
+     * * `before_ac`: (Optional) Boolean indicating if the suggestion has been sent
+     *                before receiving an AC verdict for problem run.
+     *
+     * # Promotion
+     *
+     * A user that has already solved a problem can nominate it to be promoted
+     * as a Quality Problem. This expects the `nomination` field to be
+     * `promotion` and the `contents` field should be a JSON blob with the
+     * following fields:
+     *
+     * * `statements`: A dictionary of languages to objects that contain a
+     *                 `markdown` field, which is the markdown-formatted
+     *                 problem statement for that language.
+     * * `source`: A URL or string clearly documenting the source or full name
+     *             of original author of the problem.
+     * * `tags`: An array of tag names that will be added to the problem upon
+     *           promotion.
+     *
+     * # Demotion
+     *
+     * A demoted problem is banned, and cannot be un-banned or added to any new
+     * problemsets. This expects the `nomination` field to be `demotion` and
+     * the `contents` field should be a JSON blob with the following fields:
+     *
+     * * `rationale`: A small text explaining the rationale for demotion.
+     * * `reason`: One of `['duplicate', 'no-problem-statement', 'offensive', 'other', 'spam']`.
+     * * `original`: If the `reason` is `duplicate`, the alias of the original
+     *               problem.
+     * # Dismissal
+     * A user that has already solved a problem can dismiss suggestions. The
+     * `contents` field is empty.
+     *
+     * @param \OmegaUp\Request $r
+     *
+     * @return array
+     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
+     */
+    public static function apiCreate(\OmegaUp\Request $r) {
+        if (OMEGAUP_LOCKDOWN) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException('lockdown');
+        }
+
+        // Validate request
+        $r->ensureMainUserIdentity();
+
+        \OmegaUp\Validators::validateStringNonEmpty(
+            $r['problem_alias'],
+            'problem_alias'
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $r['nomination'],
+            'nomination',
+            ['suggestion', 'promotion', 'demotion', 'dismissal']
+        );
+        \OmegaUp\Validators::validateStringNonEmpty($r['contents'], 'contents');
+        /**
+         * @var null|array{tags?: mixed, before_ac?: mixed, difficulty?: mixed, quality?: mixed, statements?: mixed, source?: mixed, reason?: mixed, original?: mixed} $contents
+         */
+        $contents = json_decode($r['contents'], true /*assoc*/);
+        if (!is_array($contents)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'contents'
+            );
+        }
+        $problem = \OmegaUp\DAO\Problems::getByAlias($r['problem_alias']);
+        if (is_null($problem)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+
+        $nomination = \OmegaUp\Controllers\QualityNomination::createNomination(
+            $problem,
+            $r->user,
+            strval(
+                $r['nomination']
+            ),
+            $contents
+        );
 
         return [
             'status' => 'ok',

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -182,7 +182,7 @@ class ProblemList extends OmegaupTestCase {
         }
 
         QualityNominationFactory::createSuggestion(
-            $login[0],
+            $users[0],
             $problemData[0]['request']['problem_alias'],
             4, // difficulty
             3, // quality
@@ -191,7 +191,7 @@ class ProblemList extends OmegaupTestCase {
         );
 
         QualityNominationFactory::createSuggestion(
-            $login[1],
+            $users[1],
             $problemData[0]['request']['problem_alias'],
             4, // difficulty
             4, // quality
@@ -200,7 +200,7 @@ class ProblemList extends OmegaupTestCase {
         );
 
         QualityNominationFactory::createSuggestion(
-            $login[2],
+            $users[2],
             $problemData[0]['request']['problem_alias'],
             4, // difficulty
             2, // quality
@@ -209,7 +209,7 @@ class ProblemList extends OmegaupTestCase {
         );
 
         QualityNominationFactory::createSuggestion(
-            $login[3],
+            $users[3],
             $problemData[0]['request']['problem_alias'],
             4, // difficulty
             4, // quality
@@ -218,7 +218,7 @@ class ProblemList extends OmegaupTestCase {
         );
 
         QualityNominationFactory::createSuggestion(
-            $login[4],
+            $users[4],
             $problemData[0]['request']['problem_alias'],
             4, // difficulty
             4, // quality

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -5,15 +5,16 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        $login = self::login($contestant);
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'ew',
                 'reason' => 'offensive',
-            ]
-        );
+            ]),
+        ]));
 
         $nominations = \OmegaUp\DAO\QualityNominations::getNominations(
             null,
@@ -27,18 +28,19 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
-        $nomination = QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        $login = self::login($contestant);
+        $result = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'ew',
                 'reason' => 'offensive',
-            ]
-        );
+            ]),
+        ]));
 
         $nomination = \OmegaUp\DAO\QualityNominations::getById(
-            $nomination->qualitynomination_id
+            $result['qualitynomination_id']
         );
         self::assertArrayHasKey('author', $nomination);
         self::assertArrayHasKey('nominator', $nomination);
@@ -52,30 +54,30 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $contents = [
-            'statements' => [
-            'es' => [
-                'markdown' => 'a + b',
-            ],
-            ],
-            'rationale' => 'ew',
-            'reason' => 'offensive',
-        ];
+        $contents = json_encode([
+                 'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
+                 ],
+                 'rationale' => 'ew',
+                 'reason' => 'offensive',
+            ]);
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            $contents
-        );
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => $contents,
+        ]));
 
         // Login as a reviewer and approve ban.
         $reviewerLogin = self::login(QualityNominationFactory::$reviewers[0]);
         $request = new \OmegaUp\Request(
             [
-                'auth_token' => $reviewerLogin->auth_token,
-                'qualitynomination_id' => $qualitynomination->qualitynomination_id
-            ]
+            'auth_token' => $reviewerLogin->auth_token,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id']]
         );
 
         $details = \OmegaUp\Controllers\QualityNomination::apiDetails($request);
@@ -96,7 +98,10 @@ class QualityNominationTest extends OmegaupTestCase {
         );
         $this::assertArrayHasKey('author', $details);
         $this->assertEquals(
-            $contents,
+            json_decode(
+                $contents,
+                true
+            ),
             $details['contents'],
             'Should have set contents'
         );
@@ -106,7 +111,7 @@ class QualityNominationTest extends OmegaupTestCase {
             'Should have set reviewer'
         );
         $this->assertEquals(
-            $qualitynomination->qualitynomination_id,
+            $qualitynomination['qualitynomination_id'],
             $details['qualitynomination_id'],
             'Should have set qualitynomination_id'
         );
@@ -121,23 +126,24 @@ class QualityNominationTest extends OmegaupTestCase {
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
 
-        $contents = [
-            'statements' => [
-                'es' => [
-                    'markdown' => 'a + b',
+        $login = self::login($contestant);
+        $r = new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'promotion',
+            'contents' => json_encode([
+                'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
                 ],
-            ],
-            'source' => 'omegaUp',
-            'tags' => [],
-        ];
+                'source' => 'omegaUp',
+                'tags' => [],
+            ]),
+        ]);
 
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'promotion',
-                $contents
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate($r);
             $this->fail('Should not have been able to nominate the problem');
         } catch (\OmegaUp\Exceptions\PreconditionFailedException $e) {
             // still expected.
@@ -145,14 +151,8 @@ class QualityNominationTest extends OmegaupTestCase {
 
         RunsFactory::gradeRun($runData);
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'promotion',
-            $contents
-        );
+        \OmegaUp\Controllers\QualityNomination::apiCreate($r);
 
-        $login = self::login($contestant);
         $response = \OmegaUp\Controllers\QualityNomination::apiMyList(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
         ]));
@@ -191,19 +191,20 @@ class QualityNominationTest extends OmegaupTestCase {
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
 
-        $contents = [
-            // No difficulty!
-            'quality' => 3,
-            'tags' => [],
-        ];
+        $login = self::login($contestant);
+        $r = new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'suggestion',
+            'contents' => json_encode([
+                // No difficulty!
+                'quality' => 3,
+                'tags' => [],
+            ]),
+        ]);
 
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'suggestion',
-                $contents
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate($r);
             $this->fail(
                 'Should not have been able to make suggestion about the problem'
             );
@@ -213,20 +214,10 @@ class QualityNominationTest extends OmegaupTestCase {
 
         RunsFactory::gradeRun($runData);
 
-        $response = QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'suggestion',
-            $contents
-        );
+        $response = \OmegaUp\Controllers\QualityNomination::apiCreate($r);
 
-        $login = self::login($contestant);
-        $nomination = \OmegaUp\Controllers\QualityNomination::apiDetails(
-            new \OmegaUp\Request([
-                'auth_token' => $login->auth_token,
-                'qualitynomination_id' => $response->qualitynomination_id,
-            ])
-        );
+        $r['qualitynomination_id'] = $response['qualitynomination_id'];
+        $nomination = \OmegaUp\Controllers\QualityNomination::apiDetails($r);
         $this->assertEquals(
             $problemData['request']['problem_alias'],
             $nomination['problem']['alias']
@@ -241,15 +232,16 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        $login = self::login($contestant);
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'ew',
                 'reason' => 'offensive',
-            ]
-        );
+            ]),
+        ]));
     }
 
     public function testExtractAliasFromArgument() {
@@ -282,24 +274,23 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'ew',
                 'reason' => 'offensive',
-            ]
-        );
+            ]),
+        ]));
 
-        $login = self::login($user);
         $request = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'status' => 'approved',
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew plus something else'
         ]);
-
         try {
             $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
                 $request
@@ -317,27 +308,28 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
-                'statements' => [
-                   'es' => [
-                       'markdown' => 'a + b',
-                   ],
-                ],
-                'rationale' => 'ew',
-                'reason' => 'offensive',
-            ]
-        );
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
+                 'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
+                 ],
+                 'rationale' => 'ew',
+                 'reason' => 'offensive',
+            ]),
+        ]));
         // Login as a reviewer and approve ban.
         $reviewerLogin = self::login(QualityNominationFactory::$reviewers[0]);
         $request = new \OmegaUp\Request([
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'approved',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew plus something else',
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -363,7 +355,7 @@ class QualityNominationTest extends OmegaupTestCase {
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'denied',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -393,27 +385,28 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
-                'statements' => [
-                   'es' => [
-                       'markdown' => 'a + b',
-                   ],
-                ],
-                'rationale' => 'qwert',
-                'reason' => 'offensive',
-            ]
-        );
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
+                 'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
+                 ],
+                 'rationale' => 'qwert',
+                 'reason' => 'offensive',
+            ]),
+        ]));
         // Login as a reviewer and approve ban.
         $reviewerLogin = self::login(QualityNominationFactory::$reviewers[0]);
         $request = new \OmegaUp\Request([
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'approved',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'qwert plus something else'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -445,27 +438,28 @@ class QualityNominationTest extends OmegaupTestCase {
         ]));
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
-                'statements' => [
-                   'es' => [
-                       'markdown' => 'a + b',
-                   ],
-                ],
-                'rationale' => 'ew',
-                'reason' => 'offensive',
-            ]
-        );
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
+                 'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
+                 ],
+                 'rationale' => 'ew',
+                 'reason' => 'offensive',
+            ]),
+        ]));
         // Login as a reviewer and deny ban.
         $reviewerLogin = self::login(QualityNominationFactory::$reviewers[0]);
         $request = new \OmegaUp\Request([
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'denied',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -494,27 +488,28 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
-                'statements' => [
-                   'es' => [
-                       'markdown' => 'a + b',
-                   ],
-                ],
-                'rationale' => 'ew',
-                'reason' => 'offensive',
-            ]
-        );
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
+                 'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
+                 ],
+                 'rationale' => 'ew',
+                 'reason' => 'offensive',
+            ]),
+        ]));
         // Login as a reviewer and approve ban.
         $reviewerLogin = self::login(QualityNominationFactory::$reviewers[0]);
         $request = new \OmegaUp\Request([
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'approved',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew plus something else'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -540,7 +535,7 @@ class QualityNominationTest extends OmegaupTestCase {
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'open',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -572,27 +567,28 @@ class QualityNominationTest extends OmegaupTestCase {
         ]));
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
-        $qualitynomination = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
-                'statements' => [
-                   'es' => [
-                       'markdown' => 'a + b',
-                   ],
-                ],
-                'rationale' => 'ew',
-                'reason' => 'offensive',
-            ]
-        );
+        $login = self::login($user);
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
+                 'statements' => [
+                    'es' => [
+                        'markdown' => 'a + b',
+                    ],
+                 ],
+                 'rationale' => 'ew',
+                 'reason' => 'offensive',
+            ]),
+        ]));
         // Login as a reviewer and approve ban.
         $reviewerLogin = self::login(QualityNominationFactory::$reviewers[0]);
         $request = new \OmegaUp\Request([
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'approved',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew plus something else'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -618,7 +614,7 @@ class QualityNominationTest extends OmegaupTestCase {
             'auth_token' => $reviewerLogin->auth_token,
             'status' => 'denied',
             'problem_alias' => $problemData['request']['problem_alias'],
-            'qualitynomination_id' => $qualitynomination->qualitynomination_id,
+            'qualitynomination_id' => $qualitynomination['qualitynomination_id'],
             'rationale' => 'ew'
         ]);
         $response = \OmegaUp\Controllers\QualityNomination::apiResolve(
@@ -649,15 +645,19 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $user, 'identity' => $identity] = UserFactory::createUser();
 
+        $login = self::login($user);
+
         try {
-            QualityNominationFactory::createSuggestion(
-                $user,
-                $problemData['request']['problem_alias'],
-                null,
-                3,
-                ['ez-pz', 'ez', 'ez'],
-                true
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'nomination' => 'suggestion',
+                'contents' => json_encode([
+                    'quality' => 3,
+                    'tags' => ['ez-pz', 'ez', 'ez'],
+                    'before_ac' => true,
+                ]),
+            ]));
             $this->fail('Must have tried to solve the problem first.');
         } catch (\OmegaUp\Exceptions\PreconditionFailedException $e) {
             $this->assertEquals(
@@ -669,38 +669,46 @@ class QualityNominationTest extends OmegaupTestCase {
         // Now TRY to solve the problem
         $runData = RunsFactory::createRunToProblem($problemData, $user);
         RunsFactory::gradeRun($runData, 0, 'WA', 60);
-        $result = QualityNominationFactory::createSuggestion(
-            $user,
-            $problemData['request']['problem_alias'],
-            null,
-            3,
-            ['ez-pz', 'ez'],
-            true
-        );
-        $this->assertNotNull($result);
+        $login = self::login($user);
+        $result = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'suggestion',
+            'contents' => json_encode([
+                'quality' => 3,
+                'tags' => ['ez-pz', 'ez'],
+                'before_ac' => true,
+            ]),
+        ]));
+        $this->assertEquals($result['status'], 'ok');
 
         // Dismissals could be sent before AC also
-        $result = QualityNominationFactory::createQualityNomination(
-            $user,
-            $problemData['request']['problem_alias'],
-            'dismissal',
-            ['before_ac' => true]
-        );
-        $this->assertNotNull($result);
+        $result = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'dismissal',
+            'contents' => json_encode([
+                'before_ac' => true
+            ]),
+        ]));
+        $this->assertEquals($result['status'], 'ok');
 
         // Now solve the problem, it must not be allowed to send a before AC
         // nomination, as the problem is already solved
         $runData = RunsFactory::createRunToProblem($problemData, $user);
         RunsFactory::gradeRun($runData);
+        $login = self::login($user);
         try {
-            QualityNominationFactory::createSuggestion(
-                $user,
-                $problemData['request']['problem_alias'],
-                null,
-                3,
-                ['ez-pz', 'ez', 'ez'],
-                true
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'nomination' => 'suggestion',
+                'contents' => json_encode([
+                    'quality' => 3,
+                    'tags' => ['ez-pz', 'ez'],
+                    'before_ac' => true,
+                ]),
+            ]));
             $this->fail('Must not have solved the problem.');
         } catch (\OmegaUp\Exceptions\PreconditionFailedException $e) {
             $this->assertEquals(
@@ -718,58 +726,60 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
 
+        $login = self::login($contestant);
+
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'demotion',
-                [
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'nomination' => 'demotion',
+                'contents' => json_encode([
                     'rationale' => 'ew',
                     'reason' => 'duplicate',
-                ]
-            );
+                ]),
+            ]));
             $this->fail('Missing "original" should have been caught');
         } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
             // Expected.
         }
 
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'demotion',
-                [
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'nomination' => 'demotion',
+                'contents' => json_encode([
                     'rationale' => 'otro sumas',
                     'reason' => 'duplicate',
                     'original' => '$invalid problem alias$',
-                ]
-            );
+                ]),
+            ]));
             $this->fail('Invalid "original" should have been caught');
         } catch (\OmegaUp\Exceptions\NotFoundException $e) {
             // Expected.
         }
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'otro sumas',
                 'reason' => 'duplicate',
                 'original' => $originalProblemData['request']['problem_alias'],
-            ]
-        );
+            ]),
+        ]));
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'otro sumas',
                 'reason' => 'duplicate',
                 'original' => 'https://omegaup.com/arena/problem/' . $originalProblemData['request']['problem_alias'] . '#problems',
-            ]
-        );
+            ]),
+        ]));
     }
 
     /**
@@ -781,11 +791,12 @@ class QualityNominationTest extends OmegaupTestCase {
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'promotion',
-            [
+        $login = self::login($contestant);
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'promotion',
+            'contents' => json_encode([
                 'rationale' => 'cool!',
                 'statements' => [
                     'es' => [
@@ -794,8 +805,8 @@ class QualityNominationTest extends OmegaupTestCase {
                 ],
                 'source' => 'omegaUp',
                 'tags' => ['ez-pz'],
-            ]
-        );
+            ]),
+        ]));
 
         // Login as an arbitrary reviewer.
         $login = self::login(QualityNominationFactory::$reviewers[0]);
@@ -843,12 +854,13 @@ class QualityNominationTest extends OmegaupTestCase {
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
         RunsFactory::gradeRun($runData);
 
+        $login = self::login($contestant);
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'promotion',
-                [
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'nomination' => 'promotion',
+                'contents' => json_encode([
                     'rationale' => 'cool!',
                     'statements' => [
                         'es' => [
@@ -857,32 +869,34 @@ class QualityNominationTest extends OmegaupTestCase {
                     ],
                     'source' => 'omegaUp',
                     'tags' => ['ez-pz', 'ez', 'ez'],
-                ]
-            );
+                ]),
+            ]));
             $this->fail('Duplicate tags should be caught.');
         } catch (\OmegaUp\Exceptions\DuplicatedEntryInArrayException $e) {
             // Expected.
         }
 
         try {
-            QualityNominationFactory::createSuggestion(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                null,
-                3,
-                ['ez-pz', 'ez', 'ez'],
-                false
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'nomination' => 'suggestion',
+                'contents' => json_encode([
+                    // No difficulty!
+                    'quality' => 3,
+                    'tags' => ['ez-pz', 'ez', 'ez'],
+                ]),
+            ]));
             $this->fail('Duplicate tags should be caught.');
         } catch (\OmegaUp\Exceptions\DuplicatedEntryInArrayException $e) {
             // Expected.
         }
 
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'promotion',
-            [
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'promotion',
+            'contents' => json_encode([
                 'rationale' => 'cool!',
                 'statements' => [
                     'es' => [
@@ -891,17 +905,19 @@ class QualityNominationTest extends OmegaupTestCase {
                 ],
                 'source' => 'omegaUp',
                 'tags' => ['ez-pz', 'ez'],
-            ]
-        );
+            ]),
+        ]));
 
-        QualityNominationFactory::createSuggestion(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            null,
-            3,
-            ['ez-pz', 'ez'],
-            false
-        );
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'suggestion',
+            'contents' => json_encode([
+                // No difficulty!
+                'quality' => 3,
+                'tags' => ['ez-pz', 'ez'],
+            ]),
+        ]));
     }
 
     /**
@@ -915,42 +931,43 @@ class QualityNominationTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runData);
 
         // Create promotion nomination.
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'promotion',
-            [
+        $login = self::login($contestant);
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'promotion',
+            'contents' => json_encode([
                 'rationale' => 'cool!',
                 'statements' => [
                     'es' => [
                         'markdown' => 'a + b',
                     ],
                 ],
-                'tags' => ['DP', 'Math'],
                 'source' => 'omegaUp',
-            ]
-        );
+                'tags' => ['ez-pz'],
+            ]),
+        ]));
 
         // Create demotion nomination.
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'demotion',
-            [
+        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'demotion',
+            'contents' => json_encode([
                 'rationale' => 'ew',
                 'reason' => 'offensive',
-            ]
-        );
+            ]),
+        ]));
 
         // Create dismissal nomination.
-        QualityNominationFactory::createQualityNomination(
-            $contestant,
-            $problemData['request']['problem_alias'],
-            'dismissal',
-            []
-        );
+        \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'dismissal',
+            'contents' => json_encode([]),
+        ]));
 
-        // Create suggestion nomination.
+        // Create dismissal nomination.
         QualityNominationFactory::createSuggestion(
             $contestant,
             $problemData['request']['problem_alias'],
@@ -994,28 +1011,27 @@ class QualityNominationTest extends OmegaupTestCase {
         $problemData = ProblemsFactory::createProblem();
         ['user' => $contestant, 'identity' => $identity] = UserFactory::createUser();
         $runData = RunsFactory::createRunToProblem($problemData, $contestant);
-        $nominationType = 'dismissal';
+        $login = self::login($contestant);
+        $r = new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemData['request']['problem_alias'],
+            'nomination' => 'dismissal',
+            'contents' => json_encode([]),
+        ]);
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'dismissal',
-                []
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate($r);
             $this->fail('Should not have been able to dismissed the problem');
         } catch (\OmegaUp\Exceptions\PreconditionFailedException $e) {
             // Expected.
         }
-        $problem = \OmegaUp\DAO\Problems::getByAlias(
-            $problemData['request']['problem_alias']
-        );
+        $problem = \OmegaUp\DAO\Problems::getByAlias($r['problem_alias']);
         if (is_null($problem)) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemDismissed = \OmegaUp\DAO\QualityNominations::getByUserAndProblem(
-            $contestant->user_id,
+            $r->user->user_id,
             $problem->problem_id,
-            $nominationType,
+            $r['nomination'],
             json_encode([]), // re-encoding it for normalization.
             'open'
         );
@@ -1032,16 +1048,11 @@ class QualityNominationTest extends OmegaupTestCase {
             // Expected.
         }
         try {
-            QualityNominationFactory::createQualityNomination(
-                $contestant,
-                $problemData['request']['problem_alias'],
-                'dismissal',
-                []
-            );
+            \OmegaUp\Controllers\QualityNomination::apiCreate($r);
             $pd = \OmegaUp\DAO\QualityNominations::getByUserAndProblem(
-                $contestant->user_id,
+                $r->user->user_id,
                 $problem->problem_id,
-                $nominationType,
+                $r['nomination'],
                 json_encode([]), // re-encoding it for normalization.
                 'open'
             );

--- a/frontend/tests/factories/QualityNominationFactory.php
+++ b/frontend/tests/factories/QualityNominationFactory.php
@@ -99,7 +99,6 @@ class QualityNominationFactory {
         $contents
     ): \OmegaUp\DAO\VO\QualityNominations {
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-
         if (is_null($problem)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'

--- a/frontend/tests/factories/QualityNominationFactory.php
+++ b/frontend/tests/factories/QualityNominationFactory.php
@@ -53,20 +53,20 @@ class QualityNominationFactory {
     /**
      * @param ScopedLoginToken $login
      * @param string $problemAlias
-     * @param null|float $difficulty
-     * @param null|float $quality
+     * @param null|int $difficulty
+     * @param null|int $quality
      * @param null|string[] $tags
      * @param bool $beforeAC
-     * @return array{status: string, qualitynomination_id: int}
+     * @return \OmegaUp\DAO\VO\QualityNominations
      */
     public static function createSuggestion(
-        ScopedLoginToken $login,
+        \OmegaUp\DAO\VO\Users $user,
         string $problemAlias,
-        ?float $difficulty,
-        ?float $quality,
+        ?int $difficulty,
+        ?int $quality,
         ?array $tags,
         bool $beforeAC
-    ): array {
+    ): \OmegaUp\DAO\VO\QualityNominations {
         $contents = [];
         if (!is_null($difficulty)) {
             $contents['difficulty'] = $difficulty;
@@ -81,7 +81,7 @@ class QualityNominationFactory {
             $contents['before_ac'] = true;
         }
         return self::createQualityNomination(
-            $login,
+            $user,
             $problemAlias,
             'suggestion',
             $contents
@@ -90,25 +90,27 @@ class QualityNominationFactory {
 
     /**
      * @param array{difficulty?: float, quality?: float, tags?: string[], before_AC?: boolean} $contents
-     * @return array{status: string, qualitynomination_id: int}
+     * @return \OmegaUp\DAO\VO\QualityNominations
      */
     public static function createQualityNomination(
-        ScopedLoginToken $login,
+        \OmegaUp\DAO\VO\Users $user,
         string $problemAlias,
         string $type,
         $contents
-    ) {
-        $contentsJson = json_encode($contents);
-        $request = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'problem_alias' => $problemAlias,
-            'nomination' => $type,
-            'contents' => $contentsJson,
-        ]);
-        /** @var array{status: string, qualitynomination_id: int} */
-        $qualitynomination = \OmegaUp\Controllers\QualityNomination::apiCreate(
-            $request
+    ): \OmegaUp\DAO\VO\QualityNominations {
+        $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
+
+        if (is_null($problem)) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'problemNotFound'
+            );
+        }
+
+        return \OmegaUp\Controllers\QualityNomination::createNomination(
+            $problem,
+            $user,
+            $type,
+            $contents
         );
-        return $qualitynomination;
     }
 }

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1360,7 +1360,7 @@
     <PossiblyNullArgument occurrences="2">
       <code>$qualitynominationlog-&gt;rationale</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyFetch occurrences="2"/>
+    <PossiblyNullPropertyFetch occurrences="1"/>
   </file>
   <file src="frontend/server/src/Controllers/Reset.php">
     <MissingParamType occurrences="2">


### PR DESCRIPTION
# Comentarios

Tal y como se propuso en PR #2944 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
