### PR TITLE
Arreglando el cierre del popup de nominaciones

### DIFF
--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -44,11 +44,21 @@ def test_user_ranking_course(driver):
         driver.update_score_in_course(problem, assignment_alias)
 
         # When user has tried or solved a problem, feedback popup will be shown
+        with util.dismiss_status(driver):
+            driver.wait.until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR,
+                     '.popup button.close'))).click()
+            driver.wait.until(
+                EC.invisibility_of_element_located(
+                    (By.CSS_SELECTOR,
+                     '.popup button.close')))
+
         driver.wait.until(
             EC.element_to_be_clickable(
-                (By.CSS_SELECTOR,
-                 '.popup button.close'))).click()
-
+                (By.XPATH,
+                 ('//a[contains(text(), "%s")]/parent::div' %
+                  problem.title())))).click()
         driver.wait.until(
             EC.element_to_be_clickable(
                 (By.CSS_SELECTOR,


### PR DESCRIPTION
Este cambio hace que al cerrar el popup de nominaciones, se espere a que
ya no esté en la pantalla. También, como al cerrar ese popup se muestra
el statusbar, también se cierra ese. Y como al cerrar ese, se navega
afuera del problema, hay que volver a entrar para continuar la prueba.