### PR TITLE
Cambiando varios scripts a modo asincrono

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -15,7 +15,7 @@
 		<title>{if isset($htmlTitle)}{$htmlTitle} &ndash; {/if}omegaUp</title>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/jquery-3.4.1.min.js"}"></script>
 		<script type="text/javascript" src="{version_hash src="/js/jquery_error_handler.js"}"></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/highstock.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/highstock.js"}" defer></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/sugar.js"}"></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/knockout-3.5.0beta.js"}"></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/knockout-secure-binding.min.js"}"></script>
@@ -26,19 +26,19 @@
 		{js_include entrypoint="arena"}
 {/if}
 {if (isset($inArena) && $inArena) || (isset($loadMarkdown) && $loadMarkdown)}
-		<script type="text/javascript" src="{version_hash src="/third_party/js/jquery.tableSort.js"}"></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/jquery.tableSort.js"}" defer></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js" defer}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js" defer}"></script>
 {else}
-		<script type="text/javascript" src="{version_hash src="/js/omegaup-graph.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/js/omegaup-graph.js"}" defer></script>
 {/if}
 
 {if isset($jsfile)}
 		<script type="text/javascript" src="{$jsfile}"></script>
 {/if}
 {if isset($LOAD_MATHJAX) && $LOAD_MATHJAX}
-		<script type="text/javascript" src="{version_hash src="/js/mathjax-config.js"}"></script>
-		<script type="text/javascript" src="/third_party/js/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+		<script type="text/javascript" src="{version_hash src="/js/mathjax-config.js"}" defer></script>
+		<script type="text/javascript" src="/third_party/js/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML" defer></script>
 {/if}
 		<link rel="stylesheet" href="/third_party/css/reset.css" />
 		<script type="text/javascript" src="{version_hash src="/js/langtools.js"}"></script>
@@ -47,24 +47,24 @@
 		<!-- Latest compiled and minified CSS -->
 		<link rel="stylesheet" href="/third_party/bootstrap-3.4.1/css/bootstrap.min.css">
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="{version_hash src="/third_party/bootstrap-3.4.1/js/bootstrap.min.js"}"></script>
+		<script src="{version_hash src="/third_party/bootstrap-3.4.1/js/bootstrap.min.js"}" defer></script>
 		<!-- Bootstrap datepicker plugin from http://www.eyecon.ro/bootstrap-datepicker/ -->
 		<link rel="stylesheet" href="/third_party/css/bootstrap-datepicker.css">
-		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datepicker.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datepicker.js"}" defer></script>
 		<!-- typeahead plugin from https://github.com/twitter/typeahead.js -->
-		<script type="text/javascript" src="{version_hash src="/third_party/js/typeahead.jquery.min.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/typeahead.jquery.min.js"}" defer></script>
 		<!-- Bootstrap datetimepicker plugin from http://www.malot.fr/bootstrap-datetimepicker/demo.php -->
 		<link rel="stylesheet" href="/third_party/css/bootstrap-datetimepicker.css">
-		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datetimepicker.min.js"}"></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.es.js"}"></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js"}"></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datetimepicker.min.js"}" defer></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.es.js"}" defer></script>
+		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js"}" defer></script>
 
 {if isset($inArena) && $inArena}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/ux/arena.css"}" />
 {else}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/css/style.css"}">
 		<!-- Bootstrap table plugin from https://github.com/wenzhixin/bootstrap-table/releases -->
-		<script src="{version_hash src="/third_party/js/bootstrap-table.min.js"}"></script>
+		<script src="{version_hash src="/third_party/js/bootstrap-table.min.js"}" defer></script>
 		<link rel="stylesheet" href="/third_party/css/bootstrap-table.min.css">
 {/if}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/css/common.css"}" />
@@ -73,9 +73,9 @@
 		<link rel="shortcut icon" href="/favicon.ico" />
 
 {if isset($LOAD_PAGEDOWN) && $LOAD_PAGEDOWN}
-	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>
-	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}"></script>
-	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}"></script>
+	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}" defer></script>
+	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}" defer></script>
+	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}" defer></script>
 	<link rel="stylesheet" type="text/css" href="/css/markdown-editor-widgets.css" />
 {/if}
 {if !empty($ENABLED_EXPERIMENTS)}


### PR DESCRIPTION
# Descripción

Cambiando varios scripts a modo asincrono (usando 'defer')
Cargamos muchos scripts que no se necesitan sino hasta que el usuario interactua con elementos de la pagina. Segun Analytics esta es la principal sugerencia para mejorar la responsividad del sitio.

Aqui hay un ejemplo:
https://developers.google.com/speed/pagespeed/insights/?utm_source=analytics&tab=desktop&url=http%3A%2F%2Fwww.omegaup.com%2Fcourse%2Fintroduccion_a_cpp

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.