### PR TITLE
Limpiando la tabla User_Rank

### DIFF
--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -228,6 +228,7 @@ class Utils {
             'Submission_Log',
             'Tags',
             'User_Roles',
+            'User_Rank',
             'Users',
             'Users_Badges',
             'Users_Experiments',

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -39,7 +39,10 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
             $r->method = $req['api'];
             $fullResponse = \OmegaUp\ApiCaller::call($r);
             if ($fullResponse['status'] !== 'ok') {
-                throw new Exception($fullResponse['error']);
+                throw new Exception(
+                    'request=' . json_encode($req) .
+                    "\nresponse=" . json_encode($fullResponse)
+                );
             }
             if ($r->method === '\\OmegaUp\\Controllers\\Run::apiCreate') {
                 $points = array_key_exists(
@@ -180,7 +183,11 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
                 "$alias:> The file test.json doesn't exist."
             );
 
-            self::runBadgeTest($testPath, $queryPath, $alias);
+            try {
+                self::runBadgeTest($testPath, $queryPath, $alias);
+            } catch (Exception $e) {
+                $this->fail("For badge {$alias}: $e");
+            }
         }
     }
 


### PR DESCRIPTION
Este cambio limpia la tabla User_Rank antes de ejecutar las pruebas de
los badges. Esto evita errores.

De paso se mejoran un poco los mensajes de error de los badges.