### PR TITLE
Desactivando las consultas de escuelas del mes

### DIFF
--- a/frontend/server/src/DAO/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/SchoolOfTheMonth.php
@@ -24,6 +24,8 @@ class SchoolOfTheMonth extends \OmegaUp\DAO\Base\SchoolOfTheMonth {
         string $finishDate,
         int $limit
     ): array {
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        return [];
         $sql = '
             SELECT
                 s.school_id,

--- a/frontend/server/src/DAO/Schools.php
+++ b/frontend/server/src/DAO/Schools.php
@@ -55,6 +55,8 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
         int $offset,
         int $rowcount
     ): array {
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        return [];
         $sql = '
             SELECT
                 s.school_id,
@@ -111,6 +113,8 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
         int $schoolId,
         int $monthsNumber
     ): array {
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        return [];
         $sql = '
         SELECT
             IFNULL(YEAR(su.time), 0) AS year,

--- a/frontend/tests/controllers/SchoolOfTheMonthTest.php
+++ b/frontend/tests/controllers/SchoolOfTheMonthTest.php
@@ -166,6 +166,9 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
 
         self::setUpSchoolsRuns($schoolsData);
 
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        return;
+
         $schools = \OmegaUp\DAO\SchoolOfTheMonth::calculateSchoolsOfMonthByGivenDate(
             $today
         );
@@ -269,6 +272,9 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
 
         self::setUpSchoolsRuns($schoolsData);
 
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        return;
+
         // API should return school1
         $response = \OmegaUp\Controllers\School::getSchoolOfTheMonth();
         $this->assertEquals(
@@ -328,6 +334,9 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         $lastDayOfMonth = $runDate;
         $lastDayOfMonth->modify('last day of this month');
         \OmegaUp\Time::setTimeForTesting($lastDayOfMonth->getTimestamp());
+
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        return;
 
         $result = \OmegaUp\Controllers\School::apiSelectSchoolOfTheMonth(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,

--- a/frontend/tests/controllers/SchoolRankTest.php
+++ b/frontend/tests/controllers/SchoolRankTest.php
@@ -87,6 +87,8 @@ class SchoolRankTest extends \OmegaUp\Test\ControllerTestCase {
             strtotime($runCreationDate)
         );
 
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        /*
         $response = \OmegaUp\Controllers\School::apiMonthlySolvedProblemsCount(new \OmegaUp\Request([
             'school_id' => $schoolData['school']->school_id,
             'months_count' => 3,
@@ -97,16 +99,15 @@ class SchoolRankTest extends \OmegaUp\Test\ControllerTestCase {
             $response[0]['count'],
             $firstMonthExpectedCount
         );
+        */
 
-        /**
-         * One month ago:
-         * user2 => problem0, problem1 = 2 distinct problems
-         * user0 => problem0 (the user has solved it the last month and also so it has
-         *                      been solved by user3 this month) = 0 distinct problems
-         * user1 => problem2 = 1 distinct problem
-         *
-         * Total expected count: 3
-         */
+        // One month ago:
+        // user2 => problem0, problem1 = 2 distinct problems
+        // user0 => problem0 (the user has solved it the last month and also so it has
+        //                      been solved by user3 this month) = 0 distinct problems
+        // user1 => problem2 = 1 distinct problem
+        //
+        // Total expected count: 3
         $runCreationDate = date_create($runCreationDate);
         date_add(
             $runCreationDate,
@@ -159,6 +160,8 @@ class SchoolRankTest extends \OmegaUp\Test\ControllerTestCase {
             strtotime($runCreationDate)
         );
 
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        /*
         $response = \OmegaUp\Controllers\School::apiMonthlySolvedProblemsCount(new \OmegaUp\Request([
             'school_id' => $schoolData['school']->school_id,
             'months_count' => 3,
@@ -174,14 +177,13 @@ class SchoolRankTest extends \OmegaUp\Test\ControllerTestCase {
             $response[1]['count'],
             $secondMonthExpectedCount
         );
+        */
 
-        /**
-         * This month:
-         * user1 => problem1 (he has already solved it, doesn't count)
-         *
-         * Total expected count: 0, the month/year won't be retrieved as no distinct
-         * problems are going to be found
-         */
+        // This month:
+        // user1 => problem1 (he has already solved it, doesn't count)
+        //
+        // Total expected count: 0, the month/year won't be retrieved as no distinct
+        // problems are going to be found
         $currentMonth = intval(date_create($today)->format('m'));
 
         $runData = \OmegaUp\Test\Factories\Run::createRunToProblem(
@@ -190,11 +192,14 @@ class SchoolRankTest extends \OmegaUp\Test\ControllerTestCase {
         );
         \OmegaUp\Test\Factories\Run::gradeRun($runData);
 
+        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
+        /*
         $response = \OmegaUp\Controllers\School::apiMonthlySolvedProblemsCount(new \OmegaUp\Request([
             'school_id' => $schoolData['school']->school_id,
             'months_count' => 3,
         ]))['distinct_problems_solved'];
         $this->assertCount(2, $response); // just two months (first and second)
+        */
     }
 
     /**


### PR DESCRIPTION
Este cambio desactiva las consultas de escuelas del mes hasta que
tengamos una manera de arreglar el problema de raíz.

Part of: #3438