### PR TITLE
Reportando la razón de falla de envíos

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1606,9 +1606,7 @@ export class Arena {
           self.qualityNominationForm = new Vue({
             el: '#qualitynomination-popup',
             mounted: function() {
-              if (typeof ga == 'function') {
-                ga('send', 'event', 'quality-nomination', 'shown');
-              }
+              UI.reportEvent('quality-nomination', 'shown');
             },
             render: function(createElement) {
               return createElement('qualitynomination-popup', {
@@ -1640,9 +1638,7 @@ export class Arena {
                       contents: JSON.stringify(contents),
                     })
                       .then(() => {
-                        if (typeof ga == 'function') {
-                          ga('send', 'event', 'quality-nomination', 'submit');
-                        }
+                        UI.reportEvent('quality-nomination', 'submit');
                       })
                       .fail(UI.apiError);
                   },
@@ -1657,9 +1653,7 @@ export class Arena {
                     })
                       .then(function(data) {
                         UI.info(T.qualityNominationRateProblemDesc);
-                        if (typeof ga == 'function') {
-                          ga('send', 'event', 'quality-nomination', 'dismiss');
-                        }
+                        UI.reportEvent('quality-nomination', 'dismiss');
                       })
                       .fail(UI.apiError);
                   },
@@ -2067,9 +2061,7 @@ export class Arena {
       }),
     )
       .then(function(run) {
-        if (typeof ga == 'function') {
-          ga('send', 'event', 'submission', 'submit');
-        }
+        UI.reportEvent('submission', 'submit');
         if (self.options.isLockdownMode && sessionStorage) {
           sessionStorage.setItem('run:' + run.guid, code);
         }
@@ -2098,9 +2090,7 @@ export class Arena {
       .fail(function(run) {
         alert(run.error);
         $('input', self.elements.submitForm).prop('disabled', false);
-        if (typeof ga == 'function') {
-          ga('send', 'event', 'submission', 'submit-fail');
-        }
+        UI.reportEvent('submission', 'submit-fail', run.errorname);
       });
   }
 

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -1031,6 +1031,13 @@ let UI = {
 
     return converter;
   },
+
+  reportEvent: function(category, action, label) {
+    if (typeof ga !== 'function') {
+      return;
+    }
+    ga('send', 'event', category, action, label);
+  },
 };
 
 export { UI as default };


### PR DESCRIPTION
Este cambio agrega un wrapper (`OmegaUp.UI.reportEvent`) para reportar
eventos a Google Analytics. También se envían la razón por la cual un
envío falló.