### PR TITLE
Removiendo escuelas no usadas y preservando las relaciones de las duplicadas

### DIFF
--- a/frontend/database/106_remove_duplicated_schools.sql
+++ b/frontend/database/106_remove_duplicated_schools.sql
@@ -1,0 +1,90 @@
+# Take just one of the duplicated elements as the one that will remain id DB.
+# Update the relations with Courses
+UPDATE
+    `Courses`
+INNER JOIN (
+    SELECT
+        `sc`.`school_id`, `min_id`
+    FROM
+        `Schools` `sc`
+    INNER JOIN (
+        SELECT
+            `name`, min(`school_id`) as `min_id`
+        FROM
+            `Schools`
+        GROUP BY
+            `name`
+        HAVING
+            COUNT(*) > 1
+    ) `dups` # duplicates
+    ON `sc`.`name` = `dups`.`name`
+) `upd` # updatable
+ON
+    `Courses`.`school_id` = `upd`.`school_id`
+SET
+    `Courses`.`school_id` = `upd`.`min_id`;
+
+# Update the relations with User_Rank
+UPDATE
+    `User_Rank`
+INNER JOIN (
+    SELECT
+        `sc`.`school_id`, `min_id`
+    FROM
+        `Schools` `sc`
+    INNER JOIN (
+        SELECT
+            `name`, min(`school_id`) as `min_id`
+        FROM
+            `Schools`
+        GROUP BY
+            `name`
+        HAVING
+            COUNT(*) > 1
+    ) `dups` # duplicates
+    ON `sc`.`name` = `dups`.`name`
+) `upd` # updatable
+ON
+    `User_Rank`.`school_id` = `upd`.`school_id`
+SET
+    `User_Rank`.`school_id` = `upd`.`min_id`;
+
+# Update the relations with User_Rank
+UPDATE
+    `Identities`
+INNER JOIN (
+    SELECT
+        `sc`.`school_id`, `min_id`
+    FROM
+        `Schools` `sc`
+    INNER JOIN (
+        SELECT
+            `name`, min(`school_id`) as `min_id`
+        FROM
+            `Schools`
+        GROUP BY
+            `name`
+        HAVING
+            COUNT(*) > 1
+    ) `dups` # duplicates
+    ON `sc`.`name` = `dups`.`name`
+) `upd` # updatable
+ON
+    `Identities`.`school_id` = `upd`.`school_id`
+SET
+    `Identities`.`school_id` = `upd`.`min_id`;
+
+# Now remove all the Schools that have no relations with any tables (unused schools).
+DELETE FROM
+    `Schools`
+WHERE
+    `school_id` NOT IN (
+        SELECT DISTINCT `school_id`
+        FROM `Identities`
+        UNION
+        SELECT DISTINCT `school_id`
+        FROM `Courses`
+        UNION
+        SELECT DISTINCT `school_id`
+        FROM `User_Rank`
+    );

--- a/frontend/database/106_remove_duplicated_schools.sql
+++ b/frontend/database/106_remove_duplicated_schools.sql
@@ -9,20 +9,20 @@ INNER JOIN (
         `Schools` `sc`
     INNER JOIN (
         SELECT
-            `name`, min(`school_id`) as `min_id`
+            `name`, MIN(`school_id`) as `min_id`
         FROM
             `Schools`
         GROUP BY
-            `name`
+            `name`, `country_id`, `state_id`
         HAVING
             COUNT(*) > 1
-    ) `dups` # duplicates
-    ON `sc`.`name` = `dups`.`name`
-) `upd` # updatable
+    ) `duplicates`
+    ON `sc`.`name` = `duplicates`.`name`
+) `updatables`
 ON
-    `Courses`.`school_id` = `upd`.`school_id`
+    `Courses`.`school_id` = `updatables`.`school_id`
 SET
-    `Courses`.`school_id` = `upd`.`min_id`;
+    `Courses`.`school_id` = `updatables`.`min_id`;
 
 # Update the relations with User_Rank
 UPDATE
@@ -34,20 +34,20 @@ INNER JOIN (
         `Schools` `sc`
     INNER JOIN (
         SELECT
-            `name`, min(`school_id`) as `min_id`
+            `name`, MIN(`school_id`) as `min_id`
         FROM
             `Schools`
         GROUP BY
-            `name`
+            `name`, `country_id`, `state_id`
         HAVING
             COUNT(*) > 1
-    ) `dups` # duplicates
-    ON `sc`.`name` = `dups`.`name`
-) `upd` # updatable
+    ) `duplicates`
+    ON `sc`.`name` = `duplicates`.`name`
+) `updatables`
 ON
-    `User_Rank`.`school_id` = `upd`.`school_id`
+    `User_Rank`.`school_id` = `updatables`.`school_id`
 SET
-    `User_Rank`.`school_id` = `upd`.`min_id`;
+    `User_Rank`.`school_id` = `updatables`.`min_id`;
 
 # Update the relations with User_Rank
 UPDATE
@@ -59,20 +59,20 @@ INNER JOIN (
         `Schools` `sc`
     INNER JOIN (
         SELECT
-            `name`, min(`school_id`) as `min_id`
+            `name`, MIN(`school_id`) as `min_id`
         FROM
             `Schools`
         GROUP BY
-            `name`
+            `name`, `country_id`, `state_id`
         HAVING
             COUNT(*) > 1
-    ) `dups` # duplicates
-    ON `sc`.`name` = `dups`.`name`
-) `upd` # updatable
+    ) `duplicates`
+    ON `sc`.`name` = `duplicates`.`name`
+) `updatables`
 ON
-    `Identities`.`school_id` = `upd`.`school_id`
+    `Identities`.`school_id` = `updatables`.`school_id`
 SET
-    `Identities`.`school_id` = `upd`.`min_id`;
+    `Identities`.`school_id` = `updatables`.`min_id`;
 
 # Now remove all the Schools that have no relations with any tables (unused schools).
 DELETE FROM
@@ -88,3 +88,7 @@ WHERE
         SELECT DISTINCT `school_id`
         FROM `User_Rank`
     );
+
+# Add UNIQUE index to Schools
+ALTER TABLE `Schools`
+    ADD UNIQUE KEY `name_country_id_state_id` (`name`, `country_id`, `state_id`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -763,6 +763,7 @@ CREATE TABLE `Schools` (
   `state_id` char(3) DEFAULT NULL,
   `name` varchar(128) NOT NULL,
   PRIMARY KEY (`school_id`),
+  UNIQUE KEY `name_country_id_state_id` (`name`,`country_id`,`state_id`),
   KEY `country_id` (`country_id`),
   KEY `state_id` (`country_id`,`state_id`),
   CONSTRAINT `fk_scc_country_id` FOREIGN KEY (`country_id`) REFERENCES `Countries` (`country_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,


### PR DESCRIPTION
Fixes: #2932 

# Comentarios

Acá hice algunas pruebas: http://sqlfiddle.com/#!9/425280/2
Estoy proponiendo eliminar las escuelas sin usar, en lugar de remover solo las duplicadas.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
