### PR TITLE
Excluyendo los problemas que no aceptan envíos en progreso de tareas

### DIFF
--- a/frontend/database/122_recalculate_max_points_in_problems_with_no_submissions.sql
+++ b/frontend/database/122_recalculate_max_points_in_problems_with_no_submissions.sql
@@ -1,0 +1,51 @@
+-- All the problems in assignments with no submissions will change their points value to 0
+UPDATE
+  Problemset_Problems p
+INNER JOIN
+	(
+		SELECT
+		    p.title,
+		    psp.problemset_id,
+		    p.problem_id,
+		    psp.points,
+		    p.languages
+		FROM
+		    Problemsets ps
+		INNER JOIN
+		    Problemset_Problems psp
+		ON
+		    psp.problemset_id = ps.problemset_id
+		INNER JOIN
+		    Problems p
+		ON
+		    p.problem_id = psp.problem_id
+		WHERE
+		    ps.type = 'Assignment'
+		    AND p.languages = ''
+	) q
+ON
+  p.problemset_id = q.problemset_id AND p.problem_id = q.problem_id
+SET
+  p.points = 0;
+
+-- Recalculate max_points to all affected assignments
+UPDATE
+    Assignments a
+JOIN
+	(
+		SELECT
+			assignment_id,
+			sum(psp.points) AS max_points
+    	FROM
+			Assignments a
+		INNER JOIN
+			Problemset_Problems psp
+        ON
+        	a.problemset_id = psp.problemset_id
+        GROUP BY
+        	a.assignment_id
+    ) q
+ON
+    a.assignment_id = q.assignment_id
+SET
+    a.max_points = q.max_points;

--- a/frontend/database/122_recalculate_max_points_in_problems_with_no_submissions.sql
+++ b/frontend/database/122_recalculate_max_points_in_problems_with_no_submissions.sql
@@ -2,27 +2,27 @@
 UPDATE
   Problemset_Problems p
 INNER JOIN
-	(
-		SELECT
-		    p.title,
-		    psp.problemset_id,
-		    p.problem_id,
-		    psp.points,
-		    p.languages
-		FROM
-		    Problemsets ps
-		INNER JOIN
-		    Problemset_Problems psp
-		ON
-		    psp.problemset_id = ps.problemset_id
-		INNER JOIN
-		    Problems p
-		ON
-		    p.problem_id = psp.problem_id
-		WHERE
-		    ps.type = 'Assignment'
-		    AND p.languages = ''
-	) q
+  (
+    SELECT
+      p.title,
+      psp.problemset_id,
+      p.problem_id,
+      psp.points,
+      p.languages
+    FROM
+      Problemsets ps
+    INNER JOIN
+      Problemset_Problems psp
+    ON
+      psp.problemset_id = ps.problemset_id
+    INNER JOIN
+      Problems p
+    ON
+      p.problem_id = psp.problem_id
+    WHERE
+      ps.type = 'Assignment'
+    AND p.languages = ''
+  ) q
 ON
   p.problemset_id = q.problemset_id AND p.problem_id = q.problem_id
 SET
@@ -30,22 +30,22 @@ SET
 
 -- Recalculate max_points to all affected assignments
 UPDATE
-    Assignments a
+  Assignments a
 JOIN
-	(
-		SELECT
-			assignment_id,
-			sum(psp.points) AS max_points
-    	FROM
-			Assignments a
-		INNER JOIN
-			Problemset_Problems psp
-        ON
-        	a.problemset_id = psp.problemset_id
-        GROUP BY
-        	a.assignment_id
-    ) q
+  (
+    SELECT
+      assignment_id,
+      sum(psp.points) AS max_points
+    FROM
+      Assignments a
+    INNER JOIN
+      Problemset_Problems psp
+    ON
+      a.problemset_id = psp.problemset_id
+    GROUP BY
+      a.assignment_id
+  ) q
 ON
-    a.assignment_id = q.assignment_id
+  a.assignment_id = q.assignment_id
 SET
-    a.max_points = q.max_points;
+  a.max_points = q.max_points;

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -507,7 +507,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         int $problemsetId,
         \OmegaUp\DAO\VO\Identities $identity,
         bool $validateVisibility,
