### PR TITLE
Arreglando más caracteres especiales en Markdown

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -778,8 +778,12 @@ let UI = {
                 columns += 2;
               } else {
                 result += `<td><pre>${escapeCharacters(
-                  matches[i + 1].replace(/\s+$/, ''),
-                  ' \t*_{}[]()>#+-=.!|`',
+                  matches[i + 1]
+                    .replace(/\s+$/, '')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;'),
+                  ' \t*_{}[]()<>#+=.!|`-',
                   /*afterBackslash=*/ false,
                   /*doNotEscapeTildeAnDollar=*/ true,
                 )}</pre></td>`;
@@ -821,7 +825,7 @@ let UI = {
           }
           contents = escapeCharacters(
             lines.join('\n'),
-            ' \t*_{}[]()>#+-=.!|`',
+            ' \t*_{}[]()<>#+=.!|`-',
             /*afterBackslash=*/ false,
             /*doNotEscapeTildeAnDollar=*/ true,
           );

--- a/frontend/www/js/omegaup/ui.test.js
+++ b/frontend/www/js/omegaup/ui.test.js
@@ -118,12 +118,14 @@ ____
 github flavored markdown
 \`\`\`
 
-> hi
-> hello
+> hi <
+> hello <
 
     other kind of blockquote
 
 Other escapes: $~~T~D~E32E
+
+Tags <b>hello</b>
 ||output
 0
 ||end`),
@@ -152,12 +154,14 @@ ____
 github flavored markdown
 \`\`\`
 
-> hi
-> hello
+&gt; hi &lt;
+&gt; hello &lt;
 
     other kind of blockquote
 
-Other escapes: $~~T~D~E32E</pre></td><td><pre>0</pre></td></tr></tbody>
+Other escapes: $~~T~D~E32E
+
+Tags &lt;b&gt;hello&lt;/b&gt;</pre></td><td><pre>0</pre></td></tr></tbody>
 </table>`);
     });
 


### PR DESCRIPTION
Este cambio arregla los caracteres <, >, y & en Markdown. Se están
HTML-escapando ahora para que se muestren bien.

Fixes: #3258