### PR TITLE
Aplicando algunas correcciones de psalm en Controller::Problem

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2743,14 +2743,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
-        $problemAdmin = \OmegaUp\Authorization::isProblemAdmin(
+        $isProblemAdmin = \OmegaUp\Authorization::isProblemAdmin(
             $r->identity,
             $problem
         );
 
         $clarifications = \OmegaUp\DAO\Clarifications::GetProblemClarifications(
             $problem->problem_id,
-            $problemAdmin,
+            $isProblemAdmin,
             $r->identity->identity_id,
             $r['offset'],
             $r['rowcount']

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -734,7 +734,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details of a run. Includes admin details if admin.
      *
-     * @return array{admin: bool, compile_error?: string, details?: array{contest_score: int, judged_by: string, score: int, verdict: string}, guid: string, judged_by?: string, language: string, logs?: string, source: string}
+     * @return array{admin: bool, compile_error?: string, details?: array{compile_meta?: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups?: array<array-key, array{cases: array<array-key, array{contest_score: float, max_score: float, meta: array<string, mixed>, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score?: float, memory?: float, score: float, time?: float, verdict: string, wall_time?: float}, guid: string, judged_by?: string, language: string, logs?: string, source?: string}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
         // Get the user who is calling this API
@@ -816,7 +816,7 @@ class Run extends \OmegaUp\Controllers\Controller {
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
-     * @return array{compile_error?: string, details?: array{contest_score: int, judged_by: string, score: int, verdict: string}, source: string}
+     * @return array{compile_error?: string, details?: array{compile_meta?: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups?: array<array-key, array{cases: array<array-key, array{contest_score: float, max_score: float, meta: array<string, mixed>, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score?: float, memory?: float, score: float, time?: float, verdict: string, wall_time?: float}, source: string}
      */
     public static function apiSource(\OmegaUp\Request $r): array {
         // Get the user who is calling this API
@@ -850,7 +850,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{compile_error?: string, details?: array{contest_score: int, judged_by: string, score: int, verdict: string}, source: string}
+     * @return array{compile_error?: string, details?: array{compile_meta?: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups?: array<array-key, array{cases: array<array-key, array{contest_score: float, max_score: float, meta: array<string, mixed>, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score?: float, memory?: float, score: float, time?: float, verdict: string, wall_time?: float}, source: string}
      */
     private static function getOptionalRunDetails(
         \OmegaUp\DAO\VO\Submissions $submission,

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -341,7 +341,7 @@ class Run extends \OmegaUp\Controllers\Controller {
                         // time the user opened the problem
                         $opened = \OmegaUp\DAO\ProblemsetProblemOpened::getByPK(
                             $problemsetId,
-                            $r['problem']->problem_id,
+                            intval($r['problem']->problem_id),
                             $r->identity->identity_id
                         );
 
@@ -734,7 +734,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details of a run. Includes admin details if admin.
      *
-     * @return array{admin: bool, guid: string, language: string, source?: string, compile_error?: string, details?: array{compile_meta: array<string, array{verdict: string, time: float, sys_time: float, wall_time: float, memory: float}>, contest_score: float, groups: array{group: string, score: float, contest_score: float, max_score: float, cases: array{name: string, score: float, contest_score: float, max_score: float, verdict: string, meta: array<string, mixed>}[]}[], judged_by: string, max_score: float, memory: float, score: float, time: float, verdict: string, wall_time: float}, logs?: string, judged_by?: string}
+     * @return array{admin: bool, compile_error?: string, details?: array{contest_score: int, judged_by: string, score: int, verdict: string}, guid: string, judged_by?: string, language: string, logs?: string, source: string}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
         // Get the user who is calling this API
@@ -816,7 +816,7 @@ class Run extends \OmegaUp\Controllers\Controller {
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
-     * @return array{compile_error?: string, details?: array{compile_meta: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups: array<array-key, array{cases: array<array-key, array{contest_score: float, max_score: float, meta: array<string, mixed>, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score: float, memory: float, score: float, time: float, verdict: string, wall_time: float}, source: string}
+     * @return array{compile_error?: string, details?: array{contest_score: int, judged_by: string, score: int, verdict: string}, source: string}
      */
     public static function apiSource(\OmegaUp\Request $r): array {
         // Get the user who is calling this API
@@ -850,7 +850,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{compile_error?: string, details?: array{compile_meta: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups: array<array-key, array{cases: array<array-key, array{contest_score: float, max_score: float, meta: array<string, mixed>, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score: float, memory: float, score: float, time: float, verdict: string, wall_time: float}, source: string}
+     * @return array{compile_error?: string, details?: array{contest_score: int, judged_by: string, score: int, verdict: string}, source: string}
      */
     private static function getOptionalRunDetails(
         \OmegaUp\DAO\VO\Submissions $submission,
@@ -872,7 +872,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         if (!is_string($detailsJson)) {
             return $response;
         }
-        /** @var array<string, mixed> */
+        /** @var array{verdict: string, contest_score: int, score: int, judged_by: string} */
         $details = json_decode($detailsJson, true);
         if (
             isset($details['compile_error']) &&

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -872,7 +872,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         if (!is_string($detailsJson)) {
             return $response;
         }
-        /** @var array{verdict: string, contest_score: int, score: int, judged_by: string} */
+        /** @var array{compile_meta?: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups?: array<array-key, array{cases: array<array-key, array{contest_score: float, max_score: float, meta: array<string, mixed>, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score?: float, memory?: float, score: float, time?: float, verdict: string, wall_time?: float} */
         $details = json_decode($detailsJson, true);
         if (
             isset($details['compile_error']) &&

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -951,7 +951,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     /**
      * Gets the runs that were inserted due to a version change.
      *
-     * @param \OmegaUp\DAO\VO\Problems $problem the problem.
+     * @return list<\OmegaUp\DAO\VO\Runs>
      */
     final public static function getNewRunsForVersion(\OmegaUp\DAO\VO\Problems $problem): array {
         $sql = '

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -147,7 +147,8 @@ class ProblemParams {
             \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
             \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
             \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED,
-            \OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED
+            \OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED,
+            \OmegaUp\ProblemParams::VISIBILITY_PROMOTED,
         ] : [
             \OmegaUp\ProblemParams::VISIBILITY_PRIVATE,
             \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -189,7 +189,7 @@
     <InvalidArrayOffset occurrences="1">
       <code>$result['settings']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="37">
+    <MixedArgument occurrences="28">
       <code>$r['selected_tags']</code>
       <code>$r['problem_alias']</code>
       <code>$r['usernameOrEmail']</code>
@@ -199,31 +199,17 @@
       <code>$run</code>
       <code>$_FILES['problem_contents']['tmp_name']</code>
       <code>$updatePublished</code>
-      <code>$run-&gt;run_id</code>
       <code>$r['problem_alias']</code>
       <code>$updatePublished</code>
       <code>$r['contest_alias']</code>
       <code>$r['lang']</code>
       <code>$updatePublished</code>
-      <code>$run-&gt;run_id</code>
-      <code>$r['username']</code>
-      <code>$r['status']</code>
-      <code>$r['verdict']</code>
-      <code>$r['language']</code>
-      <code>!is_null($r['identity']) ? $r['identity']-&gt;identity_id : null</code>
       <code>$r['offset']</code>
       <code>$r['rowcount']</code>
       <code>$run</code>
       <code>$r['contest_alias']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$_FILES['problem_contents']['tmp_name']</code>
-      <code>$group['cases']</code>
-      <code>$case['name']</code>
-      <code>$case['name']</code>
-      <code>$case['name']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="10">
       <code>$run</code>
       <code>$updatePublished</code>
       <code>$run</code>
@@ -233,11 +219,8 @@
       <code>$lang</code>
       <code>$logEntry['tree'][$treeEntry['path']]</code>
       <code>$updatePublished</code>
-      <code>$problemSettings</code>
       <code>$run</code>
       <code>$run</code>
-      <code>$group</code>
-      <code>$case</code>
     </MixedAssignment>
     <MixedPropertyAssignment occurrences="5">
       <code>$run</code>
@@ -246,22 +229,13 @@
       <code>$run</code>
       <code>$run</code>
     </MixedPropertyAssignment>
-    <MixedPropertyFetch occurrences="4">
-      <code>$run-&gt;run_id</code>
-      <code>$run-&gt;run_id</code>
-      <code>$r['identity']-&gt;identity_id</code>
-      <code>$case-&gt;score</code>
-    </MixedPropertyFetch>
-    <PossiblyNullArgument occurrences="12">
+    <PossiblyNullArgument occurrences="11">
       <code>$problem-&gt;alias</code>
       <code>$problem</code>
       <code>$problem-&gt;alias</code>
       <code>$problem-&gt;alias</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="2"/>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$problemDeployer-&gt;publishedCommit</code>
-    </PossiblyNullPropertyAssignmentValue>
     <PossiblyNullPropertyFetch occurrences="3">
       <code>$acl-&gt;owner_id</code>
       <code>$problemsetter-&gt;username</code>
@@ -298,7 +272,7 @@
       <code>rand()</code>
       <code>$run-&gt;run_id</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="29">
+    <MixedArgument occurrences="28">
       <code>$r['problem']-&gt;languages</code>
       <code>$r['contest']-&gt;languages</code>
       <code>$r['problem']</code>


### PR DESCRIPTION
# Descripción

Arreglando una serie de errores de `psalm` que aparecían en el cambio #3140 
pero que no necesariamente pertenecen a ese cambio. Esto ayuda para que el
tamaño de dicho PR no crezca tanto.

Part of: #3066

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
