### PR TITLE
Moviendo validaciones a la clase ProblemParams

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -57,7 +57,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
      *
      */
     private static function convertRequestToProblemParams(
-        \OmegaUp\Request $r
+        \OmegaUp\Request $r,
+        bool $isUpdate = false
     ): \OmegaUp\ProblemParams {
         // We need to check problem_alias
         \OmegaUp\Validators::validateStringNonEmpty(
@@ -123,7 +124,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         if (!is_null($r['visibility'])) {
             $params['visibility'] = intval($r['visibility']);
         }
-        return new \OmegaUp\ProblemParams($params);
+        return new \OmegaUp\ProblemParams($params, $isUpdate);
     }
 
     /**
@@ -322,7 +323,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r,
             $r['title'],
             $r['problem_alias'],
-            $r['validator'],
+            $r['validator'] ?? \OmegaUp\ProblemParams::VALIDATOR_TOKEN,
             $r['time_limit'],
             $r['validator_time_limit'],
             $r['overall_wall_time_limit'],
@@ -330,9 +331,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r['memory_limit'],
             $r['output_limit'],
             $r['input_limit'],
-            $r['source'],
+            $r['source'] ?? '',
             $r['email_clarifications'],
-            $r['visibility'],
+            $r['visibility'] ?? \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
             $r->user,
             $r->identity
         );
@@ -355,7 +356,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         int $inputLimit,
         ?string $source,
         ?string $emailClarifications,
-        bool $visibility,
+        int $visibility,
         \OmegaUp\DAO\VO\Users $user,
         \OmegaUp\DAO\VO\Identities $identity
     ): void {
@@ -3761,7 +3762,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     ) ? strval(
                         $r['email_clarifications']
                     ) : null,
-                    boolval($r['visibility']),
+                    intval($r['visibility']),
                     $r->user,
                     $r->identity
                 );

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -50,7 +50,7 @@ class ProblemParams {
     public $title;
 
     /**
-     * @var \OmegaUp\ProblemParams::VISIBILITY_DELETED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC|\OmegaUp\ProblemParams::VISIBILITY_PROMOTED
+     * @var \OmegaUp\ProblemParams::VISIBILITY_DELETED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC|\OmegaUp\ProblemParams::VISIBILITY_PROMOTED|null
      */
     public $visibility;
 
@@ -74,19 +74,19 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var string
+     * @var string|null
      */
     public $source;
 
     /**
      * @readonly
-     * @var \OmegaUp\ProblemParams::VALIDATOR_TOKEN|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_CASELESS|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_NUMERIC|\OmegaUp\ProblemParams::VALIDATOR_LITERAL
+     * @var \OmegaUp\ProblemParams::VALIDATOR_TOKEN|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_CASELESS|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_NUMERIC|\OmegaUp\ProblemParams::VALIDATOR_LITERAL|null
      */
     public $validator;
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $timeLimit;
 
@@ -110,7 +110,7 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $memoryLimit;
 
@@ -133,13 +133,69 @@ class ProblemParams {
     public $emailClarifications;
 
     /**
-     * @param array{email_clarifications?: bool, extra_wall_time?: int, input_limit?: int, languages?: string, memory_limit?: int, output_limit?: int, overall_wall_time_limit?: int, problem_alias: string, selected_tags?: string, source?: string, time_limit?: int, title?: string, update_published?: \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NONE|\OmegaUp\ProblemParams::UPDATE_PUBLISHED_NON_PROBLEMSET|\OmegaUp\ProblemParams::UPDATE_PUBLISHED_OWNED_PROBLEMSETS|\OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS, validator?: \OmegaUp\ProblemParams::VALIDATOR_TOKEN|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_CASELESS|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_NUMERIC|\OmegaUp\ProblemParams::VALIDATOR_LITERAL, validator_time_limit?: int, visibility?: \OmegaUp\ProblemParams::VISIBILITY_DELETED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC|\OmegaUp\ProblemParams::VISIBILITY_PROMOTED} $params
+     * @readonly
+     * @var string
      */
-    public function __construct($params) {
-        $isRequired = true;
+    public $order;
+
+    /**
+     * @param array{email_clarifications?: bool, extra_wall_time?: int, input_limit?: int, languages?: string, memory_limit?: int, order?: string, output_limit?: int, overall_wall_time_limit?: int, problem_alias: string, selected_tags?: string, source?: string, time_limit?: int, title?: string, update_published?: \OmegaUp\ProblemParams::UPDATE_PUBLISHED_NONE|\OmegaUp\ProblemParams::UPDATE_PUBLISHED_NON_PROBLEMSET|\OmegaUp\ProblemParams::UPDATE_PUBLISHED_OWNED_PROBLEMSETS|\OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS, validator?: \OmegaUp\ProblemParams::VALIDATOR_TOKEN|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_CASELESS|\OmegaUp\ProblemParams::VALIDATOR_TOKEN_NUMERIC|\OmegaUp\ProblemParams::VALIDATOR_LITERAL, validator_time_limit?: int, visibility?: \OmegaUp\ProblemParams::VISIBILITY_DELETED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED|\OmegaUp\ProblemParams::VISIBILITY_PRIVATE|\OmegaUp\ProblemParams::VISIBILITY_PUBLIC|\OmegaUp\ProblemParams::VISIBILITY_PROMOTED} $params
+     */
+    public function __construct($params, bool $isUpdate = false) {
+        $isRequired = !$isUpdate;
+        $visibilityStatements = $isUpdate ? [
+            \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
+            \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
+            \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED,
+            \OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED
+        ] : [
+            \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
+            \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
+        ];
+        if (isset($params['visibility'])) {
+            \OmegaUp\Validators::validateInEnum(
+                $params['visibility'],
+                'visibility',
+                $visibilityStatements,
+                $isRequired
+            );
+        }
+        if (isset($params['validator'])) {
+            \OmegaUp\Validators::validateInEnum(
+                $params['validator'],
+                'validator',
+                [
+                    \OmegaUp\ProblemParams::VALIDATOR_TOKEN,
+                    \OmegaUp\ProblemParams::VALIDATOR_TOKEN_CASELESS,
+                    \OmegaUp\ProblemParams::VALIDATOR_TOKEN_NUMERIC,
+                    \OmegaUp\ProblemParams::VALIDATOR_LITERAL,
+                    \OmegaUp\ProblemParams::VALIDATOR_CUSTOM,
+                ],
+                $isRequired
+            );
+        }
+        if (isset($params['time_limit'])) {
+            \OmegaUp\Validators::validateNumberInRange(
+                $params['time_limit'],
+                'time_limit',
+                /*$lowerBound=*/ 0,
+                /*$uppperBound=*/ null,
+                $isRequired
+            );
+        }
+        if (isset($params['memory_limit'])) {
+            \OmegaUp\Validators::validateNumberInRange(
+                $params['memory_limit'],
+                'memory_limit',
+                /*$lowerBound=*/ 0,
+                /*$uppperBound=*/ null,
+                $isRequired
+            );
+        }
+
         $this->problemAlias = $params['problem_alias'];
         $this->title = $params['title'] ?? null;
-        $this->visibility = $params['visibility'] ?? \OmegaUp\ProblemParams::VISIBILITY_PRIVATE;
+        $this->visibility = $params['visibility'] ?? null;
         $this->languages = isset(
             $params['languages']
         ) ? explode(
@@ -148,15 +204,16 @@ class ProblemParams {
         ) : null;
         $this->updatePublished = $params['update_published'] ?? \OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS;
         $this->selectedTagsAsJSON = $params['selected_tags'] ?? null;
-        $this->source = $params['source'] ?? '';
-        $this->validator = $params['validator'] ?? \OmegaUp\ProblemParams::VALIDATOR_TOKEN;
-        $this->timeLimit = $params['time_limit'] ?? 1000;
+        $this->source = $params['source'] ?? null;
+        $this->validator = $params['validator'] ?? null;
+        $this->timeLimit = $params['time_limit'] ?? null;
         $this->validatorTimeLimit = $params['validator_time_limit'] ?? 1000;
         $this->overallWallTimeLimit = $params['overall_wall_time_limit'] ?? 60000;
         $this->extraWallTime = $params['extra_wall_time'] ?? 0;
-        $this->memoryLimit = $params['memory_limit'] ?? 32768;
+        $this->memoryLimit = $params['memory_limit'] ?? null;
         $this->outputLimit = $params['output_limit'] ?? 10240;
         $this->inputLimit = $params['input_limit'] ?? 10240;
         $this->emailClarifications = $params['email_clarifications'] ?? false;
+        $this->order = $params['order'] ?? 'normal';
     }
 }

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -754,15 +754,9 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             \OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS,
             $problemParams->updatePublished
         );
-        $this->assertEquals(
-            \OmegaUp\ProblemParams::VALIDATOR_TOKEN,
-            $problemParams->validator
-        );
-        $this->assertEquals(1000, $problemParams->timeLimit);
         $this->assertEquals(1000, $problemParams->validatorTimeLimit);
         $this->assertEquals(60000, $problemParams->overallWallTimeLimit);
         $this->assertEquals(0, $problemParams->extraWallTime);
-        $this->assertEquals(32768, $problemParams->memoryLimit);
         $this->assertEquals(10240, $problemParams->outputLimit);
         $this->assertEquals(10240, $problemParams->inputLimit);
         $this->assertFalse($problemParams->emailClarifications);


### PR DESCRIPTION
# Descripción

Se mueven algunas validaciones a la clase `ProblemParams` al momento de 
crear o actualizar un problema.

Part of: #3066 

# Comentarios

Una vez que se apruebe este PR, hay que quitar las validaciones de la función
`validateCreateUpdate`, ya que por el momento estarán duplicadas

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
