### PR TITLE
Quitando unique index a Identities_Schools

### DIFF
--- a/frontend/database/124_identities_schools_drop_unique_constraint.sql
+++ b/frontend/database/124_identities_schools_drop_unique_constraint.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    `Identities_Schools`
+DROP INDEX
+    `identity_school_graduation_date`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -333,7 +333,6 @@ CREATE TABLE `Identities_Schools` (
   `creation_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `end_time` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`identity_school_id`),
-  UNIQUE KEY `identity_school_graduation_date` (`identity_id`,`school_id`,`graduation_date`),
   KEY `identity_id` (`identity_id`),
   KEY `school_id` (`school_id`),
   CONSTRAINT `fk_isi_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,

--- a/frontend/tests/controllers/UserUpdateTest.php
+++ b/frontend/tests/controllers/UserUpdateTest.php
@@ -179,6 +179,27 @@ class UserUpdateTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals($identitySchool->school_id, $newSchool->school_id);
         $this->assertEquals($identitySchool->graduation_date, $graduationDate);
         $this->assertNull($identitySchool->end_time);
+
+        // Update the school one more time, set the first school again
+        \OmegaUp\Controllers\User::apiUpdate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'school_id' => $school->school_id,
+        ]));
+
+        // Previous IdentitySchool should have end_time filled.
+        $previousIdentitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
+            $identitySchool->identity_school_id
+        );
+        $this->assertNotNull($previousIdentitySchool->end_time);
+
+        $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
+            $identity->username
+        );
+        $identitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
+            $identity->current_identity_school_id
+        );
+        $this->assertEquals($identitySchool->school_id, $school->school_id);
+        $this->assertNull($identitySchool->end_time);
     }
 
     /**


### PR DESCRIPTION
# Descripción

Antes habíamos considerado que no era permitido que un mismo usuario tenga más de un registro en `Identities_Schools` donde la escuela y la fecha de graduación sean las mismas. Pero eso prohíbe que un usuario corrija una actualización errada que haya tenido.

Part of: #3331 

# Comentarios

No estoy del todo seguro si sea bueno quitar esa restricción, no veo la razón de que un usuario se "equivoque" al cambiar de Universidad y luego regresar a la anterior. Qué opinas tú @lhchavez ?

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
