### PR TITLE
Atrapando el error del ProblemDeployer para mostrarlo en pantalla

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3843,14 +3843,30 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // Validate commit message.
         \OmegaUp\Validators::validateStringNonEmpty($r['message'], 'message');
         if ($r['request'] === 'submit') {
-            self::updateProblem(
-                $r->identity,
-                $r->user,
-                $problemParams,
-                strval($r['message']),
-                $problemParams->updatePublished,
-                boolval($r['redirect'])
-            );
+            try {
+                self::updateProblem(
+                    $r->identity,
+                    $r->user,
+                    $problemParams,
+                    strval($r['message']),
+                    $problemParams->updatePublished,
+                    boolval($r['redirect'])
+                );
+            } catch (\OmegaUp\Exceptions\ApiException $e) {
+                /** @var array{error?: string} */
+                $response = $e->asResponseArray();
+                if (empty($response['error'])) {
+                    $statusError = '{error}';
+                } else {
+                    $statusError = $response['error'];
+                }
+                return [
+                    'IS_UPDATE' => true,
+                    'LOAD_MATHJAX' => true,
+                    'LOAD_PAGEDOWN' => true,
+                    'STATUS_ERROR' => $statusError,
+                ];
+            }
         } elseif ($r['request'] === 'markdown') {
             [
                 'problem' => $problem,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3818,7 +3818,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{IS_UPDATE: bool, LOAD_MATHJAX: bool, LOAD_PAGEDOWN: bool, STATUS_SUCCESS: null|string}
+     * @return array{IS_UPDATE: bool, LOAD_MATHJAX: bool, LOAD_PAGEDOWN: bool, STATUS_ERROR?: string, STATUS_SUCCESS?: null|string}
      */
     public static function getProblemEditDetailsForSmarty(
         \OmegaUp\Request $r


### PR DESCRIPTION
# Descripción

Se agrega este cambio para atrapar el mensaje de error que manda 
el  `ProblemDeployer` y así poder encontrar el error reportado en el 
issue #3120 

Part of: #3120

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
