### PR TITLE
Permitiendo regenerar las imágenes automáticamente

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -107,3 +107,18 @@ location ~ '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/([a-zA-Z0-9_.-]+)$' {
   # Try re-generating the template. Once this is done, it will cause a redirect to nginx.
   rewrite '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/(.*)$' /problems/template.php?problem_alias=$1&commit=$2&filename=$3? last;
 }
+
+# problem images
+location ~ '^/img/([a-zA-Z0-9_-]+)/([0-9a-f]{40})\.([a-zA-Z0-9._-]+)$' {
+  if (-f $request_filename) {
+    break;
+  }
+  if ($args != '') {
+    # The re-generation process was already run, and we still
+    # could not find that file. Give up to avoid infinitely
+    # redirecting.
+    return 404;
+  }
+  # Try re-generating the image. Once this is done, it will cause a redirect to nginx.
+  rewrite /problems/image.php?problem_alias=$1&object_id=$2&extension=$3? last;
+}

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -63,6 +63,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
         'tt', 'tw', 'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'cy',
         'wo', 'fy', 'xh', 'yi', 'yo', 'za', 'zu'];
 
+    const IMAGE_EXTENSIONS = [
+        'bmp', 'gif', 'ico', 'jpe', 'jpeg', 'jpg', 'png', 'svg',
+        'svgz', 'tif', 'tiff',
+    ];
+
     // Number of rows shown in problems list
     const PAGE_SIZE = 1000;
 
@@ -1407,11 +1412,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         // Get all the images' mappings.
         $statementFiles = $problemArtifacts->lsTree($params['directory']);
-        $imageExtensions = ['bmp', 'gif', 'ico', 'jpe', 'jpeg', 'jpg', 'png',
-                            'svg', 'svgz', 'tif', 'tiff'];
         foreach ($statementFiles as $file) {
             $extension = pathinfo($file['name'], PATHINFO_EXTENSION);
-            if (!in_array($extension, $imageExtensions)) {
+            if (!in_array($extension, self::IMAGE_EXTENSIONS)) {
                 continue;
             }
             $result['images'][$file['name']] = (
@@ -1422,9 +1425,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
             );
             if (!@file_exists($imagePath)) {
                 @mkdir(IMAGES_PATH . $params['alias'], 0755, true);
-                file_put_contents($imagePath, $problemArtifacts->get(
-                    "{$params['directory']}/{$file['name']}"
-                ));
+                file_put_contents(
+                    $imagePath,
+                    $problemArtifacts->get(
+                        "{$params['directory']}/{$file['name']}"
+                    )
+                );
             }
         }
         return $result;
@@ -3724,5 +3730,74 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
         $problemDeployer = new \OmegaUp\ProblemDeployer($problem->alias);
         $problemDeployer->generateLibinteractiveTemplates($commit);
+    }
+
+    public static function apiImage(\OmegaUp\Request $r): void {
+        \OmegaUp\Validators::validateStringNonEmpty(
+            $r['problem_alias'],
+            'problem_alias'
+        );
+        \OmegaUp\Validators::validateStringOfLengthInRange(
+            $r['object_id'],
+            'object_id',
+            40,
+            40
+        );
+        if (
+            preg_match(
+                '/^[0-9a-f]{40}$/',
+                $r['object_id']
+            ) !== 1
+        ) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'object_id'
+            );
+        }
+        \OmegaUp\Validators::validateInEnum(
+            $r['extension'],
+            'extension',
+            self::IMAGE_EXTENSIONS
+        );
+
+        self::regenerateImage(
+            $r['problem_alias'],
+            $r['object_id'],
+            strval($r['extension'])
+        );
+
+        //The noredirect=1 part lets nginx know to not call us again if the file is not found.
+        header(
+            'Location: ' . IMAGES_URL_PATH . "{$r['problem_alias']}/{$r['object_id']}.{$r['extension']}?noredirect=1"
+        );
+        header('HTTP/1.1 303 See Other');
+        die();
+    }
+
+    public static function regenerateImage(
+        string $problemAlias,
+        string $objectId,
+        string $extension
+    ): void {
+        $problem = \OmegaUp\DAO\Problems::getByAlias(
+            $problemAlias
+        );
+        if (is_null($problem) || is_null($problem->alias)) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'problemNotFound'
+            );
+        }
+        $problemArtifacts = new \OmegaUp\ProblemArtifacts(
+            $problem->alias,
+            $objectId
+        );
+        $imagePath = (
+            IMAGES_PATH . "{$problem->alias}/{$objectId}.{$extension}"
+        );
+        @mkdir(IMAGES_PATH . $problem->alias, 0755, true);
+        file_put_contents(
+            $imagePath,
+            $problemArtifacts->getByRevision()
+        );
     }
 }

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -440,6 +440,20 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $response['statement']['images']['bunny.jpg']
         );
         $this->assertFileExists(IMAGES_PATH . $imagePath);
+        $expectedImageHash = sha1(file_get_contents(IMAGES_PATH . $imagePath));
+
+        // Delete the image and check that it exists after
+        // regeneration.
+        unlink(IMAGES_PATH . $imagePath);
+        $this->assertFileNotExists(IMAGES_PATH . $imagePath);
+        \OmegaUp\Controllers\Problem::regenerateImage(
+            $r['problem_alias'],
+            $imageGitObjectId,
+            $imageExtension
+        );
+        $this->assertFileExists(IMAGES_PATH . $imagePath);
+        $actualImageHash = sha1(file_get_contents(IMAGES_PATH . $imagePath));
+        $this->assertEquals($expectedImageHash, $actualImageHash);
     }
 
     /**

--- a/frontend/www/problems/image.php
+++ b/frontend/www/problems/image.php
@@ -1,0 +1,11 @@
+<?php
+namespace OmegaUp;
+require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
+
+try {
+    \OmegaUp\Controllers\Problem::apiImage(
+        new \OmegaUp\Request($_REQUEST)
+    );
+} catch (\Exception $e) {
+    \OmegaUp\ApiCaller::handleException($e);
+}

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -42,7 +42,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.4.0/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.4.1/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.


### PR DESCRIPTION
Este cambio permite regenerar las imágenes de los problemas automáticamente si
no se encuentran. Esto es necesario para poder tener más de una instancia del
frontend corriendo concurrentemente.