### PR TITLE
Permitiendo regenerar las plantillas automáticamente

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -85,3 +85,25 @@ rewrite ^/user/verifyemail/([a-zA-Z0-9_]+)/?$ /userverifyemail.php?id=$1 last;
 location ~ (/dist/|^/third_party/|^/media/|^/css|^/js/|^/img/) {
   add_header  Cache-Control "max-age=31557600";
 }
+
+# libinteractive templates
+location ~ '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/([a-zA-Z0-9_.-]+)$' {
+  if (-f $request_filename) {
+    # Normal case: file is found and nginx can handle it natively.
+    break;
+  }
+  if (-d $document_root/templates/$1/$2) {
+    # Directory was found, but file was not. That means that the
+    # re-generation process was already run, so we will never be
+    # able to find that file.
+    return 404;
+  }
+  if ($args != '') {
+    # The re-generation process was already run, and we still
+    # could not find that file. Give up to avoid infinitely
+    # redirecting.
+    return 404;
+  }
+  # Try re-generating the template. Once this is done, it will cause a redirect to nginx.
+  rewrite '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/(.*)$' /problems/template.php?problem_alias=$1&commit=$2&filename=$3? last;
+}

--- a/frontend/www/problems/template.php
+++ b/frontend/www/problems/template.php
@@ -1,0 +1,11 @@
+<?php
+namespace OmegaUp;
+require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
+
+try {
+    \OmegaUp\Controllers\Problem::apiTemplate(
+        new \OmegaUp\Request($_REQUEST)
+    );
+} catch (\Exception $e) {
+    \OmegaUp\ApiCaller::handleException($e);
+}


### PR DESCRIPTION
Este cambio permite regenerar las plantillas de libinteractive
automáticamente si no se encuentran. Esto es necesario para poder tener
más de una instancia del frontend corriendo concurrentemente.