### PR TITLE
Arreglando pruebas para poder eliminar username y password de Users

### DIFF
--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -295,7 +295,6 @@ class Group extends \OmegaUp\Controllers\Controller {
     /**
      * Create a scoreboard set to a group
      *
-     * @param \OmegaUp\Request $r
      * @return array{status: string}
      */
     public static function apiCreateScoreboard(\OmegaUp\Request $r) {

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2155,7 +2155,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @param \OmegaUp\Request $r
      */
     public static function apiUpdateMainEmail(\OmegaUp\Request $r) {
-        $r->ensureIdentity();
+        $r->ensureMainUserIdentity();
 
         \OmegaUp\Validators::validateEmail($r['email'], 'email');
 

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -78,6 +78,9 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
         return new \OmegaUp\DAO\VO\Assignments($row);
     }
 
+    /**
+     * @return null|\OmegaUp\DAO\VO\Assignments
+     */
     final public static function getByAliasAndCourse(
         string $assignmentAlias,
         int $courseId
@@ -92,6 +95,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
                     alias = ?
                 LIMIT 1;';
 
+        /** @var null|array{assignment_id: int, course_id: int, problemset_id: int, acl_id: int, name: string, description: string, alias: string, publish_time_delay: null|int, assignment_type: string, start_time: int, finish_time: int, max_points: float, order: int} */
         $row = \OmegaUp\MySQLConnection::getInstance()->GetRow(
             $sql,
             [$courseId, $assignmentAlias]

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -78,9 +78,6 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
         return new \OmegaUp\DAO\VO\Assignments($row);
     }
 
-    /**
-     * @return null|\OmegaUp\DAO\VO\Assignments
-     */
     final public static function getByAliasAndCourse(
         string $assignmentAlias,
         int $courseId

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -105,7 +105,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         WHERE
             admission_mode = \'private\' and a.owner_id = ?;';
         $params = [$user->user_id];
-
+        /** @var array{total: int} */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
 
         if (!array_key_exists('total', $rs)) {

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -324,7 +324,9 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
         return $courses;
     }
 
-    final public static function getByAlias(string $alias): ?\OmegaUp\DAO\VO\Courses {
+    final public static function getByAlias(
+        string $alias
+    ): ?\OmegaUp\DAO\VO\Courses {
         $sql = 'SELECT * FROM Courses WHERE (alias = ?) LIMIT 1;';
 
         $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$alias]);

--- a/frontend/server/src/Experiments.php
+++ b/frontend/server/src/Experiments.php
@@ -96,7 +96,7 @@ class Experiments {
         $this->loadExperimentsFromConfig($defines, $knownExperiments);
 
         if (!is_null($identity)) {
-            $this->loadExperimentsForUser($identity, $knownExperiments);
+            $this->loadExperimentsForIdentity($identity, $knownExperiments);
         }
 
         if (!is_null($requestExperiments)) {
@@ -126,12 +126,12 @@ class Experiments {
     }
 
     /**
-     * Loads experiments for a particular user.
+     * Loads experiments for a particular identity.
      * @param \OmegaUp\DAO\VO\Identities $identity The identity.
      * @param string[] $knownExperiments Typically
      * \OmegaUp\Experiments::KNOWN_EXPERIMENTS, except in tests.
      */
-    private function loadExperimentsForUser(
+    private function loadExperimentsForIdentity(
         \OmegaUp\DAO\VO\Identities $identity,
         array $knownExperiments
     ): void {

--- a/frontend/server/src/Experiments.php
+++ b/frontend/server/src/Experiments.php
@@ -72,7 +72,7 @@ class Experiments {
     /**
      * Creates an instance of Experiments.
      * @param null|string $requestExperiments Typically $_REQUEST['experiments'], except in tests.
-     * @param \OmegaUp\DAO\VO\Users $user The currently logged in user.
+     * @param \OmegaUp\DAO\VO\Identities $identity The currently logged in identity.
      * @param array<string, mixed> $defines Typically get_defined_constants(true)['user'],
      *                       except in tests.
      * @param string[] $knownExperiments Typically
@@ -81,7 +81,7 @@ class Experiments {
      */
     public function __construct(
         ?string $requestExperiments,
-        \OmegaUp\DAO\VO\Users $user = null,
+        \OmegaUp\DAO\VO\Identities $identity = null,
         array $defines = null,
         array $knownExperiments = null
     ) {
@@ -95,8 +95,8 @@ class Experiments {
 
         $this->loadExperimentsFromConfig($defines, $knownExperiments);
 
-        if (!is_null($user)) {
-            $this->loadExperimentsForUser($user, $knownExperiments);
+        if (!is_null($identity)) {
+            $this->loadExperimentsForUser($identity, $knownExperiments);
         }
 
         if (!is_null($requestExperiments)) {
@@ -127,20 +127,21 @@ class Experiments {
 
     /**
      * Loads experiments for a particular user.
-     * @param \OmegaUp\DAO\VO\Users $user The user.
+     * @param \OmegaUp\DAO\VO\Identities $identity The identity.
      * @param string[] $knownExperiments Typically
      * \OmegaUp\Experiments::KNOWN_EXPERIMENTS, except in tests.
      */
     private function loadExperimentsForUser(
-        \OmegaUp\DAO\VO\Users $user,
+        \OmegaUp\DAO\VO\Identities $identity,
         array $knownExperiments
     ): void {
-        if (is_null($user->user_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('userNotFound');
+        if (is_null($identity->user_id)) {
+            // No experiments can be enabled for unassociated identities.
+            return;
         }
         foreach (
             \OmegaUp\DAO\UsersExperiments::getByUserId(
-                $user->user_id
+                $identity->user_id
             ) as $ue
         ) {
             if (
@@ -270,7 +271,7 @@ class Experiments {
             }
             self::$_instance = new Experiments(
                 $requestExperiments,
-                $session['user']
+                $session['identity']
             );
         }
         return self::$_instance;

--- a/frontend/tests/ControllerTestCase.php
+++ b/frontend/tests/ControllerTestCase.php
@@ -423,9 +423,9 @@ class ScopedLoginToken {
      */
     public $auth_token = null;
 
-    public function __construct(string $auth_token) {
+    public function __construct(string $authToken) {
         \OmegaUp\Authorization::clearCacheForTesting();
-        $this->auth_token = $auth_token;
+        $this->auth_token = $authToken;
     }
 
     public function __destruct() {

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -201,7 +201,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
      * Mentor can see the last coder of the month email
      */
     public function testMentorCanSeeLastCoderOfTheMonthEmail() {
-        ['user' => $mentorUser, 'identity' => $mentorIdentity] = \OmegaUp\Test\Factories\User::createMentorIdentity();
+        ['user' => $mentor, 'identity' => $mentorIdentity] = \OmegaUp\Test\Factories\User::createMentorIdentity();
 
         $login = self::login($mentorIdentity);
         $response = \OmegaUp\Controllers\User::apiCoderOfTheMonthList(new \OmegaUp\Request([
@@ -247,7 +247,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
      * already has a coder of the month selected
      */
     public function testMentorSelectsUserAsCoderOfTheMonth() {
-        ['user' => $mentorUser, 'identity' => $mentorIdentity] = \OmegaUp\Test\Factories\User::createMentorIdentity();
+        ['user' => $mentor, 'identity' => $mentorIdentity] = \OmegaUp\Test\Factories\User::createMentorIdentity();
 
         // Setting time to the 15th of next month.
         $runCreationDate = new DateTimeImmutable(
@@ -346,7 +346,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $this->assertEquals(
             $response['userinfo']['username'],
-            $user3->username
+            $identity3->username
         );
         $response = \OmegaUp\Controllers\User::apiCoderOfTheMonthList(
             new \OmegaUp\Request()
@@ -385,7 +385,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         $this->createRuns(null, null, 3);
         $this->createRuns(null, null, 2);
 
-        ['user' => $mentorUser, 'identity' => $mentorIdentity] = \OmegaUp\Test\Factories\User::createMentorIdentity();
+        ['user' => $mentor, 'identity' => $mentorIdentity] = \OmegaUp\Test\Factories\User::createMentorIdentity();
 
         $login = self::login($mentorIdentity);
         $this->assertTrue(\OmegaUp\Authorization::isMentor($mentorIdentity));

--- a/frontend/tests/controllers/ContestAddAdminTest.php
+++ b/frontend/tests/controllers/ContestAddAdminTest.php
@@ -92,7 +92,7 @@ class ContestAddAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($contestData['director']);
         $r = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $user->username,
+            'usernameOrEmail' => $identity->username,
             'contest_alias' => $contestData['request']['alias'],
         ]);
 

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -269,7 +269,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         $problemset_identity = \OmegaUp\DAO\ProblemsetIdentities::getByPK(
-            $contestant->main_identity_id,
+            $identity->identity_id,
             $contest->problemset_id
         );
         $firstAccessTime = $problemset_identity->access_time;
@@ -278,7 +278,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         $response = \OmegaUp\Controllers\Contest::apiDetails($r);
 
         $problemset_identity = \OmegaUp\DAO\ProblemsetIdentities::getByPK(
-            $contestant->main_identity_id,
+            $identity->identity_id,
             $contest->problemset_id
         );
         $this->assertEquals(
@@ -315,7 +315,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
             $contestData['request']['alias']
         );
         $problemset_identity = \OmegaUp\DAO\ProblemsetIdentities::getByPK(
-            $contestant->main_identity_id,
+            $identity->identity_id,
             $contest->problemset_id
         );
         $firstAccessTime = $problemset_identity->access_time;
@@ -324,7 +324,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         $response = \OmegaUp\Controllers\Contest::apiDetails($r);
 
         $problemset_identity = \OmegaUp\DAO\ProblemsetIdentities::getByPK(
-            $contestant->main_identity_id,
+            $identity->identity_id,
             $contest->problemset_id
         );
         $this->assertEquals(
@@ -365,7 +365,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
             $contestData['request']['alias']
         );
         $problemset_identity = \OmegaUp\DAO\ProblemsetIdentities::getByPK(
-            $contestant->main_identity_id,
+            $identity->identity_id,
             $contest->problemset_id
         );
         $firstAccessTime = $problemset_identity->access_time;
@@ -374,7 +374,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         $response = \OmegaUp\Controllers\Contest::apiDetails($r);
 
         $problemset_identity = \OmegaUp\DAO\ProblemsetIdentities::getByPK(
-            $contestant->main_identity_id,
+            $identity->identity_id,
             $contest->problemset_id
         );
         $this->assertEquals(

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -329,10 +329,8 @@ class CourseCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $courseData['request']['course']->group_id
         );
         // User not linked to course
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
-        $identityUser = \OmegaUp\DAO\Identities::getByPK(
-            $user->main_identity_id
-        );
+        ['user' => $user, 'identity' => $identityUser] = \OmegaUp\Test\Factories\User::createUser();
+
         // User linked to course
         ['user' => $student, 'identity' => $identityStudent] = \OmegaUp\Test\Factories\User::createUser();
         $response = \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([

--- a/frontend/tests/controllers/ExperimentTest.php
+++ b/frontend/tests/controllers/ExperimentTest.php
@@ -85,7 +85,7 @@ class ExperimentsTest extends \OmegaUp\Test\ControllerTestCase {
         $experiments = new
             \OmegaUp\Experiments(
                 null,
-                $user,
+                $identity,
                 [],
                 self::$kKnownExperiments
             );
@@ -93,17 +93,17 @@ class ExperimentsTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEmpty($experiments->getEnabledExperiments());
         $this->assertFalse($experiments->isEnabled(self::TEST));
 
-        // After adding the user-experiment relationship to the database, the
+        // After adding the identity-experiment relationship to the database, the
         // experiment should be enabled.
         \OmegaUp\DAO\UsersExperiments::create(new \OmegaUp\DAO\VO\UsersExperiments([
-            'user_id' => $user->user_id,
+            'user_id' => $identity->user_id,
             'experiment' => self::TEST,
         ]));
 
         $experiments = new
             \OmegaUp\Experiments(
                 null,
-                $user,
+                $identity,
                 [],
                 self::$kKnownExperiments
             );

--- a/frontend/tests/controllers/GroupsTest.php
+++ b/frontend/tests/controllers/GroupsTest.php
@@ -58,7 +58,7 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Add user to group
+     * Add identity to group
      */
     public function testAddUserToGroup() {
         $group = GroupsFactory::createGroup();
@@ -67,7 +67,7 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($group['owner']);
         $response = \OmegaUp\Controllers\Group::apiAddUser(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $user->username,
+            'usernameOrEmail' => $identity->username,
             'group_alias' => $group['group']->alias
         ]));
         $this->assertEquals('ok', $response['status']);

--- a/frontend/tests/controllers/IdentityUpdateTest.php
+++ b/frontend/tests/controllers/IdentityUpdateTest.php
@@ -73,6 +73,54 @@ class IdentityUpdateTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
+     * Test for updating a no-main identity's username
+     */
+    public function testUpdateNoMainIdentityUsername() {
+        // Identity creator group member will create an identity
+        ['user' => $user, 'identity' => $creator] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup(
+            $creator,
+            null,
+            null,
+            null,
+            $creatorLogin
+        );
+
+        $identityName = substr(\OmegaUp\Test\Utils::CreateRandomString(), - 10);
+        $username = "{$group['group']->alias}:{$identityName}";
+        $password = \OmegaUp\Test\Utils::CreateRandomString();
+        // Call api using identity creator group member
+        \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'username' => $username,
+            'name' => $identityName,
+            'password' => $password,
+            'country_id' => 'MX',
+            'state_id' => 'QUE',
+            'gender' => 'male',
+            'school_name' => \OmegaUp\Test\Utils::CreateRandomString(),
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $identity = \OmegaUp\Controllers\Identity::resolveIdentity($username);
+        $identity->password = $password;
+        $login = self::login($identity);
+        $newUsername = 'newname';
+
+        try {
+            \OmegaUp\Controllers\User::apiUpdate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                //new username
+                'username' => $newUsername
+            ]));
+            $this->fail('User should not be able to change username');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals($e->getMessage(), 'userNotAllowed');
+        }
+    }
+
+    /**
      * Test for changing identity password
      */
     public function testChangePasswordIdentity() {
@@ -120,6 +168,54 @@ class IdentityUpdateTest extends \OmegaUp\Test\ControllerTestCase {
         $identity->password = $newPassword;
 
         $identityLogin = self::login($identity);
+    }
+
+    /**
+     * Test for changing no-main identity password
+     */
+    public function testChangePasswordNoMainIdentity() {
+        // Identity creator group member will create an identity
+        ['user' => $user, 'identity' => $creator] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        $creatorLogin = self::login($creator);
+        $group = GroupsFactory::createGroup(
+            $creator,
+            null,
+            null,
+            null,
+            $creatorLogin
+        );
+
+        $identityName = substr(\OmegaUp\Test\Utils::CreateRandomString(), - 10);
+        $username = "{$group['group']->alias}:{$identityName}";
+        $originalPassword = \OmegaUp\Test\Utils::CreateRandomString();
+        // Call api using identity creator group member
+        \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'username' => $username,
+            'name' => $identityName,
+            'password' => $originalPassword,
+            'country_id' => 'MX',
+            'state_id' => 'QUE',
+            'gender' => 'male',
+            'school_name' => \OmegaUp\Test\Utils::CreateRandomString(),
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $identity = \OmegaUp\Controllers\Identity::resolveIdentity($username);
+        $identity->password = $originalPassword;
+        $identityLogin = self::login($identity);
+        $newPassword = 'anypassword';
+
+        try {
+            \OmegaUp\Controllers\User::apiUpdateBasicInfo(new \OmegaUp\Request([
+                'auth_token' => $identityLogin->auth_token,
+                'username' => $username,
+                'password' => $newPassword,
+            ]));
+            $this->fail('User shold not be able to change password');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals($e->getMessage(), 'userNotAllowed');
+        }
     }
 
     /**

--- a/frontend/tests/controllers/LoginTest.php
+++ b/frontend/tests/controllers/LoginTest.php
@@ -7,7 +7,7 @@
  */
 class LoginTest extends \OmegaUp\Test\ControllerTestCase {
     /**
-     * Test user login with valid credentials, username and password
+     * Test identity login with valid credentials, username and password
      *
      */
     public function testNativeLoginByUserPositive() {
@@ -24,7 +24,7 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
             )
         );
 
-        // Inflate request with user data
+        // Inflate request with identity data
         $r = new \OmegaUp\Request([
             'usernameOrEmail' => $identity->username,
             'password' => $identity->password
@@ -48,7 +48,7 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Test user login with valid credentials, email and password
+     * Test identity login with valid credentials, email and password
      *
      */
     public function testNativeLoginByEmailPositive() {
@@ -57,7 +57,7 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
             new \OmegaUp\Test\Factories\UserParams(['email' => $email])
         );
 
-        // Inflate request with user data
+        // Inflate request with identity data
         $r = new \OmegaUp\Request([
             'usernameOrEmail' => $email,
             'password' => $identity->password
@@ -162,12 +162,12 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
      *
      */
     public function test2ConsecutiveLogins() {
-        // Create an user in omegaup
+        // Create an identity in omegaup
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
-        // Inflate request with user data
+        // Inflate request with identity data
         $r = new \OmegaUp\Request([
-            'usernameOrEmail' => $user->username,
+            'usernameOrEmail' => $identity->username,
             'password' => $identity->password
         ]);
 
@@ -188,7 +188,7 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Test user login with valid credentials, username and password
+     * Test identity login with valid credentials, username and password
      *
      * @expectedException \OmegaUp\Exceptions\InvalidCredentialsException
      */

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -52,8 +52,8 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Verify author username -> author id conversion
         $acl = \OmegaUp\DAO\ACLs::getByPK($problem->acl_id);
-        $user = \OmegaUp\DAO\Users::getByPK($acl->owner_id);
-        $this->assertEquals($user->username, $r['author_username']);
+        $identity = \OmegaUp\DAO\Identities::findByUserId($acl->owner_id);
+        $this->assertEquals($identity->username, $r['author_username']);
 
         // Verify problem settings.
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($r['problem_alias']);
@@ -323,8 +323,8 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Verify author username -> author id conversion
         $acl = \OmegaUp\DAO\ACLs::getByPK($problem->acl_id);
-        $user = \OmegaUp\DAO\Users::getByPK($acl->owner_id);
-        $this->assertEquals($user->username, $r['author_username']);
+        $identity = \OmegaUp\DAO\Identities::findByUserId($acl->owner_id);
+        $this->assertEquals($identity->username, $r['author_username']);
 
         // Verify problem contents were copied
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($problem->alias);
@@ -684,8 +684,8 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Verify author username -> author id conversion
         $acl = \OmegaUp\DAO\ACLs::getByPK($problem->acl_id);
-        $user = \OmegaUp\DAO\Users::getByPK($acl->owner_id);
-        $this->assertEquals($user->username, $r['author_username']);
+        $identity = \OmegaUp\DAO\Identities::findByUserId($acl->owner_id);
+        $this->assertEquals($identity->username, $r['author_username']);
 
         // Verify problem contents were copied
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($problem->alias);

--- a/frontend/tests/controllers/UserPrivilegesTest.php
+++ b/frontend/tests/controllers/UserPrivilegesTest.php
@@ -92,7 +92,9 @@ class UserPrivilegesTest extends \OmegaUp\Test\ControllerTestCase {
             'username' => $username,
             'group' => 'omegaup:mentor'
         ]));
-        $systemGroups = \OmegaUp\DAO\UserRoles::getSystemGroups($user->user_id);
+        $systemGroups = \OmegaUp\DAO\UserRoles::getSystemGroups(
+            $identity->user_id
+        );
         $this->assertNotContains('omegaup:mentor', $systemGroups);
     }
 }

--- a/frontend/tests/controllers/UserRegistrationTest.php
+++ b/frontend/tests/controllers/UserRegistrationTest.php
@@ -56,10 +56,10 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         $password = \OmegaUp\Test\Utils::createRandomString();
 
         \OmegaUp\Controllers\Session::LoginViaGoogle($username . '@isp.com');
-        $user = \OmegaUp\DAO\Users::FindByUsername($username);
+        $identity = \OmegaUp\DAO\Identities::findByUsername($username);
 
         // Users logged via google, facebook, linkedin does not have password
-        $this->assertNull($user->password);
+        $this->assertNull($identity->password);
 
         // Inflate request
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
@@ -73,10 +73,10 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         // Call API
         $response = \OmegaUp\Controllers\User::apiCreate($r);
 
-        $user = \OmegaUp\DAO\Users::FindByUsername($username);
+        $identity = \OmegaUp\DAO\Identities::findByUsername($username);
 
         // Users logged in native mode must have password
-        $this->assertNotNull($user->password);
+        $this->assertNotNull($identity->password);
     }
 
     /**
@@ -89,10 +89,11 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
 
         \OmegaUp\Controllers\Session::LoginViaGoogle($email);
         $user = \OmegaUp\DAO\Users::FindByUsername($username);
+        $identity = \OmegaUp\DAO\Identities::FindByUserId($user->user_id);
         $email_user = \OmegaUp\DAO\Emails::getByPK($user->main_email_id);
 
         // Asserts that user has the initial username and email
-        $this->assertEquals($user->username, $username);
+        $this->assertEquals($identity->username, $username);
         $this->assertEquals($email, $email_user->email);
 
         // Inflate request
@@ -112,7 +113,7 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         $email_user = \OmegaUp\DAO\Emails::getByPK($user->main_email_id);
 
         // Asserts that user has different username but the same email
-        $this->assertNotEquals($user->username, $username);
+        $this->assertNotEquals($identity->username, $username);
         $this->assertEquals($email, $email_user->email);
     }
 }

--- a/frontend/tests/controllers/UserUpdateTest.php
+++ b/frontend/tests/controllers/UserUpdateTest.php
@@ -127,16 +127,17 @@ class UserUpdateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testUsernameUpdate() {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
-        $new_username = \OmegaUp\Test\Utils::createRandomString();
+        $newUsername = \OmegaUp\Test\Utils::createRandomString();
         $r = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             //new username
-            'username' => $new_username
+            'username' => $newUsername
         ]);
         \OmegaUp\Controllers\User::apiUpdate($r);
-        $user_db = \OmegaUp\DAO\AuthTokens::getUserByToken($r['auth_token']);
+        $user = \OmegaUp\DAO\AuthTokens::getUserByToken($r['auth_token']);
+        $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
 
-        $this->assertEquals($user_db->username, $new_username);
+        $this->assertEquals($identity->username, $newUsername);
     }
 
     /**
@@ -324,7 +325,7 @@ class UserUpdateTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
         $this->assertNotEquals($response['token'], '');
 
-        $dbUser = \OmegaUp\DAO\Users::FindByUsername($user->username);
+        $dbUser = \OmegaUp\DAO\Users::FindByUsername($identity->username);
         $this->assertNotNull($dbUser->git_token);
         $this->assertTrue(
             \OmegaUp\SecurityTools::compareHashedStrings(

--- a/frontend/tests/factories/CoursesFactory.php
+++ b/frontend/tests/factories/CoursesFactory.php
@@ -235,11 +235,14 @@ class CoursesFactory {
     }
 
     /**
+     * @param array{course_alias: string} $courseData
      * @param \OmegaUp\DAO\VO\Identities[] $students
      * @param string[] $assignmentAliases
+     * @param array $problemAssignmentsMap
+     * @return array<string|null, array<string, int>>
      */
     public static function submitRunsToAssignmentsInCourse(
-        $courseData,
+        array $courseData,
         array $students,
         array $assignmentAliases,
         array $problemAssignmentsMap
@@ -251,7 +254,9 @@ class CoursesFactory {
         $expectedScores = [];
         foreach ($students as $s => $student) {
             if (is_null($student->username)) {
-                throw new \OmegaUp\Exceptions\NotFoundException('userNotFound');
+                throw new \OmegaUp\Exceptions\NotFoundException(
+                    'userNotFound'
+                );
             }
             $studentUsername = $student->username;
             $expectedScores[$studentUsername] = [];

--- a/frontend/tests/factories/CoursesFactory.php
+++ b/frontend/tests/factories/CoursesFactory.php
@@ -238,14 +238,14 @@ class CoursesFactory {
      * @param array{course_alias: string} $courseData
      * @param \OmegaUp\DAO\VO\Identities[] $students
      * @param string[] $assignmentAliases
-     * @param array $problemAssignmentsMap
-     * @return array<string|null, array<string, int>>
+     * @param array<string, list<array{author: \OmegaUp\DAO\VO\Identities, authorUser: \OmegaUp\DAO\VO\Users, problem: \OmegaUp\DAO\VO\Problems, request: \OmegaUp\Request}>> $problemAssignmentsMap
+     * @return array<string, array<string, int>>
      */
     public static function submitRunsToAssignmentsInCourse(
-        array $courseData,
-        array $students,
-        array $assignmentAliases,
-        array $problemAssignmentsMap
+        $courseData,
+        $students,
+        $assignmentAliases,
+        $problemAssignmentsMap
     ) {
         $course = \OmegaUp\DAO\Courses::getByAlias($courseData['course_alias']);
         if (is_null($course) || is_null($course->course_id)) {

--- a/frontend/tests/factories/GroupsFactory.php
+++ b/frontend/tests/factories/GroupsFactory.php
@@ -7,11 +7,11 @@ class GroupsFactory {
      * @return array{group: \OmegaUp\DAO\VO\Groups, owner: \OmegaUp\DAO\VO\Identities, request: \OmegaUp\Request, response: array{status: string}}
      */
     public static function createGroup(
-        \OmegaUp\DAO\VO\Identities $owner = null,
-        string $name = null,
-        string $description = null,
-        string $alias = null,
-        \OmegaUp\Test\ScopedLoginToken $login = null
+        ?\OmegaUp\DAO\VO\Identities $owner = null,
+        ?string $name = null,
+        ?string $description = null,
+        ?string $alias = null,
+        ?\OmegaUp\Test\ScopedLoginToken $login = null
     ) {
         if (is_null($owner)) {
             ['user' => $user, 'identity' => $owner] = \OmegaUp\Test\Factories\User::createUser();
@@ -85,9 +85,9 @@ class GroupsFactory {
      */
     public static function createGroupScoreboard(
         array $groupData,
-        string $name = null,
-        string $description = null,
-        string $alias = null
+        ?string $name = null,
+        ?string $description = null,
+        ?string $alias = null
     ) {
         if (is_null($name)) {
             $name = \OmegaUp\Test\Utils::createRandomString();

--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -257,11 +257,15 @@ class Driver:  # pylint: disable=too-many-instance-attributes
         user_id = util.database_utils.mysql(
             ('''
             SELECT
-                `user_id`
+                `u`.`user_id`
             FROM
-                `Users`
+                `Users` `u`
+            INNER JOIN
+                `Identities` `i`
+            ON
+                `u`.`main_identity_id` = `i`.`identity_id`
             WHERE
-                `username` = '%s';
+                `i`.`username` = '%s';
             ''') % (user),
             dbname='omegaup', auth=self.mysql_auth())
         self.enable_experiment_identities_to_user(user_id)

--- a/frontend/www/admin/user.php
+++ b/frontend/www/admin/user.php
@@ -7,7 +7,8 @@ require_once('../../server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 \OmegaUp\UITools::redirectIfNoAdmin();
 
-$user = \OmegaUp\DAO\Users::FindByUsername(strval($_REQUEST['username']));
+$username = strval($_REQUEST['username']);
+$user = \OmegaUp\DAO\Users::FindByUsername($username);
 if (is_null($user) || is_null($user->user_id)) {
     header('HTTP/1.1 404 Not found');
     die();
@@ -45,7 +46,7 @@ $payload = [
         return ['name' => $role->name];
     }, $roles),
     'systemRoles' => $systemRoles,
-    'username' => $user->username,
+    'username' => $username,
     'verified' => $user->verified != 0,
 ];
 

--- a/frontend/www/permissions.php
+++ b/frontend/www/permissions.php
@@ -11,8 +11,14 @@ if (!OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT) {
 
 [
     'user' => $user,
+    'identity' => $identity,
 ] = \OmegaUp\Controllers\Session::getCurrentSession();
-if (is_null($user) || is_null($user->user_id)) {
+if (
+    is_null($user) ||
+    is_null($user->user_id) ||
+    is_null($identity) ||
+    is_null($identity->username)
+) {
     header('HTTP/1.1 404 Not found');
     die();
 }
@@ -42,7 +48,7 @@ foreach ($groups as $key => $group) {
 $payload = [
     'userSystemRoles' => $userSystemRoles,
     'userSystemGroups' => $userSystemGroups,
-    'username' => $user->username,
+    'username' => $identity->username,
 ];
 
 $smarty->assign('payload', $payload);

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1387,7 +1387,7 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strpos($email, '@')</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="16">
+    <PossiblyNullArgument occurrences="15">
       <code>$user-&gt;main_email_id</code>
       <code>$user-&gt;main_email_id</code>
       <code>$user-&gt;main_identity_id</code>
@@ -1409,22 +1409,19 @@
     <PossiblyNullArrayOffset occurrences="1">
       <code>$usersAdded</code>
     </PossiblyNullArrayOffset>
-    <PossiblyNullPropertyAssignment occurrences="5">
+    <PossiblyNullPropertyAssignment occurrences="4">
       <code>$identity</code>
       <code>$r-&gt;user</code>
       <code>$r-&gt;user</code>
       <code>$email</code>
       <code>$r-&gt;user</code>
     </PossiblyNullPropertyAssignment>
-    <PossiblyNullPropertyFetch occurrences="7">
+    <PossiblyNullPropertyFetch occurrences="4">
       <code>$email-&gt;email</code>
       <code>$identity-&gt;password</code>
       <code>$user-&gt;main_identity_id</code>
       <code>$identity-&gt;username</code>
       <code>$user-&gt;main_identity_id</code>
-      <code>$r-&gt;user-&gt;main_email_id</code>
-      <code>$r-&gt;user-&gt;verified</code>
-      <code>$r-&gt;user-&gt;verification_id</code>
     </PossiblyNullPropertyFetch>
     <UndefinedDocblockClass occurrences="9">
       <code>$response</code>
@@ -1579,13 +1576,9 @@
       <code>$page</code>
       <code>$page</code>
     </MixedOperand>
-    <PossiblyNullArgument occurrences="2">
-      <code>$rs</code>
+    <PossiblyNullArgument occurrences="1">
       <code>$alias</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$rs['total']</code>
-    </PossiblyNullArrayAccess>
     <PossiblyUndefinedVariable occurrences="11">
       <code>$params</code>
       <code>$params</code>
@@ -2237,7 +2230,7 @@
     </UndefinedDocblockClass>
   </file>
   <file src="frontend/tests/factories/CoursesFactory.php">
-    <MissingParamType occurrences="7">
+    <MissingParamType occurrences="6">
       <code>$public</code>
       <code>$requestsUserInformation</code>
       <code>$showScoreboard</code>
@@ -2247,19 +2240,12 @@
       <code>$courseAlias</code>
       <code>$assignmentAlias</code>
       <code>$problems</code>
-      <code>$courseData</code>
     </MissingParamType>
-    <MissingReturnType occurrences="2">
+    <MissingReturnType occurrences="1">
       <code>addProblemsToAssignment</code>
-      <code>submitRunsToAssignmentsInCourse</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$courseData['course_alias']</code>
-      <code>$courseData['course_alias']</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="4">
+    <MixedArrayAccess occurrences="3">
       <code>$problem['problem']</code>
-      <code>$courseData['course_alias']</code>
       <code>$problemData['request']</code>
       <code>$problemData['request']</code>
     </MixedArrayAccess>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -2244,14 +2244,11 @@
     <MissingReturnType occurrences="1">
       <code>addProblemsToAssignment</code>
     </MissingReturnType>
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess occurrences="1">
       <code>$problem['problem']</code>
-      <code>$problemData['request']</code>
-      <code>$problemData['request']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$problem</code>
-      <code>$problemData</code>
     </MixedAssignment>
     <MixedPropertyFetch occurrences="1">
       <code>$problem['problem']-&gt;alias</code>


### PR DESCRIPTION
# Descripción

Separando en lo mayor posible los cambios de pruebas para dejar de utilizar
los campos `username` y `pasword` de la tabla `Users`. Esto para que el cambio
de PR #2915 se enfoque en eliminar los campos de la base de datos.

Part of: #2910

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
