### PR TITLE
Agregando SameSite=Lax a las cookies

### DIFF
--- a/frontend/server/src/SessionManager.php
+++ b/frontend/server/src/SessionManager.php
@@ -23,15 +23,32 @@ class SessionManager {
         // Set the new one
         $domain = OMEGAUP_COOKIE_DOMAIN;
         $_COOKIE[$name] = $value;
-        setcookie(
-            $name,
-            $value,
-            $expire,
-            $path,
-            $domain,
-            /*secure=*/!empty($_SERVER['HTTPS']),
-            /*httponly=*/true
-        );
+        if (PHP_VERSION_ID < 70300) {
+            setcookie(
+                $name,
+                $value,
+                $expire,
+                "{$path}; SameSite=Lax",  // This hack only works for PHP < 7.3.
+                $domain,
+                /*secure=*/!empty($_SERVER['HTTPS']),
+                /*httponly=*/true
+            );
+        } else {
+            /**
+             * @psalm-suppress TooManyArguments this is needed to support
+             *                                  Same-Site cookies.
+             */
+            setcookie(
+                $name,
+                $value,
+                $expire,
+                $path,
+                $domain,
+                /*secure=*/!empty($_SERVER['HTTPS']),
+                /*httponly=*/true,
+                /*samesite=*/'Lax'
+            );
+        }
     }
 
     public function getCookie(string $name): ?string {


### PR DESCRIPTION
Este cambio agrega SameSite=Lax a las cookies para que Chrome >= 80 siga
funcionando. Más información en:
https://web.dev/samesite-cookies-explained

Fixes: #2974