### PR TITLE
Dejando de usar @psalm-return

### DIFF
--- a/frontend/server/src/DAO/Base/ACLs.php
+++ b/frontend/server/src/DAO/Base/ACLs.php
@@ -136,10 +136,8 @@ abstract class ACLs {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ACLs[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ACLs> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ACLs}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ACLs>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Announcement.php
+++ b/frontend/server/src/DAO/Base/Announcement.php
@@ -144,10 +144,8 @@ abstract class Announcement {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Announcement[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Announcement> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Announcement}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Announcement>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Assignments.php
+++ b/frontend/server/src/DAO/Base/Assignments.php
@@ -185,10 +185,8 @@ abstract class Assignments {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Assignments[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Assignments> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Assignments}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Assignments>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -206,10 +206,8 @@ abstract class AuthTokens {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\AuthTokens[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\AuthTokens> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\AuthTokens}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\AuthTokens>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Clarifications.php
+++ b/frontend/server/src/DAO/Base/Clarifications.php
@@ -171,10 +171,8 @@ abstract class Clarifications {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Clarifications[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Clarifications> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Clarifications}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Clarifications>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/CoderOfTheMonth.php
@@ -166,10 +166,8 @@ abstract class CoderOfTheMonth {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\CoderOfTheMonth[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\CoderOfTheMonth> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\CoderOfTheMonth}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\CoderOfTheMonth>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ContestLog.php
+++ b/frontend/server/src/DAO/Base/ContestLog.php
@@ -154,10 +154,8 @@ abstract class ContestLog {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ContestLog[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ContestLog> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ContestLog}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ContestLog>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Contests.php
+++ b/frontend/server/src/DAO/Base/Contests.php
@@ -220,10 +220,8 @@ abstract class Contests {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Contests[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Contests> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Contests}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Contests>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Countries.php
+++ b/frontend/server/src/DAO/Base/Countries.php
@@ -174,10 +174,8 @@ abstract class Countries {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Countries[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Countries> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Countries}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Countries>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Courses.php
+++ b/frontend/server/src/DAO/Base/Courses.php
@@ -181,10 +181,8 @@ abstract class Courses {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Courses[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Courses> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Courses}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Courses>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Emails.php
+++ b/frontend/server/src/DAO/Base/Emails.php
@@ -139,10 +139,8 @@ abstract class Emails {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Emails[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Emails> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Emails}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Emails>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Favorites.php
+++ b/frontend/server/src/DAO/Base/Favorites.php
@@ -109,10 +109,8 @@ abstract class Favorites {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Favorites[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Favorites> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Favorites}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Favorites>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/GroupRoles.php
+++ b/frontend/server/src/DAO/Base/GroupRoles.php
@@ -114,10 +114,8 @@ abstract class GroupRoles {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\GroupRoles[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\GroupRoles> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\GroupRoles}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\GroupRoles>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -150,10 +150,8 @@ abstract class Groups {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Groups[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Groups> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Groups}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Groups>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/GroupsIdentities.php
+++ b/frontend/server/src/DAO/Base/GroupsIdentities.php
@@ -229,10 +229,8 @@ abstract class GroupsIdentities {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\GroupsIdentities[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\GroupsIdentities> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\GroupsIdentities}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\GroupsIdentities>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/GroupsScoreboards.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboards.php
@@ -150,10 +150,8 @@ abstract class GroupsScoreboards {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\GroupsScoreboards[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\GroupsScoreboards> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\GroupsScoreboards}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\GroupsScoreboards>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
@@ -199,10 +199,8 @@ abstract class GroupsScoreboardsProblemsets {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\GroupsScoreboardsProblemsets[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\GroupsScoreboardsProblemsets> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\GroupsScoreboardsProblemsets}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\GroupsScoreboardsProblemsets>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Identities.php
+++ b/frontend/server/src/DAO/Base/Identities.php
@@ -168,10 +168,8 @@ abstract class Identities {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Identities[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Identities> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Identities}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Identities>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/Base/IdentitiesSchools.php
@@ -156,10 +156,8 @@ abstract class IdentitiesSchools {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\IdentitiesSchools[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\IdentitiesSchools> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\IdentitiesSchools}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\IdentitiesSchools>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/IdentityLoginLog.php
+++ b/frontend/server/src/DAO/Base/IdentityLoginLog.php
@@ -34,10 +34,8 @@ abstract class IdentityLoginLog {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\IdentityLoginLog[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\IdentityLoginLog> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\IdentityLoginLog}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\IdentityLoginLog>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Interviews.php
+++ b/frontend/server/src/DAO/Base/Interviews.php
@@ -159,10 +159,8 @@ abstract class Interviews {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Interviews[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Interviews> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Interviews}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Interviews>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Languages.php
+++ b/frontend/server/src/DAO/Base/Languages.php
@@ -135,10 +135,8 @@ abstract class Languages {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Languages[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Languages> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Languages}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Languages>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Messages.php
+++ b/frontend/server/src/DAO/Base/Messages.php
@@ -154,10 +154,8 @@ abstract class Messages {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Messages[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Messages> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Messages}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Messages>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Notifications.php
+++ b/frontend/server/src/DAO/Base/Notifications.php
@@ -147,10 +147,8 @@ abstract class Notifications {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Notifications[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Notifications> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Notifications}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Notifications>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Permissions.php
+++ b/frontend/server/src/DAO/Base/Permissions.php
@@ -135,10 +135,8 @@ abstract class Permissions {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Permissions[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Permissions> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Permissions}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Permissions>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
@@ -148,10 +148,8 @@ abstract class PrivacyStatementConsentLog {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\PrivacyStatementConsentLog[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\PrivacyStatementConsentLog> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\PrivacyStatementConsentLog}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\PrivacyStatementConsentLog>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/PrivacyStatements.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatements.php
@@ -135,10 +135,8 @@ abstract class PrivacyStatements {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\PrivacyStatements[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\PrivacyStatements> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\PrivacyStatements}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\PrivacyStatements>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
+++ b/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
@@ -142,10 +142,8 @@ abstract class ProblemOfTheWeek {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemOfTheWeek[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemOfTheWeek> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemOfTheWeek}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemOfTheWeek>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemViewed.php
+++ b/frontend/server/src/DAO/Base/ProblemViewed.php
@@ -197,10 +197,8 @@ abstract class ProblemViewed {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemViewed[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemViewed> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemViewed}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemViewed>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Problems.php
+++ b/frontend/server/src/DAO/Base/Problems.php
@@ -203,10 +203,8 @@ abstract class Problems {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Problems[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Problems> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Problems}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Problems>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsForfeited.php
+++ b/frontend/server/src/DAO/Base/ProblemsForfeited.php
@@ -197,10 +197,8 @@ abstract class ProblemsForfeited {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsForfeited[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsForfeited> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsForfeited}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsForfeited>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsLanguages.php
+++ b/frontend/server/src/DAO/Base/ProblemsLanguages.php
@@ -109,10 +109,8 @@ abstract class ProblemsLanguages {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsLanguages[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsLanguages> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsLanguages}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsLanguages>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsTags.php
+++ b/frontend/server/src/DAO/Base/ProblemsTags.php
@@ -199,10 +199,8 @@ abstract class ProblemsTags {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsTags[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsTags> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsTags}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsTags>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
+++ b/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
@@ -34,10 +34,8 @@ abstract class ProblemsetAccessLog {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsetAccessLog[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsetAccessLog> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsetAccessLog}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsetAccessLog>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentities.php
@@ -253,10 +253,8 @@ abstract class ProblemsetIdentities {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsetIdentities[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsetIdentities> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsetIdentities}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsetIdentities>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
@@ -227,10 +227,8 @@ abstract class ProblemsetIdentityRequest {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsetIdentityRequest[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsetIdentityRequest> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsetIdentityRequest}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsetIdentityRequest>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
@@ -162,10 +162,8 @@ abstract class ProblemsetIdentityRequestHistory {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsetIdentityRequestHistory[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsetIdentityRequestHistory> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsetIdentityRequestHistory}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsetIdentityRequestHistory>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
@@ -212,10 +212,8 @@ abstract class ProblemsetProblemOpened {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsetProblemOpened[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsetProblemOpened> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsetProblemOpened}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsetProblemOpened>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblems.php
@@ -211,10 +211,8 @@ abstract class ProblemsetProblems {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\ProblemsetProblems[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\ProblemsetProblems> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\ProblemsetProblems}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\ProblemsetProblems>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -178,10 +178,8 @@ abstract class Problemsets {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Problemsets[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Problemsets> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Problemsets}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Problemsets>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/QualityNominationComments.php
+++ b/frontend/server/src/DAO/Base/QualityNominationComments.php
@@ -158,10 +158,8 @@ abstract class QualityNominationComments {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\QualityNominationComments[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\QualityNominationComments> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\QualityNominationComments}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\QualityNominationComments>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/QualityNominationLog.php
+++ b/frontend/server/src/DAO/Base/QualityNominationLog.php
@@ -157,10 +157,8 @@ abstract class QualityNominationLog {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\QualityNominationLog[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\QualityNominationLog> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\QualityNominationLog}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\QualityNominationLog>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/QualityNominationReviewers.php
+++ b/frontend/server/src/DAO/Base/QualityNominationReviewers.php
@@ -109,10 +109,8 @@ abstract class QualityNominationReviewers {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\QualityNominationReviewers[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\QualityNominationReviewers> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\QualityNominationReviewers}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\QualityNominationReviewers>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/QualityNominations.php
+++ b/frontend/server/src/DAO/Base/QualityNominations.php
@@ -157,10 +157,8 @@ abstract class QualityNominations {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\QualityNominations[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\QualityNominations> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\QualityNominations}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\QualityNominations>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Roles.php
+++ b/frontend/server/src/DAO/Base/Roles.php
@@ -135,10 +135,8 @@ abstract class Roles {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Roles[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Roles> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Roles}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Roles>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/RolesPermissions.php
+++ b/frontend/server/src/DAO/Base/RolesPermissions.php
@@ -109,10 +109,8 @@ abstract class RolesPermissions {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\RolesPermissions[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\RolesPermissions> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\RolesPermissions}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\RolesPermissions>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/RunCounts.php
+++ b/frontend/server/src/DAO/Base/RunCounts.php
@@ -180,10 +180,8 @@ abstract class RunCounts {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\RunCounts[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\RunCounts> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\RunCounts}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\RunCounts>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -172,10 +172,8 @@ abstract class Runs {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Runs[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Runs> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Runs}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Runs>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
@@ -153,10 +153,8 @@ abstract class SchoolOfTheMonth {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\SchoolOfTheMonth[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\SchoolOfTheMonth> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\SchoolOfTheMonth}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\SchoolOfTheMonth>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Schools.php
+++ b/frontend/server/src/DAO/Base/Schools.php
@@ -148,10 +148,8 @@ abstract class Schools {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Schools[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Schools> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Schools}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Schools>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/States.php
+++ b/frontend/server/src/DAO/Base/States.php
@@ -185,10 +185,8 @@ abstract class States {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\States[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\States> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\States}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\States>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/SubmissionLog.php
+++ b/frontend/server/src/DAO/Base/SubmissionLog.php
@@ -238,10 +238,8 @@ abstract class SubmissionLog {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\SubmissionLog[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\SubmissionLog> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\SubmissionLog}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\SubmissionLog>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -181,10 +181,8 @@ abstract class Submissions {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Submissions[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Submissions> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Submissions}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Submissions>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Tags.php
+++ b/frontend/server/src/DAO/Base/Tags.php
@@ -132,10 +132,8 @@ abstract class Tags {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Tags[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Tags> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Tags}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Tags>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -236,10 +236,8 @@ abstract class UserRank {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\UserRank[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\UserRank> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\UserRank}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\UserRank>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/UserRankCutoffs.php
+++ b/frontend/server/src/DAO/Base/UserRankCutoffs.php
@@ -34,10 +34,8 @@ abstract class UserRankCutoffs {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\UserRankCutoffs[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\UserRankCutoffs> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\UserRankCutoffs}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\UserRankCutoffs>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/UserRoles.php
+++ b/frontend/server/src/DAO/Base/UserRoles.php
@@ -114,10 +114,8 @@ abstract class UserRoles {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\UserRoles[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\UserRoles> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\UserRoles}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\UserRoles>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/Users.php
+++ b/frontend/server/src/DAO/Base/Users.php
@@ -185,10 +185,8 @@ abstract class Users {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\Users[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\Users> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\Users}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\Users>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/UsersBadges.php
+++ b/frontend/server/src/DAO/Base/UsersBadges.php
@@ -144,10 +144,8 @@ abstract class UsersBadges {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\UsersBadges[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\UsersBadges> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\UsersBadges}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\UsersBadges>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/DAO/Base/UsersExperiments.php
+++ b/frontend/server/src/DAO/Base/UsersExperiments.php
@@ -34,10 +34,8 @@ abstract class UsersExperiments {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\UsersExperiments[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\UsersExperiments> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\UsersExperiments}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\UsersExperiments>
      */
     final public static function getAll(
         ?int $pagina = null,

--- a/frontend/server/src/Exceptions/ApiException.php
+++ b/frontend/server/src/Exceptions/ApiException.php
@@ -41,9 +41,7 @@ abstract class ApiException extends \Exception {
     }
 
     /**
-     * @return array
-     *
-     * @psalm-return array<string, mixed>
+     * @return array<string, mixed>
      */
     final public function asArray(): array {
         $previous = $this->getPrevious();

--- a/frontend/server/src/MySQLConnection.php
+++ b/frontend/server/src/MySQLConnection.php
@@ -201,9 +201,7 @@ class MySQLConnection {
     /**
      * Executes a MySQL query and returns the first row as an associative array.
      *
-     * @return mixed[]|null
-     *
-     * @psalm-return array<string, mixed>|null
+     * @return array<string, mixed>|null
      */
     public function GetRow(string $sql, array $params = []): ?array {
         $result = $this->Query($sql, $params, MYSQLI_USE_RESULT);
@@ -221,9 +219,7 @@ class MySQLConnection {
     /**
      * Executes a MySQL query and returns all rows as associative arrays.
      *
-     * @return array{string: mixed}[]
-     *
-     * @psalm-return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     public function GetAll(string $sql, array $params = []): array {
         $result = $this->Query($sql, $params, MYSQLI_USE_RESULT);
@@ -231,7 +227,7 @@ class MySQLConnection {
             return [];
         }
         try {
-            /** @var array<int, array<string, mixed>> */
+            /** @var list<array<string, mixed>> */
             $resultArray = [];
             /** @var array<string, mixed> $row */
             while (!is_null($row = $result->fetch_assoc())) {

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -250,10 +250,8 @@ abstract class {{ table.class_name }} {
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
-     * @return \OmegaUp\DAO\VO\{{ table.class_name }}[] Un arreglo que contiene objetos del tipo
+     * @return list<\OmegaUp\DAO\VO\{{ table.class_name }}> Un arreglo que contiene objetos del tipo
      * {@link \OmegaUp\DAO\VO\{{ table.class_name }}}.
-     *
-     * @psalm-return array<int, \OmegaUp\DAO\VO\{{ table.class_name }}>
      */
     final public static function getAll(
         ?int $pagina = null,


### PR DESCRIPTION
No hay razón para usar @psalm-return porque podemos usar @return sin
miedo.