### PR TITLE
Agregando ga.js al repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ frontend/.DS_Store
 frontend/www/apc.php
 frontend/www/coverage/
 frontend/www/img/
-frontend/www/js/google-analytics.js
 frontend/www/pmamini.php
 frontend/www/phpminiadmin/
 frontend/www/templates/

--- a/frontend/templates/common.analytics.tpl
+++ b/frontend/templates/common.analytics.tpl
@@ -1,4 +1,4 @@
 {if $OMEGAUP_GA_TRACK eq 1}
-	<script type="text/javascript" src="{version_hash src="/js/google-analytics.js"}"></script>
+	<script type="text/javascript" src="{version_hash src="/js/ga.js"}"></script>
 {/if}
 

--- a/frontend/www/js/ga.js
+++ b/frontend/www/js/ga.js
@@ -1,0 +1,13 @@
+var _gaq = _gaq || [];
+_gaq.push(['_setAccount', 'UA-20989675-1']);
+_gaq.push(['_trackPageview']);
+(function() {
+  var ga = document.createElement('script');
+  ga.type = 'text/javascript';
+  ga.async = true;
+  ga.src =
+    ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') +
+    '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(ga, s);
+})();


### PR DESCRIPTION
No tiene caso tener este archivo fuera del control de versiones porque
no contiene nada secreto, así que antes de migrar a google-analytics.js
de verdad, primero hay que tener el archivo actual en mano.

Part of: #2951