### PR TITLE
Arreglando la validación de los aliases de grupos

### DIFF
--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -61,7 +61,7 @@ class Group extends \OmegaUp\Controllers\Controller {
     public static function apiCreate(\OmegaUp\Request $r) {
         $r->ensureMainUserIdentity();
 
-        \OmegaUp\Validators::validateValidAlias($r['alias'], 'alias', true);
+        \OmegaUp\Validators::validateValidAlias($r['alias'], 'alias');
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['description'],
@@ -119,7 +119,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      */
     public static function apiAddUser(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        \OmegaUp\Validators::validateValidAlias(
+        \OmegaUp\Validators::validateValidNamespacedAlias(
             $r['group_alias'],
             'group_alias'
         );
@@ -166,7 +166,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      */
     public static function apiRemoveUser(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        \OmegaUp\Validators::validateValidAlias(
+        \OmegaUp\Validators::validateValidNamespacedAlias(
             $r['group_alias'],
             'group_alias'
         );
@@ -261,7 +261,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        \OmegaUp\Validators::validateValidAlias(
+        \OmegaUp\Validators::validateValidNamespacedAlias(
             $r['group_alias'],
             'group_alias'
         );
@@ -297,7 +297,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      */
     public static function apiMembers(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        \OmegaUp\Validators::validateValidAlias(
+        \OmegaUp\Validators::validateValidNamespacedAlias(
             $r['group_alias'],
             'group_alias'
         );
@@ -323,7 +323,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      */
     public static function apiCreateScoreboard(\OmegaUp\Request $r) {
         $r->ensureIdentity();
-        \OmegaUp\Validators::validateValidAlias(
+        \OmegaUp\Validators::validateValidNamespacedAlias(
             $r['group_alias'],
             'group_alias'
         );
@@ -335,11 +335,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        \OmegaUp\Validators::validateValidAlias(
-            $r['alias'],
-            'alias',
-            true
-        );
+        \OmegaUp\Validators::validateValidAlias($r['alias'], 'alias');
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
         \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['description'],

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -179,6 +179,44 @@ class Validators {
     }
 
     /**
+     * Enforces namespaced alias (of the form "namespace:alias").
+     *
+     * @param mixed $parameter
+     * @param string $parameterName
+     * @psalm-assert string $parameter
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     */
+    public static function validateValidNamespacedAlias(
+        $parameter,
+        string $parameterName
+    ): void {
+        if (!self::isPresent($parameter, $parameterName, /*required=*/true)) {
+            return;
+        }
+        if (
+            !is_string($parameter) ||
+            strlen($parameter) < 2 ||
+            strlen($parameter) > 32
+        ) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalidAlias',
+                $parameterName
+            );
+        }
+        if (self::isRestrictedAlias($parameter)) {
+            throw new \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException(
+                'aliasInUse'
+            );
+        }
+        if (!preg_match('/^(?:[a-zA-Z0-9_-]+:)?[a-zA-Z0-9_-]+$/', $parameter)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalidAlias',
+                $parameterName
+            );
+        }
+    }
+
+    /**
      * Enforces username requirements
      *
      * @param mixed $parameter


### PR DESCRIPTION
Este cambio hace que se puedan volver a administrar los grupos con `:`
en el nombre (los grupos de sistema) desde la interfaz de usuario.