### PR TITLE
Agregando entradas de Cursos en Problemsets

### DIFF
--- a/frontend/database/133_add_course_problemset.sql
+++ b/frontend/database/133_add_course_problemset.sql
@@ -1,0 +1,34 @@
+-- Problemsets
+ALTER TABLE `Problemsets`
+    ADD COLUMN `course_id` int(11) DEFAULT NULL COMMENT 'Id del curso',
+    MODIFY COLUMN `assignment_id` int(11) DEFAULT NULL COMMENT 'Id de la tarea o examen del curso',
+    MODIFY COLUMN `scoreboard_url` varchar(30) DEFAULT NULL COMMENT 'Token para la url del scoreboard en problemsets',
+    MODIFY COLUMN `scoreboard_url_admin` varchar(30) DEFAULT NULL COMMENT 'Token para la url del scoreboard de admin en problemsets',
+    MODIFY COLUMN `type` enum('Contest','Assignment','Interview','Course') NOT NULL DEFAULT 'Contest' COMMENT 'Almacena el tipo de problemset que se ha creado',
+    CHANGE `access_mode` `admission_mode` enum('private','public','registration') NOT NULL DEFAULT 'private' COMMENT 'La modalidad de acceso a este conjunto de problemas',
+    ADD CONSTRAINT UNIQUE (`problemset_id`, `contest_id`, `course_id`, `assignment_id`, `interview_id`),
+    ADD CONSTRAINT CHECK (`contest_id` IS NOT NULL OR `course_id` IS NOT NULL OR `assignment_id` IS NOT NULL OR `interview_id` IS NOT NULL),
+    ADD CONSTRAINT `fk_psc_course_id` FOREIGN KEY (`course_id`) REFERENCES `Courses` (`course_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- Adding the courses in Problemsets table
+INSERT INTO
+    `Problemsets` (`acl_id`, `admission_mode`, `needs_basic_information`, `requests_user_information`, `type`, `course_id`)
+SELECT
+    `acl_id`,
+    IF(`public` = '1', 'public', 'private'),
+    `needs_basic_information`,
+    `requests_user_information`,
+    'Course',
+    `course_id`
+FROM
+    `Courses`;
+
+-- Updating Contest admission_mode in Problemsets table
+UPDATE
+    `Problemsets`
+INNER JOIN
+    `Contests`
+ON
+    `Contests`.`problemset_id` = `Problemsets`.`problemset_id`
+SET
+    `Problemsets`.`admission_mode` = `Contests`.`admission_mode`

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -641,26 +641,30 @@ CREATE TABLE `Problemset_Problems` (
 CREATE TABLE `Problemsets` (
   `problemset_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'El identificador único para cada conjunto de problemas',
   `acl_id` int(11) NOT NULL COMMENT 'La lista de control de acceso compartida con su container',
-  `access_mode` enum('private','public','registration') NOT NULL DEFAULT 'public' COMMENT 'La modalidad de acceso a este conjunto de problemas',
+  `admission_mode` enum('private','public','registration') NOT NULL DEFAULT 'private' COMMENT 'La modalidad de acceso a este conjunto de problemas',
   `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','java','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar para resolver los problemas',
   `needs_basic_information` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Un campo opcional para indicar si es obligatorio que el usuario pueda ingresar a un concurso sólo si ya llenó su información de perfil',
   `requests_user_information` enum('no','optional','required') NOT NULL DEFAULT 'no' COMMENT 'Se solicita información de los participantes para contactarlos posteriormente.',
-  `scoreboard_url` varchar(30) NOT NULL COMMENT 'Token para la url del scoreboard en problemsets',
-  `scoreboard_url_admin` varchar(30) NOT NULL COMMENT 'Token para la url del scoreboard de admin en problemsets',
-  `type` enum('Contest','Assignment','Interview') NOT NULL DEFAULT 'Contest' COMMENT 'Almacena el tipo de problemset que se ha creado',
+  `scoreboard_url` varchar(30) DEFAULT NULL COMMENT 'Token para la url del scoreboard en problemsets',
+  `scoreboard_url_admin` varchar(30) DEFAULT NULL COMMENT 'Token para la url del scoreboard de admin en problemsets',
+  `type` enum('Contest','Assignment','Interview','Course') NOT NULL DEFAULT 'Contest' COMMENT 'Almacena el tipo de problemset que se ha creado',
   `contest_id` int(11) DEFAULT NULL COMMENT 'Id del concurso',
-  `assignment_id` int(11) DEFAULT NULL COMMENT 'Id del curso',
+  `assignment_id` int(11) DEFAULT NULL COMMENT 'Id de la tarea o examen del curso',
   `interview_id` int(11) DEFAULT NULL COMMENT 'Id de la entrevista',
+  `course_id` int(11) DEFAULT NULL COMMENT 'Id del curso',
   PRIMARY KEY (`problemset_id`),
   UNIQUE KEY `problemset_id` (`problemset_id`,`contest_id`,`assignment_id`,`interview_id`),
+  UNIQUE KEY `problemset_id_2` (`problemset_id`,`contest_id`,`course_id`,`assignment_id`,`interview_id`),
   KEY `acl_id` (`acl_id`),
   KEY `contest_id` (`contest_id`),
   KEY `assignment_id` (`assignment_id`),
   KEY `interview_id` (`interview_id`),
+  KEY `fk_psc_course_id` (`course_id`),
   CONSTRAINT `Problemsets_ibfk_1` FOREIGN KEY (`contest_id`) REFERENCES `Contests` (`contest_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `Problemsets_ibfk_2` FOREIGN KEY (`assignment_id`) REFERENCES `Assignments` (`assignment_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `Problemsets_ibfk_3` FOREIGN KEY (`interview_id`) REFERENCES `Interviews` (`interview_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
-  CONSTRAINT `fk_psa_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+  CONSTRAINT `fk_psa_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `fk_psc_course_id` FOREIGN KEY (`course_id`) REFERENCES `Courses` (`course_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Conjunto de problemas.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1298,7 +1298,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemset = new \OmegaUp\DAO\VO\Problemsets([
             'needs_basic_information' => false,
             'requests_user_information' => 'no',
-            'access_mode' => 'private', // Virtual contest must be private
+            'admission_mode' => 'private', // Virtual contest must be private
         ]);
 
         self::createContest(

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -201,7 +201,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Returns a list of contests where current user has admin rights (or is
      * the director).
      *
-     * @return array{contests: list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string}>}
+     * @return array{contests: list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string}>}
      */
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -238,9 +238,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Callback to get contests list, depending on a given method
      *
      * @param \OmegaUp\Request $r
-     * @param Closure(int, int, int, null|string):list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}> $callbackUserFunction
+     * @param Closure(int, int, int, null|string):list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}> $callbackUserFunction
      *
-     * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
+     * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
      */
     private static function getContestListInternal(
         \OmegaUp\Request $r,
@@ -274,7 +274,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests where current user is the director
      *
-     * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
+     * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
      */
     public static function apiMyList(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -299,7 +299,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests where current user is participating in
      *
-     * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
+     * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
      */
     public static function apiListParticipating(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -551,7 +551,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{smartyProperties: array{payload: array{contests: list<array{contest_id: int, problemset_id: int, acl_id?: int, title: string, description: string, original_finish_time?: string, start_time: int|null, finish_time: int|null, last_updated: int|null, window_length: null|int, rerun_id: int, admission_mode: string, alias: string, scoreboard?: int, points_decay_factor?: float, partial_score?: int, submissions_gap?: int, feedback?: string, penalty?: int, penalty_type?: string, penalty_calc_policy?: string, show_scoreboard_after?: int, urgent?: int, languages?: null|string, recommended: bool, scoreboard_url: string, scoreboard_url_admin: string}>}, privateContestsAlert: bool}, template: string}
+     * @return array{smartyProperties: array{payload: array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: string, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}, privateContestsAlert: bool}, template: string}
      */
     public static function getContestListMineForSmarty(
         \OmegaUp\Request $r

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -1065,7 +1065,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * List course assignments
      *
-     * @return array{assignments: list<array{alias: string, assignment_type: string, description: string, finish_time: null|int, has_runs: bool, name: string, order: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int}>}
+     * @return array{assignments: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, has_runs: bool, name: string, order: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>}
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     public static function apiListAssignments(\OmegaUp\Request $r) {
@@ -1947,7 +1947,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{payload: array{course: array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: array{name: string, description: string, alias: string, publish_time_delay: ?int, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}[], school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: string|null}, students: array{name: null|string, progress: array<string, float>, username: string}[], student?: string}}
+     * @return array{payload: array{course: array{alias: string, assignments?: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>, basic_information_required: bool, description: string, finish_time?: int|null, is_admin?: bool, name: string, public?: bool, requests_user_information: string, school_id?: int|null, school_name?: null|string, show_scoreboard?: bool, start_time?: int, student_count?: int}, student?: string, students: list<array{name: null|string, progress: array<string, float>, username: string}>}}
      */
     public static function getStudentsInformationForSmarty(
         \OmegaUp\Request $r
@@ -2146,7 +2146,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns course details common between admin & non-admin
-     * @return array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: list<array{name: string, description: string, alias: string, publish_time_delay: ?int, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: string|null}
+     * @return array{alias: string, assignments?: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>, basic_information_required: bool, description: string, finish_time?: int|null, is_admin?: bool, name: string, public?: bool, requests_user_information: string, school_id?: int|null, school_name?: null|string, show_scoreboard?: bool, start_time?: int, student_count?: int}
      */
     private static function getCommonCourseDetails(
         \OmegaUp\DAO\VO\Courses $course,
@@ -2222,7 +2222,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns all details of a given Course
      *
-     * @return array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: list<array{name: string, description: string, alias: string, publish_time_delay: int|null, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: null|string}
+     * @return array{alias: string, assignments?: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>, basic_information_required: bool, description: string, finish_time?: int|null, is_admin?: bool, name: string, public?: bool, requests_user_information: string, school_id?: int|null, school_name?: null|string, show_scoreboard?: bool, start_time?: int, student_count?: int}
      */
     public static function apiAdminDetails(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -2691,7 +2691,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns details of a given course
      *
-     * @return array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: list<array{name: string, description: string, alias: string, publish_time_delay: int|null, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: null|string}
+     * @return array{alias: string, assignments?: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>, basic_information_required: bool, description: string, finish_time?: int|null, is_admin?: bool, name: string, public?: bool, requests_user_information: string, school_id?: int|null, school_name?: null|string, show_scoreboard?: bool, start_time?: int, student_count?: int}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -30,7 +30,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
                     AND a.alias = ?';
         $params = [$courseId, $assignmentAlias];
 
-        /** @var array{access_mode: string, acl_id: int, assignment_id: int|null, contest_id: int|null, interview_id: int|null, languages: null|string, needs_basic_information: bool, problemset_id: int, requests_user_information: string, scoreboard_url: string, scoreboard_url_admin: string, type: string}|null */
+        /** @var array{admission_mode: string, acl_id: int, assignment_id: int|null, contest_id: int|null, interview_id: int|null, languages: null|string, needs_basic_information: bool, problemset_id: int, requests_user_information: string, scoreboard_url: string, scoreboard_url_admin: string, type: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
         if (empty($rs)) {
             return null;
@@ -171,7 +171,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
                 ON
                     `ps`.`problemset_id` = `a`.`problemset_id`
                 WHERE
-                    course_id = ?
+                    `a`.`course_id` = ?
                 ORDER BY
                     `order` ASC, `start_time` ASC';
 

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -30,7 +30,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
                     AND a.alias = ?';
         $params = [$courseId, $assignmentAlias];
 
-        /** @var array{admission_mode: string, acl_id: int, assignment_id: int|null, contest_id: int|null, interview_id: int|null, languages: null|string, needs_basic_information: bool, problemset_id: int, requests_user_information: string, scoreboard_url: string, scoreboard_url_admin: string, type: string}|null */
+        /** @var array{acl_id: int, admission_mode: string, assignment_id: int|null, contest_id: int|null, course_id: int|null, interview_id: int|null, languages: null|string, needs_basic_information: bool, problemset_id: int, requests_user_information: string, scoreboard_url: null|string, scoreboard_url_admin: null|string, type: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
         if (empty($rs)) {
             return null;
@@ -175,7 +175,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
                 ORDER BY
                     `order` ASC, `start_time` ASC';
 
-        /** @var list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, name: string, order: int, problemset_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int}> */
+        /** @var list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, name: string, order: int, problemset_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$courseId]

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -148,7 +148,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
     /**
      * Get the course assigments sorted by order and start_time
      *
-     * @return list<array{problemset_id: int, name: string, description: string, alias: string, assignment_type: string, start_time: int, finish_time: int|null, order: int, scoreboard_url: string, scoreboard_url_admin: string}>
+     * @return list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, name: string, order: int, problemset_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>
      */
     final public static function getSortedCourseAssignments(
         int $courseId

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -33,7 +33,7 @@ abstract class Problemsets {
                 `Problemsets`
             SET
                 `acl_id` = ?,
-                `access_mode` = ?,
+                `admission_mode` = ?,
                 `languages` = ?,
                 `needs_basic_information` = ?,
                 `requests_user_information` = ?,
@@ -42,7 +42,8 @@ abstract class Problemsets {
                 `type` = ?,
                 `contest_id` = ?,
                 `assignment_id` = ?,
-                `interview_id` = ?
+                `interview_id` = ?,
+                `course_id` = ?
             WHERE
                 (
                     `problemset_id` = ?
@@ -53,7 +54,7 @@ abstract class Problemsets {
                 null :
                 intval($Problemsets->acl_id)
             ),
-            $Problemsets->access_mode,
+            $Problemsets->admission_mode,
             $Problemsets->languages,
             intval($Problemsets->needs_basic_information),
             $Problemsets->requests_user_information,
@@ -74,6 +75,11 @@ abstract class Problemsets {
                 is_null($Problemsets->interview_id) ?
                 null :
                 intval($Problemsets->interview_id)
+            ),
+            (
+                is_null($Problemsets->course_id) ?
+                null :
+                intval($Problemsets->course_id)
             ),
             intval($Problemsets->problemset_id),
         ];
@@ -98,7 +104,7 @@ abstract class Problemsets {
             SELECT
                 `Problemsets`.`problemset_id`,
                 `Problemsets`.`acl_id`,
-                `Problemsets`.`access_mode`,
+                `Problemsets`.`admission_mode`,
                 `Problemsets`.`languages`,
                 `Problemsets`.`needs_basic_information`,
                 `Problemsets`.`requests_user_information`,
@@ -107,7 +113,8 @@ abstract class Problemsets {
                 `Problemsets`.`type`,
                 `Problemsets`.`contest_id`,
                 `Problemsets`.`assignment_id`,
-                `Problemsets`.`interview_id`
+                `Problemsets`.`interview_id`,
+                `Problemsets`.`course_id`
             FROM
                 `Problemsets`
             WHERE
@@ -191,7 +198,7 @@ abstract class Problemsets {
             SELECT
                 `Problemsets`.`problemset_id`,
                 `Problemsets`.`acl_id`,
-                `Problemsets`.`access_mode`,
+                `Problemsets`.`admission_mode`,
                 `Problemsets`.`languages`,
                 `Problemsets`.`needs_basic_information`,
                 `Problemsets`.`requests_user_information`,
@@ -200,7 +207,8 @@ abstract class Problemsets {
                 `Problemsets`.`type`,
                 `Problemsets`.`contest_id`,
                 `Problemsets`.`assignment_id`,
-                `Problemsets`.`interview_id`
+                `Problemsets`.`interview_id`,
+                `Problemsets`.`course_id`
             FROM
                 `Problemsets`
         ';
@@ -252,7 +260,7 @@ abstract class Problemsets {
             INSERT INTO
                 Problemsets (
                     `acl_id`,
-                    `access_mode`,
+                    `admission_mode`,
                     `languages`,
                     `needs_basic_information`,
                     `requests_user_information`,
@@ -261,8 +269,10 @@ abstract class Problemsets {
                     `type`,
                     `contest_id`,
                     `assignment_id`,
-                    `interview_id`
+                    `interview_id`,
+                    `course_id`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -281,7 +291,7 @@ abstract class Problemsets {
                 null :
                 intval($Problemsets->acl_id)
             ),
-            $Problemsets->access_mode,
+            $Problemsets->admission_mode,
             $Problemsets->languages,
             intval($Problemsets->needs_basic_information),
             $Problemsets->requests_user_information,
@@ -302,6 +312,11 @@ abstract class Problemsets {
                 is_null($Problemsets->interview_id) ?
                 null :
                 intval($Problemsets->interview_id)
+            ),
+            (
+                is_null($Problemsets->course_id) ?
+                null :
+                intval($Problemsets->course_id)
             ),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -77,7 +77,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 WHERE c.alias = ? LIMIT 1;';
         $params = [$alias];
 
-        /** @var array{acl_id: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback: string, finish_time: string, languages: null|string, last_updated: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: string, submissions_gap: int, title: string, urgent: bool, window_length: int|null}|null */
+    /** @var array{acl_id: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback: string, finish_time: string, languages: null|string, last_updated: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after: bool, start_time: string, submissions_gap: int, title: string, urgent: bool, window_length: int|null}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
         if (empty($rs)) {
             return null;
@@ -169,7 +169,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             ORDER BY
                 contest_id DESC;';
 
-        /** @var list<array{alias: string, contest_id: int, finish_time: int, last_updated: int, scoreboard_url_admin: string, start_time: int, title: string}> */
+    /** @var list<array{alias: string, contest_id: int, finish_time: int, last_updated: int, scoreboard_url_admin: null|string, start_time: int, title: string}> */
         $result = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$identityId]
@@ -239,7 +239,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $pageSize,
         ];
 
-        /** @var list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string}> */
+    /** @var list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 
@@ -321,7 +321,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             intval($pageSize),
         ];
 
-        /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string, window_length: int|null}> */
+    /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 
@@ -412,7 +412,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $params[] = intval($offset);
         $params[] = intval($pageSize);
 
-        /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string, window_length: int|null}> */
+    /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -60,7 +60,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     }
 
     /**
-     * @return array{acl_id: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback: string, finish_time: string, languages: null|string, last_updated: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: string, submissions_gap: int, title: string, urgent: bool, window_length: int|null}|null
+     * @return array{acl_id: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback: string, finish_time: string, languages: null|string, last_updated: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after: bool, start_time: string, submissions_gap: int, title: string, urgent: bool, window_length: int|null}|null
      */
     final public static function getByAliasWithExtraInformation(string $alias): ?array {
         $sql = '
@@ -77,7 +77,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 WHERE c.alias = ? LIMIT 1;';
         $params = [$alias];
 
-    /** @var array{acl_id: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback: string, finish_time: string, languages: null|string, last_updated: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after: bool, start_time: string, submissions_gap: int, title: string, urgent: bool, window_length: int|null}|null */
+        /** @var array{acl_id: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback: string, finish_time: string, languages: null|string, last_updated: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_scoreboard_after: bool, start_time: string, submissions_gap: int, title: string, urgent: bool, window_length: int|null}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
         if (empty($rs)) {
             return null;
@@ -136,7 +136,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     }
 
     /**
-     * @return list<array{alias: string, title: string, start_time: int, finish_time: int, last_updated: int, scoreboard_url_admin: string}>
+     * @return list<array{alias: string, contest_id: int, finish_time: int, last_updated: int, scoreboard_url_admin: null|string, start_time: int, title: string}>
      */
     public static function getContestsParticipated(int $identityId) {
         $sql = '
@@ -169,7 +169,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             ORDER BY
                 contest_id DESC;';
 
-    /** @var list<array{alias: string, contest_id: int, finish_time: int, last_updated: int, scoreboard_url_admin: null|string, start_time: int, title: string}> */
+        /** @var list<array{alias: string, contest_id: int, finish_time: int, last_updated: int, scoreboard_url_admin: null|string, start_time: int, title: string}> */
         $result = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$identityId]
@@ -185,7 +185,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     /**
      * Returns all contests that an identity can manage.
      *
-     * @return list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string}>
+     * @return list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string}>
      */
     final public static function getAllContestsAdminedByIdentity(
         int $identityId,
@@ -239,7 +239,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $pageSize,
         ];
 
-    /** @var list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string}> */
+        /** @var list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 
@@ -288,7 +288,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     /**
      * Returns all contests owned by a user.
      *
-     * @return list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string, window_length: int|null}>
+     * @return list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}>
      */
     final public static function getAllContestsOwnedByUser(
         int $identityId,
@@ -321,14 +321,14 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             intval($pageSize),
         ];
 
-    /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}> */
+        /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 
     /**
      * Returns all contests where a user is participating in.
      *
-     * @return list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string, window_length: int|null}>
+     * @return list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}>
      */
     final public static function getContestsParticipating(
         int $identityId,
@@ -412,7 +412,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $params[] = intval($offset);
         $params[] = intval($pageSize);
 
-    /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}> */
+        /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: string, problemset_id: int, recommended: bool, rerun_id: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int, title: string, window_length: int|null}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -66,7 +66,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
             ORDER BY
                 `order`, start_time;";
 
-        /** @var list<array{acl_id: int, alias: string, assignment_id: int, assignment_type: string, course_id: int, description: string, finish_time: null|string, max_points: float, name: string, order: int, problemset_id: int, publish_time_delay: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: string}> */
+        /** @var list<array{acl_id: int, alias: string, assignment_id: int, assignment_type: string, course_id: int, description: string, finish_time: null|string, max_points: float, name: string, order: int, problemset_id: int, publish_time_delay: int|null, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: string}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [$alias]);
 
         $ar = [];

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -37,7 +37,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
      * Given a course alias, get all of its assignments. Hides any assignments
      * that have not started, if not an admin.
      *
-     * @return list<array{name: string, description: string, alias: string, publish_time_delay: ?int, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>
+     * @return list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: null|string, scoreboard_url_admin: null|string, start_time: int}>
      */
     public static function getAllAssignments(
         string $alias,

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -197,7 +197,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 AND p.visibility >= ?
                 AND (
                     s.problemset_id IS NULL
-                    OR ps.access_mode = "public"
+                    OR ps.admission_mode = "public"
                 )
                 AND (
                     c.contest_id IS NULL

--- a/frontend/server/src/DAO/VO/Problemsets.php
+++ b/frontend/server/src/DAO/VO/Problemsets.php
@@ -18,7 +18,7 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
     const FIELD_NAMES = [
         'problemset_id' => true,
         'acl_id' => true,
-        'access_mode' => true,
+        'admission_mode' => true,
         'languages' => true,
         'needs_basic_information' => true,
         'requests_user_information' => true,
@@ -28,6 +28,7 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
         'contest_id' => true,
         'assignment_id' => true,
         'interview_id' => true,
+        'course_id' => true,
     ];
 
     public function __construct(?array $data = null) {
@@ -50,9 +51,9 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
                 $data['acl_id']
             );
         }
-        if (isset($data['access_mode'])) {
-            $this->access_mode = strval(
-                $data['access_mode']
+        if (isset($data['admission_mode'])) {
+            $this->admission_mode = strval(
+                $data['admission_mode']
             );
         }
         if (isset($data['languages'])) {
@@ -100,6 +101,11 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
                 $data['interview_id']
             );
         }
+        if (isset($data['course_id'])) {
+            $this->course_id = intval(
+                $data['course_id']
+            );
+        }
     }
 
     /**
@@ -123,7 +129,7 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
      *
      * @var string
      */
-    public $access_mode = 'public';
+    public $admission_mode = 'private';
 
     /**
      * Un filtro (opcional) de qué lenguajes se pueden usar para resolver los problemas
@@ -175,7 +181,7 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
     public $contest_id = null;
 
     /**
-     * Id del curso
+     * Id de la tarea o examen del curso
      *
      * @var int|null
      */
@@ -187,4 +193,11 @@ class Problemsets extends \OmegaUp\DAO\VO\VO {
      * @var int|null
      */
     public $interview_id = null;
+
+    /**
+     * Id del curso
+     *
+     * @var int|null
+     */
+    public $course_id = null;
 }


### PR DESCRIPTION
# Descripción

Primera parte del cambio para enviar invitación a los estudiantes de un curso.

Lo primero que se va a realizar es agregar los cursos a la tabla de problemsets
para que se puedan agrupar todas las tareas en esa misma tabla y así poder 
usar el campo de `admission_mode` que se compartirá para Cursos, Concursos
y entrevistas.

Este cambio contiene:

- [x] Creación de campo `course_id` con sus respectivas llaves.
- [x] Se agrega `Course` a los tipos de `Problemsets`
- [x] Se modifica el nombre de la columna `access_mode` por `admission_mode`
- [x] Se agregan todos los cursos en la tabla de `Problemsets`.
- [x] Se actualiza el valor de `admission_mode` para todos los concursos existentes

Part of: #3013 

# Comentarios

Una vez que este cambio sea aprobado, se agregará otro PR  en el cual se 
eliminen los campos duplicados y a su vez se guarde/actualice la información
en la tabla de `Problemsets`.

Después se procederá a agregar la funcionalidad de Crear cursos abiertos 
con registro (Similar a los concursos). Este cambio puede que se parta en 
varios PR también.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
