### PR TITLE
Limpiando la interfaz para identidades

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -539,7 +539,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{payload: array{contests: list<array{contest_id: int, problemset_id: int, acl_id?: int, title: string, description: string, original_finish_time?: string, start_time: int|null, finish_time: int|null, last_updated: int|null, window_length: null|int, rerun_id: int, admission_mode: string, alias: string, scoreboard?: int, points_decay_factor?: float, partial_score?: int, submissions_gap?: int, feedback?: string, penalty?: int, penalty_type?: string, penalty_calc_policy?: string, show_scoreboard_after?: int, urgent?: int, languages?: null|string, recommended: bool, scoreboard_url: string, scoreboard_url_admin: string}>}, privateContestsAlert: bool}
+     * @return array{smartyProperties: array{payload: array{contests: list<array{contest_id: int, problemset_id: int, acl_id?: int, title: string, description: string, original_finish_time?: string, start_time: int|null, finish_time: int|null, last_updated: int|null, window_length: null|int, rerun_id: int, admission_mode: string, alias: string, scoreboard?: int, points_decay_factor?: float, partial_score?: int, submissions_gap?: int, feedback?: string, penalty?: int, penalty_type?: string, penalty_calc_policy?: string, show_scoreboard_after?: int, urgent?: int, languages?: null|string, recommended: bool, scoreboard_url: string, scoreboard_url_admin: string}>}, privateContestsAlert: bool}, template: string}
      */
     public static function getContestListMineForSmarty(
         \OmegaUp\Request $r
@@ -564,39 +564,62 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         return [
-            'payload' => self::getContestListInternal(
-                $r,
-                function (
-                    int $identityId,
-                    int $page,
-                    int $pageSize,
-                    ?string $query
-                ) {
-                    return \OmegaUp\DAO\Contests::getAllContestsOwnedByUser(
-                        $identityId,
-                        $page,
-                        $pageSize
-                    );
-                }
-            ),
-            'privateContestsAlert' => $privateContestsAlert,
+            'smartyProperties' => [
+                'payload' => self::getContestListInternal(
+                    $r,
+                    function (
+                        int $identityId,
+                        int $page,
+                        int $pageSize,
+                        ?string $query
+                    ) {
+                        return \OmegaUp\DAO\Contests::getAllContestsOwnedByUser(
+                            $identityId,
+                            $page,
+                            $pageSize
+                        );
+                    }
+                ),
+                'privateContestsAlert' => $privateContestsAlert,
+            ],
+            'template' => 'contest.mine.tpl',
         ];
     }
 
     /**
-     * @return array{LANGUAGES: list<string>, IS_UPDATE: bool}
+     * @return array{smartyProperties: array{LANGUAGES: list<string>, IS_UPDATE: bool}, template: string}
      */
