### PR TITLE
Usando los tags canónicos como valores para la BD en Popup.vue

### DIFF
--- a/frontend/www/js/omegaup/components/qualitynomination/Popup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/Popup.vue
@@ -39,7 +39,7 @@
                 <li class="tag-select"
                     v-for="problemTopic in sortedProblemTopics"><label class=
                     "tag-select"><input type="checkbox"
-                       v-bind:value="problemTopic.text"
+                       v-bind:value="problemTopic.value"
                        v-model="tags"> {{ problemTopic.text }}</label></li>
               </ul></label>
             </div>


### PR DESCRIPTION
Fixes: #2953 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
