### PR TITLE
Notificar a Analytics sobre cambios de problema

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1683,6 +1683,12 @@ export class Arena {
       }
 
       if (problemChanged) {
+        // Ping Analytics with updated problem id
+        let page = window.location.pathname + window.location.hash;
+        if (typeof ga == 'function') {
+          ga('set', 'page', page);
+          ga('send', 'pageview');
+        }
         if (problem.statement) {
           update(problem);
         } else {


### PR DESCRIPTION
# Descripción

Notificar a Analytics sobre cambios de problema mientras se ve un problemset.

# Comentarios

Este es el primer paso para hacer analisis de cómo los usuarios se comportan al entrar a un problemset. Lo siguiente es notificar sobre envíos y veredictos. La idea es poder correlacionar comportamiento de los usuarios en problemsets particulares con métricas de retención y crecimiento.

# Checklist:

- [*] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.