-        ?int $points = 100,
+        ?float $points = 100,
         ?string $commit = null,
         ?int $order = 1
     ): void {
@@ -522,13 +522,14 @@ class Course extends \OmegaUp\Controllers\Controller {
             $commit
         );
 
+        $assignedPoints = is_null($points) ? 100 : $points;
         \OmegaUp\Controllers\Problemset::addProblem(
             $problemsetId,
             $problem,
             $masterCommit,
             $currentVersion,
             $identity,
-            is_null($points) ? 100 : $points,
+            $problem->languages === '' ? 0 : $assignedPoints,
             is_null($order) ? 1 : $order,
             $validateVisibility
         );

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -238,7 +238,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
             where a.course_id = ?;
         ';
 
-        /** @var list<array{assignment: string, score: float, max_score: float}> */
+        /** @var list<array{assignment: string, max_score: float, score: float}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$courseId, $identityId, $courseId]

--- a/frontend/tests/Factories/Course.php
+++ b/frontend/tests/Factories/Course.php
@@ -155,15 +155,16 @@ class Course {
         }
         $admin = $courseFactoryResult['admin'];
         $adminLogin = \OmegaUp\Test\ControllerTestCase::login($admin);
-        $assignmentAlias = [];
-        $assignmentProblemsetId = [];
+        $assignmentAliases = [];
+        $assignmentProblemsetIds = [];
 
         foreach ($assignmentsPerType as $assignmentType => $count) {
             for ($i = 0; $i < $count; $i++) {
+                $assignmentAlias = \OmegaUp\Test\Utils::createRandomString();
                 $r = new \OmegaUp\Request([
                     'auth_token' => $adminLogin->auth_token,
                     'name' => \OmegaUp\Test\Utils::createRandomString(),
-                    'alias' => \OmegaUp\Test\Utils::createRandomString(),
+                    'alias' => $assignmentAlias,
                     'description' => \OmegaUp\Test\Utils::createRandomString(),
                     'start_time' => (\OmegaUp\Time::get()),
                     'finish_time' => (\OmegaUp\Time::get() + 120),
@@ -173,7 +174,7 @@ class Course {
 
                 \OmegaUp\Controllers\Course::apiCreateAssignment($r);
                 $assignment = \OmegaUp\DAO\Assignments::getByAliasAndCourse(
-                    strval($r['alias']),
+                    $assignmentAlias,
                     $course->course_id
                 );
                 if (
@@ -184,16 +185,16 @@ class Course {
                         'assignmentNotFound'
                     );
                 }
-                $assignmentAlias[] = strval($r['alias']);
-                $assignmentProblemsetId[] = $assignment->problemset_id;
+                $assignmentAliases[] = $assignmentAlias;
+                $assignmentProblemsetIds[] = $assignment->problemset_id;
             }
         }
 
         return [
             'admin' => $admin,
             'course_alias' => $courseAlias,
-            'assignment_aliases' => $assignmentAlias,
-            'assignment_problemset_ids' => $assignmentProblemsetId,
+            'assignment_aliases' => $assignmentAliases,
+            'assignment_problemset_ids' => $assignmentProblemsetIds,
         ];
     }
 

--- a/frontend/tests/controllers/CourseStudentsTest.php
+++ b/frontend/tests/controllers/CourseStudentsTest.php
@@ -158,17 +158,14 @@ class CourseStudentsTest extends \OmegaUp\Test\ControllerTestCase {
         // submissions and the last one does not.
         $adminLogin = self::login($courseData['admin']);
         $problems = [];
-        for ($i = 0; $i < 4; $i++) {
-            if ($i < 3) {
-                $problems[] = \OmegaUp\Test\Factories\Problem::createProblem();
-                continue;
-            }
-            $problems[] = \OmegaUp\Test\Factories\Problem::createProblem(
-                new \OmegaUp\Test\Factories\ProblemParams([
-                    'languages' => '',
-                ])
-            );
+        for ($i = 0; $i < 3; $i++) {
+            $problems[] = \OmegaUp\Test\Factories\Problem::createProblem();
         }
+        $problems[] = \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'languages' => '',
+            ])
+        );
 
         // Problems 1 and 2 will be assigned to the first assignment, both have
         // submissions. Problem 3 and 4 will be assigned to second assignment

--- a/frontend/tests/controllers/CourseStudentsTest.php
+++ b/frontend/tests/controllers/CourseStudentsTest.php
@@ -144,4 +144,119 @@ class CourseStudentsTest extends \OmegaUp\Test\ControllerTestCase {
             $this->assertEquals('userNotAllowed', $e->getMessage());
         }
     }
+
+    /**
+     * Basic apiMyProgress test.
+     */
+    public function testStudentASsignmentProgress() {
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithAssignments(
+            /*$nAssignments=*/ 2
+        );
+        $studentsInCourse = 2;
+
+        // Prepare assignment. Create four problems: The first three accept
+        // submissions and the last one does not.
+        $adminLogin = self::login($courseData['admin']);
+        $problems = [];
+        for ($i = 0; $i < 4; $i++) {
+            if ($i < 3) {
+                $problems[] = \OmegaUp\Test\Factories\Problem::createProblem();
+                continue;
+            }
+            $problems[] = \OmegaUp\Test\Factories\Problem::createProblem(
+                new \OmegaUp\Test\Factories\ProblemParams([
+                    'languages' => '',
+                ])
+            );
+        }
+
+        // Problems 1 and 2 will be assigned to the first assignment, both have
+        // submissions. Problem 3 and 4 will be assigned to second assignment
+        foreach ($problems as $index => $problemData) {
+            $assignmentAliasIndex = ($index === 0 || $index === 1) ? 0 : 1;
+            \OmegaUp\Controllers\Course::apiAddProblem(new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course_alias' => $courseData['course_alias'],
+                'assignment_alias' => $courseData['assignment_aliases'][
+                    $assignmentAliasIndex
+                ],
+                'problem_alias' => $problemData['request']['problem_alias'],
+            ]));
+        }
+
+        // Add students to course
+        $students = [];
+        for ($i = 0; $i < $studentsInCourse; $i++) {
+            $students[] = \OmegaUp\Test\Factories\Course::addStudentToCourse(
+                $courseData
+            );
+        }
+
+        $submissionSource = "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }";
+        {
+            $studentLogin = \OmegaUp\Test\ControllerTestCase::login(
+                $students[0]
+            );
+
+            // Add one run to the first problem in the first assignment.
+            $runResponse = \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $studentLogin->auth_token,
+                'problemset_id' => $courseData['assignment_problemset_ids'][0],
+                'problem_alias' => $problems[0]['problem']->alias,
+                'language' => 'c11-gcc',
+                'source' => $submissionSource,
+            ]));
+            \OmegaUp\Test\Factories\Run::gradeRun(
+                /*$runData=*/ null,
+                1,
+                'AC',
+                null,
+                $runResponse['guid']
+            );
+
+            // Add one run to the third problem in the second assignment
+            $runResponse = \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $studentLogin->auth_token,
+                'problemset_id' => $courseData['assignment_problemset_ids'][1],
+                'problem_alias' => $problems[2]['problem']->alias,
+                'language' => 'c11-gcc',
+                'source' => $submissionSource,
+            ]));
+            \OmegaUp\Test\Factories\Run::gradeRun(
+                /*$runData=*/ null,
+                1,
+                'AC',
+                null,
+                $runResponse['guid']
+            );
+
+            $response = \OmegaUp\Controllers\Course::apiMyProgress(
+                new \OmegaUp\Request([
+                    'auth_token' => $studentLogin->auth_token,
+                    'alias' => $courseData['course_alias'],
+                    'usernameOrEmail' => $students[0]->username,
+                ])
+            );
+        }
+        // In first assignment, the student only solved one of two problem with
+        // submissions to achieve 50% of progress
+        $this->assertEquals(
+            $response['assignments'][$courseData['assignment_aliases'][0]]['score'],
+            100
+        );
+        $this->assertEquals(
+            $response['assignments'][$courseData['assignment_aliases'][0]]['max_score'],
+            200
+        );
+        // In second assignment, the student solved all the problems with
+        // submissions to achieve 100% of progress
+        $this->assertEquals(
+            $response['assignments'][$courseData['assignment_aliases'][1]]['score'],
+            100
+        );
+        $this->assertEquals(
+            $response['assignments'][$courseData['assignment_aliases'][1]]['max_score'],
+            100
+        );
+    }
 }


### PR DESCRIPTION
# Descripción

Arreglando la forma de calcular el progreso de avance en tareas de un Curso. Para
esto se tuvo que realizar las siguientes acciones:

- Asignar el valor 0 en el campo `points` de `Problemset_Problems` cuando se agrega
un problema que no acepta envíos en los Cursos que se darán de alta.

- Crear un script que actualice el valor del campo `points` en los problemas de las 
tareas que ya se dieron de alta. Además de recalcular `max_points` de cada tarea que
contenga problemas que no aceptan envíos.

Fixes: #3205 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
