### PR TITLE
Evitando un error al actualizar problemas con Tags

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -569,11 +569,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\Tags::create($tag);
         }
 
-        \OmegaUp\DAO\ProblemsTags::create(new \OmegaUp\DAO\VO\ProblemsTags([
+        \OmegaUp\DAO\ProblemsTags::replace(new \OmegaUp\DAO\VO\ProblemsTags([
             'problem_id' => $problem->problem_id,
             'tag_id' => $tag->tag_id,
             'public' => filter_var($isPublic, FILTER_VALIDATE_BOOLEAN),
-            'source' => 'voted',
+            'source' => 'owner',
         ]));
     }
 

--- a/frontend/server/src/DAO/ProblemsTags.php
+++ b/frontend/server/src/DAO/ProblemsTags.php
@@ -36,7 +36,7 @@ class ProblemsTags extends \OmegaUp\DAO\Base\ProblemsTags {
             $sql .= ' AND pt.public = 1';
         }
         if (!$includeVoted) {
-            $sql .= ' AND pt.source = "voted"';
+            $sql .= ' AND pt.source != "voted"';
         }
         $sql .= ';';
 

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -1358,13 +1358,13 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         $tags1 = array_map($extractName, $tagArrayForProblem1);
         $this->assertEquals(
             $tags1,
-            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath', 'problemTopicMatrices']
+            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath', 'problemTopicMatrices', 'lenguaje']
         );
 
         $tags3 = array_map($extractName, $tagArrayForProblem3);
         $this->assertEquals(
             $tags3,
-            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicGeometry', 'problemTopicSorting']
+            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicGeometry', 'problemTopicSorting', 'lenguaje']
         );
 
         \OmegaUp\Test\Utils::runUpdateRanks();
@@ -1433,13 +1433,13 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         $tags1 = array_map($extractName, $tagArrayForProblem1);
         $this->assertEquals(
             $tags1,
-            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath']
+            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath', 'lenguaje']
         );
 
         $tags3 = array_map($extractName, $tagArrayForProblem3);
         $this->assertEquals(
             $tags3,
-            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicGeometry', 'problemTopicSorting']
+            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicGeometry', 'problemTopicSorting', 'lenguaje']
         );
     }
 
@@ -1720,7 +1720,7 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         ));
         $this->assertEquals(
             $tags,
-            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath']
+            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath', 'lenguaje']
         );
     }
 
@@ -1999,7 +1999,7 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         sort($tags);
         $this->assertEquals(
             $tags,
-            ['problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath']
+            ['lenguaje', 'problemTopicDynamicProgramming', 'problemTopicGreedy', 'problemTopicMath']
         );
 
         $tags = array_map(function ($tag) {
@@ -2012,7 +2012,7 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         sort($tags);
         $this->assertEquals(
             $tags,
-            ['problemTopicDynamicProgramming', 'problemTopicGeometry', 'problemTopicMath', 'problemTopicSorting']
+            ['lenguaje', 'problemTopicDynamicProgramming', 'problemTopicGeometry', 'problemTopicMath', 'problemTopicSorting']
         );
     }
 }


### PR DESCRIPTION
Este cambio hace que los usuarios que mandan llamar algún método de
edición de problemas se tengan que acordar de qué tags ya le pasaron.
Ahora en vez de mandar llamar ProblemsTags::create(), se manda llamar
ProblemsTags::replace().