### PR TITLE
Reemplazando COALESCE() por IFNULL()

### DIFF
--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -28,7 +28,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
           SELECT DISTINCT
             i.user_id,
             i.username,
-            COALESCE(i.country_id, 'xx') AS country_id,
+            IFNULL(i.country_id, 'xx') AS country_id,
             isc.school_id,
             COUNT(ps.problem_id) ProblemsSolved,
             SUM(ROUND(100 / LOG(2, ps.accepted+1) , 0)) score,
@@ -109,7 +109,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             SELECT
                 cm.time,
                 i.username,
-                COALESCE(i.country_id, "xx") AS country_id,
+                IFNULL(i.country_id, "xx") AS country_id,
                 e.email
             FROM
                 Coder_Of_The_Month cm
@@ -151,22 +151,25 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
         SELECT
           cm.time,
           i.username,
-          COALESCE (
-            (SELECT urc.classname
-            FROM User_Rank_Cutoffs urc
-            WHERE
-                urc.score <= (
-                    SELECT
-                        ur.score
-                    FROM
-                        User_Rank ur
-                    WHERE
-                        ur.user_id = i.user_id
-                )
-            ORDER BY
-                urc.percentile ASC
-            LIMIT 1)
-        , "user-rank-unranked") AS classname
+          IFNULL(
+            (
+              SELECT urc.classname
+              FROM User_Rank_Cutoffs urc
+              WHERE
+                  urc.score <= (
+                      SELECT
+                          ur.score
+                      FROM
+                          User_Rank ur
+                      WHERE
+                          ur.user_id = i.user_id
+                  )
+              ORDER BY
+                  urc.percentile ASC
+              LIMIT 1
+            ),
+            "user-rank-unranked"
+          ) AS classname
         FROM
           Coder_Of_The_Month cm
         INNER JOIN
@@ -200,7 +203,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             cm.time,
             cm.rank,
             i.username,
-            COALESCE(i.country_id, "xx") AS country_id,
+            IFNULL(i.country_id, "xx") AS country_id,
             e.email,
             u.user_id
           FROM

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -196,7 +196,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
             return null;
         }
         $sql = 'SELECT
-                    COALESCE(c.`name`, "xx") AS country,
+                    IFNULL(c.`name`, "xx") AS country,
                     s.`name` AS state,
                     sc.`name` AS school,
                     e.`email`,
@@ -339,7 +339,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
                 ill.time BETWEEN FROM_UNIXTIME(?) AND FROM_UNIXTIME(?)
             UNION
             SELECT
-                COALESCE(i.gender, "unknown") AS gender,
+                IFNULL(i.gender, "unknown") AS gender,
                 COUNT(DISTINCT ill.identity_id) AS users
             FROM
                 Identity_Login_Log ill

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -171,7 +171,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 SELECT
                     ROUND(100 / LOG2(GREATEST(accepted, 1) + 1), 2)   AS points,
                     accepted / GREATEST(1, submissions)     AS ratio,
-                    ROUND(100 * COALESCE(ps.score, 0))      AS score,
+                    ROUND(100 * IFNULL(ps.score, 0))      AS score,
                     p.*
             ';
             $sql = '
@@ -206,7 +206,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 SELECT
                     ROUND(100 / LOG2(GREATEST(p.accepted, 1) + 1), 2) AS points,
                     p.accepted / GREATEST(1, p.submissions)     AS ratio,
-                    ROUND(100 * COALESCE(ps.score, 0), 2)   AS score,
+                    ROUND(100 * IFNULL(ps.score, 0), 2)   AS score,
                     p.*
             ';
             $sql = '
@@ -454,7 +454,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
     }
 
     final public static function getPracticeDeadline($id) {
-        $sql = 'SELECT COALESCE(UNIX_TIMESTAMP(MAX(finish_time)), 0) FROM Contests c INNER JOIN Problemset_Problems pp USING(problemset_id) WHERE pp.problem_id = ?';
+        $sql = 'SELECT IFNULL(UNIX_TIMESTAMP(MAX(finish_time)), 0) FROM Contests c INNER JOIN Problemset_Problems pp USING(problemset_id) WHERE pp.problem_id = ?';
         return \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, [$id]);
     }
 

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -119,7 +119,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         SELECT
             i.username,
             i.name,
