### PR TITLE
Separando los recursos de JavaScript en varios archivos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,9 +76,10 @@ frontend/.DS_Store
 frontend/www/apc.php
 frontend/www/coverage/
 frontend/www/img/
-frontend/www/pmamini.php
 frontend/www/phpminiadmin/
+frontend/www/pmamini.php
 frontend/www/templates/
+frontend/www/tests/index.html
 
 # Ignore sublime sftp config
 sftp-config.json

--- a/frontend/www/tests/jasmine.json
+++ b/frontend/www/tests/jasmine.json
@@ -4,7 +4,8 @@
     "**/*.test.js"
   ],
   "helpers": [
-    "**/*.test_helper.js"
+    "**/*.test_helper.js",
+    "dist/npm.*.js"
   ],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/stuff/webpack/tests.ejs
+++ b/stuff/webpack/tests.ejs
@@ -18,8 +18,9 @@
 		<script type="text/javascript" src="/third_party/js/knockout-3.5.0beta.js"></script>
 		<script type="text/javascript" src="/third_party/js/knockout-secure-binding.min.js"></script>
 		<script type="text/javascript" src="/third_party/js/typeahead.jquery.js"></script>
-		<script type="text/javascript" src="/js/dist/commons.js"></script>
-		<script type="text/javascript" src="/js/dist/omegaup.js"></script>
+<% for (var js in htmlWebpackPlugin.files.js) { %>
+		<script type="text/javascript" src="<%= htmlWebpackPlugin.files.js[js] %>"></script>
+<% } %>
 		<script type="text/javascript" src="/js/omegaup/api.fake.js"></script>
 		<script type="text/javascript" src="/js/mathjax-config.js"></script>
 		<script type="text/javascript" src="/third_party/js/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
Este cambio hace que la mayoría de los recursos de JavaScript (en
especial los módulos npm) se compilen por separado. Esto posiblemente
haga que el caching sea mejor.