### PR TITLE
Haciendo que apiSchoolCodersOfTheMonth retorne solo lo necesario

### DIFF
--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -234,7 +234,7 @@ class School extends \OmegaUp\Controllers\Controller {
      * Returns rank of best schools in last month
      *
      * @param \OmegaUp\Request $r
-     * @return array{time: string, username: string, country_id: string, email: string}[]
+     * @return array{time: string, username: string, classname: string}[]
      */
     public static function apiSchoolCodersOfTheMonth(\OmegaUp\Request $r): array {
         $r->ensureInt('school_id');


### PR DESCRIPTION
# Descripción

Agregando `classname` a los campos retornados por `apiSchoolCodersOfTheMonth` y quitando los campos `country_id` y `email`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
