### PR TITLE
Mejorando la manera en la que se escapan los casos de ejemplo

### DIFF
--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -792,7 +792,7 @@ let UI = {
       );
       return text;
     });
-    converter.hooks.chain('preBlockGamut', function(text, blockGamut) {
+    converter.hooks.chain('postNormalization', function(text, blockGamut) {
       // Sample I/O table.
       let settings = converter._settings || options.settings || { cases: {} };
       return text.replace(

--- a/frontend/www/js/omegaup/ui.test.js
+++ b/frontend/www/js/omegaup/ui.test.js
@@ -182,6 +182,8 @@ github flavored markdown
 Other escapes: $~~T~D~E32E
 
 Tags <b>hello</b>
+
+<pre>hi</pre>
 ||output
 0
 ||end`),
@@ -217,7 +219,9 @@ github flavored markdown
 
 Other escapes: $~~T~D~E32E
 
-Tags &lt;b&gt;hello&lt;/b&gt;</pre></td><td><pre>0</pre></td></tr></tbody>
+Tags &lt;b&gt;hello&lt;/b&gt;
+
+&lt;pre&gt;hi&lt;/pre&gt;</pre></td><td><pre>0</pre></td></tr></tbody>
 </table>`);
     });
 


### PR DESCRIPTION
Este cambio hace que se use el callback postNormalization() para escapar
los casos de ejemplo. Esto hace que cosas como `<pre>...</pre>` en un
bloque de alto nivel no se estén tratando como texto no-escapado.

Fixes: #3479