### PR TITLE
Mejorando la forma en la que se maneja la sesión de PHP

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -523,13 +523,16 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // suggesting to contribute to the community by releasing the material to
         // the public. This flag ensures that this alert is shown only once per
         // session, the first time the user visits the "My contests" page.
-        $privateContestsAlert = (
-            !isset($_SESSION['private_contests_alert']) &&
-            \OmegaUp\DAO\Contests::getPrivateContestsCount($r->user) > 0
-        );
-
+        $privateContestsAlert = false;
+        {
+            $scopedSession = \OmegaUp\Controllers\Session::getSessionManagerInstance()->sessionStart();
+            $privateContestsAlert = (
+                !isset($_SESSION['private_contests_alert']) &&
+                \OmegaUp\DAO\Contests::getPrivateContestsCount($r->user) > 0
+            );
         if ($privateContestsAlert) {
             $_SESSION['private_contests_alert'] = true;
+        }
         }
 
         return [

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2977,8 +2977,20 @@ class Problem extends \OmegaUp\Controllers\Controller {
     public static function getProblemsMineInfoForSmarty(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
 
+        $privateProblemsAlert = false;
+        {
+            $scopedSession = \OmegaUp\Controllers\Session::getSessionManagerInstance()->sessionStart();
+            $privateProblemsAlert = (
+                !isset($_SESSION['private_problems_alert']) &&
+                \OmegaUp\DAO\Problems::getPrivateCount($r->user) > 0
+            );
+        if ($privateProblemsAlert) {
+            $_SESSION['private_problems_alert'] = true;
+        }
+        }
         return [
             'isSysadmin' => \OmegaUp\Authorization::isSystemAdmin($r->identity),
+            'privateProblemsAlert' => $privateProblemsAlert,
         ];
     }
 

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -78,13 +78,14 @@ class Session extends \OmegaUp\Controllers\Controller {
     }
 
     private static function getAuthToken(\OmegaUp\Request $r): ?string {
-        $SessionM = self::getSessionManagerInstance();
-        $SessionM->sessionStart();
+        $sessionManager = self::getSessionManagerInstance();
         $authToken = null;
         if (!is_null($r['auth_token'])) {
             $authToken = strval($r['auth_token']);
         } else {
-            $authToken = $SessionM->getCookie(OMEGAUP_AUTH_TOKEN_COOKIE_NAME);
+            $authToken = $sessionManager->getCookie(
+                OMEGAUP_AUTH_TOKEN_COOKIE_NAME
+            );
         }
         if (!is_null($authToken) && self::isAuthTokenValid($authToken)) {
             return $authToken;

--- a/frontend/server/src/LinkedIn.php
+++ b/frontend/server/src/LinkedIn.php
@@ -42,24 +42,30 @@ class LinkedIn {
             'redirect_uri' => $this->_redirectUrl,
             'state' => json_encode($this->_state),
         ]);
-        $_SESSION['li-state'] = $this->_state['ct'];
+        {
+            $scopedSession = \OmegaUp\Controllers\Session::getSessionManagerInstance()->sessionStart();
+            $_SESSION['li-state'] = $this->_state['ct'];
+        }
         return "https://www.linkedin.com/oauth/v2/authorization?$query_string";
     }
 
     public function getAuthToken(string $code, string $state): string {
         /** @var null|array{ct: string} */
         $stateArray = json_decode($state, true);
+        {
+            $scopedSession = \OmegaUp\Controllers\Session::getSessionManagerInstance()->sessionStart();
         if (
-            !isset($_SESSION['li-state'])
-            || empty($stateArray)
-            || !isset($stateArray['ct'])
-            || $_SESSION['li-state'] != $stateArray['ct']
+                !isset($_SESSION['li-state'])
+                || empty($stateArray)
+                || !isset($stateArray['ct'])
+                || $_SESSION['li-state'] != $stateArray['ct']
         ) {
             throw new \OmegaUp\Exceptions\CSRFException('invalidCsrfToken');
         }
 
-        // If we make it here, the CSRF token has been consumed
-        unset($_SESSION['li-state']);
+            // If we make it here, the CSRF token has been consumed
+            unset($_SESSION['li-state']);
+        }
 
         $curl = new \OmegaUp\CurlSession(
             'https://www.linkedin.com/oauth/v2/accessToken'

--- a/frontend/server/src/SessionManager.php
+++ b/frontend/server/src/SessionManager.php
@@ -2,6 +2,17 @@
 
 namespace OmegaUp;
 
+// An RAII wrapper to manage the lifetime of a session.
+class ScopedSession {
+    public function __construct() {
+        session_start();
+    }
+
+    public function __destruct() {
+        session_write_close();
+    }
+}
+
 class SessionManager {
     public function setCookie(
         string $name,
@@ -59,10 +70,7 @@ class SessionManager {
         return strval($_COOKIE[$name]);
     }
 
-    public function sessionStart(): void {
-        if (session_status() == PHP_SESSION_ACTIVE) {
-            return;
-        }
-        @session_start();
+    public function sessionStart(): ScopedSession {
+        return new ScopedSession();
     }
 }

--- a/frontend/tests/controllers/OmegaupTestCase.php
+++ b/frontend/tests/controllers/OmegaupTestCase.php
@@ -86,8 +86,6 @@ class OmegaupTestCase extends \PHPUnit\Framework\TestCase {
     public function mockSessionManager(): void {
         $sessionManagerMock =
             $this->getMockBuilder('\\OmegaUp\\SessionManager')->getMock();
-        $sessionManagerMock->expects($this->once())
-                ->method('sessionStart');
         \OmegaUp\Controllers\Session::setSessionManagerForTesting(
             $sessionManagerMock
         );

--- a/frontend/www/problemmine.php
+++ b/frontend/www/problemmine.php
@@ -13,16 +13,4 @@ try {
 foreach ($smartyProperties as $key => $value) {
     $smarty->assign($key, $value);
 }
-
-[
-    'user' => $user,
-] = \OmegaUp\Controllers\Session::getCurrentSession();
-$privateProblemsAlert = (!isset($_SESSION['private_problems_alert']) &&
-    !is_null($user) &&
-    \OmegaUp\DAO\Problems::getPrivateCount($user) > 0);
-if ($privateProblemsAlert) {
-    $_SESSION['private_problems_alert'] = true;
-}
-$smarty->assign('privateProblemsAlert', $privateProblemsAlert);
-
 $smarty->display('../templates/problem.mine.tpl');


### PR DESCRIPTION
Este cambio hace que _no_ se creen sesiones de PHP innecesariamente, y
que se llame explícitamente session_write_close() lo más pronto posible.

Resulta que en PHP cuando se abre una sesión, se crea un lock para
evitar condiciones de carrera y no se libera hasta que se llame
session_write_close()[1]. Esto normalmente ocurre naturalmente cuando el
script termina de ejecutarse, _pero_ si por alguna razón el script
llegara a hacer timeout, eso causaría que ese lock jamás se liberara.
Eso a su vez causaría que la siguiente vez que ese mismo usuario
intentara acceder _cualquier_ página de omegaUp, se quedara esperando a
ese mismo lock. La única manera de resolver este conflicto desde el
punto de vista del usuario es usar otro navegador o eliminar las
cookies.

Fixes: #2923

1: https://www.php.net/manual/en/function.session-write-close.php