### PR TITLE
Evitando fallos de Selenium cuando Facebook no responde

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -15,6 +15,8 @@ try_define('OMEGAUP_MAINTENANCE', null);
 # ####################################
 # TEST CONFIG
 # ####################################
+try_define('IS_TEST', false);
+try_define('OMEGAUP_ENABLE_SOCIAL_MEDIA_RESOURCES', true);
 try_define('OMEGAUP_TEST_ROOT', OMEGAUP_ROOT . '/tests/controllers/');
 try_define('OMEGAUP_TEST_RESOURCES_ROOT', OMEGAUP_ROOT . '/tests/resources/');
 try_define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', false);
@@ -131,7 +133,6 @@ try_define('OMEGAUP_SESSION_CACHE_ENABLED', true);
 # SMARTY
 # #########################
 try_define('SMARTY_CACHE_DIR', '/var/tmp');
-try_define('IS_TEST', false);
 
 # #########################
 # PAGER CONSTANTS

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -60,6 +60,10 @@ class UITools {
         }
 
         $smarty->assign('GOOGLECLIENTID', OMEGAUP_GOOGLE_CLIENTID);
+        $smarty->assign(
+            'ENABLE_SOCIAL_MEDIA_RESOURCES',
+            OMEGAUP_ENABLE_SOCIAL_MEDIA_RESOURCES
+        );
         $smarty->assign('LOGGED_IN', '0');
 
         /** @psalm-suppress RedundantCondition OMEGAUP_GA_TRACK may be defined differently. */

--- a/frontend/templates/footer.tpl
+++ b/frontend/templates/footer.tpl
@@ -8,14 +8,15 @@
 					<h6><a href="mailto:hello@omegaup.com">hello@omegaup.com</a></h6>
 					<div class="row">
 						<div class="col-md-4">
+							{if $ENABLE_SOCIAL_MEDIA_RESOURCES}
 							<!-- Facebook like button -->
-							<div id="fb-root"></div>
-							<div class="fb-like" data-href="https://www.facebook.com/omegaup" data-layout="button_count" data-action="like" data-height="20" data-show-faces="false" data-share="true"></div>
+							<iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Fwww.facebook.com%2Fomegaup&width=137&layout=button_count&action=like&size=small&show_faces=false&share=true&height=46&appId" width="137" height="46" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
 						</div>
 						<div class="col-md-4">
 							<!-- Twitter follow -->
 							<a href="https://twitter.com/omegaup?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-width="300px" data-height="20" data-show-screen-name="false" data-dnt="true" data-show-count="true">Follow @omegaup</a>
 							<script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+							{/if}
 						</div>
 					</div>
 				</div>

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -44,9 +44,7 @@
 		<link rel="stylesheet" href="/third_party/css/reset.css" />
 		<script type="text/javascript" src="{version_hash src="/js/langtools.js"}"></script>
 		<script type="text/javascript" src="{version_hash src="/js/head.sugar_locale.js"}"></script>
-        <!-- Social media button -->
-        <script async defer src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12" charset="utf-8"></script>
-		<!-- Bootstrap from CDN -->
+		<!-- Bootstrap -->
 		<!-- Latest compiled and minified CSS -->
 		<link rel="stylesheet" href="/third_party/css/bootstrap.min.css">
 		<!-- Latest compiled and minified JavaScript -->

--- a/frontend/templates/index.tpl
+++ b/frontend/templates/index.tpl
@@ -57,16 +57,17 @@
 	</div>
 
 	<div class="col-md-4">
+		{if $ENABLE_SOCIAL_MEDIA_RESOURCES}
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<!-- Facebook like button -->
-                <div id="fb-root"></div>
-                <div class="fb-like" data-href="https://www.facebook.com/omegaup" data-layout="button_count" data-action="like" data-height="20" data-show-faces="false" data-share="true"></div>
+				<iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Fwww.facebook.com%2Fomegaup&width=137&layout=button_count&action=like&size=small&show_faces=false&share=true&height=46&appId" width="137" height="46" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
 				<br/>
 				<!-- Twitter follow -->
 				<a href="https://twitter.com/omegaup?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-width="300px" data-height="20" data-show-screen-name="false" data-dnt="true" data-show-count="true">Follow @omegaup</a>
-                </div>
+				</div>
 		</div>
+		{/if}
 
 		{if isset($coderOfTheMonthData)}
 		<div class="panel panel-default">

--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -178,6 +178,10 @@ def assert_no_js_errors(driver, *, path_whitelist=(), message_whitelist=()):
             if 'WebSocket' in entry['message']:
                 # Travis does not have broadcaster yet.
                 continue
+            if 'https://www.facebook.com/' in entry['message']:
+                # Let's not block submissions when Facebook is
+                # having a bad day.
+                continue
             if is_path_whitelisted(entry['message'], path_whitelist):
                 continue
             if is_message_whitelisted(entry['message'], message_whitelist):

--- a/stuff/travis/nginx/config.php.tpl
+++ b/stuff/travis/nginx/config.php.tpl
@@ -10,4 +10,5 @@ define('OMEGAUP_DB_USER', 'travis');
 define('OMEGAUP_ENVIRONMENT', 'production');
 define('OMEGAUP_GRADER_FAKE', true);
 define('OMEGAUP_LOG_FILE', '/tmp/omegaup.log');
+define('OMEGAUP_ENABLE_SOCIAL_MEDIA_RESOURCES', false);
 define('SMARTY_CACHE_DIR', '/tmp');


### PR DESCRIPTION
Este cambio ignora cualquier error que venga de Facebook en la consola
de JavaScript. No deberíamos de estar rompiéndonos cada que Facebook se
cae.