### PR TITLE
Arreglando back button en arena cuando se visita un problema individual

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -348,8 +348,6 @@ export class Arena {
       attached: false,
     };
 
-    window.history.replaceState({}, '', '#' + self.activeTab);
-
     // The interval of time that submissions button will be disabled
     self.submissionGapInterval = 0;
 

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -348,6 +348,8 @@ export class Arena {
       attached: false,
     };
 
+    window.history.replaceState({}, '', '#' + self.activeTab);
+
     // The interval of time that submissions button will be disabled
     self.submissionGapInterval = 0;
 

--- a/frontend/www/ux/contest.js
+++ b/frontend/www/ux/contest.js
@@ -83,7 +83,8 @@ omegaup.OmegaUp.on('ready', function() {
     }
 
     if (!foundHash) {
-      window.location.hash = '#' + arenaInstance.activeTab;
+      // Change the URL to the deafult tab but don't break the back button.
+      window.history.replaceState({}, '', '#' + arenaInstance.activeTab);
     }
 
     if (arenaInstance.activeTab == 'problems') {


### PR DESCRIPTION
# Descripción

Se usa `window.history.replaceState` para hacer el cambio inicial del `window.location.hash`
en la vista de Problemas individuales. Eso arregla la historia del navegador.

Fixes: #2046 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
