### PR TITLE
Eliminando School::getStateIdFromCountryAndState()

### DIFF
--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -199,14 +199,15 @@ class Identity extends \OmegaUp\Controllers\Controller {
     ) {
         self::validateIdentity($username, $name, $gender, $aliasGroup);
 
-        $state = \OmegaUp\Controllers\School::getStateIdFromCountryAndState(
-            $countryId,
-            $stateId
-        );
+        $state = null;
+        if (!is_null($countryId) && !is_null($stateId)) {
+            $state = \OmegaUp\DAO\States::getByPK(
+                $countryId,
+                $stateId
+            );
+        }
         $schoolId = \OmegaUp\Controllers\School::createSchool(
-            trim(
-                $school
-            ),
+            trim($school),
             $state
         );
 
@@ -427,14 +428,15 @@ class Identity extends \OmegaUp\Controllers\Controller {
     ) {
         self::validateIdentity($username, $name, $gender, $aliasGroup);
 
-        $state = \OmegaUp\Controllers\School::getStateIdFromCountryAndState(
-            $countryId,
-            $stateId
-        );
+        $state = null;
+        if (!is_null($countryId) && !is_null($stateId)) {
+            $state = \OmegaUp\DAO\States::getByPK(
+                $countryId,
+                $stateId
+            );
+        }
         $schoolId = \OmegaUp\Controllers\School::createSchool(
-            trim(
-                $school
-            ),
+            trim($school),
             $state
         );
 

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -52,11 +52,22 @@ class School extends \OmegaUp\Controllers\Controller {
         $r->ensureIdentity();
 
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
-
-        $state = self::getStateIdFromCountryAndState(
+        \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['country_id'],
-            $r['state_id']
+            'country_id'
         );
+        \OmegaUp\Validators::validateOptionalStringNonEmpty(
+            $r['state_id'],
+            'country_id'
+        );
+
+        $state = null;
+        if (!is_null($r['country_id']) && !is_null($r['state_id'])) {
+            $state = \OmegaUp\DAO\States::getByPK(
+                $r['country_id'],
+                $r['state_id']
+            );
+        }
 
         return [
             'status' => 'ok',
@@ -265,16 +276,5 @@ class School extends \OmegaUp\Controllers\Controller {
             'availableFilters' => [],
         ];
         return $schoolsRank;
-    }
-
-    public static function getStateIdFromCountryAndState(
-        ?string $countryId,
-        ?string $stateId
-    ): ?\OmegaUp\DAO\VO\States {
-        if (is_null($countryId) || is_null($stateId)) {
-            // Both state and country must be specified together.
-            return null;
-        }
-        return \OmegaUp\DAO\States::getByPK($countryId, $stateId);
     }
 }

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1154,10 +1154,8 @@
     <MissingReturnType occurrences="1">
       <code>apiList</code>
     </MissingReturnType>
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="6">
       <code>$r[$param]</code>
-      <code>$r['country_id']</code>
-      <code>$r['state_id']</code>
       <code>$offset</code>
       <code>$rowCount</code>
       <code>$startTime</code>


### PR DESCRIPTION
Este cambio elimina un método que es demasiado simple como para
justificar su existencia y además el nombre no corresponde con lo que
hace.