### PR TITLE
Forzando al año a desplegarse con cuatro dígitos

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -486,7 +486,7 @@ let UI = {
     // The expected format is yyyy-MM-dd in the local timezone, which is
     // why we cannot use date.toISOSTring().
     return (
-      String(date.getFullYear()) +
+      String(date.getFullYear()).padStart(4, '0') +
       '-' +
       // Months in JavaScript start at 0.
       String(date.getMonth() + 1).padStart(2, '0') +


### PR DESCRIPTION
Este cambio hace que los años en formatDate{,Time}Local siempre se
muestren con cuatro dígitos, porque si no a los navegadores no le gusta.

Fixes: #3077