### PR TITLE
Haciendo que los tags de categoría tengan un color diferente

### DIFF
--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -57,7 +57,7 @@
                 <a
                   v-bind:class="`tag tag-${tag.source}`"
                   v-bind:href="hrefForProblemTag(currentTags, tag.name)"
-                  v-for="tag in problem.tags"
+                  v-for="tag in sortedTags(problem.tags)"
                   >{{ T.hasOwnProperty(tag.name) ? T[tag.name] : tag.name }}</a
                 >
               </div>
@@ -103,6 +103,10 @@
 <style>
 .tag {
   margin-right: 0.25em;
+}
+
+.tag-quality {
+  background: #d0c532;
 }
 
 .omegaup-quality-badge {
@@ -154,6 +158,14 @@ export default class ProblemList extends Vue {
     T.qualityFormDifficultyHard,
     T.qualityFormDifficultyVeryHard,
   ];
+
+  sortedTags(tags: omegaup.Tag[]): omegaup.Tag[] {
+    return tags.sort((a: omegaup.Tag, b: omegaup.Tag): number => {
+      if (a.source === 'quality' && b.source !== 'quality') return -1;
+      else if (a.source !== 'quality' && b.source === 'quality') return 1;
+      return a.name.localeCompare(b.name, this.T.lang);
+    });
+  }
 
   rowClassForProblem(problemVisibility: number): string {
     return problemVisibility >= 2 ? 'high-quality' : '';

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -49,15 +49,11 @@
               <a v-bind:href="`/arena/problem/${problem.alias}`">{{
                 problem.title
               }}</a>
-              <div
-                class="tag-list"
-                v-bind:title="`${problem.tags.map(tag =&gt; tag.name).join(' ')}`"
-                v-if="problem.tags.length"
-              >
+              <div class="tag-list" v-if="problem.tags.length">
                 <a
                   v-bind:class="`tag tag-${tag.source}`"
                   v-bind:href="hrefForProblemTag(currentTags, tag.name)"
-                  v-for="tag in sortedTags(problem.tags)"
+                  v-for="tag in problem.tags"
                   >{{ T.hasOwnProperty(tag.name) ? T[tag.name] : tag.name }}</a
                 >
               </div>
@@ -106,7 +102,7 @@
 }
 
 .tag-quality {
-  background: #d0c532;
+  background: #ffeb3b;
 }
 
 .omegaup-quality-badge {
@@ -158,14 +154,6 @@ export default class ProblemList extends Vue {
     T.qualityFormDifficultyHard,
     T.qualityFormDifficultyVeryHard,
   ];
-
-  sortedTags(tags: omegaup.Tag[]): omegaup.Tag[] {
-    return tags.sort((a: omegaup.Tag, b: omegaup.Tag): number => {
-      if (a.source === 'quality' && b.source !== 'quality') return -1;
-      else if (a.source !== 'quality' && b.source === 'quality') return 1;
-      return a.name.localeCompare(b.name, this.T.lang);
-    });
-  }
 
   rowClassForProblem(problemVisibility: number): string {
     return problemVisibility >= 2 ? 'high-quality' : '';


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/20785082/73853446-dcce6300-47fe-11ea-917b-298f23e055b0.png)


Fixes: #3423 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
