### PR TITLE
Agregando modificadores a omegaup.UI.formatString

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -72,14 +72,21 @@ let UI = {
   },
 
   formatString: function(template, values) {
-    for (var key in values) {
-      if (!values.hasOwnProperty(key)) continue;
-      template = template.replace(
-        new RegExp('%\\(' + key + '\\)', 'g'),
-        values[key],
-      );
-    }
-    return template;
+    const re = new RegExp('%\\(([^!)]+)(?:!([^)]+))?\\)', 'g');
+    return template.replace(re, (match, key, modifier) => {
+      if (!values.hasOwnProperty(key)) {
+        // If the array does not provide a replacement for the key, just return
+        // the original substring.
+        return match;
+      }
+      let replacement = values[key];
+      if (modifier === 'date') {
+        replacement = UI.formatDate(new Date(replacement));
+      } else if (modifier === 'timestamp') {
+        replacement = UI.formatDateTime(new Date(replacement));
+      }
+      return replacement;
+    });
   },
 
   contestUpdated: function(data, contestAlias) {

--- a/frontend/www/js/omegaup/ui.test.js
+++ b/frontend/www/js/omegaup/ui.test.js
@@ -22,6 +22,18 @@ describe('omegaup.ui', function() {
       expect(omegaup.UI.formatString('%(x)', { x: 42 })).toEqual('42');
     });
 
+    it('Should handle dates', function() {
+      expect(omegaup.UI.formatString('%(x!date)', { x: 0 })).toEqual(
+        omegaup.UI.formatDate(new Date(0)),
+      );
+    });
+
+    it('Should handle timestamps', function() {
+      expect(omegaup.UI.formatString('%(x!timestamp)', { x: 0 })).toEqual(
+        omegaup.UI.formatDateTime(new Date(0)),
+      );
+    });
+
     it('Should handle strings with multiple replacements', function() {
       expect(omegaup.UI.formatString('%(x) %(x)', { x: 'foo' })).toEqual(
         'foo foo',


### PR DESCRIPTION
Este cambio hace que omegaup.UI.formatString pueda tener modificadores
estilo `format()` de Python, donde `!r` manda llamar `repr()`. En
nuestro caso, lo que nos interesa es poder representar fechas y
timestamps, usando `omegaup.UI.formatDate` y
`omegaup.UI.formatDateTime`.

Part of: #2907