### PR TITLE
Ocultando panel de ubicación de escuela si ésta no está definida.

### DIFF
--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -17,7 +17,7 @@
                 v-bind:country="country.id"
               ></omegaup-country-flag>
             </li>
-            <li class="list-group-item">
+            <li class="list-group-item" v-if="stateName">
               <strong>{{ T.profileState }}:</strong> {{ stateName }}
             </li>
           </ul>

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -8,7 +8,7 @@
     </div>
     <div class="row">
       <div class="col-md-4">
-        <div class="panel panel-default">
+        <div class="panel panel-default" v-if="country">
           <ul class="list-group">
             <li class="list-group-item">
               <strong>{{ T.wordsCountry }}:</strong>


### PR DESCRIPTION
# Descripción

Esto ocasionaba errores en algunas escuelas con país/estado no definidos: https://omegaup.com/schools/profile/933/

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
