### PR TITLE
Arreglando bug que no permitía mostrar filtros en el rank de usuarios

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2820,19 +2820,19 @@ class User extends \OmegaUp\Controllers\Controller {
         if (is_null($identity)) {
             return ['filteredBy' => null, 'value' => null];
         }
-        if ($filteredBy == 'country') {
+        if ($filteredBy === 'country') {
             return [
                 'filteredBy' => $filteredBy,
                 'value' => $identity->country_id
             ];
         }
-        if ($filteredBy == 'state') {
+        if ($filteredBy === 'state') {
             return [
                 'filteredBy' => $filteredBy,
                 'value' => "{$identity->country_id}-{$identity->state_id}"
             ];
         }
-        if ($filteredBy == 'school') {
+        if ($filteredBy === 'school') {
             $schoolId = null;
             if (!is_null($identity->current_identity_school_id)) {
                 $identitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
@@ -3110,6 +3110,7 @@ class User extends \OmegaUp\Controllers\Controller {
                     'wordsFilterBySchool'
                 );
         }
+        $response['smartyProperties']['rankTablePayload']['availableFilters'] = $availableFilters;
         return $response;
     }
 

--- a/frontend/server/src/DAO/UserRank.php
+++ b/frontend/server/src/DAO/UserRank.php
@@ -47,28 +47,28 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
                     ),
                     "user-rank-unranked"
                 ) as `classname`';
-        $sql_count = '
+        $sqlCount = '
               SELECT
                 COUNT(1)';
         $params = [];
-        $sql_from = '
+        $sqlFrom = '
               FROM
                 `User_Rank` `ur`';
-        if ($filteredBy == 'state' && is_string($value)) {
+        if ($filteredBy === 'state' && is_string($value)) {
             $values = explode('-', $value);
             $params[] = $values[0];
             $params[] = $values[1];
-            $sql_from .= ' WHERE `ur`.`country_id` = ? AND `ur`.`state_id` = ?';
+            $sqlFrom .= ' WHERE `ur`.`country_id` = ? AND `ur`.`state_id` = ?';
         } elseif (!empty($filteredBy)) {
             $params[] = $value;
-            $sql_from .= ' WHERE `ur`.`' . \OmegaUp\MySQLConnection::getInstance()->escape(
+            $sqlFrom .= ' WHERE `ur`.`' . \OmegaUp\MySQLConnection::getInstance()->escape(
                 $filteredBy
             ) . '_id` = ?';
         }
         if (!is_null($order)) {
-            $sql_from .= ' ORDER BY `ur`.`' . \OmegaUp\MySQLConnection::getInstance()->escape(
+            $sqlFrom .= ' ORDER BY `ur`.`' . \OmegaUp\MySQLConnection::getInstance()->escape(
                 $order
-            ) . '` ' . ($orderType == 'DESC' ? 'DESC' : 'ASC');
+            ) . '` ' . ($orderType === 'DESC' ? 'DESC' : 'ASC');
         }
         $paramsLimit = [
             (($page - 1) * intval($colsPerPage)), // Offset
@@ -78,7 +78,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
         // Get total rows
         /** @var int */
         $totalRows = \OmegaUp\MySQLConnection::getInstance()->GetOne(
-            $sql_count . $sql_from,
+            "{$sqlCount}{$sqlFrom}",
             $params
         ) ?? 0;
 
@@ -87,7 +87,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
         // Get rows
         /** @var list<array{classname: string, country_id: null|string, name: null|string, problems_solved: int, rank: int, score: float, user_id: int, username: string}> */
         $allData = \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            $sql . $sql_from . $sqlLimit,
+            "{$sql}{$sqlFrom}{$sqlLimit}",
             $params
         );
         return [


### PR DESCRIPTION
# Descripción

Se arregla bug que no permitía mostrar los filtros en el rank de usuarios cuando
un usuario ya actualizó su perfil con la información básica (escuela, estado y país).

Se agrega una prueba en `PHPUnit` para evitar regresiones.

Fixes: #3371 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
