### PR TITLE
Agregando función para obtener todas las escuelas del mes

### DIFF
--- a/frontend/server/src/DAO/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/SchoolOfTheMonth.php
@@ -136,8 +136,7 @@ class SchoolOfTheMonth extends \OmegaUp\DAO\Base\SchoolOfTheMonth {
     }
 
     /**
-     * Gets all the best schools based on the month
-     * of a certain date.
+     * Gets the best school of each month
      *
      * @return list<array{school_id: int, name: string, country_id: string, time: string}>
      */

--- a/frontend/server/src/DAO/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/SchoolOfTheMonth.php
@@ -136,6 +136,43 @@ class SchoolOfTheMonth extends \OmegaUp\DAO\Base\SchoolOfTheMonth {
     }
 
     /**
+     * Gets all the best schools based on the month
+     * of a certain date.
+     *
+     * @return list<array{school_id: int, name: string, country_id: string, time: string}>
+     */
+    public static function getSchoolsOfTheMonth(): array {
+        $sql = '
+            SELECT
+                sotm.school_id,
+                sotm.time,
+                s.name,
+                s.country_id
+            FROM
+                School_Of_The_Month sotm
+            INNER JOIN
+                Schools s ON s.school_id = sotm.school_id
+            WHERE
+                sotm.selected_by IS NOT NULL
+                OR (
+                    sotm.rank = 1 AND
+                    NOT EXISTS (
+                        SELECT
+                            *
+                        FROM
+                            School_Of_The_Month
+                        WHERE
+                            time = sotm.time AND selected_by IS NOT NULL
+                    )
+                )
+            ORDER BY
+                sotm.time DESC;';
+
+        /** @var list<array{school_id: int, name: string, country_id: string, time: string}> */
+        return \OmegaUp\MySQLConnection::getInstance()->getAll($sql, []);
+    }
+
+    /**
      * @return \OmegaUp\DAO\VO\SchoolOfTheMonth[]
      */
     public static function getByTime(

--- a/frontend/tests/controllers/SchoolOfTheMonthTest.php
+++ b/frontend/tests/controllers/SchoolOfTheMonthTest.php
@@ -343,5 +343,7 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         // Should contain exactly two schools of the month, the one from previous test and
         // the one selected on the current one.
         $this->assertCount(2, $results);
+        $this->assertEquals($schoolsData[0]['school']->name, $results[1]['name']);
+        $this->assertGreaterThan($results[1]['time'], $results[0]['time']);
     }
 }

--- a/frontend/tests/controllers/SchoolOfTheMonthTest.php
+++ b/frontend/tests/controllers/SchoolOfTheMonthTest.php
@@ -343,7 +343,10 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         // Should contain exactly two schools of the month, the one from previous test and
         // the one selected on the current one.
         $this->assertCount(2, $results);
-        $this->assertEquals($schoolsData[0]['school']->name, $results[1]['name']);
+        $this->assertEquals(
+            $schoolsData[0]['school']->name,
+            $results[1]['name']
+        );
         $this->assertGreaterThan($results[1]['time'], $results[0]['time']);
     }
 }

--- a/frontend/tests/controllers/SchoolOfTheMonthTest.php
+++ b/frontend/tests/controllers/SchoolOfTheMonthTest.php
@@ -338,5 +338,10 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
         $this->assertEquals('ok', $result['status']);
         \OmegaUp\Time::setTimeForTesting(null);
+
+        $results = \OmegaUp\DAO\SchoolOfTheMonth::getSchoolsOfTheMonth();
+        // Should contain exactly two schools of the month, the one from previous test and
+        // the one selected on the current one.
+        $this->assertCount(2, $results);
     }
 }


### PR DESCRIPTION
Fixes: #3171 

# Comentarios

@lhchavez en esta consulta estoy asegurándome de que solo se retorne una escuela por mes: la seleccionada por un mentor O la de rank 1 (en caso no haya sido seleccionada alguna en el mismo mes). El mismo approach deberíamos seguir con Coder del Mes, no? Hasta ahora no se ha notado el bug porque no han sido guardados todos los demás coders del mes también en BD, pero con el último cambio que hice en `apiCoderOfTheMonth()`, el otro mes ya se notará, me parece.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
