### PR TITLE
Haciendo que apiCoderOfTheMonth también guarde a los demás coders candidatos

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1354,15 +1354,22 @@ class User extends \OmegaUp\Controllers\Controller {
                 ];
             }
 
-            // First place of list is going to be returned
-            $coderOfTheMonthUserId = $users[0]['user_id'];
-            foreach ($users as $index => $user) {
-                \OmegaUp\DAO\CoderOfTheMonth::create(new \OmegaUp\DAO\VO\CoderOfTheMonth([
-                    'user_id' => $user['user_id'],
-                    'school_id' => $user['school_id'],
-                    'time' => $firstDay,
-                    'rank' => $index + 1,
-                ]));
+            try {
+                \OmegaUp\DAO\DAO::transBegin();
+                // First place of list is going to be returned
+                $coderOfTheMonthUserId = $users[0]['user_id'];
+                foreach ($users as $index => $user) {
+                    \OmegaUp\DAO\CoderOfTheMonth::create(new \OmegaUp\DAO\VO\CoderOfTheMonth([
+                        'user_id' => $user['user_id'],
+                        'school_id' => $user['school_id'],
+                        'time' => $firstDay,
+                        'rank' => $index + 1,
+                    ]));
+                }
+                \OmegaUp\DAO\DAO::transEnd();
+            } catch (\Exception $e) {
+                \OmegaUp\DAO\DAO::transRollback();
+                throw $e;
             }
         } else {
             $coderOfTheMonthUserId = $codersOfTheMonth[0]->user_id;

--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -85,7 +85,8 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
           GROUP BY
             up.identity_id
           ORDER BY
-            score DESC
+            score DESC,
+            ProblemsSolved DESC
           LIMIT 100
         ";
 

--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -182,7 +182,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
     final public static function getMonthlyList(string $firstDay): array {
         $date = date('Y-m-01', strtotime($firstDay));
         $sql = '
-          SELECT DISTINCT
+          SELECT
             cm.time,
             cm.rank,
             i.username,
@@ -194,9 +194,9 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
           INNER JOIN
             Users u ON u.user_id = cm.user_id
           INNER JOIN
-            Identities i ON u.user_id = i.user_id
+            Identities i ON u.main_identity_id = i.identity_id
           LEFT JOIN
-            Emails e ON e.user_id = u.user_id
+            Emails e ON e.email_id = u.main_email_id
           WHERE
             cm.time = ?
           ORDER BY

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -19,13 +19,14 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             'school_id' => $school->school_id,
         ]));
 
-        // Creating 10 AC runs for our user in the last month
+        // First user solves two problems, second user solves just one
         $runCreationDate = new DateTimeImmutable(date('Y-m-d'));
         $runCreationDate = $runCreationDate->modify('first day of last month');
         $runCreationDate = $runCreationDate->format('Y-m-d');
 
-        $this->createRuns($identity, $runCreationDate, 10 /*numRuns*/);
-        $this->createRuns($extraIdentity, $runCreationDate, 5 /*numRuns*/);
+        $this->createRuns($identity, $runCreationDate, 1 /*numRuns*/);
+        $this->createRuns($identity, $runCreationDate, 1 /*numRuns*/);
+        $this->createRuns($extraIdentity, $runCreationDate, 1 /*numRuns*/);
 
         $response = \OmegaUp\Controllers\User::apiCoderOfTheMonth(
             new \OmegaUp\Request()
@@ -78,13 +79,15 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
 
         $response = \OmegaUp\Controllers\User::apiCoderOfTheMonthList($r);
 
-        $this->assertCount(0, $response['coders']);
+        // Just one Coder of The Month, the one calculated on the previous test.
+        $this->assertCount(1, $response['coders']);
 
         // Adding parameter date should return the same value, it helps
-        // to test getMonthlyList function, which never was tested
+        // to test getMonthlyList function.
+        // It should return two users (the ones that got stored on the previous test)
         $r['date'] = date('Y-m-d', \OmegaUp\Time::get());
         $response = \OmegaUp\Controllers\User::apiCoderOfTheMonthList($r);
-        $this->assertCount(0, $response['coders']);
+        $this->assertCount(2, $response['coders']);
     }
 
     public function testCodersOfTheMonthBySchool() {

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -8,7 +8,7 @@
     </div>
     <div class="row">
       <div class="col-md-4">
-        <div class="panel panel-default">
+        <div class="panel panel-default" v-if="country">
           <ul class="list-group">
             <li class="list-group-item">
               <strong>{{ T.wordsCountry }}:</strong>
@@ -17,7 +17,7 @@
                 v-bind:country="country.id"
               ></omegaup-country-flag>
             </li>
-            <li class="list-group-item">
+            <li class="list-group-item" v-if="stateName">
               <strong>{{ T.profileState }}:</strong> {{ stateName }}
             </li>
           </ul>


### PR DESCRIPTION
Fixes: #2973 

# Comentarios

Cuando hice la corrección para este issue en el pasado, solo traté `apiSelectCoderOfTheMonth()`, me falto `apiCoderOfTheMonth()`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
