### PR TITLE
Agregando métricas de Prometheus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,3 +48,6 @@
 [submodule "paragonie/sodium_compat"]
 	path = frontend/server/libs/third_party/sodium_compat
 	url = https://github.com/paragonie/sodium_compat.git
+[submodule "endclothing/prometheus_client_php"]
+	path = frontend/server/libs/third_party/prometheus_client_php
+	url = https://github.com/endclothing/prometheus_client_php

--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -61,6 +61,7 @@ rewrite ^/login/google/?$ /logingoogle.php last;
 rewrite ^/login/password/recover/?$ /loginpasswordrecover.php last;
 rewrite ^/login/password/reset/?$ /loginpasswordreset.php last;
 rewrite ^/logout/?$ /logout.php last;
+rewrite ^/metrics/?$ /metrics.php last;
 rewrite ^/nomination/?$ /problems/qualitynomination.php last;
 rewrite ^/nomination/([0-9]+)/?$ /problems/qualitynomination.php?qualitynomination_id=$1 last;
 rewrite ^/nomination/mine/?$ /problems/qualitynomination_mine.php last;

--- a/frontend/server/src/Metrics.php
+++ b/frontend/server/src/Metrics.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * A class that wraps the prometheus metrics.
+ */
+class Metrics {
+    /** @var null|\OmegaUp\Metrics */
+    private static $instance = null;
+
+    /** @var \Prometheus\CollectorRegistry */
+    private $registry;
+
+    private function __construct() {
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Exception/MetricNotFoundException.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Storage/Adapter.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Collector.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/CollectorRegistry.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Counter.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/MetricFamilySamples.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/RenderTextFormat.php';
+        require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Sample.php';
+        if (function_exists('apcu_clear_cache')) {
+            require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Storage/APC.php';
+            $adapter = new \Prometheus\Storage\APC();
+        } else {
+            require_once 'libs/third_party/prometheus_client_php/src/Prometheus/Storage/InMemory.php';
+            $adapter = new \Prometheus\Storage\InMemory();
+        }
+        $this->registry = new \Prometheus\CollectorRegistry($adapter);
+    }
+
+    public static function getInstance(): \OmegaUp\Metrics {
+        if (is_null(self::$instance)) {
+            self::$instance = new \OmegaUp\Metrics();
+            return self::$instance;
+        }
+        return self::$instance;
+    }
+
+    public function apiStatus(string $apiName, int $status): void {
+        $this
+            ->registry
+            ->getOrRegisterCounter(
+                'frontend',
+                'api_request_status_count',
+                'status per API request',
+                ['api', 'status']
+            )
+            ->inc([$apiName, $status]);
+
+        $this
+            ->registry
+            ->getOrRegisterCounter(
+                'frontend',
+                'api_request_total',
+                'API call count',
+                ['api']
+            )
+            ->inc([$apiName]);
+    }
+
+    public function getMetrics(): string {
+        $renderer = new \Prometheus\RenderTextFormat();
+        return $renderer->render($this->registry->getMetricFamilySamples());
+    }
+
+    public function render(): void {
+        header('Content-type: ' . \Prometheus\RenderTextFormat::MIME_TYPE);
+        echo $this->getMetrics();
+    }
+}

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -31,6 +31,12 @@ class Request extends \ArrayObject {
     public $method = null;
 
     /**
+     * The name of the method that will be called.
+     * @var null|string
+     */
+    public $methodName = null;
+
+    /**
      * A global per-request unique(-ish) ID.
      * @var string
      */

--- a/frontend/www/metrics.php
+++ b/frontend/www/metrics.php
@@ -1,0 +1,5 @@
+<?php
+namespace OmegaUp;
+require_once(dirname(__DIR__, 1) . '/server/bootstrap.php');
+
+\OmegaUp\Metrics::getInstance()->render();

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -9,6 +9,7 @@ init_submodules() {
 		frontend/server/libs/third_party/log4php \
 		frontend/server/libs/third_party/paseto \
 		frontend/server/libs/third_party/phpmailer \
+		frontend/server/libs/third_party/prometheus_client_php \
 		frontend/server/libs/third_party/smarty \
 		frontend/server/libs/third_party/sodium_compat
 }


### PR DESCRIPTION
Este cambio hace que el frontend acumule métricas para poder consumirlas
luego. Esto nos debería ayudar a monitorear un poco mejor.