### PR TITLE
Permitiendo a los APIs no regresar 'status'

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -67,7 +67,6 @@ class ApiCaller {
      * Handles main API workflow. All HTTP API calls start here.
      */
     public static function httpEntryPoint(): string {
-        $r = null;
         /** @var null|\OmegaUp\Exceptions\ApiException */
         $apiException = null;
         try {
@@ -76,6 +75,12 @@ class ApiCaller {
             }
             $r = self::createRequest();
             $response = $r->execute();
+            if (
+                self::isAssociativeArray($response) &&
+                !isset($response['status'])
+            ) {
+                $response['status'] = 'ok';
+            }
         } catch (\OmegaUp\Exceptions\ApiException $e) {
             $apiException = $e;
         } catch (\Exception $e) {
@@ -109,7 +114,7 @@ class ApiCaller {
         $i = 0;
         /** @var mixed $_ */
         foreach ($array as $key => $_) {
-            if ($key != $i++) {
+            if ($key !== $i++) {
                 return true;
             }
         }

--- a/frontend/server/src/Controllers/Time.php
+++ b/frontend/server/src/Controllers/Time.php
@@ -13,14 +13,11 @@ class Time extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for /time API
      *
-     * @param \OmegaUp\Request $r
-     * @return array
+     * @return array{time: int}
      */
-    public static function apiGet(\OmegaUp\Request $r = null) {
-        $response = [];
-        $response['time'] = \OmegaUp\Time::get();
-        $response['status'] = 'ok';
-
-        return $response;
+    public static function apiGet(?\OmegaUp\Request $r = null): array {
+        return [
+            'time' => \OmegaUp\Time::get(),
+        ];
     }
 }

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -315,7 +315,7 @@ def update_scoreboard_for_contest(driver, contest_alias):
         '/api/scoreboard/refresh/alias/%s/token/secret' %
         urllib.parse.quote(contest_alias, safe=''))
     driver.browser.get(scoreboard_refresh_url)
-    assert '{"status":"ok"}' in driver.browser.page_source
+    assert '"status":"ok"' in driver.browser.page_source
 
 
 @util.annotate

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -316,7 +316,7 @@ def update_scoreboard_for_assignment(driver, assignment_alias, course_alias):
         (urllib.parse.quote(assignment_alias, safe=''),
          urllib.parse.quote(course_alias, safe='')))
     driver.browser.get(scoreboard_refresh_url)
-    assert '{"status":"ok"}' in driver.browser.page_source
+    assert '"status":"ok"' in driver.browser.page_source
 
 
 @util.annotate

--- a/stuff/replay.py
+++ b/stuff/replay.py
@@ -143,7 +143,7 @@ def main():
                                     'run': str(run_id)})
         ).read()
         t1 = time.time()
-        assert response == '{"status":"ok"}', response
+        assert '"status":"ok"' in response, response
         times.append(t1 - t0)
     t1_all = time.time()
 


### PR DESCRIPTION
Como absolutamente todos los APIs establecen 'status' => 'ok', no tiene
sentido seguirlos obligando a hacerlo. En vez, el API caller es el que
debería de establecer esto.