### PR TITLE
Corriendo hook_tools como el usuario actual

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -24,8 +24,13 @@ else
 fi
 
 exec /usr/bin/docker run $TTY_ARGS --rm \
+	--user "$(id -u):$(id -g)" \
+	--env "GIT_AUTHOR_NAME=$(git config user.name)" \
+	--env "GIT_AUTHOR_EMAIL=$(git config user.email)" \
+	--env "GIT_COMMITTER_NAME=$(git config user.name)" \
+	--env "GIT_COMMITTER_EMAIL=$(git config user.email)" \
 	--volume "${OMEGAUP_ROOT}:/src" \
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \
 	--env "MYPYPATH=${OMEGAUP_ROOT}/stuff" \
-	omegaup/hook_tools:20191127 $ARGS
+	omegaup/hook_tools:20200221 $ARGS


### PR DESCRIPTION
Este cambio hace que hook_tools se corra como el usuario actual. Además,
se le pasan las variables de entorno necesarias para poder hacer commits
como el usuario actual sin necesidad de un archivo de configuración.