### PR TITLE
Extendiendo la longitud del campo name en la Tabla tags.

### DIFF
--- a/frontend/database/105_extend_tags_name_length.sql
+++ b/frontend/database/105_extend_tags_name_length.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `Tags`
-  MODIFY `name` varchar(50) NOT NULL;
+  MODIFY COLUMN `name` varchar(50) NOT NULL;

--- a/frontend/database/105_extend_tags_name_length.sql
+++ b/frontend/database/105_extend_tags_name_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `Tags`
+  MODIFY `name` varchar(50) NOT NULL;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -826,7 +826,7 @@ CREATE TABLE `Submissions` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Tags` (
   `tag_id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(32) NOT NULL,
+  `name` varchar(50) NOT NULL,
   PRIMARY KEY (`tag_id`),
   UNIQUE KEY `tag_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Tags privados para los problemas.';


### PR DESCRIPTION
# Descripción

Esto permitirá que los nuevos tags canónicos, con prefijo `problemTopic`, puedan alcanzar y ser almacenados en la base de datos.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
