### PR TITLE
Evitando que se haga un commit vacío en git al cambiar problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -915,14 +915,198 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * Update problem contents
      *
      * @param \OmegaUp\Request $r
-     * @return array{rejudged: bool, status: string}
+     * @return array{rejudged: bool}
      * @throws \OmegaUp\Exceptions\ApiException
      */
     public static function apiUpdate(\OmegaUp\Request $r) {
-        $response = self::updateProblem($r);
-        // All clear
-        $response['status'] = 'ok';
-        return $response;
+        return self::updateProblem($r);
+    }
+
+    /**
+     * @psalm-suppress MixedInferredReturnType foo
+     * @psalm-suppress MismatchingDocblockReturnType foo
+     * @template T
+     * @param T $array
+     * @return T
+     */
+    private static function arrayDeepCopy($array): array {
+        $copy = [];
+        /** @var string $key */
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $copy[$key] = self::arrayDeepCopy($value);
+            } else {
+                $copy[$key] = $value;
+            }
+        }
+        /** @var T */
+        return $copy;
+    }
+
+    /**
+     * Converts a duration into milliseconds.
+     */
+    private static function parseDuration(string $duration): float {
+        $milliseconds = 0.0;
+        if (
+            preg_match_all(
+                '/([0-9]*(?:\\.[0-9]*)?)([a-zµ]+)/',
+                $duration,
+                $matches,
+                PREG_SET_ORDER
+            ) === false
+        ) {
+            return $milliseconds;
+        }
+        /** @var list<string> $match */
+        foreach ($matches as $match) {
+            if ($match[2] == 'h') {
+                $milliseconds += intval($match[1]) * 3600 * 1000;
+            } elseif ($match[2] == 'm') {
+                $milliseconds += intval($match[1]) * 60 * 1000;
+            } elseif ($match[2] == 's') {
+                $milliseconds += intval($match[1]) * 1000;
+            } elseif ($match[2] == 'ms') {
+                $milliseconds += intval($match[1]);
+            } elseif ($match[2] == 'us' || $match[2] == 'µs') {
+                $milliseconds += intval($match[1]) / 1000.0;
+            } elseif ($match[2] == 'ns') {
+                $milliseconds += intval($match[1]) / (1000.0 * 1000.0);
+            } else {
+                throw new \Exception("Unrecognized suffix: {$match[2]}");
+            }
+        }
+        return $milliseconds;
+    }
+
+    /**
+     * Converts a size into bytes.
+     * @param int|string $size
+     */
+    private static function parseSize($size): int {
+        if (is_numeric($size)) {
+            return intval($size);
+        }
+        $bytes = 0;
+        if (
+            preg_match_all(
+                '/([0-9]+)([A-Za-z]+)/',
+                $size,
+                $matches,
+                PREG_SET_ORDER
+            ) === false
+        ) {
+            return $bytes;
+        }
+        /** @var list<string> $match */
+        foreach ($matches as $match) {
+            if ($match[2] == 'TiB') {
+                $bytes += intval($match[1]) * 1024 * 1024 * 1024 * 1024;
+            } elseif ($match[2] == 'GiB') {
+                $bytes += intval($match[1]) * 1024 * 1024 * 1024;
+            } elseif ($match[2] == 'MiB') {
+                $bytes += intval($match[1]) * 1024 * 1024;
+            } elseif ($match[2] == 'KiB') {
+                $bytes += intval($match[1]) * 1024;
+            } elseif ($match[2] == 'B') {
+                $bytes += intval($match[1]);
+            } else {
+                throw new \Exception("Unrecognized suffix: {$match[2]}");
+            }
+        }
+        return $bytes;
+    }
+
+    /**
+     * @param array{limits: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance: float, limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}}} $a
+     * @param array{limits: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance: float, limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}}} $b
+     */
+    private static function diffProblemSettings(array $a, array $b): bool {
+        if (
+            self::parseDuration($a['limits']['TimeLimit']) !=
+            self::parseDuration($b['limits']['TimeLimit'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseDuration($a['limits']['ExtraWallTime']) !=
+            self::parseDuration($b['limits']['ExtraWallTime'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseDuration($a['limits']['OverallWallTimeLimit']) !=
+            self::parseDuration($b['limits']['OverallWallTimeLimit'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseSize($a['limits']['MemoryLimit']) !=
+            self::parseSize($b['limits']['MemoryLimit'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseSize($a['limits']['OutputLimit']) !=
+            self::parseSize($b['limits']['OutputLimit'])
+        ) {
+            return true;
+        }
+        if ($a['validator']['name'] != $b['validator']['name']) {
+            return true;
+        }
+        if ($a['validator']['tolerance'] != $b['validator']['tolerance']) {
+            return true;
+        }
+        if (
+            empty($a['validator']['limits']) !=
+            empty($b['validator']['limits'])
+        ) {
+            return true;
+        }
+        // No further checks are necessary.
+        if (
+            empty($a['validator']['limits']) ||
+            empty($b['validator']['limits'])
+        ) {
+            return false;
+        }
+
+        if (
+            self::parseDuration($a['validator']['limits']['TimeLimit']) !=
+            self::parseDuration($b['validator']['limits']['TimeLimit'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseDuration($a['validator']['limits']['ExtraWallTime']) !=
+            self::parseDuration($b['validator']['limits']['ExtraWallTime'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseDuration(
+                $a['validator']['limits']['OverallWallTimeLimit']
+            ) !=
+            self::parseDuration(
+                $b['validator']['limits']['OverallWallTimeLimit']
+            )
+        ) {
+            return true;
+        }
+        if (
+            self::parseSize($a['validator']['limits']['MemoryLimit']) !=
+            self::parseSize($b['validator']['limits']['MemoryLimit'])
+        ) {
+            return true;
+        }
+        if (
+            self::parseSize($a['validator']['limits']['OutputLimit']) !=
+            self::parseSize($b['validator']['limits']['OutputLimit'])
+        ) {
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -952,7 +1136,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         self::updateValueProperties($r, $problem, $valueProperties);
 
         $response = [
-            'rejudged' => false
+            'rejudged' => false,
         ];
 
         $problemSettings = self::getProblemSettingsDistrib(
@@ -961,7 +1145,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
         unset($problemSettings['cases']);
         unset($problemSettings['slow']);
+        $originalProblemSettings = self::arrayDeepCopy($problemSettings);
         self::updateProblemSettings($problemSettings, $r);
+        $settingsUpdated = self::diffProblemSettings(
+            $originalProblemSettings,
+            $problemSettings
+        );
         $acceptsSubmissions = $problem->languages !== '';
         $updatePublished = \OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS;
         if (!is_null($r['update_published'])) {
@@ -982,42 +1171,46 @@ class Problem extends \OmegaUp\Controllers\Controller {
             ) {
                 $operation = \OmegaUp\ProblemDeployer::UPDATE_CASES;
             }
-            $problemDeployer = new \OmegaUp\ProblemDeployer(
-                $problem->alias,
-                $acceptsSubmissions,
-                $updatePublished != \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NONE
-            );
-            $problemDeployer->commit(
-                $r['message'],
-                $r->identity,
-                $operation,
-                $problemSettings
-            );
-
-            $response['rejudged'] = false;
-            $needsUpdate = false;
-            if (!is_null($problemDeployer->publishedCommit)) {
-                $oldCommit = $problem->commit;
-                $oldVersion = $problem->current_version;
-                [$problem->commit, $problem->current_version] = \OmegaUp\Controllers\Problem::resolveCommit(
-                    $problem,
-                    $problemDeployer->publishedCommit
+            if ($operation != \OmegaUp\ProblemDeployer::UPDATE_SETTINGS || $settingsUpdated) {
+                $problemDeployer = new \OmegaUp\ProblemDeployer(
+                    $problem->alias,
+                    $acceptsSubmissions,
+                    $updatePublished != \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NONE
                 );
-                $response['rejudged'] = ($oldVersion != $problem->current_version);
-                $needsUpdate = $response['rejudged'] || ($oldCommit != $problem->commit);
-            }
+                $problemDeployer->commit(
+                    $r['message'],
+                    $r->identity,
+                    $operation,
+                    $problemSettings
+                );
 
-            if ($needsUpdate) {
-                \OmegaUp\DAO\Runs::createRunsForVersion($problem);
-                \OmegaUp\DAO\Runs::updateVersionToCurrent($problem);
-                if ($updatePublished != \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NON_PROBLEMSET) {
-                    \OmegaUp\DAO\ProblemsetProblems::updateVersionToCurrent(
+                $needsUpdate = false;
+                if (!is_null($problemDeployer->publishedCommit)) {
+                    $oldCommit = $problem->commit;
+                    $oldVersion = $problem->current_version;
+                    [
+                        $problem->commit,
+                        $problem->current_version,
+                    ] = \OmegaUp\Controllers\Problem::resolveCommit(
                         $problem,
-                        $r->user,
-                        $updatePublished
+                        $problemDeployer->publishedCommit
                     );
+                    $response['rejudged'] = ($oldVersion != $problem->current_version);
+                    $needsUpdate = $response['rejudged'] || ($oldCommit != $problem->commit);
                 }
-                $updatedStatementLanguages = $problemDeployer->getUpdatedLanguages();
+
+                if ($needsUpdate) {
+                    \OmegaUp\DAO\Runs::createRunsForVersion($problem);
+                    \OmegaUp\DAO\Runs::updateVersionToCurrent($problem);
+                    if ($updatePublished != \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NON_PROBLEMSET) {
+                        \OmegaUp\DAO\ProblemsetProblems::updateVersionToCurrent(
+                            $problem,
+                            $r->user,
+                            $updatePublished
+                        );
+                    }
+                    $updatedStatementLanguages = $problemDeployer->getUpdatedLanguages();
+                }
             }
 
             // Save the contest object with data sent by user to the database
@@ -1034,8 +1227,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         } catch (\Exception $e) {
             // Operation failed in the data layer, rollback transaction
             \OmegaUp\DAO\DAO::transRollback();
-            self::$log->error('Failed to update problem');
-            self::$log->error($e);
+            self::$log->error('Failed to update problem', $e);
 
             throw $e;
         }
@@ -1068,7 +1260,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         if ($r['redirect'] === true) {
-            header('Location: ' . $_SERVER['HTTP_REFERER']);
+            header("Location: {$_SERVER['HTTP_REFERER']}");
         }
 
         self::invalidateCache($problem, $updatedStatementLanguages);
@@ -1566,17 +1758,17 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * if needed.
      *
      * @param \OmegaUp\DAO\VO\Problems $problem the problem.
-     * @return array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int}, validator: mixed}
+     * @return array{cases: array<string, mixed>, limits: array{ExtraWallTime: string, TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int|string, OutputLimit: int|string}, validator: array{limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, name: string, tolerance: float}}
      */
     private static function getProblemSettingsDistrib(
         \OmegaUp\DAO\VO\Problems $problem,
         string $commit
     ): array {
-        /** @var array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int}, validator: mixed} */
+        /** @var array{cases: array<string, mixed>, limits: array{ExtraWallTime: string, TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int|string, OutputLimit: int|string}, validator: array{limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, name: string, tolerance: float}} */
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::PROBLEM_SETTINGS_DISTRIB,
             "{$problem->alias}-{$problem->commit}",
-            /** @return array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int}, validator: mixed} */
+            /** @return array{cases: array<string, mixed>, limits: array{ExtraWallTime: string, TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int|int, OutputLimit: int|string}, validator: array{limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, name: string, tolerance: float}} */
             function () use ($problem): array {
                 return \OmegaUp\Controllers\Problem::getProblemSettingsDistribImpl([
                     'alias' => strval($problem->alias),
@@ -1591,10 +1783,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * Gets the distributable problem settings for the problem.
      *
      * @param array{alias: string, commit: string} $params
-     * @return array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int}, validator: mixed}
+     * @return array{cases: array<string, mixed>, limits: array{ExtraWallTime: string, TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int|int, OutputLimit: int|string}, validator: array{limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, name: string, tolerance: float}}
      */
     public static function getProblemSettingsDistribImpl(array $params): array {
-        /** @var array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int}, validator: mixed} */
+        /** @var array{cases: array<string, mixed>, limits: array{ExtraWallTime: string, TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int|int, OutputLimit: int|string}, validator: array{limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, name: string, tolerance: float}} */
         return json_decode(
             (new \OmegaUp\ProblemArtifacts(
                 $params['alias'],
@@ -1785,7 +1977,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get the extra problem details with all the validations
-     * @return null|array{statement: array{language: string, images: array<string, string>, markdown: string}, settings: array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int}, validator: mixed}, preferred_language?: string, problemsetter?: array{username: string, name: string, creation_date: int}, version: string, commit: string, title: string, alias: string, input_limit: int, visits: int, submissions: int, accepted: int, difficulty: null|float, creation_date: int, source?: string, order: string, points: null|float, visibility: int, languages: string[], email_clarifications: bool, runs?: array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float, time: int, submit_delay: int, alias: string, username: string}[], admin?: bool, solvers?: array{username: string, language: string, runtime: float, memory: float, time: int}[], points: float, score: float}
+     * @return null|array{statement: array{language: string, images: array<string, string>, markdown: string}, settings: array{cases: array<string, mixed>, limits: array{TimeLimit: string, OverallWallTimeLimit: string, MemoryLimit: int|string}, validator: mixed}, preferred_language?: string, problemsetter?: array{username: string, name: string, creation_date: int}, version: string, commit: string, title: string, alias: string, input_limit: int, visits: int, submissions: int, accepted: int, difficulty: null|float, creation_date: int, source?: string, order: string, points: null|float, visibility: int, languages: string[], email_clarifications: bool, runs?: array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float, time: int, submit_delay: int, alias: string, username: string}[], admin?: bool, solvers?: array{username: string, language: string, runtime: float, memory: float, time: int}[], points: float, score: float}
      */
     private static function getProblemDetails(
         \OmegaUp\Request $r,
@@ -1872,7 +2064,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\Problems::isVisible($problem) ||
             \OmegaUp\Authorization::isProblemAdmin($r->identity, $problem)
         ) {
-            $acl = \OmegaUp\DAO\ACLs::getByPK($problem->acl_id);
+            $acl = \OmegaUp\DAO\ACLs::getByPK(intval($problem->acl_id));
             if (is_null($acl->owner_id)) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotFound');
             }
@@ -3187,7 +3379,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a Problem settings object with default values.
      *
-     * @return array The Problem settings object.
+     * @return array{limits: array{ExtraWallTime: string, MemoryLimit: string, OutputLimit: string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance: float}} The Problem settings object.
      */
     private static function getDefaultProblemSettings(): array {
         return [
@@ -3201,13 +3393,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'validator' => [
                 'name' => \OmegaUp\ProblemParams::VALIDATOR_TOKEN,
                 'tolerance' => 1e-9,
-                'limits' => [
-                    'ExtraWallTime' => '0s',
-                    'MemoryLimit' => '256MiB',
-                    'OutputLimit' => '10KiB',
-                    'OverallWallTimeLimit' => '5s',
-                    'TimeLimit' => '30s',
-                ],
             ],
         ];
     }
@@ -3215,8 +3400,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Updates the Problem's settings with the values from the request.
      *
-     * @param array $problemSettings the original problem settings.
+     * @param array{limits: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance: float, limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}}} $problemSettings the original problem settings.
      * @param \OmegaUp\Request $r the request
+     * @psalm-suppress ReferenceConstraintViolation for some reason, psalm cannot correctly infer the type for $problemSettings['validator']['limit']
      */
     private static function updateProblemSettings(
         array &$problemSettings,
@@ -3233,14 +3419,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
             ) . 'KiB';
         }
         if (!is_null($r['output_limit'])) {
-            $problemSettings['limits']['OutputLimit'] = intval(
+            $problemSettings['limits']['OutputLimit'] = strval(
                 $r['output_limit']
             );
         }
         if (!is_null($r['overall_wall_time_limit'])) {
-            $problemSettings['limits']['OverallWallTimeLimit'] = (
-                intval($r['overall_wall_time_limit']) . 'ms'
-            );
+            $problemSettings['limits']['OverallWallTimeLimit'] = intval(
+                $r['overall_wall_time_limit']
+            ) . 'ms';
         }
         if (!is_null($r['time_limit'])) {
             $problemSettings['limits']['TimeLimit'] = intval(
@@ -3248,9 +3434,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             ) . 'ms';
         }
         if (!is_null($r['validator'])) {
-            $problemSettings['validator']['name'] = $r['validator'];
+            $problemSettings['validator']['name'] = strval($r['validator']);
         }
-        if (!is_null($r['validator_time_limit'])) {
+        if ($problemSettings['validator']['name'] == 'custom') {
             if (empty($problemSettings['validator']['limits'])) {
                 $problemSettings['validator']['limits'] = [
                     'ExtraWallTime' => '0s',
@@ -3260,9 +3446,15 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'TimeLimit' => '30s',
                 ];
             }
-            $problemSettings['validator']['limits']['TimeLimit'] = (
-                intval($r['validator_time_limit']) . 'ms'
-            );
+            if (!is_null($r['validator_time_limit'])) {
+                $problemSettings['validator']['limits']['TimeLimit'] = intval(
+                    $r['validator_time_limit']
+                ) . 'ms';
+            }
+        } else {
+            if (!empty($problemSettings['validator']['limits'])) {
+                unset($problemSettings['validator']['limits']);
+            }
         }
     }
 
@@ -3352,7 +3544,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             isset($details['settings']['cases']['sample']) &&
             isset($result['settings']['cases']['sample']['in'])
         ) {
-            $result['sample_input'] = $result['settings']['cases']['sample']['in'];
+            $result['sample_input'] = strval(
+                $result['settings']['cases']['sample']['in']
+            );
         }
         $details['histogram'] = [
             'difficulty_histogram' => $problem->difficulty_histogram,
@@ -3548,7 +3742,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         if (isset($r['request']) && ($r['request'] === 'submit')) {
             // HACK to prevent fails in validateCreateOrUpdate
-            $r['problem_alias'] = $r['alias'];
+            $r['problem_alias'] = strval($r['alias']);
 
             try {
                 self::createProblem(

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -90,16 +90,14 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'problem_alias' => $problemData['request']['problem_alias'],
             'message' => 'Changed some properties',
         ]));
+        $this->assertTrue($response['rejudged']);
+        unset($_FILES['problem_contents']);
 
         // Verify data in DB
         $problems = \OmegaUp\DAO\Problems::getByTitle($newTitle);
 
         // Check that we only retreived 1 element
         $this->assertEquals(1, count($problems));
-
-        // Validate rsponse
-        $this->assertEquals('ok', $response['status']);
-        $this->assertEquals(true, $response['rejudged']);
 
         {
             $problemArtifacts = new \OmegaUp\ProblemArtifacts(
@@ -144,8 +142,8 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'problem_alias' => $problemData['request']['problem_alias'],
             'message' => 'Add example',
         ]));
-        $this->assertEquals('ok', $response['status']);
-        $this->assertEquals(false, $response['rejudged']);
+        $this->assertFalse($response['rejudged']);
+        unset($_FILES['problem_contents']);
         {
             $problemArtifacts = new \OmegaUp\ProblemArtifacts(
                 $problemData['request']['problem_alias']
@@ -230,13 +228,8 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'problem_alias' => $problemAlias,
             'message' => 'Increased time limit',
         ]));
-
-        // Validate response
-        $this->assertEquals('ok', $response['status']);
-        $this->assertTrue(
-            $response['rejudged'],
-            'Problem should have been rejudged'
-        );
+        $this->assertTrue($response['rejudged']);
+        unset($_FILES['problem_contents']);
 
         // Verify problem settings were set.
         {
@@ -281,6 +274,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'problem_alias' => $problemData['request']['problem_alias'],
             'message' => 'Changed alias and languages',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         // Verify data in DB
         $problem = \OmegaUp\DAO\Problems::getByAlias(
@@ -290,28 +284,28 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         // Check that we only retrieved 1 element
         $this->assertNotNull($problem);
         $this->assertEqualSets($languages, $problem->languages);
-
-        // Validate response
-        $this->assertEquals('ok', $response['status']);
     }
 
-    /**
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
-     */
     public function testUpdateProblemWithInvalidLanguages() {
         // Get a problem
         $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
 
         $login = self::login($problemData['author']);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'languages' => 'cows,hs,java,pl',
-            'problem_alias' => $problemData['request']['alias'],
-            'message' => 'Changed invalid languages',
-        ]);
 
-        //Call API
-        $response = \OmegaUp\Controllers\Problem::apiUpdate($r);
+        try {
+            \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'languages' => 'cows,hs,java,pl',
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'message' => 'Changed invalid languages',
+            ]));
+            $this->fail('Expected update to fail');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals(
+                'parameterNotInExpectedSet',
+                $e->getMessage()
+            );
+        }
     }
 
     /**
@@ -424,11 +418,9 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         // Update Problem calls grader to rejudge, we need to detour grader calls
         $detourGrader = new \OmegaUp\Test\ScopedGraderDetour();
 
-        // Set file upload context. This problem should fail
-        $_FILES['problem_contents']['tmp_name'] = OMEGAUP_TEST_RESOURCES_ROOT . 'nostmt.zip';
-
         // Call API. Should fail
         try {
+            $_FILES['problem_contents']['tmp_name'] = OMEGAUP_TEST_RESOURCES_ROOT . 'nostmt.zip';
             $login = self::login($problemData['author']);
             \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
@@ -443,6 +435,8 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
                 'problemDeployerNoStatements',
                 $e->getMessage()
             );
+        } finally {
+            unset($_FILES['problem_contents']);
         }
 
         // Verify contents were not erased
@@ -489,6 +483,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'title' => $newTitle,
             'message' => 'Admin powers',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         // Verify data in DB
         $problems = \OmegaUp\DAO\Problems::getByTitle($newTitle);
@@ -535,6 +530,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'title' => $newTitle,
             'message' => 'Non-admin powers',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         // Verify data in DB
         $problems = \OmegaUp\DAO\Problems::getByTitle($newTitle);
@@ -651,51 +647,58 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         $problem = $problemData['problem'];
 
         // Make it private.
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
             'message' => 'public -> private',
         ]));
+        $this->assertFalse($response['rejudged']);
 
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
             'message' => 'no-op',
         ]));
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $this->assertFalse($response['rejudged']);
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'message' => 'no-op',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         // Make it public
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
             'message' => 'private -> public',
         ]));
+        $this->assertFalse($response['rejudged']);
 
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
             'message' => 'no-op',
         ]));
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $this->assertFalse($response['rejudged']);
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'message' => 'no-op',
         ]));
+        $this->assertFalse($response['rejudged']);
 
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED,
             'message' => 'public -> banned',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         try {
             \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
@@ -706,23 +709,29 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             ]));
             $this->fail('Cannot ban problem from API');
         } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals(
+                $e->getMessage(),
+                'qualityNominationProblemHasBeenBanned'
+            );
         }
 
         // Ban the problem.
         $problem->visibility = \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED;
         \OmegaUp\DAO\Problems::update($problem);
 
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED,
             'message' => 'no-op',
         ]));
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $this->assertFalse($response['rejudged']);
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'message' => 'no-op',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         try {
             \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
@@ -758,17 +767,19 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         $problem->visibility = \OmegaUp\ProblemParams::VISIBILITY_PROMOTED;
         \OmegaUp\DAO\Problems::update($problem);
 
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'visibility' => \OmegaUp\ProblemParams::VISIBILITY_PROMOTED,
             'message' => 'no-op',
         ]));
-        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+        $this->assertFalse($response['rejudged']);
+        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'problem_alias' => $problem->alias,
             'message' => 'no-op',
         ]));
+        $this->assertFalse($response['rejudged']);
 
         try {
             \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
@@ -902,7 +913,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         {
             $_FILES['problem_contents']['tmp_name'] = OMEGAUP_TEST_RESOURCES_ROOT . 'mrkareltastic.zip';
             $detourGrader = new \OmegaUp\Test\ScopedGraderDetour();
-            \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+            $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'problem_alias' => $problem->alias,
                 'message' => 'Changed to mrkareltastic',
@@ -914,7 +925,9 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
                 'memory_limit' => 64000,
                 'output_limit' => 20480,
             ]));
+            $this->assertTrue($response['rejudged']);
             $this->assertEquals(1, $detourGrader->getGraderCallCount());
+            unset($_FILES['problem_contents']);
         foreach ($detourGrader->getRuns() as $run) {
             \OmegaUp\Test\Factories\Run::gradeRun(
                 null,
@@ -949,7 +962,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         {
             $_FILES['problem_contents']['tmp_name'] = OMEGAUP_TEST_RESOURCES_ROOT . 'testproblem.zip';
             $detourGrader = new \OmegaUp\Test\ScopedGraderDetour();
-            \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+            $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'problem_alias' => $problem->alias,
                 'message' => 'Changed back',
@@ -961,7 +974,9 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
                 'memory_limit' => 32000,
                 'output_limit' => 10240,
             ]));
+            $this->assertTrue($response['rejudged']);
             $this->assertEquals(0, $detourGrader->getGraderCallCount());
+            unset($_FILES['problem_contents']);
         }
 
         $restoredVersionData = \OmegaUp\Controllers\Problem::apiVersions(new \OmegaUp\Request([
@@ -1152,7 +1167,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             // Change the problem to something completely different.
             $_FILES['problem_contents']['tmp_name'] = OMEGAUP_TEST_RESOURCES_ROOT . 'mrkareltastic.zip';
             $detourGrader = new \OmegaUp\Test\ScopedGraderDetour();
-            \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+            $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'problem_alias' => $problem->alias,
                 'message' => 'Changed to mrkareltastic',
@@ -1165,6 +1180,10 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
                 'output_limit' => 20480,
                 'update_published' => $updatePublished,
             ]));
+            $this->assertEquals(
+                $response['rejudged'],
+                $updatePublished != 'none'
+            );
             // Runs are only added when the publishing mode is not none.
             $this->assertEquals(
                 $updatePublished === \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NONE ? 0 : 3,
@@ -1191,6 +1210,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             ];
         } finally {
             \OmegaUp\Time::setTimeForTesting($originalTime);
+            unset($_FILES['problem_contents']);
         }
     }
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -655,20 +655,10 @@
       <code>$casesStats['counts']</code>
       <code>$casesStats['counts']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="8">
-      <code>$problemSettings['limits']['ExtraWallTime']</code>
-      <code>$problemSettings['limits']['MemoryLimit']</code>
-      <code>$problemSettings['limits']['OutputLimit']</code>
-      <code>$problemSettings['limits']['OverallWallTimeLimit']</code>
-      <code>$problemSettings['limits']['TimeLimit']</code>
-      <code>$problemSettings['validator']['name']</code>
-      <code>$problemSettings['validator']['limits']</code>
-      <code>$problemSettings['validator']['limits']</code>
-    </MixedArrayAssignment>
     <MixedArrayOffset occurrences="1">
       <code>$casesStats['counts'][$case['name']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="31">
+    <MixedAssignment occurrences="30">
       <code>$response['tags']</code>
       <code>$run</code>
       <code>$problem</code>
@@ -703,8 +693,6 @@
       <code>$problemArray</code>
       <code>$addedProblems[]</code>
       <code>$deletedLanguages</code>
-      <code>$problemSettings['validator']['name']</code>
-      <code>$result['sample_input']</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
@@ -713,8 +701,7 @@
       <code>asArray</code>
       <code>asArray</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="2">
-      <code>$_SERVER['HTTP_REFERER']</code>
+    <MixedOperand occurrences="1">
       <code>$casesStats['counts'][$case['name']]</code>
     </MixedOperand>
     <MixedPropertyAssignment occurrences="5">
@@ -756,7 +743,6 @@
       <code>$r-&gt;identity</code>
       <code>$problem</code>
       <code>$r-&gt;identity</code>
-      <code>$problem-&gt;acl_id</code>
       <code>$r-&gt;identity</code>
       <code>$r-&gt;user</code>
       <code>$problem-&gt;alias</code>


### PR DESCRIPTION
Este cambio hace que si no se está cambiando nada en la configuración
del problema, no se inserte ningún commit en la historia de git.