### PR TITLE
Mejorando la compatibilidad con Ubuntu Focal

### DIFF
--- a/frontend/database/138_remove_problemsets_constrain.sql
+++ b/frontend/database/138_remove_problemsets_constrain.sql
@@ -1,0 +1,3 @@
+/*!80000 ALTER TABLE `Problemsets` DROP CONSTRAINT `Problemsets_chk_1` */;
+ALTER TABLE `Problemsets`
+  ADD CONSTRAINT CHECK (CAST(`contest_id` IS NOT NULL AS UNSIGNED) + CAST(`assignment_id` IS NOT NULL AS UNSIGNED) + CAST(`interview_id` IS NOT NULL AS UNSIGNED) <= 1);

--- a/frontend/database/19_qualitynomination.sql
+++ b/frontend/database/19_qualitynomination.sql
@@ -73,10 +73,10 @@ BEGIN
     SET @ties_count = 0;
 
     INSERT INTO
-        User_Rank (user_id, rank, problems_solved_count, score, username, name, country_id)
+        User_Rank (user_id, `rank`, problems_solved_count, score, username, name, country_id)
     SELECT
         user_id,
-        rank,
+        `rank`,
         problems_solved_count,
         score,
         username,
@@ -99,7 +99,7 @@ BEGIN
         CASE
             WHEN @prev_value = score THEN @rank_count
             WHEN @prev_value := score THEN @rank_count := @rank_count + 1 + @prev_ties_count
-        END AS rank
+        END AS `rank`
         FROM
         (
             SELECT
@@ -128,7 +128,7 @@ BEGIN
             ORDER BY
                 score DESC
         ) AS UsersProblemsSolved
-    ) AS Rank;
+    ) AS `Rank`;
     COMMIT;
 END$$
 DELIMITER ;

--- a/frontend/database/1_initial_schema.sql
+++ b/frontend/database/1_initial_schema.sql
@@ -987,10 +987,10 @@ BEGIN
     SET @ties_count = 0;
 
     INSERT INTO
-        User_Rank (user_id, rank, problems_solved_count, score, username, name, country_id)
+        User_Rank (user_id, `rank`, problems_solved_count, score, username, name, country_id)
     SELECT
         user_id,
-        rank,
+        `rank`,
         problems_solved_count,
         score,
         username,
@@ -1013,7 +1013,7 @@ BEGIN
         CASE
             WHEN @prev_value = score THEN @rank_count
             WHEN @prev_value := score THEN @rank_count := @rank_count + 1 + @prev_ties_count
-        END AS rank
+        END AS `rank`
         FROM
         (
             SELECT
@@ -1042,7 +1042,7 @@ BEGIN
             ORDER BY
                 score DESC
         ) AS UsersProblemsSolved
-    ) AS Rank;
+    ) AS `Rank`;
     COMMIT;
 END$$
 DELIMITER ;

--- a/frontend/database/37_rank_filters.sql
+++ b/frontend/database/37_rank_filters.sql
@@ -27,10 +27,10 @@ BEGIN
     SET @ties_count = 0;
 
     INSERT INTO
-        User_Rank (user_id, rank, problems_solved_count, score, username, name, country_id, state_id, school_id)
+        User_Rank (user_id, `rank`, problems_solved_count, score, username, name, country_id, state_id, school_id)
     SELECT
         user_id,
-        rank,
+        `rank`,
         problems_solved_count,
         score,
         username,
@@ -57,7 +57,7 @@ BEGIN
         CASE
             WHEN @prev_value = score THEN @rank_count
             WHEN @prev_value := score THEN @rank_count := @rank_count + 1 + @prev_ties_count
-        END AS rank
+        END AS `rank`
         FROM
         (
             SELECT
@@ -88,7 +88,7 @@ BEGIN
             ORDER BY
                 score DESC
         ) AS UsersProblemsSolved
-    ) AS Rank;
+    ) AS `Rank`;
     COMMIT;
 END$$
 DELIMITER ;

--- a/frontend/database/58_coder_of_the_month_rank.sql
+++ b/frontend/database/58_coder_of_the_month_rank.sql
@@ -1,5 +1,5 @@
 -- Add rank column to coder of the month
