### PR TITLE
Arreglando el token que se usa para comunicarse con gitserver

### DIFF
--- a/frontend/server/src/Controllers/Authorization.php
+++ b/frontend/server/src/Controllers/Authorization.php
@@ -11,7 +11,7 @@ class Authorization extends \OmegaUp\Controllers\Controller {
         // gitserver. Regular sessions cannot be used since they
         // expire, so use a pre-shared secret to authenticate that
         // grants admin-level privileges just for this call.
-        if ($r['token'] !== OMEGAUP_GRADER_SECRET) {
+        if ($r['token'] !== OMEGAUP_GITSERVER_SECRET_TOKEN) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -438,7 +438,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         RunsFactory::gradeRun($runData);
 
         $result = \OmegaUp\Controllers\Authorization::apiProblem(new \OmegaUp\Request([
-            'token' => OMEGAUP_GRADER_SECRET,
+            'token' => OMEGAUP_GITSERVER_SECRET_TOKEN,
             'username' => $contestant->username,
             'problem_alias' => $problemData['request']['problem_alias'],
         ]));
@@ -448,7 +448,7 @@ class ProblemDetailsTest extends OmegaupTestCase {
         $this->assertFalse($result['can_edit']);
 
         $result = \OmegaUp\Controllers\Authorization::apiProblem(new \OmegaUp\Request([
-            'token' => OMEGAUP_GRADER_SECRET,
+            'token' => OMEGAUP_GITSERVER_SECRET_TOKEN,
             'username' => $problemData['author']->username,
             'problem_alias' => $problemData['request']['problem_alias'],
         ]));

--- a/frontend/tests/controllers/gitserver-start.sh
+++ b/frontend/tests/controllers/gitserver-start.sh
@@ -22,6 +22,7 @@ cat > "${DIR}/gitserver.config.json" <<EOF
 		"Port": ${PORT},
 		"PprofPort": 0,
 		"SecretToken": "cbaf89d3bb2ee6b0a90bc7a90d937f9ade16739ed9f573c76e1ac72064e397aac2b35075040781dd0df9a8f1d6fc4bd4a4941eb6b0b62541b0a35fb0f89cfc3f",
+		"AllowSecretTokenAuthentication": true,
 		"PublicKey": "",
 		"AllowDirectPushToMaster": true,
 		"RootPath": "${ROOT_PATH}"

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,7 +42,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.3.20/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.4.0/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.


### PR DESCRIPTION
Este cambio hace que sea posible usar gitserver v1.4.0+ con el
frontend.

Part of: #2984