### PR TITLE
Arreglando las pruebas locales de badges

### DIFF
--- a/frontend/tests/BadgesTestCase.php
+++ b/frontend/tests/BadgesTestCase.php
@@ -16,10 +16,27 @@ class BadgesTestCase extends \OmegaUp\Test\ControllerTestCase {
     const QUERY_FILE = 'query.sql';
     const TEST_FILE = 'test.json';
 
+    /**
+     * @readonly
+     * @var \OmegaUp\FileUploader
+     */
+    private $originalFileUploader;
+
     public function setUp() {
         parent::setUp();
         \OmegaUp\Time::setTimeForTesting(null);
         \OmegaUp\Test\Utils::CleanupDb();
+        $this->originalFileUploader = \OmegaUp\FileHandler::getfileUploader();
+        \OmegaUp\FileHandler::setFileUploaderForTesting(
+            $this->createFileUploaderMock()
+        );
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+        \OmegaUp\FileHandler::setFileUploaderForTesting(
+            $this->originalFileUploader
+        );
     }
 
     public static function getSortedResults(string $query) {

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -30,7 +30,9 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
                 $params[$k] = $v;
             }
             if (array_key_exists('files', $req)) {
-                $_FILES['problem_contents']['tmp_name'] = $req['files']['problem_contents'];
+                $_FILES['problem_contents']['tmp_name'] = (
+                    OMEGAUP_ROOT . "/../{$req['files']['problem_contents']}"
+                );
             }
             if ($req['api'] === '\\OmegaUp\\Controllers\\QualityNomination::apiCreate') {
                 $params['contents'] = json_encode($params['contents']);
@@ -115,9 +117,6 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
     }
 
     public function runBadgeTest($testPath, $queryPath, $badge): void {
-        \OmegaUp\FileHandler::setFileUploaderForTesting(
-            $this->createFileUploaderMock()
-        );
         $content = json_decode(file_get_contents($testPath), true);
         \OmegaUp\Test\Utils::cleanupFilesAndDB();
         switch ($content['testType']) {


### PR DESCRIPTION
Este cambio hace que BadgestTestCase sea el que establece (y regresa) el
FileUploaderMock. Esto hace que si se corren las pruebas de badges
individualmente de manera local, no fallen.