### PR TITLE
Mejorando la forma en la que se despliegan los concursos

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -115,6 +115,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $r->identity->identity_id,
                 $page,
                 $page_size,
+                $activeContests,
                 $query
             );
         } elseif ($public) {
@@ -314,6 +315,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $identityId,
                     $page,
                     $pageSize,
+                    \OmegaUp\DAO\Enum\ActiveStatus::ALL,
                     $query
                 );
             }

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -178,9 +178,6 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             // We need to get contest_id just to be able to ORDER BY it, but we
             // should not return it to users.
             unset($row['contest_id']);
-            $row['start_time'] = intval($row['start_time']);
-            $row['finish_time'] = intval($row['finish_time']);
-            $row['last_updated'] = intval($row['last_updated']);
         }
         return $result;
     }
@@ -337,10 +334,11 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         int $identityId,
         int $page = 1,
         int $pageSize = 1000,
+        int $active = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
         ?string $query = null
     ) {
-        $endCondition = \OmegaUp\DAO\Enum\ActiveStatus::sql(
-            \OmegaUp\DAO\Enum\ActiveStatus::ACTIVE
+        $activeCondition = \OmegaUp\DAO\Enum\ActiveStatus::sql(
+            $active
         );
         $recommendedCondition = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
             \OmegaUp\DAO\Enum\ActiveStatus::ALL
@@ -391,7 +389,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 pi.identity_id = ?
             WHERE
                 $recommendedCondition AND
-                $endCondition AND
+                $activeCondition AND
                 $queryCondition
         ";
         $params = [

--- a/frontend/www/js/omegaup/arena/contest_list.js
+++ b/frontend/www/js/omegaup/arena/contest_list.js
@@ -9,8 +9,6 @@ omegaup.arena.ContestList = function(domElement, apiParams, uiParams) {
     {
       active: 'ALL',
       recommended: 'ALL',
-      participating: 'NO',
-      public: 'NO',
       // TODO: Make this match uiParams.pageSize and do smaller requests.
       page_size: 1000,
     },
@@ -20,9 +18,7 @@ omegaup.arena.ContestList = function(domElement, apiParams, uiParams) {
     {
       header: omegaup.T.wordsContests,
       pageSize: 10,
-      showTimes:
-        actualApiParams.active == 'ACTIVE' ||
-        actualApiParams.active == 'FUTURE',
+      showTimes: actualApiParams.active != 'PAST',
       showPractice: actualApiParams.active == 'PAST',
       showVirtual: actualApiParams.active == 'PAST',
       showPublicUpdated: actualApiParams.public == 'YES',

--- a/frontend/www/ux/arena.js
+++ b/frontend/www/ux/arena.js
@@ -2,63 +2,73 @@ omegaup.OmegaUp.on('ready', function() {
   Date.setLocale(omegaup.T.locale);
 
   var contestListConfigs = [
-    // List Id, Active, Recommended, List, Public header
-    [
-      '#participating-current-contests',
-      'ACTIVE',
-      'NOT_RECOMMENDED',
-      'YES',
-      'NO',
-      omegaup.T.arenaMyActiveContests,
-    ],
-    [
-      '#recommended-current-contests',
-      'ACTIVE',
-      'RECOMMENDED',
-      'NO',
-      'NO',
-      omegaup.T.arenaRecommendedCurrentContests,
-    ],
-    [
-      '#current-contests',
-      'ACTIVE',
-      'NOT_RECOMMENDED',
-      'NO',
-      'NO',
-      omegaup.T.arenaCurrentContests,
-    ],
-    [
-      '#list-current-public-contest',
-      'ACTIVE',
-      'NOT_RECOMMENDED',
-      'NO',
-      'YES',
-      omegaup.T.arenaCurrentPublicContests,
-    ],
-    [
-      '#future-contests',
-      'FUTURE',
-      'NOT_RECOMMENDED',
-      'NO',
-      'NO',
-      omegaup.T.arenaFutureContests,
-    ],
-    [
-      '#recommended-past-contests',
-      'PAST',
-      'RECOMMENDED',
-      'NO',
-      'NO',
-      omegaup.T.arenaRecommendedOldContests,
-    ],
-    [
-      '#past-contests',
-      'PAST',
-      'NOT_RECOMMENDED',
-      'NO',
-      'NO',
-      omegaup.T.arenaOldContests,
-    ],
+    {
+      id: '#participating-current-contests',
+      header: omegaup.T.arenaMyActiveContests,
+      requestParams: {
+        participating: 'YES',
+      },
+    },
+    {
+      id: '#recommended-current-contests',
+      header: omegaup.T.arenaRecommendedCurrentContests,
+      requestParams: {
+        active: 'ACTIVE',
+        recommended: 'RECOMMENDED',
+        participating: 'NO',
+        public: 'NO',
+      },
+    },
+    {
+      id: '#current-contests',
+      header: omegaup.T.arenaCurrentContests,
+      requestParams: {
+        active: 'ACTIVE',
+        recommended: 'NOT_RECOMMENDED',
+        participating: 'NO',
+        public: 'NO',
+      },
+    },
+    {
+      id: '#list-current-public-contest',
+      header: omegaup.T.arenaCurrentPublicContests,
+      requestParams: {
+        active: 'ACTIVE',
+        recommended: 'NOT_RECOMMENDED',
+        participating: 'NO',
+        public: 'YES',
+      },
+    },
+    {
+      id: '#future-contests',
+      header: omegaup.T.arenaFutureContests,
+      requestParams: {
+        active: 'FUTURE',
+        recommended: 'NOT_RECOMMENDED',
+        participating: 'NO',
+        public: 'NO',
+      },
+    },
+    {
+      id: '#recommended-past-contests',
+      header: omegaup.T.arenaRecommendedOldContests,
+      requestParams: {
+        active: 'PAST',
+        recommended: 'RECOMMENDED',
+        participating: 'NO',
+        public: 'NO',
+      },
+    },
+    {
+      id: '#past-contests',
+      header: omegaup.T.arenaOldContests,
+      requestParams: {
+        active: 'PAST',
+        recommended: 'NOT_RECOMMENDED',
+        participating: 'NO',
+        public: 'NO',
+      },
+    },
   ];
 
   var requests = [];
@@ -67,16 +77,19 @@ omegaup.OmegaUp.on('ready', function() {
 
   for (var i = 0, len = contestListConfigs.length; i < len; i++) {
     var config = contestListConfigs[i];
+    var request = {
+      query: query,
+    };
+    for (var name in config.requestParams) {
+      if (!config.requestParams.hasOwnProperty(name)) {
+        continue;
+      }
+      request[name] = config.requestParams[name];
+    }
     var contestList = new omegaup.arena.ContestList(
-      document.querySelector(config[0]),
-      {
-        active: config[1],
-        recommended: config[2],
-        participating: config[3],
-        public: config[4],
-        query: query,
-      },
-      { header: config[5] },
+      document.querySelector(config.id),
+      request,
+      { header: config.header },
     );
     contestLists.push(contestList);
     requests.push(contestList.deferred);


### PR DESCRIPTION
Este cambio hace que la pestaña de "Mis Concursos" despliegue los
concursos pasados, presentes y futuros en los que el usuario ha sido
agregado. Esto evita confusión al entrar a la arena porque el concurso
que buscas es muy posiblemente el primero que se despliega en la lista.
Además, eso hace que una vez que el concurso termina, no tengas que ir a
cazarlo a otro lado.

Fixes: #3420