### PR TITLE
Arreglando el Markdown en bloques literales

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -637,7 +637,12 @@ let UI = {
 
     // These two functions are adapted from Markdown.Converter.js. They are
     // needed to support images with some special characters in their name.
-    function escapeCharacters(text, charsToEscape, afterBackslash) {
+    function escapeCharacters(
+      text,
+      charsToEscape,
+      afterBackslash,
+      doNotEscapeTildeAndDollar,
+    ) {
       // First we have to escape the escape characters so that
       // we can build a character class out of them
       const regexString = `([${charsToEscape.replace(/([\[\]\\])/g, '\\$1')}])`;
@@ -647,10 +652,10 @@ let UI = {
       }
 
       const regex = new RegExp(regexString, 'g');
-      return text
-        .replace(/~/g, '~T')
-        .replace(/\$/g, '~D')
-        .replace(regex, (wholeMatch, m1) => `~E${m1.charCodeAt(0)}E`);
+      if (!doNotEscapeTildeAndDollar) {
+        text = text.replace(/~/g, '~T').replace(/\$/g, '~D');
+      }
+      return text.replace(regex, (wholeMatch, m1) => `~E${m1.charCodeAt(0)}E`);
     }
     function unescapeCharacters(text) {
       //
@@ -707,46 +712,6 @@ let UI = {
         },
       );
       return text;
-    });
-    converter.hooks.chain('preBlockGamut', function(
-      text,
-      blockGamut,
-      spanGamut,
-    ) {
-      // GitHub-flavored fenced code blocks
-      function fencedCodeBlock(
-        whole,
-        indentation,
-        fence,
-        infoString,
-        contents,
-      ) {
-        contents = contents.replace(/&/g, '&amp;');
-        contents = contents.replace(/</g, '&lt;');
-        contents = contents.replace(/>/g, '&gt;');
-        if (indentation != '') {
-          let lines = [];
-          let stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
-          for (let line of contents.split('\n')) {
-            lines.push(line.replace(stripPrefix, ''));
-          }
-          contents = lines.join('\n');
-        }
-        let className = '';
-        infoString = infoString.trim();
-        if (infoString != '') {
-          className = ` class="language-${infoString.split(/\s+/)[0]}"`;
-        }
-        return `<pre><code${className}>${contents}</code></pre>`;
-      }
-      text = text.replace(
-        /^( {0,3})(`{3,})([^`\n]*)\n(.*?\n|) {0,3}\2`* *$/gms,
-        fencedCodeBlock,
-      );
-      return text.replace(
-        /^( {0,3})((?:~T){3,})(?!~)([^\n]*)\n(.*?\n|) {0,3}\2(?:~T)* *$/gms,
-        fencedCodeBlock,
-      );
     });
     converter.hooks.chain('preBlockGamut', function(text, blockGamut) {
       // Sample I/O table.
@@ -812,9 +777,11 @@ let UI = {
                 )}</pre></td>`;
                 columns += 2;
               } else {
-                result += `<td><pre>${matches[i + 1].replace(
-                  /\s+$/,
-                  '',
+                result += `<td><pre>${escapeCharacters(
+                  matches[i + 1].replace(/\s+$/, ''),
+                  ' \t*_{}[]()>#+-=.!|`',
+                  /*afterBackslash=*/ false,
+                  /*doNotEscapeTildeAnDollar=*/ true,
                 )}</pre></td>`;
                 columns++;
               }
@@ -828,6 +795,51 @@ let UI = {
 
           return '<table class="sample_io">\n' + result + '\n</table>\n';
         },
+      );
+    });
+    converter.hooks.chain('preBlockGamut', function(
+      text,
+      blockGamut,
+      spanGamut,
+    ) {
+      // GitHub-flavored fenced code blocks
+      function fencedCodeBlock(
+        whole,
+        indentation,
+        fence,
+        infoString,
+        contents,
+      ) {
+        contents = contents.replace(/&/g, '&amp;');
+        contents = contents.replace(/</g, '&lt;');
+        contents = contents.replace(/>/g, '&gt;');
+        if (indentation != '') {
+          let lines = [];
+          let stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
+          for (let line of contents.split('\n')) {
+            lines.push(line.replace(stripPrefix, ''));
+          }
+          contents = escapeCharacters(
+            lines.join('\n'),
+            ' \t*_{}[]()>#+-=.!|`',
+            /*afterBackslash=*/ false,
+            /*doNotEscapeTildeAnDollar=*/ true,
+          );
+        }
+        let className = '';
+        infoString = infoString.trim();
+        if (infoString != '') {
+          className = ` class="language-${infoString.split(/\s+/)[0]}"`;
+        }
+        return `<pre><code${className}>${contents}</code></pre>`;
+      }
+      text = text.replace(
+        /^( {0,3})(`{3,})([^`\n]*)\n(.*?\n|) {0,3}\2`* *$/gms,
+        fencedCodeBlock,
+      );
+      return text.replace(
+        /^( {0,3})((?:~T){3,})(?!~)([^\n]*)\n(.*?\n|) {0,3}\2(?:~T)* *$/gms,
+        fencedCodeBlock,
       );
     });
     converter.hooks.chain('preBlockGamut', function(

--- a/frontend/www/js/omegaup/ui.test.js
+++ b/frontend/www/js/omegaup/ui.test.js
@@ -91,6 +91,76 @@ Case #2: 15
 </table>`);
     });
 
+    it('Should handle sample I/O tables with markdown', function() {
+      expect(
+        converter.makeHtml(`# Ejemplo
+
+||input
+5 5 2
+#####
+#A#B#
+#...#
+#b#a#
+#####
+
+headers
+=======
+
+- lists
+
+****
+
+----
+
+____
+
+\`\`\`
+github flavored markdown
+\`\`\`
+
+> hi
+> hello
+
+    other kind of blockquote
+
+Other escapes: $~~T~D~E32E
+||output
+0
+||end`),
+      ).toEqual(`<h1>Ejemplo</h1>
+
+<table class="sample_io">
+<thead><tr><th>Entrada</th><th>Salida</th></tr></thead><tbody><tr><td><pre>5 5 2
+#####
+#A#B#
+#...#
+#b#a#
+#####
+
+headers
+=======
+
+- lists
+
+****
+
+----
+
+____
+
+\`\`\`
+github flavored markdown
+\`\`\`
+
+> hi
+> hello
+
+    other kind of blockquote
+
+Other escapes: $~~T~D~E32E</pre></td><td><pre>0</pre></td></tr></tbody>
+</table>`);
+    });
+
     it('Should handle GitHub-flavored Markdown tables', function() {
       expect(
         converter.makeHtml(`| foo | bar |


### PR DESCRIPTION
Este cambio hace que el markdown que se encuentre dentro de un bloque
literal, ya sea un caso de entrada/salida o un fenced code block, se
escape para evitar que otras partes del Markdown puedan hacer cosas con
él.

Fixes: #3218