### PR TITLE
Cambiando las opciones de Webpack para hacer polling

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -210,6 +210,11 @@ let config = [
     devServer: { historyApiFallback: true, noInfo: true },
     performance: { hints: false },
     devtool: 'cheap-source-map',
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000,
+      ignored: /node_modules/,
+    },
   },
   {
     name: 'style',


### PR DESCRIPTION
Este cambio hace que Webpack haga polling en vez de usar inotify para
detectar cambios en el sistema de archivos.

Por alguna razón, en la VM hay demasiados notificadores abiertos y
webpack no está pudiendo auto-actualizarse. Hacer polling cada segundo
permite volver a ejecutar `yarn run dev`.