### PR TITLE
Previniendo un error de tipos al verificar usuarios

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -513,29 +513,28 @@ class User extends \OmegaUp\Controllers\Controller {
 
             self::$log->info("Admin verifying user... {$r['usernameOrEmail']}");
             $user = self::resolveUser($r['usernameOrEmail']);
-            $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
-                $r['usernameOrEmail']
-            );
         } else {
             // Normal user verification path
             \OmegaUp\Validators::validateStringNonEmpty($r['id'], 'id');
             $user = \OmegaUp\DAO\Users::getByVerification($r['id']);
-            $identity = \OmegaUp\DAO\Identities::getByPK(
-                $user->main_identity_id
-            );
         }
 
-        if (is_null($user)) {
+        if (is_null($user) || is_null($user->main_identity_id)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'verificationIdInvalid'
             );
         }
+        $identity = \OmegaUp\DAO\Identities::getByPK(
+            $user->main_identity_id
+        );
 
         $user->verified = true;
         $user->verification_id = null;
         \OmegaUp\DAO\Users::update($user);
 
-        self::$log->info("User verification complete for {$user->username}");
+        self::$log->info(
+            "User verification complete for {$identity->username}"
+        );
 
         // Expire profile cache
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1731,7 +1731,7 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strpos($email, '@')</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="17">
+    <PossiblyNullArgument occurrences="16">
       <code>$user-&gt;main_email_id</code>
       <code>$user-&gt;main_email_id</code>
       <code>$user-&gt;main_identity_id</code>
@@ -1760,7 +1760,7 @@
       <code>$email</code>
       <code>$r-&gt;user</code>
     </PossiblyNullPropertyAssignment>
-    <PossiblyNullPropertyFetch occurrences="8">
+    <PossiblyNullPropertyFetch occurrences="7">
       <code>$email-&gt;email</code>
       <code>$identity-&gt;password</code>
       <code>$user-&gt;main_identity_id</code>


### PR DESCRIPTION
Este cambio hace que cuando un usuario con un token inválido (por
ejemplo, porque ya la había verirficado), en vez de recibir un error
500, se le despliegue un mensaje diciéndole que ese token es inválido.