-    public static function getContestNewDetailsForSmarty(
-        \OmegaUp\Request $r,
-        bool $isUpdate = false
+    public static function getContestNewForSmarty(
+        \OmegaUp\Request $r
     ): array {
-        $result = [
-            'LANGUAGES' => array_keys(
-                \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
-            ),
-            'IS_UPDATE' => $isUpdate,
+        $r->ensureMainUserIdentity();
+        return [
+            'smartyProperties' => [
+                'LANGUAGES' => array_keys(
+                    \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                ),
+                'IS_UPDATE' => false,
+            ],
+            'template' => 'contest.new.tpl',
         ];
-        return $result;
+    }
+
+    /**
+     * @return array{smartyProperties: array{LANGUAGES: list<string>, IS_UPDATE: bool}, template: string}
+     */
+    public static function getContestEditForSmarty(
+        \OmegaUp\Request $r
+    ): array {
+        $r->ensureMainUserIdentity();
+        return [
+            'smartyProperties' => [
+                'LANGUAGES' => array_keys(
+                    \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                ),
+                'IS_UPDATE' => true,
+            ],
+            'template' => 'contest.edit.tpl',
+        ];
     }
 
     /**

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3544,7 +3544,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{isSysadmin: bool, privateProblemsAlert: bool}
+     * @return array{smartyProperties: array{isSysadmin: bool, privateProblemsAlert: bool}, template: string}
      */
     public static function getProblemsMineInfoForSmarty(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -3561,8 +3561,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
         }
         return [
-            'isSysadmin' => \OmegaUp\Authorization::isSystemAdmin($r->identity),
-            'privateProblemsAlert' => $privateProblemsAlert,
+            'smartyProperties' => [
+                'isSysadmin' => \OmegaUp\Authorization::isSystemAdmin(
+                    $r->identity
+                ),
+                'privateProblemsAlert' => $privateProblemsAlert,
+            ],
+            'template' => 'problem.mine.tpl',
         ];
     }
 
@@ -3722,7 +3727,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{KEYWORD: string, LANGUAGE: string, MODE: string, ORDER_BY: string, current_tags: string[]|string, pager_items: array{class: string, label: string, url: string}[], problems: array{alias: string, difficulty: float|null, difficulty_histogram: list<int>, points: float, quality: float|null, quality_histogram: list<int>, ratio: float, score: float, tags: array{source: string, name: string}[], title: string, visibility: int}[]}
+     * @return array{smartyProperties: array{KEYWORD: string, LANGUAGE: string, MODE: string, ORDER_BY: string, current_tags: string[]|string, pager_items: array{class: string, label: string, url: string}[], problems: array{alias: string, difficulty: float|null, difficulty_histogram: list<int>, points: float, quality: float|null, quality_histogram: list<int>, ratio: float, score: float, tags: array{source: string, name: string}[], title: string, visibility: int}[]}, template: string}
      */
     public static function getProblemListForSmarty(
         \OmegaUp\Request $r
@@ -3784,13 +3789,16 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         return [
-            'KEYWORD' => $keyword,
-            'MODE' => $mode,
-            'ORDER_BY' => $orderBy,
-            'LANGUAGE' => $language,
-            'problems' => $response['results'],
-            'current_tags' => $tags,
-            'pager_items' => $pagerItems,
+            'smartyProperties' => [
+                'KEYWORD' => $keyword,
+                'MODE' => $mode,
+                'ORDER_BY' => $orderBy,
+                'LANGUAGE' => $language,
+                'problems' => $response['results'],
+                'current_tags' => $tags,
+                'pager_items' => $pagerItems,
+            ],
+            'template' => 'problems.tpl',
         ];
     }
 
@@ -3869,13 +3877,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{ALIAS: string, EMAIL_CLARIFICATIONS: string, EXTRA_WALL_TIME: string, INPUT_LIMIT: string, LANGUAGES: string, MEMORY_LIMIT: string, OUTPUT_LIMIT: string, OVERALL_WALL_TIME_LIMIT: string, SELECTED_TAGS: string, SOURCE: string, TIME_LIMIT: string, TITLE: string, VALIDATOR: string, VALIDATOR_TIME_LIMIT: string, VISIBILITY: string}
+     * @return array{smartyProperties: array{ALIAS: string, EMAIL_CLARIFICATIONS: string, EXTRA_WALL_TIME: string, INPUT_LIMIT: string, LANGUAGES: string, MEMORY_LIMIT: string, OUTPUT_LIMIT: string, OVERALL_WALL_TIME_LIMIT: string, SELECTED_TAGS: string, SOURCE: string, TIME_LIMIT: string, TITLE: string, VALIDATOR: string, VALIDATOR_TIME_LIMIT: string, VISIBILITY: string}, template: string}
      */
     public static function getProblemNewForSmarty(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
-
         if (isset($r['request']) && ($r['request'] === 'submit')) {
             // HACK to prevent fails in validateCreateOrUpdate
             $r['problem_alias'] = strval($r['alias']);
@@ -3897,51 +3904,58 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     $statusError = $response['error'];
                 }
                 return [
-                    'TITLE' => strval($r['title']),
-                    'ALIAS' => strval($r['problem_alias']),
-                    'VALIDATOR' => strval($r['validator']),
-                    'TIME_LIMIT' => strval($r['time_limit']),
-                    'VALIDATOR_TIME_LIMIT' => strval(
-                        $r['validator_time_limit']
-                    ),
-                    'OVERALL_WALL_TIME_LIMIT' => strval(
-                        $r['overall_wall_time_limit']
-                    ),
-                    'EXTRA_WALL_TIME' => strval($r['extra_wall_time']),
-                    'OUTPUT_LIMIT' => strval($r['output_limit']),
-                    'INPUT_LIMIT' => strval($r['input_limit']),
-                    'MEMORY_LIMIT' => strval($r['memory_limit']),
-                    'EMAIL_CLARIFICATIONS' => strval(
-                        $r['email_clarifications']
-                    ),
-                    'SOURCE' => strval($r['source']),
-                    'VISIBILITY' => strval($r['visibility']),
-                    'LANGUAGES' => strval($r['languages']),
-                    'SELECTED_TAGS' => strval($r['selected_tags']),
-                    'STATUS_ERROR' => $statusError,
+                    'smartyProperties' => [
+                        'TITLE' => strval($r['title']),
+                        'ALIAS' => strval($r['problem_alias']),
+                        'VALIDATOR' => strval($r['validator']),
+                        'TIME_LIMIT' => strval($r['time_limit']),
+                        'VALIDATOR_TIME_LIMIT' => strval(
+                            $r['validator_time_limit']
+                        ),
+                        'OVERALL_WALL_TIME_LIMIT' => strval(
+                            $r['overall_wall_time_limit']
+                        ),
+                        'EXTRA_WALL_TIME' => strval($r['extra_wall_time']),
+                        'OUTPUT_LIMIT' => strval($r['output_limit']),
+                        'INPUT_LIMIT' => strval($r['input_limit']),
+                        'MEMORY_LIMIT' => strval($r['memory_limit']),
+                        'EMAIL_CLARIFICATIONS' => strval(
+                            $r['email_clarifications']
+                        ),
+                        'SOURCE' => strval($r['source']),
+                        'VISIBILITY' => strval($r['visibility']),
+                        'LANGUAGES' => strval($r['languages']),
+                        'SELECTED_TAGS' => strval($r['selected_tags']),
+                        'STATUS_ERROR' => $statusError,
+                        'IS_UPDATE' => false,
+                    ],
+                    'template' => 'problem.new.tpl',
                 ];
             }
         }
         return [
-            'TITLE' => '',
-            'ALIAS' => '',
-            'VALIDATOR' => \OmegaUp\ProblemParams::VALIDATOR_TOKEN,
-            'TIME_LIMIT' => '1000',
-            'VALIDATOR_TIME_LIMIT' => '1000',
-            'OVERALL_WALL_TIME_LIMIT' => '60000',
-            'EXTRA_WALL_TIME' => '0',
-            'OUTPUT_LIMIT' => '10240',
-            'INPUT_LIMIT' => '10240',
-            'MEMORY_LIMIT' => '32768',
-            'EMAIL_CLARIFICATIONS' => '0',
-            'SOURCE' => '',
-            'VISIBILITY' => '0',
-            'LANGUAGES' => join(
-                ',',
-                \OmegaUp\Controllers\Run::DEFAULT_LANGUAGES
-            ),
-            'SELECTED_TAGS' => '',
-            'IS_UPDATE' => false,
+            'smartyProperties' => [
+                'TITLE' => '',
+                'ALIAS' => '',
+                'VALIDATOR' => \OmegaUp\ProblemParams::VALIDATOR_TOKEN,
+                'TIME_LIMIT' => '1000',
+                'VALIDATOR_TIME_LIMIT' => '1000',
+                'OVERALL_WALL_TIME_LIMIT' => '60000',
+                'EXTRA_WALL_TIME' => '0',
+                'OUTPUT_LIMIT' => '10240',
+                'INPUT_LIMIT' => '10240',
+                'MEMORY_LIMIT' => '32768',
+                'EMAIL_CLARIFICATIONS' => '0',
+                'SOURCE' => '',
+                'VISIBILITY' => '0',
+                'LANGUAGES' => join(
+                    ',',
+                    \OmegaUp\Controllers\Run::DEFAULT_LANGUAGES
+                ),
+                'SELECTED_TAGS' => '',
+                'IS_UPDATE' => false,
+            ],
+            'template' => 'problem.new.tpl',
         ];
     }
 

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -175,6 +175,7 @@ class UITools {
         [
             'email' => $email,
             'identity' => $identity,
+            'user' => $user,
             'is_admin' => $isAdmin,
         ] = \OmegaUp\Controllers\Session::getCurrentSession();
         $smarty->assign(
@@ -197,6 +198,7 @@ class UITools {
                         $identity->username
                     ) ? $identity->username :
                     '',
+                'isMainUserIdentity' => !is_null($user),
                 'isAdmin' => $isAdmin,
                 'lockDownImage' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAA6UlEQVQ4jd2TMYoCMRiFv5HBwnJBsFqEiGxtISps6RGmFD2CZRr7aQSPIFjmCGsnrFYeQJjGytJKRERsfp2QmahY+iDk5c97L/wJCchBFCclYAD8SmkBTI1WB1cb5Ji/gT+g7mxtgK7RausNiOIEYAm0pHSWOZR5BbSNVndPwTmlaZnnQFnGXGot0XgDfiw+NlrtjVZ7YOzRZAJCix893NZkAi4eYejRpJcYxckQ6AENKf0DO+EVoCN8DcyMVhM3eQR8WesO+WgAVWDituC28wiFDHkXHxBgv0IfKL7oO+UF1Ei/7zMsbuQKTFoqpb8KS2AAAAAASUVORK5CYII=',
                 'navbarSection' => $navbarSection,

--- a/frontend/templates/arena.index.tpl
+++ b/frontend/templates/arena.index.tpl
@@ -25,6 +25,12 @@
 
 						<div class="panel-body">
 							<ul class="nav nav-pills arena-tabs">
+								{if $LOGGED_IN == 1}
+								<li class="nav-item">
+									<a class="nav-link" href="#list-current-participating-contest" data-toggle="tab">
+										{#arenaMyActiveContests#}</a>
+								</li>
+								{/if}
 								<li class="nav-item">
 									<a class="nav-link" href="#list-recommended-current-contest" data-toggle="tab">
 										{#arenaRecommendedCurrentContests#}</a>
@@ -49,21 +55,15 @@
 									<a class="nav-link" href="#list-past-contest" data-toggle="tab">
 										{#arenaOldContests#}</a>
 								</li>
-								{if $LOGGED_IN == 1}
-								<li class="nav-item">
-									<a class="nav-link" href="#list-current-participating-contest" data-toggle="tab">
-										{#arenaMyActiveContests#}</a>
-								</li>
-								{/if}
 							</ul>
 
 							<div class="tab-content">
-								<div class="tab-pane" id="list-recommended-current-contest">
-									<div class="panel panel-primary" id="recommended-current-contests"
-										 data-bind="template: { name: 'contest-list', if: page().length > 0 }"></div>
-								</div>
 								<div class="tab-pane" id="list-current-participating-contest">
 									<div class="panel panel-primary" id="participating-current-contests"
+										 data-bind="template: { name: 'contest-list', if: page().length > 0 }"></div>
+								</div>
+								<div class="tab-pane" id="list-recommended-current-contest">
+									<div class="panel panel-primary" id="recommended-current-contests"
 										 data-bind="template: { name: 'contest-list', if: page().length > 0 }"></div>
 								</div>
 								<div class="tab-pane" id="list-current-contest">

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1097,7 +1097,7 @@ class ProblemList extends \OmegaUp\Test\ControllerTestCase {
         for ($i = 1; $i <= $pages; $i++) {
             $response = \OmegaUp\Controllers\Problem::getProblemListForSmarty(
                 $request
-            );
+            )['smartyProperties'];
             $nextPage = end($response['pager_items']);
             $nextPageURL = $nextPage['url'];
             $nextPageURLQuery = parse_url($nextPageURL);

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -157,6 +157,10 @@ def test_user_ranking_contest(driver):
         with driver.page_transition():
             driver.wait.until(
                 EC.element_to_be_clickable(
+                    (By.XPATH,
+                     '//a[@href = "#list-current-contest"]'))).click()
+            driver.wait.until(
+                EC.element_to_be_clickable(
                     (By.CSS_SELECTOR,
                      '#current-contests a[href="/arena/%s"]' %
                      contest_alias))).click()

--- a/frontend/www/contests/edit.php
+++ b/frontend/www/contests/edit.php
@@ -1,25 +1,15 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-
-try {
-    $result = \OmegaUp\Controllers\Contest::getContestNewDetailsForSmarty(
-        new \OmegaUp\Request($_REQUEST),
-        /*$isUpdate=*/true
-    );
-} catch (\Exception $e) {
-    \OmegaUp\ApiCaller::handleException($e);
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
 }
 
-foreach ($result as $key => $value) {
-    \OmegaUp\UITools::getSmartyInstance()->assign($key, $value);
-}
-
-\OmegaUp\UITools::getSmartyInstance()->display(
-    sprintf(
-        '%s/templates/contest.edit.tpl',
-        strval(
-            OMEGAUP_ROOT
-        )
-    )
+\OmegaUp\UITools::render(
+    function (\OmegaUp\Request $r) {
+        return \OmegaUp\Controllers\Contest::getContestEditForSmarty(
+            $r
+        );
+    }
 );

--- a/frontend/www/contests/mine.php
+++ b/frontend/www/contests/mine.php
@@ -1,24 +1,15 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-
-try {
-    $result = \OmegaUp\Controllers\Contest::getContestListMineForSmarty(
-        new \OmegaUp\Request($_REQUEST)
-    );
-} catch (\Exception $e) {
-    \OmegaUp\ApiCaller::handleException($e);
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
 }
 
-foreach ($result as $key => $value) {
-    \OmegaUp\UITools::getSmartyInstance()->assign($key, $value);
-}
-
-\OmegaUp\UITools::getSmartyInstance()->display(
-    sprintf(
-        '%s/templates/contest.mine.tpl',
-        strval(
-            OMEGAUP_ROOT
-        )
-    )
+\OmegaUp\UITools::render(
+    function (\OmegaUp\Request $r) {
+        return \OmegaUp\Controllers\Contest::getContestListMineForSmarty(
+            $r
+        );
+    }
 );

--- a/frontend/www/contests/new.php
+++ b/frontend/www/contests/new.php
@@ -1,24 +1,15 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-
-try {
-    $result = \OmegaUp\Controllers\Contest::getContestNewDetailsForSmarty(
-        new \OmegaUp\Request($_REQUEST)
-    );
-} catch (\Exception $e) {
-    \OmegaUp\ApiCaller::handleException($e);
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
 }
 
-foreach ($result as $key => $value) {
-    \OmegaUp\UITools::getSmartyInstance()->assign($key, $value);
-}
-
-\OmegaUp\UITools::getSmartyInstance()->display(
-    sprintf(
-        '%s/templates/contest.new.tpl',
-        strval(
-            OMEGAUP_ROOT
-        )
-    )
+\OmegaUp\UITools::render(
+    function (\OmegaUp\Request $r) {
+        return \OmegaUp\Controllers\Contest::getContestNewForSmarty(
+            $r
+        );
+    }
 );

--- a/frontend/www/contests/scoreboardmerge.php
+++ b/frontend/www/contests/scoreboardmerge.php
@@ -1,6 +1,11 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
+}
+
 \OmegaUp\UITools::getSmartyInstance()->display(
     sprintf(
         '%s/templates/scoreboardmerge.tpl',

--- a/frontend/www/index.php
+++ b/frontend/www/index.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    function (\OmegaUp\Request $r): array {
+    function (\OmegaUp\Request $r) {
         return \OmegaUp\Controllers\User::getIndexDetailsForSmarty(
             $r
         );

--- a/frontend/www/js/omegaup/api.d.ts
+++ b/frontend/www/js/omegaup/api.d.ts
@@ -285,6 +285,7 @@ declare namespace omegaup {
     gravatarURL51: string;
     currentUsername: string;
     isAdmin: boolean;
+    isMainUserIdentity: boolean;
     lockDownImage: string;
     navbarSection: string;
   }

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -25,7 +25,7 @@
       <div aria-expanded="false" class="navbar-collapse collapse">
         <ul
           class="nav navbar-nav"
-          v-if="!header.omegaUpLockDown &amp;&amp; !header.inContest"
+          v-if="!header.omegaUpLockDown && !header.inContest"
         >
           <li v-bind:class="{ active: header.navbarSection === 'arena' }">
             <a href="/arena/">{{ T.navArena }}</a>
@@ -33,7 +33,7 @@
           <li
             class="dropdown nav-contests"
             v-bind:class="{ active: header.navbarSection === 'contests' }"
-            v-show="header.isLoggedIn"
+            v-show="header.isLoggedIn && header.isMainUserIdentity"
           >
             <a class="dropdown-toggle" data-toggle="dropdown" href="#"
               ><span>{{ T.wordsContests }}</span> <span class="caret"></span
@@ -56,7 +56,7 @@
           <li
             class="dropdown nav-problems"
             v-bind:class="{ active: header.navbarSection === 'problems' }"
-            v-if="header.isLoggedIn"
+            v-if="header.isLoggedIn && header.isMainUserIdentity"
           >
             <a class="dropdown-toggle" data-toggle="dropdown" href="#"
               ><span>{{ T.wordsProblems }}</span> <span class="caret"></span

--- a/frontend/www/problems/list.php
+++ b/frontend/www/problems/list.php
@@ -1,24 +1,15 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-
-try {
-    $result = \OmegaUp\Controllers\Problem::getProblemListForSmarty(
-        new \OmegaUp\Request($_REQUEST)
-    );
-} catch (\Exception $e) {
-    \OmegaUp\ApiCaller::handleException($e);
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
 }
 
-foreach ($result as $key => $value) {
-    \OmegaUp\UITools::getSmartyInstance()->assign($key, $value);
-}
-
-\OmegaUp\UITools::getSmartyInstance()->display(
-    sprintf(
-        '%s/templates/problems.tpl',
-        strval(
-            OMEGAUP_ROOT
-        )
-    )
+\OmegaUp\UITools::render(
+    function (\OmegaUp\Request $r) {
+        return \OmegaUp\Controllers\Problem::getProblemListForSmarty(
+            $r
+        );
+    }
 );

--- a/frontend/www/problems/mine.php
+++ b/frontend/www/problems/mine.php
@@ -1,24 +1,15 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-
-try {
-    $result = \OmegaUp\Controllers\Problem::getProblemsMineInfoForSmarty(
-        new \OmegaUp\Request($_REQUEST)
-    );
-} catch (\Exception $e) {
-    \OmegaUp\ApiCaller::handleException($e);
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
 }
 
-foreach ($result as $key => $value) {
-    \OmegaUp\UITools::getSmartyInstance()->assign($key, $value);
-}
-
-\OmegaUp\UITools::getSmartyInstance()->display(
-    sprintf(
-        '%s/templates/problem.mine.tpl',
-        strval(
-            OMEGAUP_ROOT
-        )
-    )
+\OmegaUp\UITools::render(
+    function (\OmegaUp\Request $r) {
+        return \OmegaUp\Controllers\Problem::getProblemsMineInfoForSmarty(
+            $r
+        );
+    }
 );

--- a/frontend/www/problems/new.php
+++ b/frontend/www/problems/new.php
@@ -1,24 +1,15 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-
-try {
-    $result = \OmegaUp\Controllers\Problem::getProblemNewForSmarty(
-        new \OmegaUp\Request($_REQUEST)
-    );
-} catch (\Exception $e) {
-    \OmegaUp\ApiCaller::handleException($e);
+if (OMEGAUP_LOCKDOWN) {
+    header('Location: /arena/');
+    die();
 }
 
-foreach ($result as $key => $value) {
-    \OmegaUp\UITools::getSmartyInstance()->assign($key, $value);
-}
-
-\OmegaUp\UITools::getSmartyInstance()->display(
-    sprintf(
-        '%s/templates/problem.new.tpl',
-        strval(
-            OMEGAUP_ROOT
-        )
-    )
+\OmegaUp\UITools::render(
+    function (\OmegaUp\Request $r) {
+        return \OmegaUp\Controllers\Problem::getProblemNewForSmarty(
+            $r
+        );
+    }
 );

--- a/frontend/www/ux/arena.js
+++ b/frontend/www/ux/arena.js
@@ -4,6 +4,14 @@ omegaup.OmegaUp.on('ready', function() {
   var contestListConfigs = [
     // List Id, Active, Recommended, List, Public header
     [
+      '#participating-current-contests',
+      'ACTIVE',
+      'NOT_RECOMMENDED',
+      'YES',
+      'NO',
+      omegaup.T.arenaMyActiveContests,
+    ],
+    [
       '#recommended-current-contests',
       'ACTIVE',
       'RECOMMENDED',
@@ -50,14 +58,6 @@ omegaup.OmegaUp.on('ready', function() {
       'NO',
       'NO',
       omegaup.T.arenaOldContests,
-    ],
-    [
-      '#participating-current-contests',
-      'ACTIVE',
-      'NOT_RECOMMENDED',
-      'YES',
-      'NO',
-      omegaup.T.arenaMyActiveContests,
     ],
   ];
 


### PR DESCRIPTION
Este cambio elimina muchas de las opciones disponibles para identidades
que en realidad no funcionan o que no se pueden utilizar. También se
despliegan los concursos en los que participo al principio para evitar
el andar buscando a dónde ir al principio.