### PR TITLE
Haciendo más robustas las pruebas de Selenium

### DIFF
--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -93,6 +93,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
 
     /*
      * Get problemset problems including problemset alias, points, and order
+     * @return array{title: string, problem_id: int, alias: string, visibility: bool, visits: int, submissions: int, accepted: int, difficulty: float, order: int, languages: string, points: float, commit: string, version: string}
      */
     final public static function getProblemsByProblemset(
         int $problemsetId
@@ -123,10 +124,25 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                 ORDER BY
                     pp.order, pp.problem_id ASC;';
 
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            $sql,
-            [$problemsetId]
-        );
+        $result = [];
+        /** @var array{title: string, problem_id: string, alias: string, visibility: string, visits: string, submissions: string, accepted: string, difficulty: string, order: string, languages: string, points: string, commit: string, version: string} $row */
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll(
+                $sql,
+                [$problemsetId]
+            ) as $row
+        ) {
+            $row['problem_id'] = intval($row['problem_id']);
+            $row['visibility'] = boolval($row['visibility']);
+            $row['visits'] = intval($row['visits']);
+            $row['submissions'] = intval($row['submissions']);
+            $row['accepted'] = intval($row['accepted']);
+            $row['difficulty'] = floatval($row['difficulty']);
+            $row['order'] = intval($row['order']);
+            $row['points'] = floatval($row['points']);
+            $result[] = $row;
+        }
+        return $result;
     }
 
     /*

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -399,10 +399,10 @@ def add_students_bulk(driver, users):
             (By.XPATH, (
                 '//textarea[contains(@class, "contestants")]')))).send_keys(
                     ', '.join(users))
-    driver.wait.until(
-        EC.element_to_be_clickable(
-            (By.CLASS_NAME, ('user-add-bulk')))).click()
-    util.dismiss_status(driver)
+    with util.dismiss_status(driver):
+        driver.wait.until(
+            EC.element_to_be_clickable(
+                (By.CLASS_NAME, ('user-add-bulk')))).click()
     for user in users:
         driver.wait.until(
             EC.visibility_of_element_located(
@@ -427,10 +427,10 @@ def add_problem_to_contest(driver, problem):
             (By.XPATH,
              '//input[contains(concat(" ", normalize-space(@class), " "), " '
              'problem-points ")]'))).click()
-    driver.wait.until(
-        EC.element_to_be_clickable(
-            (By.CSS_SELECTOR, '.btn.add-problem'))).click()
-    util.dismiss_status(driver)
+    with util.dismiss_status(driver):
+        driver.wait.until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '.btn.add-problem'))).click()
     driver.wait.until(
         EC.visibility_of_element_located(
             (By.XPATH,
@@ -494,10 +494,10 @@ def change_contest_admission_mode(driver, contest_admission_mode):
             (By.XPATH,
              '//select[@name = "admission-mode"]')))).select_by_visible_text(
                  contest_admission_mode)
-    driver.wait.until(
-        EC.element_to_be_clickable(
-            (By.CSS_SELECTOR, '.btn.change-admission-mode'))).click()
-    util.dismiss_status(driver)
+    with util.dismiss_status(driver):
+        driver.wait.until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '.btn.change-admission-mode'))).click()
 
 
 @util.annotate

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -251,8 +251,9 @@ def add_assignment(driver, assignment_alias):
     new_assignment_form.find_element_by_css_selector('textarea').send_keys(
         'homework description')
 
-    new_assignment_form.find_element_by_css_selector(
-        'button[type=submit]').click()
+    with util.dismiss_status(driver):
+        new_assignment_form.find_element_by_css_selector(
+            'button[type=submit]').click()
     driver.wait.until(
         EC.invisibility_of_element_located(
             (By.CSS_SELECTOR, '.omegaup-course-assignmentdetails')))
@@ -261,7 +262,6 @@ def add_assignment(driver, assignment_alias):
             (By.XPATH,
              '//*[contains(@class, "omegaup-course-assignmentlist")]'
              '//a[text()="%s"]' % assignment_alias)))
-    util.dismiss_status(driver)
 
 
 @util.annotate

--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -34,6 +34,33 @@ import database_utils  # NOQA
 Identity = NamedTuple('Identity', [('username', Text), ('password', Text)])
 
 
+class StatusBarIsDismissed:
+    """A class that can wait for the status bar to be dismissed."""
+
+    def __init__(self, status_element):
+        self.status_element = status_element
+        self.counter = int(
+            self.status_element.get_attribute('data-counter') or '0')
+        self.clicked = False
+
+    def __call__(self, driver):
+        counter = int(self.status_element.get_attribute('data-counter') or '0')
+        if counter in (self.counter, self.counter + 1):
+            # We're still waiting for the status bar to open.
+            return False
+        if counter == self.counter + 2:
+            # Status has finished animating. Time to click the close button.
+            if not self.clicked:
+                self.status_element.find_element_by_css_selector(
+                    'button.close').click()
+                self.clicked = True
+            return False
+        if counter == self.counter + 3:
+            # Status is currently closing down.
+            return False
+        return self.status_element
+
+
 # pylint: disable=too-many-arguments
 def add_students(driver, users, *, tab_xpath,
                  container_xpath, parent_xpath, submit_locator):
@@ -49,26 +76,25 @@ def add_students(driver, users, *, tab_xpath,
     for user in users:
         driver.typeahead_helper(parent_xpath, user)
 
-        driver.wait.until(
-            EC.element_to_be_clickable(submit_locator)).click()
+        with dismiss_status(driver):
+            driver.wait.until(
+                EC.element_to_be_clickable(submit_locator)).click()
         driver.wait.until(
             EC.visibility_of_element_located(
                 (By.XPATH,
                  '%s//a[text()="%s"]' % (container_xpath, user))))
-        dismiss_status(driver)
 
 
+@contextlib.contextmanager
 def dismiss_status(driver):
     '''Closes the status bar and waits for it to disappear.'''
-    driver.wait.until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, '#status:not(.animating)')))
-    driver.wait.until(
-        EC.element_to_be_clickable(
-            (By.CSS_SELECTOR,
-             '#status:not(.animating) button.close'))).click()
-    driver.wait.until(
-        EC.invisibility_of_element_located((By.CSS_SELECTOR, '#status')))
+    status_element = driver.wait.until(
+        EC.presence_of_element_located((By.ID, 'status')))
+    status_bar_is_dismissed = StatusBarIsDismissed(status_element)
+    try:
+        yield
+    finally:
+        driver.wait.until(status_bar_is_dismissed)
 
 
 def create_run(driver, problem_alias, filename):

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -901,23 +901,16 @@ export class Arena {
         let problem = rank.problems[order[alias]];
         totalRuns += problem.runs;
 
-        if (self.problems[alias]) {
-          if (rank.username == OmegaUp.username) {
-            $('#problems .problem_' + alias + ' .solved').html(
-              '(' +
-                problem.points.toFixed(self.digitsAfterDecimalPoint) +
-                ' / ' +
-                self.problems[alias].points.toFixed(
-                  self.digitsAfterDecimalPoint,
-                ) +
-                ')',
-            );
-            self.updateProblemScore(
-              alias,
-              self.problems[alias].points,
-              problem.points,
-            );
-          }
+        if (self.problems[alias] && rank.username == OmegaUp.username) {
+          const currentPoints = parseFloat(self.problems[alias].points || '0');
+          $('#problems .problem_' + alias + ' .solved').html(
+            '(' +
+              problem.points.toFixed(self.digitsAfterDecimalPoint) +
+              ' / ' +
+              currentPoints.toFixed(self.digitsAfterDecimalPoint) +
+              ')',
+          );
+          self.updateProblemScore(alias, currentPoints, problem.points);
         }
       }
 

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -107,17 +107,28 @@ let UI = {
     $('#root').show();
 
     $('#status .message').html(message);
-    $('#status')
+    const statusElement = $('#status');
+    let statusCounter = parseInt(statusElement.attr('data-counter') || '0');
+    if (statusCounter % 2 == 1) {
+      statusCounter++;
+    }
+    statusElement
       .removeClass('alert-success alert-info alert-warning alert-danger')
-      .addClass(type + ' animating')
+      .addClass(type)
+      .addClass('animating')
+      .attr('data-counter', statusCounter + 1)
       .slideDown({
         complete: function() {
-          $('#status').removeClass('animating');
+          statusElement
+            .removeClass('animating')
+            .attr('data-counter', statusCounter + 2);
+          if (type == 'alert-success') {
+            setTimeout(() => {
+              UI.dismissNotifications(statusCounter + 2);
+            }, 5000);
+          }
         },
       });
-    if (type == 'alert-success') {
-      setTimeout(UI.dismissNotifications, 5000);
-    }
   },
 
   error: function(message) {
@@ -142,12 +153,27 @@ let UI = {
 
   ignoreError: function(response) {},
 
-  dismissNotifications: function() {
-    $('#status')
+  dismissNotifications: function(originalStatusCounter) {
+    const statusElement = $('#status');
+    let statusCounter = parseInt(statusElement.attr('data-counter') || '0');
+    if (
+      typeof originalStatusCounter == 'number' &&
+      statusCounter > originalStatusCounter
+    ) {
+      // This status has already been dismissed.
+      return;
+    }
+    if (statusCounter % 2 == 1) {
+      statusCounter++;
+    }
+    statusElement
       .addClass('animating')
+      .attr('data-counter', statusCounter + 1)
       .slideUp({
         complete: function() {
-          $('#status').removeClass('animating');
+          statusElement
+            .removeClass('animating')
+            .attr('data-counter', statusCounter + 2);
         },
       });
   },


### PR DESCRIPTION
Para no tener que andar re-corriendo las pruebas de selenium a cada
rato, es mejor si hacemos que sean más robustas. Este cambio en
concreto:

* Arregla un error de JavaScript que hacían que se mostrar un
  error en consola de vez en cuando, cuando la información del problema
  contenía los puntos que vale el problema como cadena en vez de como
  número.
* Evita que el timeout para darle dismiss a las notificaciones se active
  _justo_ cuando otra notificación se muestra, causando que la nueva
  notificación se cierre prematuramente.
* Sincroniza la implementación de Python para desplegar / cerrar
  notificaciones con la nueva implementación de JavaScript para detectar
  mejor esta lógica.