### PR TITLE
Refactor de \OmegaUp\Controllers\Session::apiCurrentInstance()

### DIFF
--- a/frontend/server/bootstrap_smarty.php
+++ b/frontend/server/bootstrap_smarty.php
@@ -6,124 +6,110 @@ require_once 'libs/third_party/smarty/libs/Smarty.class.php';
 $smarty = new Smarty();
 $smarty->setTemplateDir(__DIR__ . '/../templates/');
 
-/** @psalm-suppress RedundantCondition IS_TEST may be defined as true in tests. */
-if (!defined('IS_TEST') || IS_TEST !== true) {
-    $smarty->assign('CURRENT_USER_IS_ADMIN', 0);
-    if (defined('SMARTY_CACHE_DIR')) {
-        $smarty->setCacheDir(SMARTY_CACHE_DIR)->setCompileDir(SMARTY_CACHE_DIR);
-    }
-
-    $smarty->assign('GOOGLECLIENTID', OMEGAUP_GOOGLE_CLIENTID);
-
-    $smarty->assign('LOGGED_IN', '0');
-    \OmegaUp\UITools::$isLoggedIn = false;
-
-    /** @psalm-suppress RedundantCondition OMEGAUP_GA_TRACK may be defined differently. */
-    if (defined('OMEGAUP_GA_TRACK')  && OMEGAUP_GA_TRACK) {
-        $smarty->assign('OMEGAUP_GA_TRACK', 1);
-        $smarty->assign('OMEGAUP_GA_ID', OMEGAUP_GA_ID);
-    } else {
-        $smarty->assign('OMEGAUP_GA_TRACK', 0);
-    }
-
-    $identityRequest = new \OmegaUp\Request($_REQUEST);
-    $session = \OmegaUp\Controllers\Session::apiCurrentSession(
-        $identityRequest
-    )['session'];
-    if (!is_null($session['identity'])) {
-        $smarty->assign('LOGGED_IN', '1');
-        \OmegaUp\UITools::$isLoggedIn = true;
-
-        $smarty->assign(
-            'CURRENT_USER_USERNAME',
-            $session['identity']->username
-        );
-        $smarty->assign('CURRENT_USER_EMAIL', $session['email']);
-        $smarty->assign(
-            'CURRENT_USER_IS_EMAIL_VERIFIED',
-            empty(
-                $session['user']
-            ) || $session['user']->verified
-        );
-        $smarty->assign('CURRENT_USER_IS_ADMIN', $session['is_admin']);
-        $smarty->assign(
-            'CURRENT_USER_IS_REVIEWER',
-            \OmegaUp\Authorization::isQualityReviewer($session['identity'])
-        );
-        $smarty->assign('CURRENT_USER_AUTH_TOKEN', $session['auth_token']);
-        $smarty->assign(
-            'CURRENT_USER_GRAVATAR_URL_128',
-            '<img src="https://secure.gravatar.com/avatar/' . md5(
-                $session['email']
-            ) . '?s=92">'
-        );
-        $smarty->assign(
-            'CURRENT_USER_GRAVATAR_URL_16',
-            '<img src="https://secure.gravatar.com/avatar/' . md5(
-                $session['email']
-            ) . '?s=16">'
-        );
-        $smarty->assign(
-            'CURRENT_USER_GRAVATAR_URL_32',
-            '<img src="https://secure.gravatar.com/avatar/' . md5(
-                $session['email']
-            ) . '?s=32">'
-        );
-        $smarty->assign(
-            'CURRENT_USER_GRAVATAR_URL_51',
-            '<img src="https://secure.gravatar.com/avatar/' . md5(
-                $session['email']
-            ) . '?s=51">'
-        );
-
-        $smarty->assign(
-            'currentUserInfo',
-            [
-                'username' => $session['identity']->username,
-            ]
-        );
-
-        \OmegaUp\UITools::$isAdmin = $session['is_admin'];
-        $identityRequest['username'] = $session['identity']->username;
-    } else {
-        $identityRequest['username'] = null;
-        $smarty->assign(
-            'CURRENT_USER_GRAVATAR_URL_128',
-            '<img src="/media/avatar_92.png">'
-        );
-        $smarty->assign(
-            'CURRENT_USER_GRAVATAR_URL_16',
-            '<img src="/media/avatar_16.png">'
-        );
-    }
-
-    $lang = \OmegaUp\Controllers\Identity::getPreferredLanguage(
-        $identityRequest
-    );
-
-    /** @psalm-suppress TypeDoesNotContainType OMEGAUP_ENVIRONMENT is a configurable value. */
-    if (
-        defined('OMEGAUP_ENVIRONMENT') &&
-        OMEGAUP_ENVIRONMENT === 'development'
-    ) {
-        $smarty->force_compile = true;
-    } else {
-        $smarty->compile_check = false;
-    }
-} else {
-    // During testing We need smarty to load strings from *.lang files
-    $lang = 'pseudo';
-    $session = [
-        'valid' => false,
-        'email' => null,
-        'user' => null,
-        'identity' => null,
-        'auth_token' => null,
-        'is_admin' => false,
-    ];
+$smarty->assign('CURRENT_USER_IS_ADMIN', 0);
+if (defined('SMARTY_CACHE_DIR')) {
+    $smarty->setCacheDir(SMARTY_CACHE_DIR)->setCompileDir(SMARTY_CACHE_DIR);
 }
 
-$smarty->configLoad(__DIR__ . "/../templates/{$lang}.lang");
+$smarty->assign('GOOGLECLIENTID', OMEGAUP_GOOGLE_CLIENTID);
+
+$smarty->assign('LOGGED_IN', '0');
+
+/** @psalm-suppress RedundantCondition OMEGAUP_GA_TRACK may be defined differently. */
+if (defined('OMEGAUP_GA_TRACK')  && OMEGAUP_GA_TRACK) {
+    $smarty->assign('OMEGAUP_GA_TRACK', 1);
+    $smarty->assign('OMEGAUP_GA_ID', OMEGAUP_GA_ID);
+} else {
+    $smarty->assign('OMEGAUP_GA_TRACK', 0);
+}
+
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'email' => $_email,
+    'identity' => $_identity,
+    'user' => $_user,
+    'is_admin' => $_is_admin,
+    'auth_token' => $_auth_token,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+if (!is_null($_identity)) {
+    $smarty->assign('LOGGED_IN', '1');
+
+    $smarty->assign(
+        'CURRENT_USER_USERNAME',
+        $_identity->username
+    );
+    $smarty->assign('CURRENT_USER_EMAIL', $_email);
+    $smarty->assign(
+        'CURRENT_USER_IS_EMAIL_VERIFIED',
+        empty($_user) || $_user->verified
+    );
+    $smarty->assign('CURRENT_USER_IS_ADMIN', $_is_admin);
+    $smarty->assign(
+        'CURRENT_USER_IS_REVIEWER',
+        \OmegaUp\Authorization::isQualityReviewer($_identity)
+    );
+    $smarty->assign('CURRENT_USER_AUTH_TOKEN', $_auth_token);
+    $smarty->assign(
+        'CURRENT_USER_GRAVATAR_URL_128',
+        '<img src="https://secure.gravatar.com/avatar/' . md5(
+            $_email
+        ) . '?s=92">'
+    );
+    $smarty->assign(
+        'CURRENT_USER_GRAVATAR_URL_16',
+        '<img src="https://secure.gravatar.com/avatar/' . md5(
+            $_email
+        ) . '?s=16">'
+    );
+    $smarty->assign(
+        'CURRENT_USER_GRAVATAR_URL_32',
+        '<img src="https://secure.gravatar.com/avatar/' . md5(
+            $_email
+        ) . '?s=32">'
+    );
+    $smarty->assign(
+        'CURRENT_USER_GRAVATAR_URL_51',
+        '<img src="https://secure.gravatar.com/avatar/' . md5(
+            $_email
+        ) . '?s=51">'
+    );
+
+    $smarty->assign(
+        'currentUserInfo',
+        [
+            'username' => $_identity->username,
+        ]
+    );
+} else {
+    $smarty->assign(
+        'CURRENT_USER_GRAVATAR_URL_128',
+        '<img src="/media/avatar_92.png">'
+    );
+    $smarty->assign(
+        'CURRENT_USER_GRAVATAR_URL_16',
+        '<img src="/media/avatar_16.png">'
+    );
+}
+
+/** @psalm-suppress TypeDoesNotContainType OMEGAUP_ENVIRONMENT is a configurable value. */
+if (
+    defined('OMEGAUP_ENVIRONMENT') &&
+    OMEGAUP_ENVIRONMENT === 'development'
+) {
+    $smarty->force_compile = true;
+} else {
+    $smarty->compile_check = false;
+}
+
+$identityRequest = new \OmegaUp\Request();
+$identityRequest['username'] = is_null(
+    $_identity
+) ? null : $_identity->username;
+/** @var string */
+$_lang = \OmegaUp\Controllers\Identity::getPreferredLanguage(
+    $identityRequest
+);
+$smarty->configLoad(__DIR__ . "/../templates/{$_lang}.lang");
 $smarty->addPluginsDir(__DIR__ . '/../smarty_plugins/');
 
 $smarty->assign(

--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -225,11 +225,11 @@ class ApiCaller {
         }
 
         // Get the auth_token and user data from cookies
-        $cs = \OmegaUp\Controllers\Session::apiCurrentSession()['session'];
+        $session = \OmegaUp\Controllers\Session::getCurrentSession();
 
         // If we got an auth_token from cookies, replace it
-        if (!empty($cs['auth_token'])) {
-            $request['auth_token'] = $cs['auth_token'];
+        if (!empty($session['auth_token'])) {
+            $request['auth_token'] = $session['auth_token'];
         }
 
         for ($i = 4; ($i + 1) < sizeof($args); $i += 2) {

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -441,12 +441,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
         bool $shouldShowIntro
     ): array {
         // Half-authenticate, in case there is no session in place.
-        $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+        $session = \OmegaUp\Controllers\Session::getCurrentSession(
             $r
-        )['session'];
+        );
         if (!$shouldShowIntro) {
             return ['payload' => [
                 'shouldShowFirstAssociatedIdentityRunWarning' =>
+                    !is_null($session['identity']) &&
                     !is_null($session['user']) &&
                     !\OmegaUp\Controllers\User::isMainIdentity(
                         $session['user'],
@@ -512,9 +513,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Contests $contest
     ): bool {
         try {
-            $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+            $session = \OmegaUp\Controllers\Session::getCurrentSession(
                 $r
-            )['session'];
+            );
             if (is_null($session['identity'])) {
                 // No session, show the intro (if public), so that they can login.
                 return self::isPublic($contest->admission_mode);
@@ -704,9 +705,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         ] = \OmegaUp\DAO\Contests::getNeedsInformation(
             $response['contest']->problemset_id
         );
-        $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+        $session = \OmegaUp\Controllers\Session::getCurrentSession(
             $r
-        )['session'];
+        );
 
         if (
             $needsInformation

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -1054,9 +1054,9 @@ class Course extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException('lockdown');
         }
 
-        $identity = \OmegaUp\Controllers\Session::apiCurrentSession(
+        $identity = \OmegaUp\Controllers\Session::getCurrentSession(
             $r
-        )['session']['identity'];
+        )['identity'];
 
         // User doesn't have activity because is not logged.
         if (is_null($identity)) {

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2229,9 +2229,9 @@ class User extends \OmegaUp\Controllers\Controller {
             'problemset' => [],
         ];
 
-        $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+        $session = \OmegaUp\Controllers\Session::getCurrentSession(
             $r
-        )['session'];
+        );
         $identity = $session['identity'];
         if (!is_null($identity)) {
             $response['user'] = $identity->username;
@@ -2613,9 +2613,9 @@ class User extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r,
         string $filteredBy
     ): array {
-        $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+        $session = \OmegaUp\Controllers\Session::getCurrentSession(
             $r
-        )['session'];
+        );
         if (is_null($session['identity'])) {
             return ['filteredBy' => null, 'value' => null];
         }

--- a/frontend/server/src/Experiments.php
+++ b/frontend/server/src/Experiments.php
@@ -254,9 +254,9 @@ class Experiments {
                 $request = [];
             }
 
-            $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+            $session = \OmegaUp\Controllers\Session::getCurrentSession(
                 new \OmegaUp\Request($request)
-            )['session'];
+            );
             if (
                 isset($request[self::EXPERIMENT_REQUEST_NAME])
                 && !empty($request[self::EXPERIMENT_REQUEST_NAME])
@@ -270,7 +270,7 @@ class Experiments {
             }
             self::$_instance = new Experiments(
                 $requestExperiments,
-                !is_null($session) ? $session['user'] : null
+                $session['user']
             );
         }
         return self::$_instance;

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -183,10 +183,10 @@ class Request extends \ArrayObject {
         }
         $this->user = null;
         $this->identity = null;
-        $session = \OmegaUp\Controllers\Session::apiCurrentSession(
+        $session = \OmegaUp\Controllers\Session::getCurrentSession(
             $this
-        )['session'];
-        if (is_null($session) || is_null($session['identity'])) {
+        );
+        if (is_null($session['identity'])) {
             throw new \OmegaUp\Exceptions\UnauthorizedException();
         }
         $this->identity = $session['identity'];

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -3,34 +3,35 @@
 namespace OmegaUp;
 
 class UITools {
-    /** @var bool */
-    public static $isLoggedIn = false;
-    /** @var bool */
-    public static $isAdmin = false;
-
     /**
      * If user is not logged in, redirect to login page
      */
     public static function redirectToLoginIfNotLoggedIn(): void {
-        if (\OmegaUp\UITools::$isLoggedIn === false) {
-            header(
-                'Location: /login.php?redirect=' . urlencode(
-                    strval(
-                        $_SERVER['REQUEST_URI']
-                    )
-                )
-            );
-            die();
+        if (
+            !is_null(
+                \OmegaUp\Controllers\Session::getCurrentSession()['identity']
+            )
+        ) {
+            return;
         }
+        header(
+            'Location: /login.php?redirect=' . urlencode(
+                strval(
+                    $_SERVER['REQUEST_URI']
+                )
+            )
+        );
+        die();
     }
 
     /**
      * If user is not logged in or isn't an admin, redirect to home page
      */
     public static function redirectIfNoAdmin(): void {
-        if (\OmegaUp\UITools::$isAdmin !== true) {
-            header('Location: /');
-            die();
+        if (\OmegaUp\Controllers\Session::getCurrentSession()['is_admin']) {
+            return;
         }
+        header('Location: /');
+        die();
     }
 }

--- a/frontend/www/admin/support.php
+++ b/frontend/www/admin/support.php
@@ -4,7 +4,14 @@ require_once('../../server/bootstrap_smarty.php');
 
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
-if (!\OmegaUp\Authorization::isSupportTeamMember($session['identity'])) {
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'identity' => $_identity,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+if (
+    is_null($_identity) ||
+    !\OmegaUp\Authorization::isSupportTeamMember($_identity)
+) {
     header('HTTP/1.1 404 Not found');
     die();
 }

--- a/frontend/www/arena/problem.php
+++ b/frontend/www/arena/problem.php
@@ -2,9 +2,6 @@
 require_once('../../server/bootstrap_smarty.php');
 
 try {
-    $session = \OmegaUp\Controllers\Session::apiCurrentSession(
-        new \OmegaUp\Request($_REQUEST)
-    )['session'];
     $smartyProperties = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
         new \OmegaUp\Request($_REQUEST)
     );

--- a/frontend/www/arena/problemprint.php
+++ b/frontend/www/arena/problemprint.php
@@ -2,7 +2,6 @@
 require_once('../../server/bootstrap_smarty.php');
 
 $r = new \OmegaUp\Request($_REQUEST);
-$session = \OmegaUp\Controllers\Session::apiCurrentSession($r)['session'];
 $r['statement_type'] = 'markdown';
 $r['show_solvers'] = true;
 try {

--- a/frontend/www/coderofthemonth.php
+++ b/frontend/www/coderofthemonth.php
@@ -2,13 +2,15 @@
 
 require_once('../server/bootstrap_smarty.php');
 
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'identity' => $_identity,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+
 try {
-    $session = \OmegaUp\Controllers\Session::apiCurrentSession(
-        new \OmegaUp\Request($_REQUEST)
-    )['session'];
     $smartyProperties = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForSmarty(
         new \OmegaUp\Request($_REQUEST),
-        $session['identity']
+        $_identity
     );
 } catch (Exception  $e) {
     \OmegaUp\ApiCaller::handleException($e);

--- a/frontend/www/contestmine.php
+++ b/frontend/www/contestmine.php
@@ -2,6 +2,11 @@
 
 require_once('../server/bootstrap_smarty.php');
 
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'user' => $_user,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+
 try {
     $payload = \OmegaUp\Controllers\Contest::apiMyList(
         new \OmegaUp\Request(
@@ -13,9 +18,9 @@ try {
     // suggesting to contribute to the community by releasing the material to
     // the public. This flag ensures that this alert is shown only once per
     // session, the first time the user visits the "My contests" page.
-    $privateContestsAlert = (!is_null($session['identity']) &&
+    $privateContestsAlert = (!is_null($_user) &&
         !isset($_SESSION['private_contests_alert']) &&
-        \OmegaUp\DAO\Contests::getPrivateContestsCount($session['user']) > 0);
+        \OmegaUp\DAO\Contests::getPrivateContestsCount($_user) > 0);
 
     if ($privateContestsAlert) {
         $_SESSION['private_contests_alert'] = true;

--- a/frontend/www/groupedit.php
+++ b/frontend/www/groupedit.php
@@ -2,9 +2,12 @@
 
 require_once('../server/bootstrap_smarty.php');
 
-$r = new \OmegaUp\Request($_REQUEST);
-$session = \OmegaUp\Controllers\Session::apiCurrentSession($r)['session'];
-if (is_null($session['identity'])) {
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'identity' => $_identity,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+
+if (is_null($_identity)) {
     header('HTTP/1.1 404 Not Found');
     die();
 }
@@ -12,7 +15,7 @@ if (is_null($session['identity'])) {
 $isOrganizer = \OmegaUp\Experiments::getInstance()->isEnabled(
     \OmegaUp\Experiments::IDENTITIES
 ) &&
-    \OmegaUp\Authorization::canCreateGroupIdentities($session['identity']);
+    \OmegaUp\Authorization::canCreateGroupIdentities($_identity);
 $smarty->assign('IS_ORGANIZER', $isOrganizer);
 $smarty->assign('payload', [
     'countries' => \OmegaUp\DAO\Countries::getAll(null, 100, 'name'),

--- a/frontend/www/permissions.php
+++ b/frontend/www/permissions.php
@@ -9,15 +9,21 @@ if (!OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT) {
 
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
-$r = new \OmegaUp\Request($_REQUEST);
-$session = \OmegaUp\Controllers\Session::apiCurrentSession($r)['session'];
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'user' => $_user,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+if (is_null($_user)) {
+    header('HTTP/1.1 404 Not found');
+    die();
+}
 
 $systemRoles = \OmegaUp\DAO\UserRoles::getSystemRoles(
-    $session['user']->user_id
+    $_user->user_id
 );
 $roles = \OmegaUp\DAO\Roles::getAll();
 $systemGroups = \OmegaUp\DAO\UserRoles::getSystemGroups(
-    $session['user']->user_id
+    $_user->user_id
 );
 $groups = \OmegaUp\DAO\Groups::SearchByName('omegaup:');
 $userSystemRoles = [];
@@ -37,7 +43,7 @@ foreach ($groups as $key => $group) {
 $payload = [
     'userSystemRoles' => $userSystemRoles,
     'userSystemGroups' => $userSystemGroups,
-    'username' => $session['user']->username,
+    'username' => $_user->username,
 ];
 
 $smarty->assign('payload', $payload);

--- a/frontend/www/problemmine.php
+++ b/frontend/www/problemmine.php
@@ -14,8 +14,12 @@ foreach ($smartyProperties as $key => $value) {
     $smarty->assign($key, $value);
 }
 
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'user' => $_user,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
 $privateProblemsAlert = (!isset($_SESSION['private_problems_alert']) &&
-    \OmegaUp\DAO\Problems::getPrivateCount($session['user']) > 0);
+    \OmegaUp\DAO\Problems::getPrivateCount($_user) > 0);
 if ($privateProblemsAlert) {
     $_SESSION['private_problems_alert'] = true;
 }

--- a/frontend/www/profileedit.php
+++ b/frontend/www/profileedit.php
@@ -19,14 +19,17 @@ try {
     $smarty->assign('STATUS_ERROR', $e->getErrorMessage());
 }
 
-$ses = \OmegaUp\Controllers\Session::apiCurrentSession()['session'];
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'identity' => $_identity,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
 
 $smarty->assign(
     'PROGRAMMING_LANGUAGES',
     \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
 );
 $smarty->assign('COUNTRIES', \OmegaUp\DAO\Countries::getAll(null, 100, 'name'));
-if (is_null($ses['user']->password)) {
+if (is_null($_identity) || is_null($_identity->password)) {
     $smarty->display('../templates/user.basicedit.tpl');
 } else {
     $smarty->display('../templates/user.edit.tpl');

--- a/frontend/www/qualitynomination.php
+++ b/frontend/www/qualitynomination.php
@@ -5,6 +5,11 @@ $qualitynomination_id = isset(
     $_GET['qualitynomination_id']
 ) ? $_GET['qualitynomination_id'] : null;
 
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'identity' => $_identity,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+
 try {
     if (!is_null($qualitynomination_id)) {
         $payload = \OmegaUp\Controllers\QualityNomination::apiDetails(new \OmegaUp\Request([
@@ -20,8 +25,8 @@ try {
         )['nominations'],
         'myView' => false,
         ];
-        if (!is_null($session['identity'])) {
-            $payload['currentUser'] = $session['identity']->username;
+        if (!is_null($_identity)) {
+            $payload['currentUser'] = $_identity->username;
         }
         $template = '../templates/quality.nomination.list.tpl';
     }

--- a/frontend/www/qualitynomination_mine.php
+++ b/frontend/www/qualitynomination_mine.php
@@ -1,7 +1,13 @@
 <?php
 
 require_once('../server/bootstrap_smarty.php');
-\OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
+
+/** @var ?\OmegaUp\DAO\VO\Identities */
+$identity = \OmegaUp\Controllers\Session::getCurrentSession()['identity'];
+if (is_null($identity)) {
+    \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
+    die();
+}
 
 try {
     $payload = [
@@ -10,7 +16,7 @@ try {
             []
         )
     )['nominations'],
-    'currentUser' => $session['identity']->username,
+    'currentUser' => $identity->username,
     'myView' => true,
     ];
     $smarty->assign('payload', $payload);

--- a/frontend/www/rank.php
+++ b/frontend/www/rank.php
@@ -1,13 +1,15 @@
 <?php
 require_once('../server/bootstrap_smarty.php');
 
+/** @var array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool} */
+[
+    'identity' => $_identity,
+] = \OmegaUp\Controllers\Session::getCurrentSession();
+
 try {
-    $session = \OmegaUp\Controllers\Session::apiCurrentSession(
-        new \OmegaUp\Request($_REQUEST)
-    )['session'];
     $smartyProperties = \OmegaUp\Controllers\User::getRankDetailsForSmarty(
         new \OmegaUp\Request($_REQUEST),
-        $session['identity'],
+        $_identity,
         $smarty
     );
 } catch (Exception  $e) {

--- a/frontend/www/useremailedit.php
+++ b/frontend/www/useremailedit.php
@@ -19,7 +19,7 @@ try {
     $smarty->assign('STATUS_ERROR', $e->getErrorMessage());
 }
 
-$currentSession = \OmegaUp\Controllers\Session::apiCurrentSession()['session'];
+$currentSession = \OmegaUp\Controllers\Session::getCurrentSession();
 $smarty->assign('payload', [
     'email' => $currentSession['email'],
 ]);

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,33 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.6.2@05ace258176795e87ef07b4262b5ceba3fd27de3">
-  <file src="frontend/server/bootstrap_smarty.php">
-    <MixedArrayAccess occurrences="13">
-      <code>$session['identity']</code>
-      <code>$session['email']</code>
-      <code>$session['is_admin']</code>
-      <code>$session['identity']</code>
-      <code>$session['auth_token']</code>
-      <code>$session['email']</code>
-      <code>$session['email']</code>
-      <code>$session['email']</code>
-      <code>$session['email']</code>
-      <code>$session['identity']</code>
-      <code>$session['is_admin']</code>
-      <code>$session['identity']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
-      <code>$session</code>
-      <code>\OmegaUp\UITools::$isAdmin</code>
-      <code>$identityRequest['username']</code>
-      <code>$lang</code>
-    </MixedAssignment>
-    <MixedPropertyFetch occurrences="4">
-      <code>$session['identity']-&gt;username</code>
-      <code>$session['user']-&gt;verified</code>
-      <code>$session['identity']-&gt;username</code>
-      <code>$session['identity']-&gt;username</code>
-    </MixedPropertyFetch>
-  </file>
   <file src="frontend/server/src/Controllers/ACL.php">
     <MissingParamType occurrences="12">
       <code>$acl_id</code>
@@ -386,8 +358,7 @@
     <PossiblyFalseArgument occurrences="1">
       <code>$result['requestsUserInformation']</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="28">
-      <code>$session['identity']</code>
+    <PossiblyNullArgument occurrences="27">
       <code>$contest-&gt;acl_id</code>
       <code>$acl-&gt;owner_id</code>
       <code>$contest-&gt;problemset_id</code>
@@ -408,14 +379,6 @@
       <code>$problemsetIdentity</code>
       <code>$contest-&gt;problemset_id</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="5">
-      <code>$session['user']</code>
-      <code>$session['identity']</code>
-      <code>$session['identity']</code>
-      <code>$session['identity']</code>
-      <code>$session['identity']</code>
-      <code>$session['identity']</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset occurrences="1"/>
     <PossiblyNullIterator occurrences="1">
       <code>$resultAdmins</code>
@@ -697,7 +660,6 @@
       <code>$course-&gt;course_id</code>
       <code>$course-&gt;group_id</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1"/>
     <PossiblyNullPropertyFetch occurrences="2">
       <code>$resolvedUser-&gt;user_id</code>
     </PossiblyNullPropertyFetch>
@@ -1844,13 +1806,6 @@
       <code>$identity</code>
       <code>$email</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="5">
-      <code>$session['identity']</code>
-      <code>$session['is_admin']</code>
-      <code>$session['is_admin']</code>
-      <code>$session['is_admin']</code>
-      <code>$session['identity']</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset occurrences="1">
       <code>$usersAdded</code>
     </PossiblyNullArrayOffset>
@@ -3750,11 +3705,6 @@
       <code>Boolean</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="frontend/www/admin/support.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$session['identity']</code>
-    </MixedArrayAccess>
-  </file>
   <file src="frontend/www/admin/user.php">
     <MissingClosureParamType occurrences="3">
       <code>$email</code>
@@ -3810,8 +3760,7 @@
     </MixedAssignment>
   </file>
   <file src="frontend/www/arena/problem.php">
-    <MixedAssignment occurrences="3">
-      <code>$session</code>
+    <MixedAssignment occurrences="2">
       <code>$smartyProperties</code>
       <code>$value</code>
     </MixedAssignment>
@@ -3827,8 +3776,7 @@
       <code>$result['settings']</code>
       <code>$result['settings']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$session</code>
+    <MixedAssignment occurrences="2">
       <code>$result</code>
       <code>$problem</code>
     </MixedAssignment>
@@ -3843,11 +3791,7 @@
     </MixedArrayAccess>
   </file>
   <file src="frontend/www/coderofthemonth.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$session['identity']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$session</code>
+    <MixedAssignment occurrences="2">
       <code>$smartyProperties</code>
       <code>$value</code>
     </MixedAssignment>
@@ -3859,7 +3803,6 @@
     </MixedArrayAccess>
   </file>
   <file src="frontend/www/contestmine.php">
-    <MixedArrayAccess occurrences="2"/>
     <MixedAssignment occurrences="1">
       <code>$payload</code>
     </MixedAssignment>
@@ -3896,15 +3839,6 @@
   <file src="frontend/www/cspreport.php">
     <MixedAssignment occurrences="1">
       <code>$log</code>
-    </MixedAssignment>
-  </file>
-  <file src="frontend/www/groupedit.php">
-    <MixedArrayAccess occurrences="2">
-      <code>$session['identity']</code>
-      <code>$session['identity']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$session</code>
     </MixedAssignment>
   </file>
   <file src="frontend/www/grouplist.php">
@@ -4031,17 +3965,11 @@
     </MixedOperand>
   </file>
   <file src="frontend/www/permissions.php">
-    <MixedArrayAccess occurrences="3">
-      <code>$session['user']</code>
-      <code>$session['user']</code>
-      <code>$session['user']</code>
-    </MixedArrayAccess>
     <MixedArrayOffset occurrences="2">
       <code>$userSystemRoles[$key]</code>
       <code>$userSystemGroups[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="7">
-      <code>$session</code>
+    <MixedAssignment occurrences="6">
       <code>$systemRoles</code>
       <code>$roles</code>
       <code>$systemGroups</code>
@@ -4049,14 +3977,11 @@
       <code>$role</code>
       <code>$group</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="7">
-      <code>$session['user']-&gt;user_id</code>
-      <code>$session['user']-&gt;user_id</code>
+    <MixedPropertyFetch occurrences="4">
       <code>$role-&gt;name</code>
       <code>$role-&gt;name</code>
       <code>$group-&gt;name</code>
       <code>$group-&gt;name</code>
-      <code>$session['user']-&gt;username</code>
     </MixedPropertyFetch>
   </file>
   <file src="frontend/www/problemedit.php">
@@ -4117,7 +4042,6 @@
     </MixedAssignment>
   </file>
   <file src="frontend/www/problemmine.php">
-    <MixedArrayAccess occurrences="1"/>
     <MixedAssignment occurrences="2">
       <code>$smartyProperties</code>
       <code>$value</code>
@@ -4157,40 +4081,25 @@
     </MixedAssignment>
   </file>
   <file src="frontend/www/profileedit.php">
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess occurrences="2">
       <code>$response['userinfo']</code>
       <code>$response['userinfo']</code>
-      <code>$ses['user']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$response</code>
-      <code>$ses</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="1">
-      <code>$ses['user']-&gt;password</code>
-    </MixedPropertyFetch>
   </file>
   <file src="frontend/www/qualitynomination.php">
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess occurrences="1">
       <code>$_GET['qualitynomination_id']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$qualitynomination_id</code>
       <code>$payload</code>
-      <code>$payload['currentUser']</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="1"/>
-  </file>
-  <file src="frontend/www/qualitynomination_mine.php">
-    <MixedArrayAccess occurrences="1"/>
-    <MixedPropertyFetch occurrences="1"/>
   </file>
   <file src="frontend/www/rank.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$session['identity']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$session</code>
+    <MixedAssignment occurrences="2">
       <code>$smartyProperties</code>
       <code>$value</code>
     </MixedAssignment>


### PR DESCRIPTION
Este cambio crea un nuevo método,
\OmegaUp\Controllers\Session::getCurrentInstance(), para evitar llamar
APIs.