### PR TITLE
Arrojando excepción cuando no se encuentra el perfil del coder del mes

### DIFF
--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -93,7 +93,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
                     Users u
                 INNER JOIN
                     Identities i ON u.main_identity_id = i.identity_id
-                INNER JOIN
+                LEFT JOIN
                     Emails e ON u.main_email_id = e.email_id
                 LEFT JOIN
                     Countries c ON i.country_id = c.country_id

--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -313,7 +313,6 @@ demotionProblemEmailSubject = "Problem [%(problem_name)] has been reported as in
 duplicateTagsNotAllowed = "Duplicate tags are not allowed"
 editFieldRequired = "Missing required field"
 email = "E-Mail"
-emailInUse = "E-Mail already exists"
 emailNotVerified = "Your email is not verified yet. Please look for the verification email in your inbox and spam folder. If you still have problems, please contact omegaup-soporte@googlegroups.com for support."
 enterContest = "Enter Contest"
 enterCourse = "Enter course"

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -313,7 +313,6 @@ demotionProblemEmailSubject = "El problema [%(problem_name)] ha sido reportado c
 duplicateTagsNotAllowed = "No se permiten etiquetas duplicadas"
 editFieldRequired = "Falta un valor requerido"
 email = "Correo electrónico"
-emailInUse = "Correo electrónico en uso"
 emailNotVerified = "Tu dirección de correo aún no ha sido verificada. Busca el correo de verificación en tu bandeja de entrada o de spam. Si sigues teniendo problemas, escribe a omegaup-soporte@googlegroups.com para obtener ayuda."
 enterContest = "Entrar al concurso"
 enterCourse = "Entrar al curso"

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -313,7 +313,6 @@ demotionProblemEmailSubject = "(Pr0b13m [%(problem_name)] ha5 b33n r3p0r73d a5 i
 duplicateTagsNotAllowed = "(Dup1ica73 7ag5 ar3 n07 a110w3d)"
 editFieldRequired = "(Mi55ing r3quir3d fi31d)"
 email = "(E-Mai1)"
-emailInUse = "(E-Mai1 a1r3ady 3xi575)"
 emailNotVerified = "(Y0ur 3mai1 i5 n07 v3rifi3d y37. P13a53 100k f0r 7h3 v3rifica7i0n 3mai1 in y0ur inb0x and 5pam f01d3r. If y0u 57i11 hav3 pr0b13m5, p13a53 c0n7ac7 0m3gaup-50p0r73@g00g13gr0up5.c0m f0r 5upp0r7.)"
 enterContest = "(En73r C0n7357)"
 enterCourse = "(En73r c0ur53)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -313,7 +313,6 @@ demotionProblemEmailSubject = "O problema [%(problem_name)] foi relatado como in
 duplicateTagsNotAllowed = "As tags duplicadas não são permitidas"
 editFieldRequired = "Um valor necessário está faltando"
 email = "Email"
-emailInUse = "Email já existe"
 emailNotVerified = "Seu e-mail não está verificado ainda. Por favor veja o e-mail de verificação em sua caixa de entrada e spam. Se você ainda tiver problemas, entre em contato omegaup-soporte@googlegroups.com para apoio."
 enterContest = "Acesse o concurso"
 enterCourse = "Acesse o curso"

