### PR TITLE
Dejando de importar incondicionalmente arena desde omegaup

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -23,6 +23,9 @@
 
 		{js_include entrypoint="omegaup" runtime}
 		<script type="text/javascript" src="{version_hash src="/js/require_helper.js"}"></script>
+{if isset($inArena) && $inArena}
+		{js_include entrypoint="arena"}
+{/if}
 {if (isset($inArena) && $inArena) || (isset($loadMarkdown) && $loadMarkdown)}
 		<script type="text/javascript" src="{version_hash src="/third_party/js/jquery.tableSort.js"}"></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>

--- a/frontend/www/js/interviews.arena.contest.js
+++ b/frontend/www/js/interviews.arena.contest.js
@@ -1,15 +1,19 @@
 omegaup.OmegaUp.on('ready', function() {
-  var arena = new omegaup.arena.Arena({
+  var arenaInstance = new arena.Arena({
     contestAlias: /\/interview\/([^\/]+)\/arena/.exec(
       window.location.pathname,
     )[1],
     isInterview: true,
   });
-  var admin = null;
 
-  omegaup.API.Interview.details({ interview_alias: arena.options.contestAlias })
-    .then(arena.problemsetLoaded.bind(arena))
+  omegaup.API.Interview.details({
+    interview_alias: arenaInstance.options.contestAlias,
+  })
+    .then(arenaInstance.problemsetLoaded.bind(arenaInstance))
     .fail(omegaup.UI.apiError);
 
-  window.addEventListener('hashchange', arena.onHashChanged.bind(arena));
+  window.addEventListener(
+    'hashchange',
+    arenaInstance.onHashChanged.bind(arenaInstance),
+  );
 });

--- a/frontend/www/js/omegaup/arena/admin_arena.test.js
+++ b/frontend/www/js/omegaup/arena/admin_arena.test.js
@@ -2,9 +2,10 @@
 
 require('../../dist/commons.js');
 var omegaup = require('../../dist/omegaup.js');
+var arena = require('../../dist/arena.js');
 var Markdown = require('../../../third_party/js/pagedown/Markdown.Sanitizer.js');
 
-describe('omegaup.arena', function() {
+describe('arena', function() {
   describe('ArenaAdmin', function() {
     beforeAll(function() {
       omegaup.OmegaUp.ready = true;
@@ -15,9 +16,9 @@ describe('omegaup.arena', function() {
       if (typeof global !== 'undefined' && !global.Markdown) {
         global.Markdown = Markdown;
       }
-      var arena = new omegaup.arena.Arena({ contestAlias: 'test' });
-      var admin = new omegaup.arena.ArenaAdmin(arena);
-      expect(arena.problemsetAdmin).toEqual(true);
+      var arenaInstance = new arena.Arena({ contestAlias: 'test' });
+      var adminInstance = new arena.ArenaAdmin(arenaInstance);
+      expect(arenaInstance.problemsetAdmin).toEqual(true);
     });
   });
 });

--- a/frontend/www/js/omegaup/arena/arena.test.js
+++ b/frontend/www/js/omegaup/arena/arena.test.js
@@ -2,9 +2,10 @@
 
 require('../../dist/commons.js');
 var omegaup = require('../../dist/omegaup.js');
+var arena = require('../../dist/arena.js');
 var Markdown = require('../../../third_party/js/pagedown/Markdown.Sanitizer.js');
 
-describe('omegaup.arena', function() {
+describe('arena', function() {
   describe('FormatDelta', function() {
     it('Should handle zeroes', function() {
       expect(omegaup.UI.formatDelta(0)).toEqual('00:00:00');
@@ -19,7 +20,7 @@ describe('omegaup.arena', function() {
 
   describe('GetOptionsFromLocation', function() {
     it('Should detect normal contests', function() {
-      var options = omegaup.arena.GetOptionsFromLocation(
+      var options = arena.GetOptionsFromLocation(
         new window.URL('http://localhost/arena/test/'),
       );
       expect(options.contestAlias).toEqual('test');
@@ -34,7 +35,7 @@ describe('omegaup.arena', function() {
     });
 
     it('Should detect practice mode', function() {
-      var options = omegaup.arena.GetOptionsFromLocation(
+      var options = arena.GetOptionsFromLocation(
         new window.URL('http://localhost/arena/test/practice'),
       );
       expect(options.contestAlias).toEqual('test');
@@ -42,7 +43,7 @@ describe('omegaup.arena', function() {
     });
 
     it('Should detect only problems', function() {
-      var options = omegaup.arena.GetOptionsFromLocation(
+      var options = arena.GetOptionsFromLocation(
         new window.URL('http://localhost/arena/problem/test/'),
       );
       expect(options.contestAlias).toEqual(null);
@@ -51,7 +52,7 @@ describe('omegaup.arena', function() {
     });
 
     it('Should detect ws=off', function() {
-      var options = omegaup.arena.GetOptionsFromLocation(
+      var options = arena.GetOptionsFromLocation(
         new window.URL('http://localhost/arena/test/?ws=off'),
       );
       expect(options.disableSockets).toEqual(true);
@@ -68,9 +69,9 @@ describe('omegaup.arena', function() {
       if (typeof global !== 'undefined' && !global.Markdown) {
         global.Markdown = Markdown;
       }
-      var arena = new omegaup.arena.Arena({ contestAlias: 'test' });
-      expect(arena.options.contestAlias).toEqual('test');
-      expect(arena.problemsetAdmin).toEqual(false);
+      var arenaInstance = new arena.Arena({ contestAlias: 'test' });
+      expect(arenaInstance.options.contestAlias).toEqual('test');
+      expect(arenaInstance.problemsetAdmin).toEqual(false);
     });
   });
 });

--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -1,12 +1,11 @@
 import API from './api.js';
 import UI from './ui.js';
-import * as arena from './arena/arena.js';
 import * as lang_en from './lang.en.js';
 import * as lang_es from './lang.es.js';
 import * as lang_pt from './lang.pt.js';
 import * as lang_pseudo from './lang.pseudo.js';
 
-export { API, UI, arena };
+export { API, UI };
 
 // This is the JavaScript version of the frontend's Experiments class.
 export class Experiments {

--- a/frontend/www/js/require_helper.js
+++ b/frontend/www/js/require_helper.js
@@ -3,6 +3,9 @@ if (typeof require === 'undefined') {
     if (name.endsWith('omegaup.js')) {
       return omegaup;
     }
+    if (name.endsWith('arena.js')) {
+      return arena;
+    }
     if (name.endsWith('Markdown.Sanitizer.js')) {
       return Markdown;
     }

--- a/frontend/www/ux/assignment.js
+++ b/frontend/www/ux/assignment.js
@@ -1,5 +1,5 @@
 omegaup.OmegaUp.on('ready', function() {
-  var options = omegaup.arena.GetOptionsFromLocation(window.location);
+  var options = arena.GetOptionsFromLocation(window.location);
   var assignmentMatch = /\/course\/([^\/]+)(?:\/assignment\/([^\/]+)\/?)?/.exec(
     window.location.pathname,
   );
@@ -8,14 +8,17 @@ omegaup.OmegaUp.on('ready', function() {
     options.assignmentAlias = assignmentMatch[2];
   }
 
-  var arena = new omegaup.arena.Arena(options);
+  var arenaInstance = new arena.Arena(options);
   Highcharts.setOptions({ global: { useUTC: false } });
   omegaup.API.Course.getAssignment({
-    course: arena.options.courseAlias,
-    assignment: arena.options.assignmentAlias,
+    course: arenaInstance.options.courseAlias,
+    assignment: arenaInstance.options.assignmentAlias,
   })
-    .then(arena.problemsetLoaded.bind(arena))
+    .then(arenaInstance.problemsetLoaded.bind(arenaInstance))
     .fail(omegaup.UI.apiError);
 
-  window.addEventListener('hashchange', arena.onHashChanged.bind(arena));
+  window.addEventListener(
+    'hashchange',
+    arenaInstance.onHashChanged.bind(arenaInstance),
+  );
 });

--- a/frontend/www/ux/assignment_admin.js
+++ b/frontend/www/ux/assignment_admin.js
@@ -1,5 +1,5 @@
 omegaup.OmegaUp.on('ready', function() {
-  var options = omegaup.arena.GetOptionsFromLocation(window.location);
+  var options = arena.GetOptionsFromLocation(window.location);
   var assignmentMatch = /\/course\/([^\/]+)(?:\/assignment\/([^\/]+)\/?)?/.exec(
     window.location.pathname,
   );
@@ -8,23 +8,26 @@ omegaup.OmegaUp.on('ready', function() {
     options.assignmentAlias = assignmentMatch[2];
   }
 
-  var arena = new omegaup.arena.Arena(options);
-  var admin = new omegaup.arena.ArenaAdmin(arena);
-  admin.refreshRuns();
+  var arenaInstance = new arena.Arena(options);
+  var adminInstance = new arena.ArenaAdmin(arenaInstance);
+  adminInstance.refreshRuns();
 
   // Trigger the event (useful on page load).
-  arena.onHashChanged();
+  arenaInstance.onHashChanged();
 
   $('#loading').fadeOut('slow');
   $('#root').fadeIn('slow');
 
   Highcharts.setOptions({ global: { useUTC: false } });
   omegaup.API.Course.getAssignment({
-    course: arena.options.courseAlias,
-    assignment: arena.options.assignmentAlias,
+    course: arenaInstance.options.courseAlias,
+    assignment: arenaInstance.options.assignmentAlias,
   })
-    .then(arena.problemsetLoaded.bind(arena))
+    .then(arenaInstance.problemsetLoaded.bind(arenaInstance))
     .fail(omegaup.UI.apiError);
 
-  window.addEventListener('hashchange', arena.onHashChanged.bind(arena));
+  window.addEventListener(
+    'hashchange',
+    arenaInstance.onHashChanged.bind(arenaInstance),
+  );
 });

--- a/frontend/www/ux/contest.js
+++ b/frontend/www/ux/contest.js
@@ -1,16 +1,16 @@
 omegaup.OmegaUp.on('ready', function() {
-  var arena = new omegaup.arena.Arena(
-    omegaup.arena.GetOptionsFromLocation(window.location),
+  var arenaInstance = new arena.Arena(
+    arena.GetOptionsFromLocation(window.location),
   );
-  var admin = null;
+  var adminInstance = null;
 
   Highcharts.setOptions({ global: { useUTC: false } });
 
   function onlyProblemLoaded(problem) {
-    arena.renderProblem(problem);
+    arenaInstance.renderProblem(problem);
 
-    arena.myRuns.filter_problem(problem.alias);
-    arena.myRuns.attach($('#problem .runs'));
+    arenaInstance.myRuns.filter_problem(problem.alias);
+    arenaInstance.myRuns.attach($('#problem .runs'));
 
     for (var i = 0; i < problem.solvers.length; i++) {
       var solver = problem.solvers[i];
@@ -42,15 +42,15 @@ omegaup.OmegaUp.on('ready', function() {
     }
 
     if (problem.user.admin) {
-      admin = new omegaup.arena.ArenaAdmin(
-        arena,
-        arena.options.onlyProblemAlias,
+      adminInstance = new arena.ArenaAdmin(
+        arenaInstance,
+        arenaInstance.options.onlyProblemAlias,
       );
-      admin.refreshRuns();
-      admin.refreshClarifications();
+      adminInstance.refreshRuns();
+      adminInstance.refreshClarifications();
       setInterval(function() {
-        admin.refreshRuns();
-        admin.refreshClarifications();
+        adminInstance.refreshRuns();
+        adminInstance.refreshClarifications();
       }, 5 * 60 * 1000);
     }
 
@@ -62,7 +62,7 @@ omegaup.OmegaUp.on('ready', function() {
     $('#problem tbody.added').remove();
     for (var idx in runs) {
       if (!runs.hasOwnProperty(idx)) continue;
-      arena.myRuns.trackRun(runs[idx]);
+      arenaInstance.myRuns.trackRun(runs[idx]);
     }
   }
 
@@ -74,8 +74,8 @@ omegaup.OmegaUp.on('ready', function() {
 
     for (var i = 0; i < tabs.length; i++) {
       if (window.location.hash.indexOf('#' + tabs[i]) == 0) {
-        tabChanged = arena.activeTab != tabs[i];
-        arena.activeTab = tabs[i];
+        tabChanged = arenaInstance.activeTab != tabs[i];
+        arenaInstance.activeTab = tabs[i];
         foundHash = true;
 
         break;
@@ -83,10 +83,10 @@ omegaup.OmegaUp.on('ready', function() {
     }
 
     if (!foundHash) {
-      window.location.hash = '#' + arena.activeTab;
+      window.location.hash = '#' + arenaInstance.activeTab;
     }
 
-    if (arena.activeTab == 'problems') {
+    if (arenaInstance.activeTab == 'problems') {
       if (window.location.hash.indexOf('/new-run') !== -1) {
         if (!omegaup.OmegaUp.loggedIn) {
           window.location = '/login/?redirect=' + escape(window.location);
@@ -96,66 +96,70 @@ omegaup.OmegaUp.on('ready', function() {
         $('#submit input').show();
         $('#submit').show();
         $('#overlay').show();
-        arena.codeEditor.code = arena.currentProblem.template;
-        arena.codeEditor.refresh();
+        arenaInstance.codeEditor.code = arenaInstance.currentProblem.template;
+        arenaInstance.codeEditor.refresh();
       }
     }
-    arena.detectShowRun();
+    arenaInstance.detectShowRun();
 
     if (tabChanged) {
       $('.tabs a.active').removeClass('active');
-      $('.tabs a[href="#' + arena.activeTab + '"]').addClass('active');
+      $('.tabs a[href="#' + arenaInstance.activeTab + '"]').addClass('active');
       $('.tab').hide();
-      $('#' + arena.activeTab).show();
+      $('#' + arenaInstance.activeTab).show();
 
-      if (arena.activeTab == 'clarifications') {
+      if (arenaInstance.activeTab == 'clarifications') {
         $('#clarifications-count').css('font-weight', 'normal');
       }
     }
   }
 
-  if (arena.options.isOnlyProblem) {
+  if (arenaInstance.options.isOnlyProblem) {
     onlyProblemLoaded(
       JSON.parse(document.getElementById('payload').firstChild.nodeValue),
     );
   } else {
-    omegaup.API.Contest.details({ contest_alias: arena.options.contestAlias })
-      .then(arena.problemsetLoaded.bind(arena))
+    omegaup.API.Contest.details({
+      contest_alias: arenaInstance.options.contestAlias,
+    })
+      .then(arenaInstance.problemsetLoaded.bind(arenaInstance))
       .fail(omegaup.UI.ignoreError);
 
     $('.clarifpager .clarifpagerprev').on('click', function() {
-      if (arena.clarificationsOffset > 0) {
-        arena.clarificationsOffset -= arena.clarificationsRowcount;
-        if (arena.clarificationsOffset < 0) {
-          arena.clarificationsOffset = 0;
+      if (arenaInstance.clarificationsOffset > 0) {
+        arenaInstance.clarificationsOffset -=
+          arenaInstance.clarificationsRowcount;
+        if (arenaInstance.clarificationsOffset < 0) {
+          arenaInstance.clarificationsOffset = 0;
         }
 
         // Refresh with previous page
-        arena.refreshClarifications();
+        arenaInstance.refreshClarifications();
       }
     });
 
     $('.clarifpager .clarifpagernext').on('click', function() {
-      arena.clarificationsOffset += arena.clarificationsRowcount;
-      if (arena.clarificationsOffset < 0) {
-        arena.clarificationsOffset = 0;
+      arenaInstance.clarificationsOffset +=
+        arenaInstance.clarificationsRowcount;
+      if (arenaInstance.clarificationsOffset < 0) {
+        arenaInstance.clarificationsOffset = 0;
       }
 
       // Refresh with previous page
-      arena.refreshClarifications();
+      arenaInstance.refreshClarifications();
     });
   }
 
   $('#clarification').on('submit', function(e) {
     $('#clarification input').attr('disabled', 'disabled');
     omegaup.API.Clarification.create({
-      contest_alias: arena.options.contestAlias,
+      contest_alias: arenaInstance.options.contestAlias,
       problem_alias: $('#clarification select[name="problem"]').val(),
       message: $('#clarification textarea[name="message"]').val(),
     })
       .then(function(run) {
-        arena.hideOverlay();
-        arena.refreshClarifications();
+        arenaInstance.hideOverlay();
+        arenaInstance.refreshClarifications();
       })
       .fail(function(run) {
         alert(run.error);
@@ -168,10 +172,10 @@ omegaup.OmegaUp.on('ready', function() {
   });
 
   window.addEventListener('hashchange', function() {
-    if (arena.options.isOnlyProblem) {
+    if (arenaInstance.options.isOnlyProblem) {
       onlyProblemHashChanged();
     } else {
-      arena.onHashChanged();
+      arenaInstance.onHashChanged();
     }
   });
 });

--- a/frontend/www/ux/scoreboard.js
+++ b/frontend/www/ux/scoreboard.js
@@ -8,30 +8,30 @@ omegaup.OmegaUp.on('ready', function() {
     contestAlias: params[1],
     scoreboardToken: params[2],
   };
-  var arena = new omegaup.arena.Arena(options);
+  var arenaInstance = new arena.Arena(options);
   var getRankingByTokenRefresh = 5 * 60 * 1000; // 5 minutes
   omegaup.API.Contest.details({
-    contest_alias: arena.options.contestAlias,
-    token: arena.options.scoreboardToken,
+    contest_alias: arenaInstance.options.contestAlias,
+    token: arenaInstance.options.scoreboardToken,
   })
     .then(function(contest) {
-      arena.initProblems(contest);
-      arena.initClock(contest.start_time, contest.finish_time);
-      arena.initProblemsetId(contest);
+      arenaInstance.initProblems(contest);
+      arenaInstance.initClock(contest.start_time, contest.finish_time);
+      arenaInstance.initProblemsetId(contest);
       $('#title .contest-title').text(omegaup.UI.contestTitle(contest));
       omegaup.API.Problemset.scoreboard({
-        problemset_id: arena.options.problemsetId,
-        token: arena.options.scoreboardToken,
+        problemset_id: arenaInstance.options.problemsetId,
+        token: arenaInstance.options.scoreboardToken,
       })
-        .then(arena.rankingChange.bind(arena))
+        .then(arenaInstance.rankingChange.bind(arenaInstance))
         .fail(omegaup.UI.ignoreError);
-      if (new Date() < contest.finish_time && !arena.socket) {
+      if (new Date() < contest.finish_time && !arenaInstance.socket) {
         setInterval(function() {
           omegaup.API.Problemset.scoreboard({
-            problemset_id: arena.options.problemsetId,
-            token: arena.options.scoreboardToken,
+            problemset_id: arenaInstance.options.problemsetId,
+            token: arenaInstance.options.scoreboardToken,
           })
-            .then(arena.rankingChange.bind(arena))
+            .then(arenaInstance.rankingChange.bind(arenaInstance))
             .fail(omegaup.UI.ignoreError);
         }, getRankingByTokenRefresh);
       }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dev": "cross-env webpack --config-name=frontend --watch --mode=development",
     "build": "cross-env webpack --progress --hide-modules --mode=production",
     "build-development": "cross-env webpack --hide-modules --mode=development",
+    "build-development-frontend": "cross-env webpack --config-name=frontend --hide-modules --mode=development",
     "refactor": "cross-env ./stuff/refactor.js"
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ let config = [
         './frontend/www/js/omegaup/polyfills.js',
         './frontend/www/js/omegaup/omegaup.js',
       ],
+      arena: './frontend/www/js/omegaup/arena/arena.js',
       activity_feed: './frontend/www/js/omegaup/activity/feed.js',
       admin_support: './frontend/www/js/omegaup/admin/support.js',
       admin_user: './frontend/www/js/omegaup/admin/user.js',
@@ -102,7 +103,7 @@ let config = [
       ]),
       new HtmlWebpackPlugin({
         inject: false,
-        chunks: ['omegaup'],
+        chunks: ['omegaup', 'arena'],
         filename: 'tests/index.html',
         template: path.resolve(__dirname, './stuff/webpack/tests.ejs'),
       }),


### PR DESCRIPTION
Este cambio hace que la arena únicamente se cargue cuando es necesario.
Esto causa que index tenga que cargar ~1MB menos de JavaScript.