### PR TITLE
Actualizando a Psalm 3.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "vimeo/psalm": "^3.6.1",
+        "vimeo/psalm": "^3.6.2",
         "jetbrains/phpstorm-stubs": "^2019.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9b00de85cbe6f7481eea79fc540b446",
+    "content-hash": "50f25ba895456d785866fdb7744cbbf1",
     "packages": [],
     "packages-dev": [
         {
@@ -1127,16 +1127,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.6.1",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "7857b07f91bed5afae98574243fed7ec4088d623"
+                "reference": "05ace258176795e87ef07b4262b5ceba3fd27de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7857b07f91bed5afae98574243fed7ec4088d623",
-                "reference": "7857b07f91bed5afae98574243fed7ec4088d623",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/05ace258176795e87ef07b4262b5ceba3fd27de3",
+                "reference": "05ace258176795e87ef07b4262b5ceba3fd27de3",
                 "shasum": ""
             },
             "require": {
@@ -1211,7 +1211,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-10-11T12:24:35+00:00"
+            "time": "2019-10-20T20:19:01+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1144,7 +1144,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\NotFoundException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
-    private static function validateDetails(\OmegaUp\Request $r) {
+    private static function validateDetails(\OmegaUp\Request $r): array {
         \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['contest_alias'],
             'contest_alias'
@@ -1600,7 +1600,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * inside a contest
      *
      * @param \OmegaUp\Request $r
-     * @return \OmegaUp\DAO\VO\Problems
+     *
+     * @return array{status?: string, exists: bool, problem: null|\OmegaUp\DAO\VO\Problems, problemset: null|\OmegaUp\DAO\VO\Problemsets}
      * @throws \OmegaUp\Exceptions\UnauthorizedException
      */
     private static function getValidProblemAndProblemset(\OmegaUp\Request $r): array {
@@ -2150,6 +2151,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Return a report of which runs would change due to a version change.
+     *
+     * @return array{status: 'ok', diff: list<array{username: string, guid: string, problemset_id: int, old_status: ?string, old_verdict: ?string, old_score: ?float, new_status: ?string, new_verdict: ?string, new_score: ?string}>}
      */
     public static function apiRunsDiff(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -2173,7 +2176,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'diff' => \OmegaUp\DAO\Runs::getRunsDiffsForVersion(
                 $problem,
                 null,
-                $problem->current_version,
+                strval($problem->current_version),
                 $r['version']
             ),
         ];

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -886,6 +886,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
      * @param ?int     $problemsetId the optional problemset.
      * @param string   $oldVersion   the old version.
      * @param string   $newVersion   the new version.
+     *
+     * @return list<array{username: string, guid: string, problemset_id: int, old_status: ?string, old_verdict: ?string, old_score: ?float, new_status: ?string, new_verdict: ?string, new_score: ?string}>
      */
     final public static function getRunsDiffsForVersion(
         \OmegaUp\DAO\VO\Problems $problem,
@@ -940,6 +942,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             LIMIT 0, 1000;
         ';
 
+        /** @var list<array{username: string, guid: string, problemset_id: int, old_status: ?string, old_verdict: ?string, old_score: ?float, new_status: ?string, new_verdict: ?string, new_score: ?string}> */
         $result = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             $params

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.6.1@7857b07f91bed5afae98574243fed7ec4088d623">
+<files psalm-version="3.6.2@05ace258176795e87ef07b4262b5ceba3fd27de3">
   <file src="frontend/server/bootstrap_smarty.php">
     <MixedArrayAccess occurrences="13">
       <code>$session['identity']</code>
@@ -982,11 +982,7 @@
     <InvalidArrayOffset occurrences="1">
       <code>$result['settings']</code>
     </InvalidArrayOffset>
-    <InvalidReturnStatement occurrences="1">
-      <code>$result</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="2">
-      <code>array</code>
+    <InvalidReturnType occurrences="1">
       <code>Array</code>
     </InvalidReturnType>
     <InvalidScalarArgument occurrences="3">
@@ -994,9 +990,6 @@
       <code>JSON_OBJECT_AS_ARRAY</code>
       <code>JSON_OBJECT_AS_ARRAY</code>
     </InvalidScalarArgument>
-    <MismatchingDocblockReturnType occurrences="1">
-      <code>\OmegaUp\DAO\VO\Problems</code>
-    </MismatchingDocblockReturnType>
     <MissingParamType occurrences="1">
       <code>$is_update</code>
     </MissingParamType>
@@ -1020,7 +1013,7 @@
       <code>apiMyList</code>
       <code>apiBestScore</code>
     </MissingReturnType>
-    <MixedArgument occurrences="56">
+    <MixedArgument occurrences="52">
       <code>$r['problem']</code>
       <code>$r['selected_tags']</code>
       <code>$_REQUEST['languages']</code>
@@ -1058,7 +1051,6 @@
       <code>$problem-&gt;alias</code>
       <code>$problem</code>
       <code>$problem</code>
-      <code>$problemset</code>
       <code>$r['lang']</code>
       <code>$container</code>
       <code>$problem</code>
@@ -1088,7 +1080,6 @@
       <code>$orderBy</code>
       <code>$query</code>
       <code>$problem</code>
-      <code>$problemset</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="12">
       <code>$_FILES['problem_contents']['tmp_name']</code>
@@ -1177,12 +1168,11 @@
       <code>$problemSettings['validator']['name']</code>
       <code>$result['sample_input']</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>array</code>
       <code>array</code>
       <code>array</code>
       <code>array</code>
-      <code>\OmegaUp\DAO\VO\Problems</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="2">
       <code>asArray</code>
@@ -1233,7 +1223,6 @@
       <code>$acl-&gt;owner_id</code>
       <code>$problem-&gt;alias</code>
       <code>$problem-&gt;alias</code>
-      <code>$problem-&gt;current_version</code>
       <code>$problem-&gt;alias</code>
       <code>$problem-&gt;alias</code>
     </PossiblyNullArgument>


### PR DESCRIPTION
Ahora Psalm muestra los miembros de los arreglos objetosos en orden
alfabético para hacer más fácil la comparación. También soporta el nuevo
tipo list<T>, que eventualmente se va a preferir sobre T[].