### PR TITLE
Invocando stuff/lint.sh desde stuff/travis/lint.sh

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -16,7 +16,14 @@ else
 	ARGS="fix ${MERGE_BASE}"
 fi
 
-exec /usr/bin/docker run --interactive --tty --rm \
+if [[ -t 0 ]]; then
+	# This is being run in an environment where stdin is connected to a TTY.
+	TTY_ARGS="--interactive --tty"
+else
+	TTY_ARGS=""
+fi
+
+exec /usr/bin/docker run $TTY_ARGS --rm \
 	--volume "${OMEGAUP_ROOT}:/src" \
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -30,10 +30,7 @@ stage_script() {
 	yarn test
 
 	python3 stuff/db-migrate.py validate
-	docker run --rm \
-		--volume "$PWD:/src" \
-		--volume "$PWD:/opt/omegaup" \
-		omegaup/hook_tools:20191016 -j4 validate --all < /dev/null
+	"${OMEGAUP_ROOT}/stuff/lint.sh" validate --all < /dev/null
 }
 
 stage_after_success() {

--- a/stuff/travis/run.sh
+++ b/stuff/travis/run.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-OMEGAUP_ROOT=$(/usr/bin/git rev-parse --show-toplevel)
+OMEGAUP_ROOT="$(/usr/bin/git rev-parse --show-toplevel)"
 
 # Load the correct provider.
 case "$1" in


### PR DESCRIPTION
Este cambio hace que el comando que usa Travis para invocar hook_tools
sea exactamente el mismo que se ejecuta al momento de correr el linter
localmente. Esto hace que ya no sea necesario actualizar la versión del
contenedor más que en un sólo lugar canónico.