### PR TITLE
Eliminar cpp11 como lenguaje valido al crear un concurso

### DIFF
--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -14,7 +14,6 @@ class Run extends \OmegaUp\Controllers\Controller {
         'kj' => 'Karel (Java)',
         'c11-gcc' => 'C11 (gcc 7.4)',
         'c11-clang' => 'C11 (clang 6.0)',
-        'cpp11' => 'C++11 (gcc 7.4)',
         'cpp11-gcc' => 'C++11 (g++ 7.4)',
         'cpp11-clang' => 'C++11 (clang++ 6.0)',
         'cpp17-gcc' => 'C++17 (g++ 7.4)',


### PR DESCRIPTION
# Descripción

Fixes: #3402 

# Checklist:

- [*] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [*] Se corrieron todas las pruebas y pasaron.
