### PR TITLE
Agregando soporte para administrar grupos de usuarios en concursos

### DIFF
--- a/frontend/server/src/DAO/GroupRoles.php
+++ b/frontend/server/src/DAO/GroupRoles.php
@@ -56,6 +56,35 @@ class GroupRoles extends \OmegaUp\DAO\Base\GroupRoles {
         return $admins;
     }
 
+    /**
+     * @return list<array{alias: string, name: string}>
+     */
+    public static function getContestantGroups(int $problemsetId): array {
+        $sql = '
+            SELECT
+                g.alias, g.name
+            FROM
+                Problemsets p
+            INNER JOIN
+                Group_Roles gr ON gr.acl_id = p.acl_id
+            INNER JOIN
+                Groups g ON g.group_id = gr.group_id
+            WHERE
+                p.problemset_id = ? AND
+                gr.role_id = ?;
+        ';
+        $params = [
+            $problemsetId,
+            \OmegaUp\Authorization::CONTESTANT_ROLE,
+        ];
+
+        /** @var list<array{alias: string, name: string}> */
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            $params
+        );
+    }
+
     public static function hasRole(
         int $identityId,
         int $aclId,

--- a/frontend/server/src/DAO/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/ProblemsetIdentities.php
@@ -31,7 +31,19 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
             intval($container->problemset_id)
         );
         if (is_null($problemsetIdentity)) {
-            if (!$grantAccess) {
+            // Identities that were added through a group are still considered
+            // to be granted access.
+            $problemset = \OmegaUp\DAO\Problemsets::getByPK(
+                intval($container->problemset_id)
+            );
+            $isInvited = (
+                !is_null($problemset) &&
+                \OmegaUp\DAO\GroupRoles::isContestant(
+                    intval($identity->identity_id),
+                    intval($problemset->acl_id)
+                )
+            );
+            if (!$grantAccess && !$isInvited) {
                 // User was not authorized to do this.
                 throw new \OmegaUp\Exceptions\ForbiddenAccessException();
             }
@@ -40,7 +52,7 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
                 'problemset_id' => intval($container->problemset_id),
                 'score' => 0,
                 'time' => 0,
-                'is_invited' => false,
+                'is_invited' => $isInvited,
                 'share_user_information' => $shareUserInformation,
             ]);
         }

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -21,7 +21,10 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
         bool $runForAdmin = true,
         bool $runForDirector = true
     ) {
-        $problemData = [\OmegaUp\Test\Factories\Problem::createProblem(), \OmegaUp\Test\Factories\Problem::createProblem()];
+        $problemData = [
+            \OmegaUp\Test\Factories\Problem::createProblem(),
+            \OmegaUp\Test\Factories\Problem::createProblem(),
+        ];
         $contestData = \OmegaUp\Test\Factories\Contest::createContest();
 
         // Add the problems to the contest
@@ -38,10 +41,16 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
         $contestants = [];
         $identities = [];
         for ($i = 0; $i < $nUsers; $i++) {
-            ['user' => $contestants[], 'identity' => $identities[]] = \OmegaUp\Test\Factories\User::createUser();
+            [
+                'user' => $contestants[],
+                'identity' => $identities[],
+            ] = \OmegaUp\Test\Factories\User::createUser();
         }
         $contestDirector = $contestData['director'];
-        ['user' => $contestAdmin, 'identity' => $contestIdentityAdmin] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $contestAdmin,
+            'identity' => $contestIdentityAdmin,
+        ] = \OmegaUp\Test\Factories\User::createUser();
         \OmegaUp\Test\Factories\Contest::addAdminUser(
             $contestData,
             $contestIdentityAdmin
@@ -86,7 +95,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             'contestData' => $contestData,
             'contestants' => $identities,
             'contestAdmin' => $contestAdmin,
-            'runMap' => $runMap
+            'runMap' => $runMap,
         ];
     }
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -131,12 +131,10 @@
       <code>$start_time</code>
     </PossiblyNullOperand>
     <PossiblyNullPropertyFetch occurrences="5">
-      <code>$r-&gt;user-&gt;user_id</code>
       <code>$acl-&gt;owner_id</code>
       <code>$contest-&gt;start_time</code>
       <code>$contest-&gt;finish_time</code>
       <code>$problemset-&gt;problemset_id</code>
-      <code>$r-&gt;user-&gt;user_id</code>
     </PossiblyNullPropertyFetch>
     <TypeDoesNotContainNull occurrences="1">
       <code>is_null($identity)</code>


### PR DESCRIPTION
Este cambio permite a los administradores de concursos agregar grupos
enteros además de poder agregar concursantes individuales. Útil para no
tener que andar agregando concursantes uno por uno en series de
concursos.