### PR TITLE
Arreglando la falta de payload en los templates de arena

### DIFF
--- a/frontend/templates/arena.contest.tpl
+++ b/frontend/templates/arena.contest.tpl
@@ -115,7 +115,11 @@
 {include file='arena.clarification_list.tpl' contest=true inline}
 		</div>
 		<div id="overlay">
+{if !empty($payload)}
 {include file='arena.runsubmit.tpl' payload=$payload inline}
+{else}
+{include file='arena.runsubmit.tpl' payload=[] inline}
+{/if}
 {include file='arena.clarification.tpl' admin=$admin inline}
 			<div id="run-details"></div>
 		</div>


### PR DESCRIPTION
Este cambio hace que abrir la página de admin de cursos/concursos no
cause un error por la falta de payload.