### PR TITLE
Evitando divulgar innecesariamente el URL del scoreboard

### DIFF
--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -126,8 +126,12 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     public static function getContestsParticipated($identity_id) {
         $sql = '
             SELECT
-                c.*,
-                p.scoreboard_url,
+                c.contest_id,
+                c.alias,
+                c.title,
+                UNIX_TIMESTAMP(c.start_time) AS start_time,
+                UNIX_TIMESTAMP(c.finish_time) AS finish_time,
+                UNIX_TIMESTAMP(c.last_updated) AS last_updated,
                 p.scoreboard_url_admin
             FROM
                 Contests c
@@ -149,9 +153,20 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             )
             ORDER BY
                 contest_id DESC;';
-        $params = [$identity_id];
 
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $result = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$identity_id]
+        );
+        foreach ($result as &$row) {
+            // We need to get contest_id just to be able to ORDER BY it, but we
+            // should not return it to users.
+            unset($row['contest_id']);
+            $row['start_time'] = intval($row['start_time']);
+            $row['finish_time'] = intval($row['finish_time']);
+            $row['last_updated'] = intval($row['last_updated']);
+        }
+        return $result;
     }
 
     /**

--- a/frontend/tests/controllers/UserProfileTest.php
+++ b/frontend/tests/controllers/UserProfileTest.php
@@ -188,12 +188,29 @@ class UserProfileTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($identity);
         $response = \OmegaUp\Controllers\User::apiContestStats(new \OmegaUp\Request(
             [
-                    'auth_token' => $login->auth_token,
-                ]
+                'auth_token' => $login->auth_token,
+            ]
         ));
 
         // Result should be 1 since user has only actually participated in 1 contest (submitted run)
         $this->assertEquals(1, count($response['contests']));
+        $alias = $contests[0]['contest']->alias;
+        $this->assertEquals(
+            $alias,
+            $response['contests'][$alias]['data']['alias']
+        );
+        $this->assertArrayHasKey(
+            'title',
+            $response['contests'][$alias]['data']
+        );
+        $this->assertArrayNotHasKey(
+            'contest_id',
+            $response['contests'][$alias]['data']
+        );
+        $this->assertArrayNotHasKey(
+            'scoreboard_url_admin',
+            $response['contests'][$alias]['data']
+        );
     }
 
     /*

--- a/frontend/www/js/omegaup/components/user/Profile.vue
+++ b/frontend/www/js/omegaup/components/user/Profile.vue
@@ -40,7 +40,7 @@
           <tbody>
             <tr v-for="contest in contests">
               <td>
-                <a v-bind:href="`/arena/${contest.data.alias}`">{{ contest.data.title }}</a>
+                <a v-bind:href="`/arena/${contest.data.alias}/`">{{ contest.data.title }}</a>
               </td>
               <td><strong>{{ contest.place }}</strong></td>
             </tr>

--- a/frontend/www/js/omegaup/user/profile.js
+++ b/frontend/www/js/omegaup/user/profile.js
@@ -62,10 +62,10 @@ OmegaUp.on('ready', function() {
       for (var contest_alias in data['contests']) {
         var now = new Date();
         var currentTimestamp =
-          data['contests'][contest_alias]['finish_time'] * 1000;
+          data.contests[contest_alias].data.finish_time * 1000;
         var end = OmegaUp.remoteTime(currentTimestamp);
-        if (data['contests'][contest_alias]['place'] != null && now > end) {
-          contests.push(data['contests'][contest_alias]);
+        if (data.contests[contest_alias]['place'] != null && now > end) {
+          contests.push(data.contests[contest_alias]);
         }
       }
       viewProfile.contests = contests;

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1222,7 +1222,7 @@
       <code>apiListAssociatedIdentities</code>
       <code>apiGenerateGitToken</code>
     </MissingReturnType>
-    <MixedArgument occurrences="23">
+    <MixedArgument occurrences="22">
       <code>$r['password']</code>
       <code>$r['password']</code>
       <code>$r['password']</code>
@@ -1234,7 +1234,6 @@
       <code>$user</code>
       <code>$user_id</code>
       <code>$problemset_id</code>
-      <code>$item</code>
       <code>$problem</code>
       <code>$problem</code>
       <code>$r[$param]</code>
@@ -1249,7 +1248,7 @@
       <code>$r['user']</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1"/>
-    <MixedArrayAccess occurrences="13">
+    <MixedArrayAccess occurrences="12">
       <code>$response['verified']</code>
       <code>$response['username']</code>
       <code>$response['userinfo']['email']</code>
@@ -1271,14 +1270,14 @@
       <code>$response['userinfo']['is_private']</code>
       <code>$response['userinfo']['classname']</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="5">
+    <MixedArrayOffset occurrences="3">
       <code>$response['userinfo'][$k]</code>
       <code>$contests[$contest['alias']]</code>
       <code>$contests[$contest['alias']]</code>
       <code>$contests[$contest['alias']]</code>
       <code>$contests[$contest['alias']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="31">
+    <MixedAssignment occurrences="29">
       <code>$userData['is_private']</code>
       <code>$identityData['name']</code>
       <code>$identityData['gender']</code>
@@ -1296,8 +1295,6 @@
       <code>$contest</code>
       <code>$identityData</code>
       <code>$contests[$contest['alias']]['place']</code>
-      <code>$contests[$contest['alias']]['data']</code>
-      <code>$item</code>
       <code>$problems</code>
       <code>$problem</code>
       <code>$problems</code>


### PR DESCRIPTION
Este cambio hace que ver el perfil de alguien no divulgue
innecesariamente el URL del scoreboard.

Fixes: #3116