### PR TITLE
Vueificando el componente de Mini Ranking del navbar left en concursos

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -316,7 +316,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     /**
      * Get all relevant identities for a problemset.
      *
-     * @return array{identity_id: int, username: string, name: string, country_id: string, is_invited: bool}[]
+     * @return array{identity_id: int, username: string, name: string, country_id: string, is_invited: bool, classname: string}[]
      */
     final public static function getAllRelevantIdentities(
         int $problemsetId,
@@ -326,19 +326,36 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         ?int $groupId = null,
         ?bool $excludeAdmin = true
     ): array {
+        $classNameQuery = '
+                        COALESCE (
+                            (SELECT urc.classname
+                            FROM User_Rank_Cutoffs urc
+                            WHERE
+                                urc.score <= (
+                                    SELECT
+                                        ur.score
+                                    FROM
+                                        User_Rank ur
+                                    WHERE
+                                        ur.user_id = i.user_id
+                                )
+                            ORDER BY
+                                urc.percentile ASC
+                            LIMIT 1)
+                        , "user-rank-unranked") AS classname';
         // Build SQL statement
         if ($showAllRuns) {
             if (is_null($groupId)) {
-                $sql = '
+                $sql = "
                     SELECT
-                        i.identity_id, i.username, i.name, i.country_id, pi.is_invited
+                        i.identity_id, i.username, i.name, i.country_id, pi.is_invited, $classNameQuery
                     FROM
                         Identities i
                     INNER JOIN
                         Problemset_Identities pi ON i.identity_id = pi.identity_id
                     WHERE
                         pi.problemset_id = ? AND
-                        (i.user_id NOT IN (SELECT ur.user_id FROM User_Roles ur WHERE ur.acl_id IN (?, ?) AND ur.role_id = ?)';
+                        (i.user_id NOT IN (SELECT ur.user_id FROM User_Roles ur WHERE ur.acl_id IN (?, ?) AND ur.role_id = ?)";
                 $val = [
                     $problemsetId,
                     $aclId,
@@ -351,9 +368,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 }
                 $sql = $sql . 'OR i.user_id IS NULL);';
             } else {
-                $sql = '
+                $sql = "
                     SELECT
-                        i.identity_id, i.username, i.name, i.country_id, 0 as is_invited
+                        i.identity_id, i.username, i.name, i.country_id, 0 as is_invited, $classNameQuery
                     FROM
                         Identities i
                     INNER JOIN
@@ -362,7 +379,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                         gi.group_id = ? AND
                         (i.user_id != (SELECT a.owner_id FROM ACLs a WHERE a.acl_id = ?) AND
                         i.user_id NOT IN (SELECT ur.user_id FROM User_Roles ur WHERE ur.acl_id IN (?, ?) AND ur.role_id = ?)
-                        OR i.user_id IS NULL);';
+                        OR i.user_id IS NULL);";
                 $val = [
                     $groupId,
                     $aclId,
@@ -372,9 +389,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 ];
             }
         } else {
-            $sql = '
+            $sql = "
                 SELECT
-                    i.identity_id, i.username, i.name, i.country_id, 0 as is_invited
+                    i.identity_id, i.username, i.name, i.country_id, 0 as is_invited, $classNameQuery
                 FROM
                     Identities i
                 INNER JOIN
@@ -387,11 +404,11 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                     ON
                         r.run_id = s.current_run_id
                     WHERE
-                        r.verdict NOT IN (\'CE\', \'JE\', \'VE\') AND
+                        r.verdict NOT IN ('CE', 'JE', 'VE') AND
                         s.problemset_id = ? AND
-                        r.status = \'ready\' AND
-                        s.type = \'normal\'
-                    ) rc ON i.identity_id = rc.identity_id';
+                        r.status = 'ready' AND
+                        s.type = 'normal'
+                    ) rc ON i.identity_id = rc.identity_id";
             $val = [$problemsetId];
             if (!is_null($filterUsersBy)) {
                 $sql .= ' WHERE i.username LIKE ?';
@@ -400,9 +417,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             $sql .= ';';
         }
 
-        /** @var array{identity_id: int, username: string, name: string, country_id: string, is_invited: bool}[] */
+        /** @var array{identity_id: int, username: string, name: string, country_id: string, is_invited: bool, classname: string}[] */
         $result = [];
-        /** @var array{identity_id: int, username: string, name: string, country_id: string, is_invited: int} $row */
+        /** @var array{identity_id: int, username: string, name: string, country_id: string, is_invited: int, classname: string} $row */
         foreach (
             \OmegaUp\MySQLConnection::getInstance()->GetAll(
                 $sql,

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -461,7 +461,7 @@ class Scoreboard {
 
     /**
      * @param array{score: float, penalty: int, contest_score: float, problem_id: int, identity_id: int, type: string, time: int, submit_delay: int, guid: string}[] $contestRuns
-     * @param array{identity_id: int, username: string, name: string, country_id: null|string, is_invited: bool}[] $rawContestIdentities
+     * @param array{identity_id: int, username: string, name: string, country_id: null|string, is_invited: bool, classname: string}[] $rawContestIdentities
      * @param array<int, array{order: int, alias: string}> $problemMapping
      * @param int $contestPenalty
      * @param string $contestPenaltyCalcPolicy
@@ -528,6 +528,7 @@ class Scoreboard {
                     $contestant['name'] :
                     $contestant['username'],
                 'country' => $contestant['country_id'],
+                'classname' => $contestant['classname'],
                 'is_invited' => boolval($contestant['is_invited']),
                 self::TOTAL_COLUMN => [
                     'points' => 0.0,
@@ -813,6 +814,7 @@ class Scoreboard {
                     'penalty' => 0.0,
                 ],
                 'country' => $identity['country_id'],
+                'classname' => $identity['classname'],
                 'is_invited' => boolval($identity['is_invited']),
                 self::TOTAL_COLUMN => [
                     'points' => 0.0,

--- a/frontend/templates/arena.contest.admin.tpl
+++ b/frontend/templates/arena.contest.admin.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile={version_hash src='/ux/admin.js'} admin=true showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true inline}
+{include file='arena.contest.tpl' jsfile={version_hash src='/ux/admin.js'} admin=true showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true inline payload=[]}
 

--- a/frontend/templates/arena.contest.tpl
+++ b/frontend/templates/arena.contest.tpl
@@ -35,25 +35,9 @@
 							<span class="solved"></span>
 						</div>
 					</div>
-{if $showRanking}
-					<table id="mini-ranking">
-						<thead>
-							<tr>
-								<th></th>
-								<th>{#wordsUser#}</th>
-								<th class="total" colspan="2">{#wordsTotal#}</th>
-							</tr>
-						</thead>
-						<tbody class="user-list-template">
-							<tr>
-								<td class="position"></td>
-								<td class="user"></td>
-								<td class="points"></td>
-								<td class="penalty"></td>
-							</tr>
-						</tbody>
-					</table>
-{/if}
+
+					<div id="arena-navbar-miniranking"></div>
+					<script type="text/json" id="arena-navbar-payload">{$showRanking|json_encode}</script>
 				</div>
 				<div id="summary" class="main">
 					<h1 data-bind="text: title"></h1>

--- a/frontend/www/js/omegaup/api.d.ts
+++ b/frontend/www/js/omegaup/api.d.ts
@@ -447,6 +447,15 @@ declare namespace omegaup {
     username: string;
   }
 
+  export interface UserRank {
+    penalty: number
+    points: number;
+    position: number;
+    username: string;
+    classname: string;
+    country: string;
+  }
+
   export interface User {
     name?: string;
     username: string;

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -894,7 +894,9 @@ export class Arena {
 
   onRankingChanged(data) {
     let self = this;
-    self.elements.miniRanking.users = [];
+    if (typeof self.elements.miniRanking !== 'undefined') {
+      self.elements.miniRanking.users = [];
+    }
 
     if (self.removeRecentEventClassTimeout) {
       clearTimeout(self.removeRecentEventClassTimeout);
@@ -944,15 +946,17 @@ export class Arena {
 
       // update miniranking
       if (i < 10) {
-        const username = UI.rankingUsername(rank);
-        self.elements.miniRanking.users.push({
-          position: rank.place,
-          username: username,
-          country: rank['country'],
-          classname: rank['classname'],
-          points: rank.total.points,
-          penalty: rank.total.penalty,
-        });
+        if (typeof self.elements.miniRanking !== 'undefined') {
+          const username = UI.rankingUsername(rank);
+          self.elements.miniRanking.users.push({
+            position: rank.place,
+            username: username,
+            country: rank['country'],
+            classname: rank['classname'],
+            points: rank.total.points,
+            penalty: rank.total.penalty,
+          });
+        }
       }
     }
 

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -6,6 +6,7 @@ import arena_CodeView from '../components/arena/CodeView.vue';
 import arena_Scoreboard from '../components/arena/Scoreboard.vue';
 import arena_RunDetails from '../components/arena/RunDetails.vue';
 import qualitynomination_Popup from '../components/qualitynomination/Popup.vue';
+import arena_Navbar_Miniranking from '../components/arena/NavbarMiniranking.vue';
 import UI from '../ui.js';
 import Vue from 'vue';
 
@@ -279,12 +280,39 @@ export class Arena {
       clarification: $('#clarification'),
       clock: $('#title .clock'),
       loadingOverlay: $('#loading'),
-      miniRanking: $('#mini-ranking'),
       problemList: $('#problem-list'),
       ranking: $('#ranking div'),
       socketStatus: $('#title .socket-status'),
       submitForm: $('#submit'),
     };
+
+    const navbar = document.getElementById('arena-navbar-payload');
+    let navbarPayload = false;
+    if (navbar !== null) {
+      navbarPayload = JSON.parse(navbar.innerText);
+    }
+
+    if (document.getElementById('arena-navbar-miniranking') !== null) {
+      self.elements.miniRanking = new Vue({
+        el: '#arena-navbar-miniranking',
+        render: function(createElement) {
+          return createElement('omegaup-arena-navbar-miniranking', {
+            props: {
+              showRanking: this.showRanking,
+              users: this.users,
+            },
+          });
+        },
+        data: {
+          showRanking: navbarPayload,
+          users: [],
+        },
+        components: {
+          'omegaup-arena-navbar-miniranking': arena_Navbar_Miniranking,
+        },
+      });
+    }
+
     if (self.elements.ranking.length) {
       self.elements.rankingTable = new Vue({
         el: self.elements.ranking[0],
@@ -866,7 +894,7 @@ export class Arena {
 
   onRankingChanged(data) {
     let self = this;
-    $('tbody.inserted', self.elements.miniRanking).remove();
+    self.elements.miniRanking.users = [];
 
     if (self.removeRecentEventClassTimeout) {
       clearTimeout(self.removeRecentEventClassTimeout);
@@ -916,26 +944,15 @@ export class Arena {
 
       // update miniranking
       if (i < 10) {
-        let r = $('tbody.user-list-template', self.elements.miniRanking)
-          .clone()
-          .removeClass('user-list-template')
-          .addClass('inserted');
-
-        $('.position', r).html(rank.place);
-        $('.user', r).html(
-          '<span title="' +
-            UI.rankingUsername(rank) +
-            '">' +
-            UI.rankingUsername(rank) +
-            UI.getFlag(rank['country']) +
-            '</span>',
-        );
-        $('.points', r).html(
-          rank.total.points.toFixed(self.digitsAfterDecimalPoint),
-        );
-        $('.penalty', r).html(rank.total.penalty.toFixed(0));
-
-        self.elements.miniRanking.append(r);
+        const username = UI.rankingUsername(rank);
+        self.elements.miniRanking.users.push({
+          position: rank.place,
+          username: username,
+          country: rank['country'],
+          classname: rank['classname'],
+          points: rank.total.points,
+          penalty: rank.total.penalty,
+        });
       }
     }
 

--- a/frontend/www/js/omegaup/components/arena/NavbarMiniranking.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarMiniranking.vue
@@ -1,0 +1,80 @@
+<template>
+  <table class="mini-ranking" v-if="showRanking">
+    <thead>
+      <tr>
+        <th></th>
+        <th>{{ T.wordsUser }}</th>
+        <th class="total" colspan="2">{{ T.wordsTotal }}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody class="user-list-template">
+      <tr v-for="user in users">
+        <td class="position">{{ user.position }}</td>
+        <td class="user">
+          <omegaup-user-username
+            v-bind:classname="user.classname"
+            v-bind:username="user.username"
+            v-bind:country="user.country"
+          >
+          </omegaup-user-username>
+        </td>
+        <td class="points">
+          {{ user.points.toFixed(digitsAfterDecimalPoint) }}
+        </td>
+        <td class="penalty">{{ user.penalty.toFixed(0) }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<style>
+.navbar .mini-ranking {
+  width: 18em;
+  margin-top: 2em;
+}
+.navbar .mini-ranking td {
+  border: 1px solid #000;
+  padding: 0.2em;
+}
+.navbar .mini-ranking th {
+  padding: 0.2em;
+}
+.navbar .mini-ranking .position,
+.navbar .mini-ranking .points,
+.navbar .mini-ranking .penalty {
+  text-align: center;
+}
+.navbar .mini-ranking .user,
+.navbar .mini-ranking .user div span {
+  width: 10em;
+  max-width: 10em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.navbar .mini-ranking td.points {
+  border-right-style: dotted;
+}
+.navbar .mini-ranking td.penalty {
+  border-left-width: 0;
+}
+</style>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import omegaup from '../../api.js';
+import { T } from '../../omegaup.js';
+import user_Username from '../user/Username.vue';
+@Component({
+  components: {
+    'omegaup-user-username': user_Username,
+  },
+})
+export default class ArenaNavbarMiniranking extends Vue {
+  @Prop() showRanking!: boolean;
+  @Prop() users!: omegaup.UserRank[];
+  @Prop({ default: 2 }) digitsAfterDecimalPoint!: number;
+  T = T;
+}
+</script>

--- a/frontend/www/js/omegaup/components/arena/NavbarMiniranking.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarMiniranking.vue
@@ -20,7 +20,7 @@
           </omegaup-user-username>
         </td>
         <td class="points">
-          {{ user.points.toFixed(digitsAfterDecimalPoint) }}
+          {{ user.points.toFixed(2) }}
         </td>
         <td class="penalty">{{ user.penalty.toFixed(0) }}</td>
       </tr>
@@ -74,7 +74,6 @@ import user_Username from '../user/Username.vue';
 export default class ArenaNavbarMiniranking extends Vue {
   @Prop() showRanking!: boolean;
   @Prop() users!: omegaup.UserRank[];
-  @Prop({ default: 2 }) digitsAfterDecimalPoint!: number;
   T = T;
 }
 </script>

--- a/frontend/www/js/omegaup/components/user/Username.vue
+++ b/frontend/www/js/omegaup/components/user/Username.vue
@@ -1,18 +1,23 @@
 <template>
-  <div>
-    <omegaup-countryflag v-bind:country="country"></omegaup-countryflag>
-    <span v-if="linkify"
-      ><a
-        v-bind:class="classname"
-        v-bind:title="username"
-        v-bind:href="`/profile/${username}/`"
-        >{{ username }}</a
-      ></span
-    >
-    <span v-bind:class="classname" v-bind:title="username" v-else="">{{
-      username
-    }}</span>
-  </div>
+  <span v-if="linkify">
+    <omegaup-countryflag
+      v-bind:country="country"
+      v-if="country != null"
+    ></omegaup-countryflag>
+    <a
+      v-bind:class="classname"
+      v-bind:title="username"
+      v-bind:href="`/profile/${username}/`"
+      >{{ username }}</a
+    ></span
+  >
+  <span v-bind:class="classname" v-bind:title="username" v-else="">
+    <omegaup-countryflag
+      v-bind:country="country"
+      v-if="country != null"
+    ></omegaup-countryflag
+    >{{ username }}</span
+  >
 </template>
 
 <style>

--- a/frontend/www/js/omegaup/components/user/Username.vue
+++ b/frontend/www/js/omegaup/components/user/Username.vue
@@ -1,10 +1,18 @@
 <template>
-  <span v-if="linkify"
-    ><a v-bind:class="classname" v-bind:href="`/profile/${username}/`">{{
+  <div>
+    <omegaup-countryflag v-bind:country="country"></omegaup-countryflag>
+    <span v-if="linkify"
+      ><a
+        v-bind:class="classname"
+        v-bind:title="username"
+        v-bind:href="`/profile/${username}/`"
+        >{{ username }}</a
+      ></span
+    >
+    <span v-bind:class="classname" v-bind:title="username" v-else="">{{
       username
-    }}</a></span
-  >
-  <span v-bind:class="classname" v-else="">{{ username }}</span>
+    }}</span>
+  </div>
 </template>
 
 <style>
@@ -40,11 +48,17 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
+import CountryFlag from '../CountryFlag.vue';
 
-@Component
+@Component({
+  components: {
+    'omegaup-countryflag': CountryFlag,
+  },
+})
 export default class UserName extends Vue {
   @Prop() username!: string;
   @Prop() classname!: string;
   @Prop() linkify!: boolean;
+  @Prop() country!: string;
 }
 </script>

--- a/frontend/www/ux/arena.css
+++ b/frontend/www/ux/arena.css
@@ -29,8 +29,7 @@ legend {
 	margin: 0 0.2em 0 0.2em;
 }
 
-.template,
-.user-list-template { display: none; }
+.template { display: none; }
 
 #root,
 #problem,
@@ -164,39 +163,6 @@ body#only-problem #problems .main {
 	position: absolute;
 	top: 0.5em;
 	right: 1em;
-}
-
-#problems #mini-ranking {
-	width: 18em;
-	margin-top: 2em;
-}
-
-#problems #mini-ranking td {
-	border: 1px solid #000;
-	padding: 0.2em;
-}
-
-#problems #mini-ranking th {
-	padding: 0.2em;
-}
-
-#problems #mini-ranking .position,
-#problems #mini-ranking .points,
-#problems #mini-ranking .penalty {
-	text-align: center;
-}
-
-#problems #mini-ranking .user,
-#problems #mini-ranking .user span {
-	width: 10em;
-	max-width: 10em;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-#problems #mini-ranking .user span {
-	display: block;
 }
 
 #problem, #summary {
@@ -455,14 +421,6 @@ body#only-problem #problems .main {
 table.clarifications {
 	width: 100%;
 	margin: 0 auto;
-}
-
-#problems #mini-ranking td.points {
-	border-right-style: dotted;
-}
-
-#problems #mini-ranking td.penalty {
-	border-left-width: 0;
 }
 
 .clarifications tbody td {


### PR DESCRIPTION
# Descripción

Se migra a vue el componente de Mini Ranking que aparece en el navbar de la 
izquierda en los cursos y concursos.

Part of: #3004 

# Comentarios

Están fallando una serie de pruebas aún cuando no estoy modificando nada que
tenga que ver con la tabla de ranking. Seguiré revisando en local que es lo que 
está ocasionando esto.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
