### PR TITLE
Agregando el nuevo dominio de google analytics al CSP

### DIFF
--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -60,6 +60,7 @@ $contentSecurityPolicy = [
         'https://js-agent.newrelic.com',
         'https://bam.nr-data.net',
         'https://ssl.google-analytics.com',
+        'https://www.google-analytics.com',
         'https://connect.facebook.net',
         'https://platform.twitter.com',
     ],


### PR DESCRIPTION
Este cambio hace que el dominio que usa analytics.js estén la lista de
dominios permitidos por CSP.

Fixes: #2951