### PR TITLE
Mejorando la manera en la que se reportan los errores en los cronjobs

### DIFF
--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -273,20 +273,30 @@ class Utils {
         self::commit();
     }
 
-    public static function runUpdateRanks(): void {
-        // Ensure all suggestions are written to the database before invoking
-        // the external script.
-        self::commit();
-
+    private static function shellExec(string $command): void {
         /** @psalm-suppress ForbiddenCode this only runs in tests. */
-        shell_exec('python3 ' . escapeshellarg(
-            strval(OMEGAUP_ROOT)
-        ) . '/../stuff/cron/update_ranks.py' .
-        ' --quiet ' .
-        ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
-        ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
-        ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
-        ' --password ' . escapeshellarg(OMEGAUP_DB_PASS));
+        $proc = proc_open(
+            $command,
+            [
+                 0 => ['file', '/dev/null', 'r'],
+                 1 => ['pipe', 'w'],
+                 2 => ['pipe', 'w'],
+            ],
+            $pipes
+        );
+        if (!is_resource($proc)) {
+            throw new \Exception("Failed to run `{$command}`");
+        }
+        $stdout = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $processStatus = proc_close($proc);
+        if ($processStatus != 0) {
+            throw new \Exception(
+                "Failed to run `{$command}`: status={$processStatus}\nstdout={$stdout}\nstderr={$stderr}"
+            );
+        }
     }
 
     public static function commit(): void {
@@ -297,33 +307,50 @@ class Utils {
         }
     }
 
+    public static function runUpdateRanks(): void {
+        // Ensure all suggestions are written to the database before invoking
+        // the external script.
+        self::commit();
+        self::shellExec(
+            ('python3 ' .
+             escapeshellarg(strval(OMEGAUP_ROOT)) .
+             '/../stuff/cron/update_ranks.py' .
+             ' --verbose ' .
+             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
+             ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
+            ' --password ' . escapeshellarg(OMEGAUP_DB_PASS))
+        );
+    }
+
     public static function runAggregateFeedback(): void {
         // Ensure all suggestions are written to the database before invoking
         // the external script.
         self::commit();
-
-        /** @psalm-suppress ForbiddenCode this only runs in tests. */
-        shell_exec('python3 ' . escapeshellarg(
-            strval(OMEGAUP_ROOT)
-        ) . '/../stuff/cron/aggregate_feedback.py' .
-                 ' --quiet ' .
-                 ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
-                 ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
-                 ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
-                 ' --password ' . escapeshellarg(OMEGAUP_DB_PASS));
+        self::shellExec(
+            ('python3 ' .
+             escapeshellarg(strval(OMEGAUP_ROOT)) .
+             '/../stuff/cron/aggregate_feedback.py' .
+             ' --verbose ' .
+             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
+             ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
+             ' --password ' . escapeshellarg(OMEGAUP_DB_PASS))
+        );
     }
 
     public static function runAssignBadges(): void {
         // Ensure everything is commited before invoking external script
         self::commit();
-        /** @psalm-suppress ForbiddenCode this only runs in tests. */
-        shell_exec('python3 ' . escapeshellarg(
-            strval(OMEGAUP_ROOT)
-        ) . '/../stuff/cron/assign_badges.py' .
-                 ' --quiet ' .
-                 ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
-                 ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
-                 ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
-                 ' --password ' . escapeshellarg(OMEGAUP_DB_PASS));
+        self::shellExec(
+            ('python3 ' .
+             escapeshellarg(strval(OMEGAUP_ROOT)) .
+             '/../stuff/cron/assign_badges.py' .
+             ' --verbose ' .
+             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
+             ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
+             ' --password ' . escapeshellarg(OMEGAUP_DB_PASS))
+        );
     }
 }

--- a/stuff/cron/assign_badges.py
+++ b/stuff/cron/assign_badges.py
@@ -103,9 +103,6 @@ def main() -> None:
         with dbconn.cursor(cursorclass=MySQLdb.cursors.DictCursor) as cur:
             process_badges(cur)  # type: ignore
         dbconn.commit()
-    except:  # noqa: bare-except
-        logging.exception(
-            'Failed to assign all badges and create notifications.')
     finally:
         dbconn.close()
         logging.info('Finished')

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -264,12 +264,14 @@ def main() -> None:
                 dbconn.commit()
             except:  # noqa: bare-except
                 logging.exception('Failed to update user ranking')
+                raise
 
             try:
                 update_school_rank(cur)
                 dbconn.commit()
             except:  # noqa: bare-except
                 logging.exception('Failed to update school ranking')
+                raise
     finally:
         dbconn.close()
         logging.info('Done')


### PR DESCRIPTION
Este cambio hace que los cronjobs siempre arrojen una excepción cuando
fallan. También normaliza la manera en la que se invocan desde Utils.php
para que la excepción muestre el log.