### PR TITLE
Dejando de usar /usr/bin/aws para obtener los resultados de los envíos

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -163,7 +163,6 @@ try_define('PASSWORD_RESET_MIN_WAIT', 5 * 60);
 # ########################
 try_define('AWS_CLI_ACCESS_KEY_ID', null);
 try_define('AWS_CLI_SECRET_ACCESS_KEY', null);
-try_define('AWS_CLI_BINARY', '/usr/bin/aws');
 
 # ########################
 # NEW RELIC CONFIG


### PR DESCRIPTION
Este cambio hace que las peticiones a AWS S3 se realicen únicamente en
PHP para evitar tener que ejecutar un proceso nuevo.

Esto además de ser significativamente más rápido puede que ayude a
evitar que el servidor se quede sin memoria, que ocurrió en algún punto
en la semana.