-ALTER TABLE Coder_Of_The_Month ADD COLUMN rank int(11) NOT NULL COMMENT 'El lugar en el que el usuario estuvo durante ese mes';
+ALTER TABLE Coder_Of_The_Month ADD COLUMN `rank` int(11) NOT NULL COMMENT 'El lugar en el que el usuario estuvo durante ese mes';
 
 -- Populate previous top coder of the month rank with 1
-UPDATE Coder_Of_The_Month SET rank=1;
+UPDATE Coder_Of_The_Month SET `rank`=1;

--- a/frontend/server/src/DAO/Base/ACLs.php
+++ b/frontend/server/src/DAO/Base/ACLs.php
@@ -198,7 +198,7 @@ abstract class ACLs {
     ): int {
         $sql = '
             INSERT INTO
-                ACLs (
+                `ACLs` (
                     `owner_id`
                 ) VALUES (
                     ?

--- a/frontend/server/src/DAO/Base/Announcement.php
+++ b/frontend/server/src/DAO/Base/Announcement.php
@@ -208,7 +208,7 @@ abstract class Announcement {
     ): int {
         $sql = '
             INSERT INTO
-                Announcement (
+                `Announcement` (
                     `user_id`,
                     `time`,
                     `description`

--- a/frontend/server/src/DAO/Base/Assignments.php
+++ b/frontend/server/src/DAO/Base/Assignments.php
@@ -258,7 +258,7 @@ abstract class Assignments {
     ): int {
         $sql = '
             INSERT INTO
-                Assignments (
+                `Assignments` (
                     `course_id`,
                     `problemset_id`,
                     `acl_id`,

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -270,7 +270,7 @@ abstract class AuthTokens {
     ): int {
         $sql = '
             INSERT INTO
-                Auth_Tokens (
+                `Auth_Tokens` (
                     `user_id`,
                     `identity_id`,
                     `token`,

--- a/frontend/server/src/DAO/Base/Clarifications.php
+++ b/frontend/server/src/DAO/Base/Clarifications.php
@@ -240,7 +240,7 @@ abstract class Clarifications {
     ): int {
         $sql = '
             INSERT INTO
-                Clarifications (
+                `Clarifications` (
                     `author_id`,
                     `receiver_id`,
                     `message`,

--- a/frontend/server/src/DAO/Base/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/CoderOfTheMonth.php
@@ -246,7 +246,7 @@ abstract class CoderOfTheMonth {
     ): int {
         $sql = '
             INSERT INTO
-                Coder_Of_The_Month (
+                `Coder_Of_The_Month` (
                     `user_id`,
                     `description`,
                     `time`,

--- a/frontend/server/src/DAO/Base/ContestLog.php
+++ b/frontend/server/src/DAO/Base/ContestLog.php
@@ -220,7 +220,7 @@ abstract class ContestLog {
     ): int {
         $sql = '
             INSERT INTO
-                Contest_Log (
+                `Contest_Log` (
                     `contest_id`,
                     `user_id`,
                     `from_admission_mode`,

--- a/frontend/server/src/DAO/Base/Contests.php
+++ b/frontend/server/src/DAO/Base/Contests.php
@@ -304,7 +304,7 @@ abstract class Contests {
     ): int {
         $sql = '
             INSERT INTO
-                Contests (
+                `Contests` (
                     `problemset_id`,
                     `acl_id`,
                     `title`,

--- a/frontend/server/src/DAO/Base/Countries.php
+++ b/frontend/server/src/DAO/Base/Countries.php
@@ -236,7 +236,7 @@ abstract class Countries {
     ): int {
         $sql = '
             INSERT INTO
-                Countries (
+                `Countries` (
                     `country_id`,
                     `name`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequest.php
@@ -286,7 +286,7 @@ abstract class CourseIdentityRequest {
     ): int {
         $sql = '
             INSERT INTO
-                Course_Identity_Request (
+                `Course_Identity_Request` (
                     `identity_id`,
                     `course_id`,
                     `request_time`,

--- a/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
@@ -228,7 +228,7 @@ abstract class CourseIdentityRequestHistory {
     ): int {
         $sql = '
             INSERT INTO
-                Course_Identity_Request_History (
+                `Course_Identity_Request_History` (
                     `identity_id`,
                     `course_id`,
                     `time`,

--- a/frontend/server/src/DAO/Base/Courses.php
+++ b/frontend/server/src/DAO/Base/Courses.php
@@ -254,7 +254,7 @@ abstract class Courses {
     ): int {
         $sql = '
             INSERT INTO
-                Courses (
+                `Courses` (
                     `name`,
                     `description`,
                     `alias`,

--- a/frontend/server/src/DAO/Base/Emails.php
+++ b/frontend/server/src/DAO/Base/Emails.php
@@ -202,7 +202,7 @@ abstract class Emails {
     ): int {
         $sql = '
             INSERT INTO
-                Emails (
+                `Emails` (
                     `email`,
                     `user_id`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/Favorites.php
+++ b/frontend/server/src/DAO/Base/Favorites.php
@@ -171,7 +171,7 @@ abstract class Favorites {
     ): int {
         $sql = '
             INSERT INTO
-                Favorites (
+                `Favorites` (
                     `user_id`,
                     `problem_id`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/GroupRoles.php
+++ b/frontend/server/src/DAO/Base/GroupRoles.php
@@ -177,7 +177,7 @@ abstract class GroupRoles {
     ): int {
         $sql = '
             INSERT INTO
-                Group_Roles (
+                `Group_Roles` (
                     `group_id`,
                     `role_id`,
                     `acl_id`

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -216,7 +216,7 @@ abstract class Groups {
     ): int {
         $sql = '
             INSERT INTO
-                Groups (
+                `Groups` (
                     `acl_id`,
                     `create_time`,
                     `alias`,

--- a/frontend/server/src/DAO/Base/GroupsIdentities.php
+++ b/frontend/server/src/DAO/Base/GroupsIdentities.php
@@ -301,7 +301,7 @@ abstract class GroupsIdentities {
     ): int {
         $sql = '
             INSERT INTO
-                Groups_Identities (
+                `Groups_Identities` (
                     `group_id`,
                     `identity_id`,
                     `share_user_information`,

--- a/frontend/server/src/DAO/Base/GroupsScoreboards.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboards.php
@@ -216,7 +216,7 @@ abstract class GroupsScoreboards {
     ): int {
         $sql = '
             INSERT INTO
-                Groups_Scoreboards (
+                `Groups_Scoreboards` (
                     `group_id`,
                     `create_time`,
                     `alias`,

--- a/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
@@ -263,7 +263,7 @@ abstract class GroupsScoreboardsProblemsets {
     ): int {
         $sql = '
             INSERT INTO
-                Groups_Scoreboards_Problemsets (
+                `Groups_Scoreboards_Problemsets` (
                     `group_scoreboard_id`,
                     `problemset_id`,
                     `only_ac`,

--- a/frontend/server/src/DAO/Base/Identities.php
+++ b/frontend/server/src/DAO/Base/Identities.php
@@ -238,7 +238,7 @@ abstract class Identities {
     ): int {
         $sql = '
             INSERT INTO
-                Identities (
+                `Identities` (
                     `username`,
                     `password`,
                     `name`,

--- a/frontend/server/src/DAO/Base/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/Base/IdentitiesSchools.php
@@ -222,7 +222,7 @@ abstract class IdentitiesSchools {
     ): int {
         $sql = '
             INSERT INTO
-                Identities_Schools (
+                `Identities_Schools` (
                     `identity_id`,
                     `school_id`,
                     `graduation_date`,

--- a/frontend/server/src/DAO/Base/IdentityLoginLog.php
+++ b/frontend/server/src/DAO/Base/IdentityLoginLog.php
@@ -97,7 +97,7 @@ abstract class IdentityLoginLog {
     ): int {
         $sql = '
             INSERT INTO
-                Identity_Login_Log (
+                `Identity_Login_Log` (
                     `identity_id`,
                     `ip`,
                     `time`

--- a/frontend/server/src/DAO/Base/Interviews.php
+++ b/frontend/server/src/DAO/Base/Interviews.php
@@ -226,7 +226,7 @@ abstract class Interviews {
     ): int {
         $sql = '
             INSERT INTO
-                Interviews (
+                `Interviews` (
                     `problemset_id`,
                     `acl_id`,
                     `alias`,

--- a/frontend/server/src/DAO/Base/Languages.php
+++ b/frontend/server/src/DAO/Base/Languages.php
@@ -198,7 +198,7 @@ abstract class Languages {
     ): int {
         $sql = '
             INSERT INTO
-                Languages (
+                `Languages` (
                     `name`,
                     `country_id`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/Messages.php
+++ b/frontend/server/src/DAO/Base/Messages.php
@@ -220,7 +220,7 @@ abstract class Messages {
     ): int {
         $sql = '
             INSERT INTO
-                Messages (
+                `Messages` (
                     `read`,
                     `sender_id`,
                     `recipient_id`,

--- a/frontend/server/src/DAO/Base/Notifications.php
+++ b/frontend/server/src/DAO/Base/Notifications.php
@@ -212,7 +212,7 @@ abstract class Notifications {
     ): int {
         $sql = '
             INSERT INTO
-                Notifications (
+                `Notifications` (
                     `user_id`,
                     `timestamp`,
                     `read`,

--- a/frontend/server/src/DAO/Base/Permissions.php
+++ b/frontend/server/src/DAO/Base/Permissions.php
@@ -198,7 +198,7 @@ abstract class Permissions {
     ): int {
         $sql = '
             INSERT INTO
-                Permissions (
+                `Permissions` (
                     `name`,
                     `description`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
@@ -212,7 +212,7 @@ abstract class PrivacyStatementConsentLog {
     ): int {
         $sql = '
             INSERT INTO
-                PrivacyStatement_Consent_Log (
+                `PrivacyStatement_Consent_Log` (
                     `identity_id`,
                     `privacystatement_id`,
                     `timestamp`

--- a/frontend/server/src/DAO/Base/PrivacyStatements.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatements.php
@@ -198,7 +198,7 @@ abstract class PrivacyStatements {
     ): int {
         $sql = '
             INSERT INTO
-                PrivacyStatements (
+                `PrivacyStatements` (
                     `git_object_id`,
                     `type`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
+++ b/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
@@ -206,7 +206,7 @@ abstract class ProblemOfTheWeek {
     ): int {
         $sql = '
             INSERT INTO
-                Problem_Of_The_Week (
+                `Problem_Of_The_Week` (
                     `problem_id`,
                     `time`,
                     `difficulty`

--- a/frontend/server/src/DAO/Base/ProblemViewed.php
+++ b/frontend/server/src/DAO/Base/ProblemViewed.php
@@ -260,7 +260,7 @@ abstract class ProblemViewed {
     ): int {
         $sql = '
             INSERT INTO
-                Problem_Viewed (
+                `Problem_Viewed` (
                     `problem_id`,
                     `identity_id`,
                     `view_time`

--- a/frontend/server/src/DAO/Base/Problems.php
+++ b/frontend/server/src/DAO/Base/Problems.php
@@ -288,7 +288,7 @@ abstract class Problems {
     ): int {
         $sql = '
             INSERT INTO
-                Problems (
+                `Problems` (
                     `acl_id`,
                     `visibility`,
                     `title`,

--- a/frontend/server/src/DAO/Base/ProblemsForfeited.php
+++ b/frontend/server/src/DAO/Base/ProblemsForfeited.php
@@ -260,7 +260,7 @@ abstract class ProblemsForfeited {
     ): int {
         $sql = '
             INSERT INTO
-                Problems_Forfeited (
+                `Problems_Forfeited` (
                     `user_id`,
                     `problem_id`,
                     `forfeited_date`

--- a/frontend/server/src/DAO/Base/ProblemsLanguages.php
+++ b/frontend/server/src/DAO/Base/ProblemsLanguages.php
@@ -171,7 +171,7 @@ abstract class ProblemsLanguages {
     ): int {
         $sql = '
             INSERT INTO
-                Problems_Languages (
+                `Problems_Languages` (
                     `problem_id`,
                     `language_id`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/ProblemsTags.php
+++ b/frontend/server/src/DAO/Base/ProblemsTags.php
@@ -263,7 +263,7 @@ abstract class ProblemsTags {
     ): int {
         $sql = '
             INSERT INTO
-                Problems_Tags (
+                `Problems_Tags` (
                     `problem_id`,
                     `tag_id`,
                     `public`,

--- a/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
+++ b/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
@@ -98,7 +98,7 @@ abstract class ProblemsetAccessLog {
     ): int {
         $sql = '
             INSERT INTO
-                Problemset_Access_Log (
+                `Problemset_Access_Log` (
                     `problemset_id`,
                     `identity_id`,
                     `ip`,

--- a/frontend/server/src/DAO/Base/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentities.php
@@ -322,7 +322,7 @@ abstract class ProblemsetIdentities {
     ): int {
         $sql = '
             INSERT INTO
-                Problemset_Identities (
+                `Problemset_Identities` (
                     `identity_id`,
                     `problemset_id`,
                     `access_time`,

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
@@ -293,7 +293,7 @@ abstract class ProblemsetIdentityRequest {
     ): int {
         $sql = '
             INSERT INTO
-                Problemset_Identity_Request (
+                `Problemset_Identity_Request` (
                     `identity_id`,
                     `problemset_id`,
                     `request_time`,

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
@@ -228,7 +228,7 @@ abstract class ProblemsetIdentityRequestHistory {
     ): int {
         $sql = '
             INSERT INTO
-                Problemset_Identity_Request_History (
+                `Problemset_Identity_Request_History` (
                     `identity_id`,
                     `problemset_id`,
                     `time`,

--- a/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
@@ -276,7 +276,7 @@ abstract class ProblemsetProblemOpened {
     ): int {
         $sql = '
             INSERT INTO
-                Problemset_Problem_Opened (
+                `Problemset_Problem_Opened` (
                     `problemset_id`,
                     `problem_id`,
                     `identity_id`,

--- a/frontend/server/src/DAO/Base/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblems.php
@@ -277,7 +277,7 @@ abstract class ProblemsetProblems {
     ): int {
         $sql = '
             INSERT INTO
-                Problemset_Problems (
+                `Problemset_Problems` (
                     `problemset_id`,
                     `problem_id`,
                     `commit`,

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -250,7 +250,7 @@ abstract class Problemsets {
     ): int {
         $sql = '
             INSERT INTO
-                Problemsets (
+                `Problemsets` (
                     `acl_id`,
                     `access_mode`,
                     `languages`,

--- a/frontend/server/src/DAO/Base/QualityNominationComments.php
+++ b/frontend/server/src/DAO/Base/QualityNominationComments.php
@@ -224,7 +224,7 @@ abstract class QualityNominationComments {
     ): int {
         $sql = '
             INSERT INTO
-                QualityNomination_Comments (
+                `QualityNomination_Comments` (
                     `qualitynomination_id`,
                     `user_id`,
                     `time`,

--- a/frontend/server/src/DAO/Base/QualityNominationLog.php
+++ b/frontend/server/src/DAO/Base/QualityNominationLog.php
@@ -224,7 +224,7 @@ abstract class QualityNominationLog {
     ): int {
         $sql = '
             INSERT INTO
-                QualityNomination_Log (
+                `QualityNomination_Log` (
                     `qualitynomination_id`,
                     `time`,
                     `user_id`,

--- a/frontend/server/src/DAO/Base/QualityNominationReviewers.php
+++ b/frontend/server/src/DAO/Base/QualityNominationReviewers.php
@@ -171,7 +171,7 @@ abstract class QualityNominationReviewers {
     ): int {
         $sql = '
             INSERT INTO
-                QualityNomination_Reviewers (
+                `QualityNomination_Reviewers` (
                     `qualitynomination_id`,
                     `user_id`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/QualityNominations.php
+++ b/frontend/server/src/DAO/Base/QualityNominations.php
@@ -224,7 +224,7 @@ abstract class QualityNominations {
     ): int {
         $sql = '
             INSERT INTO
-                QualityNominations (
+                `QualityNominations` (
                     `user_id`,
                     `problem_id`,
                     `nomination`,

--- a/frontend/server/src/DAO/Base/Roles.php
+++ b/frontend/server/src/DAO/Base/Roles.php
@@ -198,7 +198,7 @@ abstract class Roles {
     ): int {
         $sql = '
             INSERT INTO
-                Roles (
+                `Roles` (
                     `name`,
                     `description`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/RolesPermissions.php
+++ b/frontend/server/src/DAO/Base/RolesPermissions.php
@@ -171,7 +171,7 @@ abstract class RolesPermissions {
     ): int {
         $sql = '
             INSERT INTO
-                Roles_Permissions (
+                `Roles_Permissions` (
                     `role_id`,
                     `permission_id`
                 ) VALUES (

--- a/frontend/server/src/DAO/Base/RunCounts.php
+++ b/frontend/server/src/DAO/Base/RunCounts.php
@@ -243,7 +243,7 @@ abstract class RunCounts {
     ): int {
         $sql = '
             INSERT INTO
-                Run_Counts (
+                `Run_Counts` (
                     `date`,
                     `total`,
                     `ac_count`

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -244,7 +244,7 @@ abstract class Runs {
     ): int {
         $sql = '
             INSERT INTO
-                Runs (
+                `Runs` (
                     `submission_id`,
                     `version`,
                     `status`,

--- a/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
@@ -222,7 +222,7 @@ abstract class SchoolOfTheMonth {
     ): int {
         $sql = '
             INSERT INTO
-                School_Of_The_Month (
+                `School_Of_The_Month` (
                     `school_id`,
                     `time`,
                     `rank`,

--- a/frontend/server/src/DAO/Base/Schools.php
+++ b/frontend/server/src/DAO/Base/Schools.php
@@ -214,7 +214,7 @@ abstract class Schools {
     ): int {
         $sql = '
             INSERT INTO
-                Schools (
+                `Schools` (
                     `country_id`,
                     `state_id`,
                     `name`,

--- a/frontend/server/src/DAO/Base/States.php
+++ b/frontend/server/src/DAO/Base/States.php
@@ -248,7 +248,7 @@ abstract class States {
     ): int {
         $sql = '
             INSERT INTO
-                States (
+                `States` (
                     `country_id`,
                     `state_id`,
                     `name`

--- a/frontend/server/src/DAO/Base/SubmissionLog.php
+++ b/frontend/server/src/DAO/Base/SubmissionLog.php
@@ -304,7 +304,7 @@ abstract class SubmissionLog {
     ): int {
         $sql = '
             INSERT INTO
-                Submission_Log (
+                `Submission_Log` (
                     `problemset_id`,
                     `submission_id`,
                     `user_id`,

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -252,7 +252,7 @@ abstract class Submissions {
     ): int {
         $sql = '
             INSERT INTO
-                Submissions (
+                `Submissions` (
                     `current_run_id`,
                     `identity_id`,
                     `problem_id`,

--- a/frontend/server/src/DAO/Base/Tags.php
+++ b/frontend/server/src/DAO/Base/Tags.php
@@ -194,7 +194,7 @@ abstract class Tags {
     ): int {
         $sql = '
             INSERT INTO
-                Tags (
+                `Tags` (
                     `name`
                 ) VALUES (
                     ?

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -305,7 +305,7 @@ abstract class UserRank {
     ): int {
         $sql = '
             INSERT INTO
-                User_Rank (
+                `User_Rank` (
                     `user_id`,
                     `rank`,
                     `problems_solved_count`,

--- a/frontend/server/src/DAO/Base/UserRankCutoffs.php
+++ b/frontend/server/src/DAO/Base/UserRankCutoffs.php
@@ -97,7 +97,7 @@ abstract class UserRankCutoffs {
     ): int {
         $sql = '
             INSERT INTO
-                User_Rank_Cutoffs (
+                `User_Rank_Cutoffs` (
                     `score`,
                     `percentile`,
                     `classname`

--- a/frontend/server/src/DAO/Base/UserRoles.php
+++ b/frontend/server/src/DAO/Base/UserRoles.php
@@ -177,7 +177,7 @@ abstract class UserRoles {
     ): int {
         $sql = '
             INSERT INTO
-                User_Roles (
+                `User_Roles` (
                     `user_id`,
                     `role_id`,
                     `acl_id`

--- a/frontend/server/src/DAO/Base/Users.php
+++ b/frontend/server/src/DAO/Base/Users.php
@@ -260,7 +260,7 @@ abstract class Users {
     ): int {
         $sql = '
             INSERT INTO
-                Users (
+                `Users` (
                     `facebook_user_id`,
                     `git_token`,
                     `main_email_id`,

--- a/frontend/server/src/DAO/Base/UsersBadges.php
+++ b/frontend/server/src/DAO/Base/UsersBadges.php
@@ -208,7 +208,7 @@ abstract class UsersBadges {
     ): int {
         $sql = '
             INSERT INTO
-                Users_Badges (
+                `Users_Badges` (
                     `user_id`,
                     `badge_alias`,
                     `assignation_time`

--- a/frontend/server/src/DAO/Base/UsersExperiments.php
+++ b/frontend/server/src/DAO/Base/UsersExperiments.php
@@ -96,7 +96,7 @@ abstract class UsersExperiments {
     ): int {
         $sql = '
             INSERT INTO
-                Users_Experiments (
+                `Users_Experiments` (
                     `user_id`,
                     `experiment`
                 ) VALUES (

--- a/frontend/server/src/DAO/Groups.php
+++ b/frontend/server/src/DAO/Groups.php
@@ -15,7 +15,7 @@ namespace OmegaUp\DAO;
  */
 class Groups extends \OmegaUp\DAO\Base\Groups {
     public static function findByAlias(string $alias): ?\OmegaUp\DAO\VO\Groups {
-        $sql = 'SELECT g.* FROM Groups g WHERE g.alias = ? LIMIT 1;';
+        $sql = 'SELECT `g`.* FROM `Groups` AS `g` WHERE `g`.`alias` = ? LIMIT 1;';
         $params = [$alias];
         /** @var array{acl_id: int, alias: string, create_time: string, description: null|string, group_id: int, name: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);

--- a/frontend/server/src/MySQLConnection.php
+++ b/frontend/server/src/MySQLConnection.php
@@ -331,8 +331,10 @@ class MySQLConnection {
             $resultmode
         );
         if ($result === false) {
+            $errorMessage = "Failed to query MySQL ({$this->_connection->errno}): {$this->_connection->error}";
+            \Logger::getLogger('mysql')->debug($errorMessage);
             throw new \OmegaUp\Exceptions\DatabaseOperationException(
-                "Failed to query MySQL ({$this->_connection->errno}): {$this->_connection->error}",
+                $errorMessage,
                 intval($this->_connection->errno)
             );
         } elseif ($result === true) {

--- a/frontend/server/src/SessionManager.php
+++ b/frontend/server/src/SessionManager.php
@@ -61,7 +61,7 @@ class SessionManager {
                 /*secure=*/!empty($_SERVER['HTTPS']),
                 /*httponly=*/true
             );
-        } else {
+        } elseif (PHP_VERSION_ID < 70400) {
             /**
              * @psalm-suppress TooManyArguments this is needed to support
              *                                  Same-Site cookies.
@@ -75,6 +75,19 @@ class SessionManager {
                 /*secure=*/!empty($_SERVER['HTTPS']),
                 /*httponly=*/true,
                 /*samesite=*/'Lax'
+            );
+        } else {
+            setcookie(
+                $name,
+                $value,
+                [
+                    'expires' => $expire,
+                    'path' => $path,
+                    'domain' => $domain,
+                    'secure' => !empty($_SERVER['HTTPS']),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
             );
         }
     }

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -317,7 +317,7 @@ abstract class {{ table.class_name }} {
     ): int {
         $sql = '
             INSERT INTO
-                {{ table.name }} (
+                `{{ table.name }}` (
                     {{ table.columns|rejectattr('auto_increment')|listformat('`{.name}`', table=table)|join(',\n                    ') }}
                 ) VALUES (
                     {{ table.columns|rejectattr('auto_increment')|listformat('?', table=table)|join(',\n                    ') }}


### PR DESCRIPTION
Este cambio es el primero de varios en preparación de la actualización a
Ubuntu 20.04 (Focal Fossa). Notablemente:

* Para hacer feliz a MySQL, escapa nuevas pañabras reservadas, como
  Group y rank.
* Cambia la manera en la que se llama `setcookie()` porque los
  argumentos cambiaron.
* Cambia el CONSTRAIN CHECK de `Problemsets` para que únicamente se
  queje si se intentan establecer más de una llave foránea. Versiones
  anteriores de MySQL ignoraban el CHECK.