### PR TITLE
Haciendo más robusto renderSampleToClipboardButton

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -536,7 +536,13 @@ let UI = {
     document
       .querySelectorAll('.sample_io > tbody > tr > td:first-of-type')
       .forEach(function(item, index) {
-        let inputValue = item.querySelector('pre').innerHTML;
+        let preElement = item.querySelector('pre');
+        if (!preElement) {
+          // This can only happen if a user messed up with the markdown of a
+          // problem.
+          return;
+        }
+        let inputValue = preElement.innerHTML;
 
         let clipboardButton = document.createElement('button');
         clipboardButton.title = T.copySampleCaseTooltip;


### PR DESCRIPTION
En algunos problemas, si el usuario decide manualmente escribir el
markdown de las tablas y lo hace mal, puede causar problemas con el
código que despliega el botón para copiar la entrada de ejemplo al
clipboard.

Este cambio hace que se ignoren esos casos.

Fixes: #3026