### PR TITLE
Mandando un json con identidades al llamar bulkCreate

### DIFF
--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -154,7 +154,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $group = self::validateGroupOwnership($r);
 
         /** @var list<array<string, string>> */
-        $identities = $r['identities'];
+        $identities = json_decode($r['identities'], true);
         /** @var array<string, bool> */
         $seenUsernames = [];
         foreach ($identities as $identity) {

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -153,8 +153,20 @@ class Identity extends \OmegaUp\Controllers\Controller {
         );
         $group = self::validateGroupOwnership($r);
 
-        /** @var list<array<string, string>> */
+        \OmegaUp\Validators::validateStringNonEmpty(
+            $r['identities'],
+            'identities'
+        );
+
+        /** @var list<array<string, string>>|null $identities */
         $identities = json_decode($r['identities'], true);
+
+        if (!is_array($identities)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'identities'
+            );
+        }
         /** @var array<string, bool> */
         $seenUsernames = [];
         foreach ($identities as $identity) {

--- a/frontend/tests/factories/IdentityFactory.php
+++ b/frontend/tests/factories/IdentityFactory.php
@@ -9,15 +9,11 @@
  */
 
 class IdentityFactory {
-    /**
-     * @return array{username: string, name: string, country_id: string, state_id: string, gender: string, school_name: string, password: string}[]|string
-     */
     public static function getCsvData(
         string $file,
         string $group_alias,
-        string $password = '',
-        bool $asJson = true
-    ) {
+        string $password = ''
+    ): string {
         $row = 0;
         /** @var array{username: string, name: string, country_id: string, state_id: string, gender: string, school_name: string, password: string}[] */
         $identities = [];
@@ -48,10 +44,8 @@ class IdentityFactory {
             ]);
         }
         fclose($handle);
-        if ($asJson) {
-            return json_encode($identities);
-        }
-        return $identities;
+
+        return json_encode($identities);
     }
 
     public static function createIdentitiesFromAGroup(

--- a/frontend/tests/factories/IdentityFactory.php
+++ b/frontend/tests/factories/IdentityFactory.php
@@ -10,13 +10,14 @@
 
 class IdentityFactory {
     /**
-     * @return array{username: string, name: string, country_id: string, state_id: string, gender: string, school_name: string, password: string}[]
+     * @return array{username: string, name: string, country_id: string, state_id: string, gender: string, school_name: string, password: string}[]|string
      */
     public static function getCsvData(
         string $file,
         string $group_alias,
-        string $password = ''
-    ): array {
+        string $password = '',
+        bool $asJson = true
+    ) {
         $row = 0;
         /** @var array{username: string, name: string, country_id: string, state_id: string, gender: string, school_name: string, password: string}[] */
         $identities = [];
@@ -47,6 +48,9 @@ class IdentityFactory {
             ]);
         }
         fclose($handle);
+        if ($asJson) {
+            return json_encode($identities);
+        }
         return $identities;
     }
 

--- a/frontend/www/js/omegaup/group/identities.js
+++ b/frontend/www/js/omegaup/group/identities.js
@@ -13,7 +13,7 @@ OmegaUp.on('ready', function() {
         on: {
           'bulk-identities': function(identities) {
             API.Identity.bulkCreate({
-              identities: identities,
+              identities: JSON.stringify(identities),
               group_alias: groupAlias,
             })
               .then(function(data) {


### PR DESCRIPTION
# Descripción

Enviando el listado de identidades por medio de un `json` para evitar que crezca
el número de parámetros en `\OmegUp\Controllers\Identity::apiBulkCreate` y 
esta no falle en silencio.

Fixes: #3419 

# Comentarios

Hice la prueba con un archivo que tenía 300 registros y funcionó correctamente,
ahora habrá que definir si ponemos un límite máximo de Identidades creadas
por medio del bulk.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
