### PR TITLE
Arreglando error en el paginador de Problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -21,6 +21,18 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     const RESTRICTED_TAG_NAMES = ['karel', 'lenguaje', 'solo-salida', 'interactive'];
     const VALID_LANGUAGES = ['en', 'es', 'pt'];
+    const VALID_SORTING_MODES = ['asc', 'desc'];
+    const VALID_SORTING_COLUMNS = [
+        'title',
+        'quality',
+        'difficulty',
+        'submissions',
+        'accepted',
+        'ratio',
+        'points',
+        'score',
+        'creation_date'
+    ];
 
     // Do not update the published branch.
     const UPDATE_PUBLISHED_NONE = 'none';
@@ -52,7 +64,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         'wo', 'fy', 'xh', 'yi', 'yo', 'za', 'zu'];
 
     // Number of rows shown in problems list
-    const PAGE_SIZE = 1000;
+    const PAGE_SIZE = 100;
 
     /**
      * Validates a Create or Update Problem API request
@@ -2652,21 +2664,27 @@ class Problem extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Validators::validateInEnum(
             $r['mode'],
             'mode',
-            ['asc', 'desc'],
+            array_merge(
+                [''],
+                \OmegaUp\Controllers\Problem::VALID_SORTING_MODES
+            ),
             false
         );
         \OmegaUp\Validators::validateOptionalNumber($r['page'], 'page');
         \OmegaUp\Validators::validateInEnum(
             $r['order_by'],
             'order_by',
-            ['title', 'quality', 'difficulty', 'submissions', 'accepted', 'ratio', 'points', 'score', 'creation_date'],
+            array_merge(
+                [''],
+                \OmegaUp\Controllers\Problem::VALID_SORTING_COLUMNS
+            ),
             false
         );
         \OmegaUp\Validators::validateInEnum(
             $r['language'],
             'language',
             array_merge(
-                ['all'],
+                ['all', ''],
                 \OmegaUp\Controllers\Problem::VALID_LANGUAGES
             ),
             false
@@ -2744,7 +2762,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->ensureIdentity();
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
             // Do nothing, we allow unauthenticated users to use this API
-            /** @var null $r->identity */
         }
         [
             'offset' => $offset,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -64,7 +64,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         'wo', 'fy', 'xh', 'yi', 'yo', 'za', 'zu'];
 
     // Number of rows shown in problems list
-    const PAGE_SIZE = 100;
+    const PAGE_SIZE = 1000;
 
     /**
      * Validates a Create or Update Problem API request

--- a/frontend/templates/common.navbar.tpl
+++ b/frontend/templates/common.navbar.tpl
@@ -33,7 +33,7 @@
               <ul class="dropdown-menu">
                 <li><a href="/problem/new/">{#myproblemsListCreateProblem#}</a></li>
                 <li><a href="/problem/mine/">{#navMyProblems#}</a></li>
-                <li><a href="/problem/list/?page=1">{#wordsProblems#}</a></li>
+                <li><a href="/problem/">{#wordsProblems#}</a></li>
                 <li><a href="/nomination/mine/">{#navMyQualityNomination#}</a></li>
                 {if $CURRENT_USER_IS_REVIEWER eq '1'}
                   <li><a href="/nomination/">{#navQualityNominationQueue#}</a></li>

--- a/frontend/templates/common.navbar.tpl
+++ b/frontend/templates/common.navbar.tpl
@@ -33,7 +33,7 @@
               <ul class="dropdown-menu">
                 <li><a href="/problem/new/">{#myproblemsListCreateProblem#}</a></li>
                 <li><a href="/problem/mine/">{#navMyProblems#}</a></li>
-                <li><a href="/problem/">{#wordsProblems#}</a></li>
+                <li><a href="/problem/list/?page=1">{#wordsProblems#}</a></li>
                 <li><a href="/nomination/mine/">{#navMyQualityNomination#}</a></li>
                 {if $CURRENT_USER_IS_REVIEWER eq '1'}
                   <li><a href="/nomination/">{#navQualityNominationQueue#}</a></li>


### PR DESCRIPTION
# Descripción

Se arregla error en paginador de problemas que empezó a presentarse después de 
subir PR #3030 en el cual no se consideraba que desde el navegador se mandan
todos los parámetros de paginación sin importar que tengan datos.

Fixes: #3053 

# Checklist:

- [X] El código sigue la [guía de  estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
