### PR TITLE
Permitiendo actualizar identidades con /api/identities/bulkCreate/

### DIFF
--- a/frontend/tests/resources/identities_updated.csv
+++ b/frontend/tests/resources/identities_updated.csv
@@ -1,0 +1,6 @@
+﻿username,name,country_id,state_id,gender,school_name
+identity_1,Updated Identity One,MX,CMX,male,School Group
+identity_2,Updated Identity Two,MX,GUA,male,School Group
+identity_3,Updated Identity Three,MX,QUE,female,School Group
+identity_4,Updated Identity Four,MX,HID,male,School Group
+identity_6,Created Identity Six,MX,BCN,female,School Group

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -141,12 +141,11 @@
     </TypeDoesNotContainNull>
   </file>
   <file src="frontend/server/src/Controllers/Identity.php">
-    <MissingParamType occurrences="14">
+    <MissingParamType occurrences="13">
       <code>$username</code>
       <code>$name</code>
       <code>$gender</code>
       <code>$aliasGroup</code>
-      <code>$groupId</code>
       <code>$username</code>
       <code>$name</code>
       <code>$gender</code>


### PR DESCRIPTION
Este cambio permite que los administradores creen O actualicen las
identidades en un grupo mediante /api/identities/bulkCreate/. Eso evita
que tengan que modificar las identidades a mano como cavernícolas.

Fixes: #3404