-            COALESCE(qnc.vote, 0) AS vote,
+            IFNULL(qnc.vote, 0) AS vote,
             UNIX_TIMESTAMP(qnc.time) AS time
         FROM
             QualityNomination_Reviewers qnr

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -327,22 +327,25 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         ?bool $excludeAdmin = true
     ): array {
         $classNameQuery = '
-                        COALESCE (
-                            (SELECT urc.classname
-                            FROM User_Rank_Cutoffs urc
-                            WHERE
-                                urc.score <= (
-                                    SELECT
-                                        ur.score
-                                    FROM
-                                        User_Rank ur
-                                    WHERE
-                                        ur.user_id = i.user_id
-                                )
-                            ORDER BY
-                                urc.percentile ASC
-                            LIMIT 1)
-                        , "user-rank-unranked") AS classname';
+                        IFNULL(
+                            (
+                                SELECT urc.classname
+                                FROM User_Rank_Cutoffs urc
+                                WHERE
+                                    urc.score <= (
+                                        SELECT
+                                            ur.score
+                                        FROM
+                                            User_Rank ur
+                                        WHERE
+                                            ur.user_id = i.user_id
+                                    )
+                                ORDER BY
+                                    urc.percentile ASC
+                                LIMIT 1
+                            ),
+                            "user-rank-unranked"
+                        ) AS classname';
         // Build SQL statement
         if ($showAllRuns) {
             if (is_null($groupId)) {

--- a/frontend/server/src/DAO/Schools.php
+++ b/frontend/server/src/DAO/Schools.php
@@ -218,22 +218,25 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
         $sql = '
         SELECT
             i.username,
-            COALESCE (
-                (SELECT urc.classname
-                FROM User_Rank_Cutoffs urc
-                WHERE
-                    urc.score <= (
-                        SELECT
-                            ur.score
-                        FROM
-                            User_Rank ur
-                        WHERE
-                            ur.user_id = i.user_id
-                    )
-                ORDER BY
-                    urc.percentile ASC
-                LIMIT 1)
-            , "user-rank-unranked") AS classname,
+            IFNULL(
+                (
+                    SELECT urc.classname
+                    FROM User_Rank_Cutoffs urc
+                    WHERE
+                        urc.score <= (
+                            SELECT
+                                ur.score
+                            FROM
+                                User_Rank ur
+                            WHERE
+                                ur.user_id = i.user_id
+                        )
+                    ORDER BY
+                        urc.percentile ASC
+                    LIMIT 1
+                ),
+                "user-rank-unranked"
+            ) AS classname,
             (
                 SELECT
                     COUNT(DISTINCT Problems.problem_id)

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -226,7 +226,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 r.verdict,
                 r.runtime,
                 r.memory,
-                COALESCE (
+                IFNULL(
                     (
                         SELECT urc.classname
                         FROM User_Rank_Cutoffs urc

--- a/frontend/server/src/DAO/UserRank.php
+++ b/frontend/server/src/DAO/UserRank.php
@@ -33,16 +33,20 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
                 `ur`.`username`,
                 `ur`.`name`,
                 `ur`.`country_id`,
-                (SELECT
-                    `urc`.`classname`
-                 FROM
-                    `User_Rank_Cutoffs` `urc`
-                 WHERE
-                    `urc`.`score` <= `ur`.`score`
-                 ORDER BY
-                    `urc`.`percentile` ASC
-                 LIMIT
-                    1) as `classname`';
+                IFNULL(
+                    (
+                        SELECT
+                            `urc`.`classname`
+                        FROM
+                            `User_Rank_Cutoffs` `urc`
+                        WHERE
+                            `urc`.`score` <= `ur`.`score`
+                        ORDER BY
+                            `urc`.`percentile` ASC
+                        LIMIT 1
+                    ),
+                    "user-rank-unranked"
+                ) as `classname`';
         $sql_count = '
               SELECT
                 COUNT(1)';

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -80,7 +80,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
     */
     final public static function getExtendedProfileDataByPk(int $user_id): ?array {
         $sql = 'SELECT
-                    COALESCE(c.`name`, "xx") AS country,
+                    IFNULL(c.`name`, "xx") AS country,
                     c.`country_id` AS country_id,
                     s.`name` AS state,
                     s.`state_id` AS state_id,


### PR DESCRIPTION
Este cambio reemplaza COALESCE() (que regresa la unión de los tipos de
todos los argumentos) por IFNULL() (que regresa la unión del tipo del
primer argumento _excluyendo NULL_ y el segundo).

Esto hace que el analizador de tipos no agrege NULLs innecesarios.

Part of: #3261