### PR TITLE
Evitando que knockout _a veces_ cause errores

### DIFF
--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -114,6 +114,29 @@ export let OmegaUp = {
         OmegaUp.experiments = Experiments.loadGlobal();
       },
       function() {
+        // ko.secureBindingsProvider.nodeHasBindings() has a bug in which if
+        // there happens to be a comment with no content (like `<!---->`), it
+        // tries to call .trim() on undefined, and crashes.
+        ko.secureBindingsProvider.prototype.nodeHasBindings = function(node) {
+          if (node.nodeType === node.ELEMENT_NODE) {
+            return (
+              node.getAttribute(this.attribute) ||
+              (ko.components && ko.components.getComponentNameForNode(node))
+            );
+          }
+          if (node.nodeType === node.COMMENT_NODE) {
+            if (this.noVirtualElements) {
+              return false;
+            }
+            // Ensures that `value` is not undefined.
+            let value = '' + node.nodeValue || node.text;
+            if (!value) {
+              return false;
+            }
+            // See also: knockout/src/virtualElements.js
+            return value.trim().indexOf('ko ') === 0;
+          }
+        };
         ko.bindingProvider.instance = new ko.secureBindingsProvider({
           attribute: 'data-bind',
         });


### PR DESCRIPTION
Este cambio hace que ko.secureBindingsProvider.nodeHasBindings() tenga
más cuidado al momento de llamar .trim() en algo que puede ser
undefined.