### PR TITLE
Ocultando algunas cajas al Agregar Problemas dentro de cursos

### DIFF
--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -71,7 +71,7 @@
     <div class="panel-footer" v-show="showForm">
       <form>
         <div class="row">
-          <div class="col-md-4" v-show="canSeeTopicsAndLevel">
+          <div class="col-md-4" v-show="showTopicsAndLevel">
             <div class="form-group">
               <label
                 >{{ T.wordsTopics }}
@@ -110,7 +110,7 @@
             </div>
           </div>
           <div class="col-md-8">
-            <div class="row" v-show="canSeeTopicsAndLevel">
+            <div class="row" v-show="showTopicsAndLevel">
               <div class="form-group col-md-12">
                 <label
                   >{{ T.wordsProblems }}
@@ -203,7 +203,7 @@ export default class CourseProblemList extends Vue {
   topics: string[] = [];
   taggedProblemAlias = '';
   problemAlias = '';
-  canSeeTopicsAndLevel = false;
+  showTopicsAndLevel = false;
 
   get tags(): string[] {
     let t = this.topics.slice();

--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -71,7 +71,7 @@
     <div class="panel-footer" v-show="showForm">
       <form>
         <div class="row">
-          <div class="col-md-4">
+          <div class="col-md-4" v-show="canSeeTopicsAndLevel">
             <div class="form-group">
               <label
                 >{{ T.wordsTopics }}
@@ -110,7 +110,7 @@
             </div>
           </div>
           <div class="col-md-8">
-            <div class="row">
+            <div class="row" v-show="canSeeTopicsAndLevel">
               <div class="form-group col-md-12">
                 <label
                   >{{ T.wordsProblems }}
@@ -203,6 +203,7 @@ export default class CourseProblemList extends Vue {
   topics: string[] = [];
   taggedProblemAlias = '';
   problemAlias = '';
+  canSeeTopicsAndLevel = false;
 
   get tags(): string[] {
     let t = this.topics.slice();


### PR DESCRIPTION
# Descripción

Se esconden las cajas de Topics, Level y Tagged Problems en la vista de Agregar 
Problema a una tarea dentro de cursos debido a que no se ha alimentado con 
información suficiente para que estas tengan la utilidad deseada. 

Fixes: #3144 

# Comentarios

Se agregó una bandera `canSeeTopicsAndLevel` para determinar si el usuario
puede ver las cajas, ¿es necesario agregar a algún perfil/rol que requiera de 
esta funcionalidad?

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