--- a/frontend/www/js/omegaup/lang.en.js
+++ b/frontend/www/js/omegaup/lang.en.js
@@ -315,7 +315,6 @@ const translations = {
 	duplicateTagsNotAllowed: "Duplicate tags are not allowed",
 	editFieldRequired: "Missing required field",
 	email: "E-Mail",
-	emailInUse: "E-Mail already exists",
 	emailNotVerified: "Your email is not verified yet. Please look for the verification email in your inbox and spam folder. If you still have problems, please contact omegaup-soporte@googlegroups.com for support.",
 	enterContest: "Enter Contest",
 	enterCourse: "Enter course",

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -314,7 +314,6 @@
 	"duplicateTagsNotAllowed": "Duplicate tags are not allowed",
 	"editFieldRequired": "Missing required field",
 	"email": "E-Mail",
-	"emailInUse": "E-Mail already exists",
 	"emailNotVerified": "Your email is not verified yet. Please look for the verification email in your inbox and spam folder. If you still have problems, please contact omegaup-soporte@googlegroups.com for support.",
 	"enterContest": "Enter Contest",
 	"enterCourse": "Enter course",

--- a/frontend/www/js/omegaup/lang.es.js
+++ b/frontend/www/js/omegaup/lang.es.js
@@ -315,7 +315,6 @@ const translations = {
 	duplicateTagsNotAllowed: "No se permiten etiquetas duplicadas",
 	editFieldRequired: "Falta un valor requerido",
 	email: "Correo electr\u00f3nico",
-	emailInUse: "Correo electr\u00f3nico en uso",
 	emailNotVerified: "Tu direcci\u00f3n de correo a\u00fan no ha sido verificada. Busca el correo de verificaci\u00f3n en tu bandeja de entrada o de spam. Si sigues teniendo problemas, escribe a omegaup-soporte@googlegroups.com para obtener ayuda.",
 	enterContest: "Entrar al concurso",
 	enterCourse: "Entrar al curso",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -314,7 +314,6 @@
 	"duplicateTagsNotAllowed": "No se permiten etiquetas duplicadas",
 	"editFieldRequired": "Falta un valor requerido",
 	"email": "Correo electr\u00f3nico",
-	"emailInUse": "Correo electr\u00f3nico en uso",
 	"emailNotVerified": "Tu direcci\u00f3n de correo a\u00fan no ha sido verificada. Busca el correo de verificaci\u00f3n en tu bandeja de entrada o de spam. Si sigues teniendo problemas, escribe a omegaup-soporte@googlegroups.com para obtener ayuda.",
 	"enterContest": "Entrar al concurso",
 	"enterCourse": "Entrar al curso",

--- a/frontend/www/js/omegaup/lang.pseudo.js
+++ b/frontend/www/js/omegaup/lang.pseudo.js
@@ -315,7 +315,6 @@ const translations = {
 	duplicateTagsNotAllowed: "(Dup1ica73 7ag5 ar3 n07 a110w3d)",
 	editFieldRequired: "(Mi55ing r3quir3d fi31d)",
 	email: "(E-Mai1)",
-	emailInUse: "(E-Mai1 a1r3ady 3xi575)",
 	emailNotVerified: "(Y0ur 3mai1 i5 n07 v3rifi3d y37. P13a53 100k f0r 7h3 v3rifica7i0n 3mai1 in y0ur inb0x and 5pam f01d3r. If y0u 57i11 hav3 pr0b13m5, p13a53 c0n7ac7 0m3gaup-50p0r73@g00g13gr0up5.c0m f0r 5upp0r7.)",
 	enterContest: "(En73r C0n7357)",
 	enterCourse: "(En73r c0ur53)",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -314,7 +314,6 @@
 	"duplicateTagsNotAllowed": "(Dup1ica73 7ag5 ar3 n07 a110w3d)",
 	"editFieldRequired": "(Mi55ing r3quir3d fi31d)",
 	"email": "(E-Mai1)",
-	"emailInUse": "(E-Mai1 a1r3ady 3xi575)",
 	"emailNotVerified": "(Y0ur 3mai1 i5 n07 v3rifi3d y37. P13a53 100k f0r 7h3 v3rifica7i0n 3mai1 in y0ur inb0x and 5pam f01d3r. If y0u 57i11 hav3 pr0b13m5, p13a53 c0n7ac7 0m3gaup-50p0r73@g00g13gr0up5.c0m f0r 5upp0r7.)",
 	"enterContest": "(En73r C0n7357)",
 	"enterCourse": "(En73r c0ur53)",

--- a/frontend/www/js/omegaup/lang.pt.js
+++ b/frontend/www/js/omegaup/lang.pt.js
@@ -315,7 +315,6 @@ const translations = {
 	duplicateTagsNotAllowed: "As tags duplicadas n\u00e3o s\u00e3o permitidas",
 	editFieldRequired: "Um valor necess\u00e1rio est\u00e1 faltando",
 	email: "Email",
-	emailInUse: "Email j\u00e1 existe",
 	emailNotVerified: "Seu e-mail n\u00e3o est\u00e1 verificado ainda. Por favor veja o e-mail de verifica\u00e7\u00e3o em sua caixa de entrada e spam. Se voc\u00ea ainda tiver problemas, entre em contato omegaup-soporte@googlegroups.com para apoio.",
 	enterContest: "Acesse o concurso",
 	enterCourse: "Acesse o curso",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -314,7 +314,6 @@
 	"duplicateTagsNotAllowed": "As tags duplicadas n\u00e3o s\u00e3o permitidas",
 	"editFieldRequired": "Um valor necess\u00e1rio est\u00e1 faltando",
 	"email": "Email",
-	"emailInUse": "Email j\u00e1 existe",
 	"emailNotVerified": "Seu e-mail n\u00e3o est\u00e1 verificado ainda. Por favor veja o e-mail de verifica\u00e7\u00e3o em sua caixa de entrada e spam. Se voc\u00ea ainda tiver problemas, entre em contato omegaup-soporte@googlegroups.com para apoio.",
 	"enterContest": "Acesse o concurso",
 	"enterCourse": "Acesse o curso",


### PR DESCRIPTION
Este cambio arregla un FIXME que se dejó en un cambio anterior. Resulta
que por razones aún desconocidas, algunos usuarios no tenían correo.
Este cambio hace que ese caso funcione desde la consulta, y ahora sí se
arroje una excepción cuando el perfil del coder del mes no se pueda
obtener.