### PR TITLE
Más compatibilidad con focal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ bin/grader.sh
 frontend/www/runner-distrib.sh
 geckodriver.log
 yarn-error.log
+.phpunit.result.cache
 
 # Ignore Mac crap :P
 frontend/.DS_Store

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -95,7 +95,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                 INNER JOIN (
                     SELECT g.group_id
                     FROM Groups_Identities gi
-                    INNER JOIN Groups g ON g.group_id = gi.group_id
+                    INNER JOIN `Groups` AS g ON g.group_id = gi.group_id
                     WHERE gi.identity_id = ?
                 ) gg
                 ON c.group_id = gg.group_id
@@ -134,7 +134,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                     pr.alias as assignment_alias,
                     pr.assignment_score
                 FROM
-                    Groups g
+                    `Groups` AS g
                 INNER JOIN Groups_Identities gi
                     ON g.group_id = ? AND g.group_id = gi.group_id
                 INNER JOIN Identities i

--- a/frontend/server/src/DAO/GroupRoles.php
+++ b/frontend/server/src/DAO/GroupRoles.php
@@ -22,7 +22,7 @@ class GroupRoles extends \OmegaUp\DAO\Base\GroupRoles {
             FROM
                 Group_Roles gr
             INNER JOIN
-                Groups g ON g.group_id = gr.group_id
+                `Groups` AS g ON g.group_id = gr.group_id
             WHERE
                 gr.role_id = ? AND gr.acl_id IN (?, ?);';
         $params = [
@@ -68,7 +68,7 @@ class GroupRoles extends \OmegaUp\DAO\Base\GroupRoles {
             INNER JOIN
                 Group_Roles gr ON gr.acl_id = p.acl_id
             INNER JOIN
-                Groups g ON g.group_id = gr.group_id
+                `Groups` AS g ON g.group_id = gr.group_id
             WHERE
                 p.problemset_id = ? AND
                 gr.role_id = ?;

--- a/frontend/server/src/DAO/Groups.php
+++ b/frontend/server/src/DAO/Groups.php
@@ -29,7 +29,7 @@ class Groups extends \OmegaUp\DAO\Base\Groups {
      * @return \OmegaUp\DAO\VO\Groups[]
      */
     public static function SearchByName(string $name) {
-        $sql = "SELECT g.* from Groups g where g.name LIKE CONCAT('%', ?, '%') LIMIT 10;";
+        $sql = "SELECT `g`.* FROM `Groups` AS `g` WHERE `g`.`name` LIKE CONCAT('%', ?, '%') LIMIT 10;";
         $args = [$name];
 
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $args);
@@ -41,7 +41,7 @@ class Groups extends \OmegaUp\DAO\Base\Groups {
     }
 
     public static function getByName(string $name): ?\OmegaUp\DAO\VO\Groups {
-        $sql = 'SELECT g.* from Groups g where g.name = ? LIMIT 1;';
+        $sql = 'SELECT `g`.* FROM `Groups` AS `g` WHERE `g`.`name` = ? LIMIT 1;';
 
         /** @var array{acl_id: int, alias: string, create_time: string, description: null|string, group_id: int, name: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$name]);
@@ -71,7 +71,7 @@ class Groups extends \OmegaUp\DAO\Base\Groups {
                 g.name,
                 g.group_id
             FROM
-                Groups g
+                `Groups` AS g
             INNER JOIN
                 ACLs AS a ON a.acl_id = g.acl_id
             LEFT JOIN

--- a/frontend/server/src/DAO/UserRoles.php
+++ b/frontend/server/src/DAO/UserRoles.php
@@ -179,7 +179,7 @@ class UserRoles extends \OmegaUp\DAO\Base\UserRoles {
             FROM
                 Groups_Identities gi
             INNER JOIN
-                Groups g ON gi.group_id = g.group_id
+                `Groups` AS g ON gi.group_id = g.group_id
             WHERE
                 gi.identity_id = ? AND g.name LIKE '%omegaup:%';";
         $params = [

--- a/frontend/tests/ControllerTestCase.php
+++ b/frontend/tests/ControllerTestCase.php
@@ -399,6 +399,45 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
 
         self::$logObj->info('[INFO] ' . $message);
     }
+
+    /**
+     * Compatibility with PHPUnit 8.5.2.
+     */
+    public static function assertStringContainsString(
+        string $needle,
+        string $haystack,
+        string $message = ''
+    ): void {
+        if (strpos($haystack, $needle) !== false) {
+            return;
+        }
+        if (empty($message)) {
+            $message = \sprintf('"%s" contains "%s"', $haystack, $needle);
+        }
+        self::fail("failed asserting that {$message}");
+    }
+
+    /**
+     * Asserts that two variables are equal (with delta).
+     * Compatibility with PHPUnit 8.5.2.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertEqualsWithDelta(
+        $expected,
+        $actual,
+        float $delta,
+        string $message = ''
+    ): void {
+        if ($expected == $actual) {
+            return;
+        }
+        if (abs($expected - $actual) <= $delta) {
+            return;
+        }
+        self::assertEquals($expected, $actual, $message);
+    }
 }
 
 /**

--- a/frontend/tests/controllers/AssignmentProblemsTest.php
+++ b/frontend/tests/controllers/AssignmentProblemsTest.php
@@ -166,8 +166,6 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Attempts to add a problem with a normal user.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddProblemForbiddenAccess() {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
@@ -188,18 +186,21 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
         // Add one problem to the assignment with a normal user
         ['user' => $forbiddenUser, 'identity' => $forbiddenIdentity] = \OmegaUp\Test\Factories\User::createUser();
         $forbiddenUserLogin = self::login($forbiddenIdentity);
-        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
-            $forbiddenUserLogin,
-            $courseAlias,
-            $assignmentAlias,
-            [$problem]
-        );
+        try {
+            \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+                $forbiddenUserLogin,
+                $courseAlias,
+                $assignmentAlias,
+                [$problem]
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Attempts to add a problem with a student.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddProblemForbiddenAccessStudent() {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
@@ -222,18 +223,21 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
             $courseData
         );
         $forbiddenUserLogin = self::login($forbiddenUser);
-        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
-            $forbiddenUserLogin,
-            $courseAlias,
-            $assignmentAlias,
-            [$problem]
-        );
+        try {
+            \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+                $forbiddenUserLogin,
+                $courseAlias,
+                $assignmentAlias,
+                [$problem]
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Attempts to remove a problem with a normal user.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testDeleteProblemForbiddenAccess() {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
@@ -262,18 +266,21 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
         // Remove a problem from the assignment with a normal user
         ['user' => $forbiddenUser, 'identity' => $forbiddenIdentity] = \OmegaUp\Test\Factories\User::createUser();
         $forbiddenUserLogin = self::login($forbiddenIdentity);
-        $removeProblemResponse = \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
-            'auth_token' => $forbiddenUserLogin->auth_token,
-            'course_alias' => $courseAlias,
-            'assignment_alias' => $assignmentAlias,
-            'problem_alias' => $problem['problem']->alias,
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
+                'auth_token' => $forbiddenUserLogin->auth_token,
+                'course_alias' => $courseAlias,
+                'assignment_alias' => $assignmentAlias,
+                'problem_alias' => $problem['problem']->alias,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Attempts to remove a problem with a student.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testDeleteProblemForbiddenAccessStudent() {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
@@ -304,18 +311,21 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
             $courseData
         );
         $forbiddenUserLogin = self::login($forbiddenUser);
-        $removeProblemResponse = \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
-            'auth_token' => $forbiddenUserLogin->auth_token,
-            'course_alias' => $courseAlias,
-            'assignment_alias' => $assignmentAlias,
-            'problem_alias' => $problem['problem']->alias,
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
+                'auth_token' => $forbiddenUserLogin->auth_token,
+                'course_alias' => $courseAlias,
+                'assignment_alias' => $assignmentAlias,
+                'problem_alias' => $problem['problem']->alias,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Attempts to remove an invalid problem.
-     *
-     * @expectedException \OmegaUp\Exceptions\NotFoundException
      */
     public function testDeleteNonExistingProblem() {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
@@ -330,11 +340,16 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
         $assignmentAlias = $courseData['assignment_alias'];
 
         // Remove an invalid problem from the assignment
-        $removeProblemResponse = \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'course_alias' => $courseAlias,
-            'assignment_alias' => $assignmentAlias,
-            'problem_alias' => 'noexiste',
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiRemoveProblem(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'course_alias' => $courseAlias,
+                'assignment_alias' => $assignmentAlias,
+                'problem_alias' => 'noexiste',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotFoundException $e) {
+            $this->assertEquals('problemNotFound', $e->getMessage());
+        }
     }
 }

--- a/frontend/tests/controllers/ClarificationCreateTest.php
+++ b/frontend/tests/controllers/ClarificationCreateTest.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Description of CreateClarificationTest
+ * Description of ClarificationCreateTest
  *
  * @author joemmanuel
  */
 
-class CreateClarificationTest extends \OmegaUp\Test\ControllerTestCase {
+class ClarificationCreateTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Helper function to setup environment needed to create a clarification
      *
@@ -97,10 +97,8 @@ class CreateClarificationTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-    * Creates a clarification with message too long
-    *
-    * @expectedException \OmegaUp\Exceptions\InvalidParameterException
-    */
+     * Creates a clarification with message too long
+     */
     public function testCreateClarificationMessageTooLong() {
         [
             'problemData' => $problemData,
@@ -108,12 +106,17 @@ class CreateClarificationTest extends \OmegaUp\Test\ControllerTestCase {
             'contestant' => $contestant,
         ] = $this->setupContest(/*$isGraderExpectedToBeCalled=*/false);
 
-        $clarificationData = ClarificationsFactory::createClarification(
-            $problemData,
-            $contestData,
-            $contestant,
-            'Lorem ipsum dolor sit amet, mauris faucibus pede congue curae nullam, mauris maecenas tincidunt amet, nec wisi vestibulum ut cras in, velit in dolor. Elit hendrerit pede auctor tincidunt neque, lorem nunc sit a vivamus nibh. Auctor habitant, etiam ut nam'
-        );
+        try {
+            ClarificationsFactory::createClarification(
+                $problemData,
+                $contestData,
+                $contestant,
+                'Lorem ipsum dolor sit amet, mauris faucibus pede congue curae nullam, mauris maecenas tincidunt amet, nec wisi vestibulum ut cras in, velit in dolor. Elit hendrerit pede auctor tincidunt neque, lorem nunc sit a vivamus nibh. Auctor habitant, etiam ut nam'
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterStringTooLong', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/ClarificationDetailsTest.php
+++ b/frontend/tests/controllers/ClarificationDetailsTest.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Description of DetailsClarificationTest
+ * Description of ClarificationDetailsTest
  *
  * @author joemmanuel
  */
 
-class DetailsClarificationTest extends \OmegaUp\Test\ControllerTestCase {
+class ClarificationDetailsTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Validates a clarification given the clarification ID
      *
@@ -121,8 +121,6 @@ class DetailsClarificationTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Checks that private clarifications cant be viewed by someone else
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testClarificationsCreatedPrivateAsDefault() {
         // Get a problem
@@ -138,10 +136,16 @@ class DetailsClarificationTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Create our contestant who will submit the clarification
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $contestant,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         // Create our contestant who will try to view the clarification
-        ['user' => $contestant2, 'identity' => $identity2] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $contestant2,
+            'identity' => $identity2,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         // Create the clarification, note that contestant will create it
         $this->detourBroadcasterCalls();
@@ -152,15 +156,19 @@ class DetailsClarificationTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Prepare the request object
-        $r = new \OmegaUp\Request();
-        $r['clarification_id'] = $clarificationData['response']['clarification_id'];
 
         // Log in with the author of the clarification
         $login = self::login($identity2);
-        $r['auth_token'] = $login->auth_token;
 
-        // Call API, will fail
-        \OmegaUp\Controllers\Clarification::apiDetails($r);
+        try {
+            \OmegaUp\Controllers\Clarification::apiDetails(new \OmegaUp\Request([
+                'clarification_id' => $clarificationData['response']['clarification_id'],
+                'auth_token' => $login->auth_token,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     public function testPublicClarificationsCanBeViewed() {

--- a/frontend/tests/controllers/ContestAddProblemTest.php
+++ b/frontend/tests/controllers/ContestAddProblemTest.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Description of AddProblemToContestTest
+ * Description of ContestAddProblemTest
  *
  * @author joemmanuel
  */
 
-class AddProblemToContestTest extends \OmegaUp\Test\ControllerTestCase {
+class ContestAddProblemTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Check in DB for problem added to contest
      *
@@ -68,8 +68,6 @@ class AddProblemToContestTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Add a problem to contest with invalid params
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testAddProblemToContestInvalidProblem() {
         // Get a problem
@@ -79,22 +77,24 @@ class AddProblemToContestTest extends \OmegaUp\Test\ControllerTestCase {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest();
         // Build request
         $directorLogin = self::login($contestData['director']);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $directorLogin->auth_token,
-            'contest_alias' => $contestData['request']['alias'],
-            'problem_alias' => 'this problem doesnt exists',
-            'points' => 100,
-            'order_in_contest' => 1,
-        ]);
 
-        // Call API
-        $response = \OmegaUp\Controllers\Contest::apiAddProblem($r);
+        try {
+            \OmegaUp\Controllers\Contest::apiAddProblem(new \OmegaUp\Request([
+                'auth_token' => $directorLogin->auth_token,
+                'contest_alias' => $contestData['request']['alias'],
+                'problem_alias' => 'this problem doesnt exists',
+                'points' => 100,
+                'order_in_contest' => 1,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterNotFound', $e->getMessage());
+            $this->assertEquals('problem_alias', $e->parameter);
+        }
     }
 
     /**
      * Add a problem to contest with invalid params
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testAddProblemToContestInvalidContest() {
         // Get a problem
@@ -105,22 +105,25 @@ class AddProblemToContestTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Create an empty request
         $directorLogin = self::login($contestData['director']);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $directorLogin->auth_token,
-            'contest_alias' => 'invalid problem',
-            'problem_alias' => $problemData['request']['alias'],
-            'points' => 100,
-            'order_in_contest' => 1,
-        ]);
 
         // Call API
-        $response = \OmegaUp\Controllers\Contest::apiAddProblem($r);
+        try {
+            \OmegaUp\Controllers\Contest::apiAddProblem(new \OmegaUp\Request([
+                'auth_token' => $directorLogin->auth_token,
+                'contest_alias' => 'invalid problem',
+                'problem_alias' => $problemData['request']['alias'],
+                'points' => 100,
+                'order_in_contest' => 1,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterNotFound', $e->getMessage());
+            $this->assertEquals('contest_alias', $e->parameter);
+        }
     }
 
     /**
      * Add a problem to contest with unauthorized user
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddProblemToContestWithUnauthorizedUser() {
         // Get a problem
@@ -132,18 +135,20 @@ class AddProblemToContestTest extends \OmegaUp\Test\ControllerTestCase {
         // Log in as another random user
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
-        // Build request
         $userLogin = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $userLogin->auth_token,
-            'contest_alias' => $contestData['request']['alias'],
-            'problem_alias' => $problemData['request']['alias'],
-            'points' => 100,
-            'order_in_contest' => 1,
-        ]);
 
-        // Call API
-        $response = \OmegaUp\Controllers\Contest::apiAddProblem($r);
+        try {
+            \OmegaUp\Controllers\Contest::apiAddProblem(new \OmegaUp\Request([
+                'auth_token' => $userLogin->auth_token,
+                'contest_alias' => $contestData['request']['alias'],
+                'problem_alias' => $problemData['request']['alias'],
+                'points' => 100,
+                'order_in_contest' => 1,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('cannotAddProb', $e->getMessage());
+        }
     }
 
     /**
@@ -221,7 +226,7 @@ class AddProblemToContestTest extends \OmegaUp\Test\ControllerTestCase {
                 'Banned problems should not be able to be added to a contest'
             );
         } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
-            $this->assertEquals($e->getMessage(), 'problemIsBanned');
+            $this->assertEquals('problemIsBanned', $e->getMessage());
         }
 
         // Make it private. Now it should be possible to add it.

--- a/frontend/tests/controllers/ContestCloneTest.php
+++ b/frontend/tests/controllers/ContestCloneTest.php
@@ -55,8 +55,6 @@ class ContestCloneTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Creating a clone with the original contest alias
-     *
-     * @expectedException \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
     public function testCreateContestCloneWithTheSameAlias() {
         // Get a problem
@@ -75,21 +73,24 @@ class ContestCloneTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Clone the contest
         $login = self::login($contestData['director']);
-        $contestClonedData = \OmegaUp\Controllers\Contest::apiClone(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'contest_alias' => $contestData['request']['alias'],
-            'title' => \OmegaUp\Test\Utils::createRandomString(),
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => $contestData['request']['alias'],
-            'contest' => $contestData['contest'],
-            'start_time' => \OmegaUp\Time::get()
-        ]));
+        try {
+            \OmegaUp\Controllers\Contest::apiClone(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'contest_alias' => $contestData['request']['alias'],
+                'title' => \OmegaUp\Test\Utils::createRandomString(),
+                'description' => \OmegaUp\Test\Utils::createRandomString(),
+                'alias' => $contestData['request']['alias'],
+                'contest' => $contestData['contest'],
+                'start_time' => \OmegaUp\Time::get()
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals('titleInUse', $e->getMessage());
+        }
     }
 
     /**
      * Creating a clone of a private contest without its access
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testCreatePrivateContestCloneWithoutAccess() {
         // Get a problem
@@ -112,14 +113,19 @@ class ContestCloneTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
 
         // Clone the contest
-        $contestClonedData = \OmegaUp\Controllers\Contest::apiClone(new \OmegaUp\Request([
-            'auth_token' => $login['auth_token'],
-            'contest_alias' => $contestData['request']['alias'],
-            'title' => \OmegaUp\Test\Utils::createRandomString(),
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => \OmegaUp\Test\Utils::createRandomString(),
-            'contest' => $contestData['contest'],
-            'start_time' => \OmegaUp\Time::get()
-        ]));
+        try {
+            \OmegaUp\Controllers\Contest::apiClone(new \OmegaUp\Request([
+                'auth_token' => $login['auth_token'],
+                'contest_alias' => $contestData['request']['alias'],
+                'title' => \OmegaUp\Test\Utils::createRandomString(),
+                'description' => \OmegaUp\Test\Utils::createRandomString(),
+                'alias' => \OmegaUp\Test\Utils::createRandomString(),
+                'contest' => $contestData['contest'],
+                'start_time' => \OmegaUp\Time::get()
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 }

--- a/frontend/tests/controllers/ContestDetailsTest.php
+++ b/frontend/tests/controllers/ContestDetailsTest.php
@@ -271,9 +271,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Dont show private contests for users that are not in the private list
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
+     * Don't show private contests for users that are not in the private list
      */
     public function testDontShowPrivateContestForAnyUser() {
         // Get a contest
@@ -293,13 +291,16 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Prepare our request
         $login = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => $login->auth_token,
-        ]);
 
-        // Call api
-        $response = \OmegaUp\Controllers\Contest::apiDetails($r);
+        try {
+            \OmegaUp\Controllers\Contest::apiDetails(new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $login->auth_token,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
@@ -449,8 +450,6 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Try to view a contest before it has started
-     *
-     * @expectedException \OmegaUp\Exceptions\PreconditionFailedException
      */
     public function testContestNotStartedYet() {
         // Get a contest
@@ -468,13 +467,16 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Prepare our request
         $login = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => $login->auth_token,
-        ]);
 
-        // Call api
-        $response = \OmegaUp\Controllers\Contest::apiDetails($r);
+        try {
+            \OmegaUp\Controllers\Contest::apiDetails(new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $login->auth_token,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\PreconditionFailedException $e) {
+            $this->assertEquals('contestNotStarted', $e->getMessage());
+        }
     }
 
     /**
@@ -576,8 +578,6 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Test accesing api with invalid scoreboard token. Should fail.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testDetailsUsingInvalidToken() {
         // Get a private contest
@@ -592,12 +592,16 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call details using token
         $login = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'contest_alias' => $contestData['request']['alias'],
-            'token' => 'invalid token',
-        ]);
-        $detailsResponse = \OmegaUp\Controllers\Contest::apiDetails($r);
+        try {
+            \OmegaUp\Controllers\Contest::apiDetails(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'contest_alias' => $contestData['request']['alias'],
+                'token' => 'invalid token',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('invalidScoreboardUrl', $e->getMessage());
+        }
     }
 
     /**
@@ -911,7 +915,7 @@ class ContestDetailsTest extends \OmegaUp\Test\ControllerTestCase {
                 $files["runs/{$runData['response']['guid']}.{$runData['request']['language']}"],
                 $runData['request']['source']
             );
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "{$runData['response']['guid']},{$runData['contestant']->username},{$problemData['problem']->alias}",
                 $summary
             );

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -86,8 +86,6 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Removes an inexistent problem from a private contest.
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testRemoveInvalidProblemFromPrivateContest() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -106,22 +104,21 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $contestData['director']
         );
 
-        // Create a new request
-        $r = new \OmegaUp\Request(
-            [
+        try {
+            \OmegaUp\Controllers\Contest::apiRemoveProblem(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'contest_alias' => $contestData['request']['alias'],
-                'problem_alias' => 'this problem doesnt exists'
-            ]
-        );
-
-        $response = \OmegaUp\Controllers\Contest::apiRemoveProblem($r);
+                'problem_alias' => 'this problem does not exist'
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterNotFound', $e->getMessage());
+            $this->assertEquals('problem_alias', $e->parameter);
+        }
     }
 
     /**
      * Removes a problem from an inexistent contest.
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testRemoveProblemFromInvalidContest() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -140,22 +137,22 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $contestData['director']
         );
 
-        $r = new \OmegaUp\Request(
-            [
+        try {
+            \OmegaUp\Controllers\Contest::apiRemoveProblem(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
-                'contest_alias' => 'this contest doesnt exists',
-                'problem_alias' => $problemData['request']['alias']
-            ]
-        );
-
-        $response = \OmegaUp\Controllers\Contest::apiRemoveProblem($r);
+                'contest_alias' => 'this contest does not exist',
+                'problem_alias' => $problemData['request']['alias'],
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterNotFound', $e->getMessage());
+            $this->assertEquals('problem_alias', $e->parameter);
+        }
     }
 
     /**
      * Removes a problem from contest while loged in with a user that
      * is not a contest admin.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testRemoveProblemPrivateContestNotBeingContestAdmin() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -172,15 +169,16 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);
 
-        $r = new \OmegaUp\Request(
-            [
+        try {
+            \OmegaUp\Controllers\Contest::apiRemoveProblem(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'contest_alias' => $contestData['request']['alias'],
                 'problem_alias' => $problemData['request']['alias']
-            ]
-        );
-
-        $response = \OmegaUp\Controllers\Contest::apiRemoveProblem($r);
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('cannotRemoveProblem', $e->getMessage());
+        }
     }
 
     /**
@@ -279,8 +277,6 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Removes a single problem from a public contest.
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testRemoveProblemsFromPublicContestWithASingleProblem() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -296,16 +292,22 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->makeContestPublic($contestData);
 
-        $response = \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
-            $problemData,
-            $contestData
-        );
+        try {
+            \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
+                $problemData,
+                $contestData
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals(
+                'contestPublicRequiresProblem',
+                $e->getMessage()
+            );
+        }
     }
 
     /**
      * Removes all problems from a public contest.
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testRemoveAllProblemsFromPublicContestWithTwoProblems() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -332,14 +334,20 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData1,
             $contestData
         );
-
-        // Validate
         $this->assertEquals('ok', $response['status']);
 
-        $response = \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
-            $problemData2,
-            $contestData
-        );
+        try {
+            \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
+                $problemData2,
+                $contestData
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals(
+                'contestPublicRequiresProblem',
+                $e->getMessage()
+            );
+        }
     }
 
     /**
@@ -441,8 +449,6 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Removes a problem with runs from a private contest while loged in
      * with a user that is not sysadmin.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testRemoveProblemWithRunsFromPrivateContest() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -455,7 +461,10 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $contestant,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -465,17 +474,23 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $identity
         );
 
-        $response = \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
-            $problemData,
-            $contestData
-        );
+        try {
+            \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
+                $problemData,
+                $contestData
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals(
+                'cannotRemoveProblemWithSubmissions',
+                $e->getMessage()
+            );
+        }
     }
 
     /**
      * Removes a problem with runs only from admins from a private contest while
      * loged in with a user that is not sysadmin.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testRemoveProblemWithMixedRunsFromContestNotBeingSysAdmin() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -503,10 +518,18 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $identity
         );
 
-        $response = \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
-            $problemData,
-            $contestData
-        );
+        try {
+            \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
+                $problemData,
+                $contestData
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals(
+                'cannotRemoveProblemWithSubmissions',
+                $e->getMessage()
+            );
+        }
     }
 
     /**
@@ -547,8 +570,6 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Removes a problem with runs made outside and inside the contest from a private contest
      * while logged in as Contest Admin. Should fail.
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testRemoveProblemWithRunsOutsideAndInsideContestFromPrivateContest() {
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
@@ -575,10 +596,18 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $identity
         );
 
-        $response = \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
-            $problemData,
-            $contestData
-        );
+        try {
+            \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
+                $problemData,
+                $contestData
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals(
+                'cannotRemoveProblemWithSubmissions',
+                $e->getMessage()
+            );
+        }
     }
 
     /**

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -598,8 +598,6 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Test invalid token
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testScoreboardUrlInvalidToken() {
         // Create our user not added to the contest
@@ -610,14 +608,16 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call scoreboard api from the user
         $login = self::login($externalIdentity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'problemset_id' =>  $contestData['contest']->problemset_id,
-            'token' => 'invalid token',
-        ]);
-        $scoreboardResponse = \OmegaUp\Controllers\Problemset::apiScoreboard(
-            $r
-        );
+        try {
+            \OmegaUp\Controllers\Problemset::apiScoreboard(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problemset_id' =>  $contestData['contest']->problemset_id,
+                'token' => 'invalid token',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('invalidScoreboardUrl', $e->getMessage());
+        }
     }
 
     /**
@@ -807,23 +807,24 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                 $event['problem']['alias'] === $problemAlias
             ) {
                 $eventFound = $event;
+                break;
             }
         }
 
-        if ($shouldBeIn === true) {
-            if (is_null($eventFound)) {
-                $this->fail(
-                    "$username $problemAlias combination not found on events."
-                );
-            }
-        } else {
+        if ($shouldBeIn !== true) {
             if (!is_null($eventFound)) {
                 $this->fail(
                     "$username $problemAlias combination was found on events when it was not expected."
                 );
             }
+            return;
         }
 
+        if (is_null($eventFound)) {
+            $this->fail(
+                "$username $problemAlias combination not found on events."
+            );
+        }
         if ($eventFound['problem']['points'] != $runMapEntry['points'] * 100) {
             $this->fail("$username $problemAlias has unexpected points.");
         }

--- a/frontend/tests/controllers/CourseCloneTest.php
+++ b/frontend/tests/controllers/CourseCloneTest.php
@@ -90,8 +90,6 @@ class CourseCloneTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Creating a clone with the original course alias
-     *
-     * @expectedException \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
     public function testCreateCourseCloneWithTheSameAlias() {
         $homeworkCount = 2;
@@ -136,13 +134,18 @@ class CourseCloneTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Clone the course
         $adminLogin = self::login($courseData['admin']);
-        $courseClonedData = \OmegaUp\Controllers\Course::apiClone(new \OmegaUp\Request([
-            'auth_token' => $adminLogin->auth_token,
-            'course_alias' => $courseData['course_alias'],
-            'name' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => $courseData['course_alias'],
-            'start_time' => \OmegaUp\Time::get()
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiClone(new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course_alias' => $courseData['course_alias'],
+                'name' => \OmegaUp\Test\Utils::createRandomString(),
+                'alias' => $courseData['course_alias'],
+                'start_time' => \OmegaUp\Time::get()
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals('aliasInUse', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -83,14 +83,15 @@ class CourseCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Two courses cannot have the same alias
-     *
-     * @expectedException \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
     public function testCreateCourseDuplicatedName() {
         $sameAlias = \OmegaUp\Test\Utils::createRandomString();
         $sameName = \OmegaUp\Test\Utils::createRandomString();
 
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
         $r = new \OmegaUp\Request([
@@ -115,19 +116,25 @@ class CourseCreateTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Create a new Course with different alias and name
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'name' => $sameName,
-            'alias' => $sameAlias,
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'start_time' => (\OmegaUp\Time::get() + 60),
-            'finish_time' => (\OmegaUp\Time::get() + 120)
-        ]);
-
-        \OmegaUp\Controllers\Course::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Course::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => $sameName,
+                'alias' => $sameAlias,
+                'description' => \OmegaUp\Test\Utils::createRandomString(),
+                'start_time' => (\OmegaUp\Time::get() + 60),
+                'finish_time' => (\OmegaUp\Time::get() + 120)
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals('aliasInUse', $e->getMessage());
+        }
     }
 
     public function testCreateSchoolAssignment() {
@@ -270,26 +277,33 @@ class CourseCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Try to create an assignment with inverted times.
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testCreateAssignmentWithInvertedTimes() {
-        ['user' => $admin, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $admin,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
         $adminLogin = \OmegaUp\Test\ControllerTestCase::login($identity);
         $courseData = \OmegaUp\Test\Factories\Course::createCourse(
             $identity,
             $adminLogin
         );
 
-        \OmegaUp\Controllers\Course::apiCreateAssignment(new \OmegaUp\Request([
-            'auth_token' => $adminLogin->auth_token,
-            'name' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => \OmegaUp\Test\Utils::createRandomString(),
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'start_time' => (\OmegaUp\Time::get() + 120),
-            'finish_time' => (\OmegaUp\Time::get() + 60),
-            'course_alias' => $courseData['course_alias'],
-            'assignment_type' => 'homework'
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiCreateAssignment(new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'name' => \OmegaUp\Test\Utils::createRandomString(),
+                'alias' => \OmegaUp\Test\Utils::createRandomString(),
+                'description' => \OmegaUp\Test\Utils::createRandomString(),
+                'start_time' => (\OmegaUp\Time::get() + 120),
+                'finish_time' => (\OmegaUp\Time::get() + 60),
+                'course_alias' => $courseData['course_alias'],
+                'assignment_type' => 'homework',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('courseInvalidStartTime', $e->getMessage());
+        }
     }
 
     public function testCreateAssignmentWithUnlimitedDuration() {
@@ -380,23 +394,29 @@ class CourseCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Public course can't be created by default
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testCreatePublicCourseFailForNonCurator() {
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'name' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => \OmegaUp\Test\Utils::createRandomString(),
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'start_time' => (\OmegaUp\Time::get() + 60),
-            'finish_time' => (\OmegaUp\Time::get() + 120),
-            'admission_mode' => \OmegaUp\Controllers\Course::ADMISSION_MODE_PUBLIC,
-        ]);
 
-        $response = \OmegaUp\Controllers\Course::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Course::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => \OmegaUp\Test\Utils::createRandomString(),
+                'alias' => \OmegaUp\Test\Utils::createRandomString(),
+                'description' => \OmegaUp\Test\Utils::createRandomString(),
+                'start_time' => (\OmegaUp\Time::get() + 60),
+                'finish_time' => (\OmegaUp\Time::get() + 120),
+                'admission_mode' => \OmegaUp\Controllers\Course::ADMISSION_MODE_PUBLIC,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/CourseDetailsTest.php
+++ b/frontend/tests/controllers/CourseDetailsTest.php
@@ -109,22 +109,28 @@ class CourseDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Get details with user not registered to the Course. Should fail.
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testGetCourseDetailsNoCourseMember() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
         $userLogin = self::login($identity);
 
-        $response = \OmegaUp\Controllers\Course::apiDetails(new \OmegaUp\Request([
-            'auth_token' => $userLogin->auth_token,
-            'alias' => $courseData['course_alias']
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiDetails(new \OmegaUp\Request([
+                'auth_token' => $userLogin->auth_token,
+                'alias' => $courseData['course_alias']
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Get details with user not registered to the Course. Should fail even if course is Public.
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testGetCourseDetailsNoCourseMemberPublic() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourse(
@@ -135,12 +141,15 @@ class CourseDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $userLogin = self::login($identity);
-        $response = \OmegaUp\Controllers\Course::apiDetails(
-            new \OmegaUp\Request([
+        try {
+            \OmegaUp\Controllers\Course::apiDetails(new \OmegaUp\Request([
                 'auth_token' => $userLogin->auth_token,
                 'alias' => $courseData['course_alias']
-            ])
-        );
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     public function testGetCourseIntroDetailsNoCourseMemberPublic() {

--- a/frontend/tests/controllers/CourseStudentAddTest.php
+++ b/frontend/tests/controllers/CourseStudentAddTest.php
@@ -155,8 +155,6 @@ class CourseStudentAddTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Students can only be added by course admins
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddStudentNonAdmin() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourse();
@@ -166,27 +164,36 @@ class CourseStudentAddTest extends \OmegaUp\Test\ControllerTestCase {
         $nonAdminLogin = \OmegaUp\Test\ControllerTestCase::login(
             $nonAdminIdentity
         );
-        \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
-            'auth_token' => $nonAdminLogin->auth_token,
-            'usernameOrEmail' => $identity->username,
-            'course_alias' => $courseData['course_alias'],
+        try {
+            \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
+                'auth_token' => $nonAdminLogin->auth_token,
+                'usernameOrEmail' => $identity->username,
+                'course_alias' => $courseData['course_alias'],
             ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Can't self-register unless Public
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testSelfAddStudentNoPublic() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourse();
         ['user' => $student, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);
-        \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $identity->username,
-            'course_alias' => $courseData['course_alias'],
+        try {
+            \OmegaUp\Controllers\Course::apiAddStudent(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'usernameOrEmail' => $identity->username,
+                'course_alias' => $courseData['course_alias'],
             ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/CourseStudentListTest.php
+++ b/frontend/tests/controllers/CourseStudentListTest.php
@@ -37,32 +37,43 @@ class CourseStudentListTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * List can only be retreived by an admin
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testCourseStudentListNonAdmin() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourse();
 
         // Call apiStudentList by another random user
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
         $userLogin = self::login($identity);
-        $response = \OmegaUp\Controllers\Course::apiListStudents(new \OmegaUp\Request([
-            'auth_token' => $userLogin->auth_token,
-            'course_alias' => $courseData['course_alias']
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiListStudents(new \OmegaUp\Request([
+                'auth_token' => $userLogin->auth_token,
+                'course_alias' => $courseData['course_alias'],
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Course does not exists test
-     * @expectedException \OmegaUp\Exceptions\NotFoundException
      */
     public function testCourseStudentListInvalidCourse() {
         // Call apiStudentList by another random user
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $userLogin = self::login($identity);
-        $response = \OmegaUp\Controllers\Course::apiListStudents(new \OmegaUp\Request([
-            'auth_token' => $userLogin->auth_token,
-            'course_alias' => 'foo'
-        ]));
+        try {
+            \OmegaUp\Controllers\Course::apiListStudents(new \OmegaUp\Request([
+                'auth_token' => $userLogin->auth_token,
+                'course_alias' => 'foo',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotfoundException $e) {
+            $this->assertEquals('courseNotFound', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/GroupsTest.php
+++ b/frontend/tests/controllers/GroupsTest.php
@@ -53,7 +53,7 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
             ]));
             $this->fail('Group creation should have failed');
         } catch (\OmegaUp\Exceptions\DuplicatedEntryInDatabaseException $e) {
-            $this->assertEquals($e->getMessage(), 'aliasInUse');
+            $this->assertEquals('aliasInUse', $e->getMessage());
         }
     }
 
@@ -81,8 +81,6 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Add user to group
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddUserToGroupNotOwned() {
         $group = GroupsFactory::createGroup();
@@ -90,11 +88,16 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
         ['user' => $userCalling, 'identity' => $identityCalling] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identityCalling);
-        $response = \OmegaUp\Controllers\Group::apiAddUser(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $identity->username,
-            'group_alias' => $group['group']->alias
-        ]));
+        try {
+            \OmegaUp\Controllers\Group::apiAddUser(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'usernameOrEmail' => $identity->username,
+                'group_alias' => $group['group']->alias
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
@@ -123,36 +126,43 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Remove user from group test
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testRemoveUserFromGroupUserNotInGroup() {
         $groupData = GroupsFactory::createGroup();
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($groupData['owner']);
-        \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $identity->username,
-            'group_alias' => $groupData['group']->alias
-        ]));
+        try {
+            \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'usernameOrEmail' => $identity->username,
+                'group_alias' => $groupData['group']->alias
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterNotFound', $e->getMessage());
+            $this->assertEquals('User', $e->parameter);
+        }
     }
 
     /**
      * Remove user from group test
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testRemoveUserFromGroupUserNotOwner() {
         $groupData = GroupsFactory::createGroup();
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
-        \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $identity->username,
-            'group_alias' => $groupData['group']->alias
-        ]));
+        try {
+            \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'usernameOrEmail' => $identity->username,
+                'group_alias' => $groupData['group']->alias
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
@@ -275,8 +285,6 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Adding a contest to a scoreboard not being contest admin
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testAddContestToScoreboardNoContestAdmin() {
         $groupData = GroupsFactory::createGroup();
@@ -288,12 +296,17 @@ class GroupsTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         $login = self::login($groupData['owner']);
-        \OmegaUp\Controllers\GroupScoreboard::apiAddContest(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'group_alias' => $groupData['request']['alias'],
-            'scoreboard_alias' => $scoreboardData['request']['alias'],
-            'contest_alias' => $contestData['request']['alias']
-        ]));
+        try {
+            \OmegaUp\Controllers\GroupScoreboard::apiAddContest(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'group_alias' => $groupData['request']['alias'],
+                'scoreboard_alias' => $scoreboardData['request']['alias'],
+                'contest_alias' => $contestData['request']['alias']
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/InterviewCreateTest.php
+++ b/frontend/tests/controllers/InterviewCreateTest.php
@@ -138,10 +138,7 @@ class InterviewCreateTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     *
      * Only site-admins and interviewers can create interviews for now
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testOnlyInterviewersCanCreateInterviews() {
         $r = new \OmegaUp\Request();
@@ -150,11 +147,16 @@ class InterviewCreateTest extends \OmegaUp\Test\ControllerTestCase {
         ['user' => $interviewer, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
-        $response = \OmegaUp\Controllers\Interview::apiCreate(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'title' => 'My fourth interview',
-            'alias' => 'my-fourth-interview',
-            'duration' => 60,
-        ]));
+        try {
+            \OmegaUp\Controllers\Interview::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'title' => 'My fourth interview',
+                'alias' => 'my-fourth-interview',
+                'duration' => 60,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 }

--- a/frontend/tests/controllers/LoginTest.php
+++ b/frontend/tests/controllers/LoginTest.php
@@ -66,61 +66,66 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Test user login with invalid credentials, username and password
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidCredentialsException
      */
     public function testNativeLoginByUserInvalidPassword() {
         // Create an user in omegaup
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
-        $response = \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
-            'usernameOrEmail' => $identity->username,
-            'password' => 'badpasswordD:'
-        ]));
+        try {
+            \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
+                'usernameOrEmail' => $identity->username,
+                'password' => 'badpasswordD:'
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidCredentialsException $e) {
+            $this->assertEquals('usernameOrPassIsWrong', $e->getMessage());
+        }
     }
 
     /**
      * Test user login with invalid credentials, username and password
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidCredentialsException
      */
     public function testNativeLoginByUserInvalidUsername() {
-        // Inflate request with user data
-        $r = new \OmegaUp\Request([
-            'usernameOrEmail' => 'IDontExist',
-            'password' => 'badpasswordD:'
-        ]);
-
-        // Call the API
-        $response = \OmegaUp\Controllers\User::apiLogin($r);
+        try {
+            \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
+                'usernameOrEmail' => 'IDontExist',
+                'password' => 'badpasswordD:'
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidCredentialsException $e) {
+            $this->assertEquals('usernameOrPassIsWrong', $e->getMessage());
+        }
     }
 
     /**
      * Test user login with invalid credentials, email and password
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidCredentialsException
      */
     public function testNativeLoginByEmailInvalidPassword() {
         // Create an user in omegaup
         $email = \OmegaUp\Test\Utils::createRandomString() . '@mail.com';
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser(
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser(
             new \OmegaUp\Test\Factories\UserParams(['email' => $email])
         );
 
-        // Inflate request with user data
-        $r = new \OmegaUp\Request([
-            'usernameOrEmail' => $email,
-            'password' => 'badpasswordD:'
-        ]);
-
-        // Call the API
-        $response = \OmegaUp\Controllers\User::apiLogin($r);
+        try {
+            \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
+                'usernameOrEmail' => $email,
+                'password' => 'badpasswordD:'
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidCredentialsException $e) {
+            $this->assertEquals('usernameOrPassIsWrong', $e->getMessage());
+        }
     }
 
     /**
      * Test login E2E via HTTP entry point
-     *
-     *
      */
     public function testNativeLoginPositiveViaHttp() {
         // Create an user
@@ -177,8 +182,6 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Test identity login with valid credentials, username and password
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidCredentialsException
      */
     public function testNativeLoginWithOldPassword() {
         // Create an user in omegaup
@@ -191,14 +194,15 @@ class LoginTest extends \OmegaUp\Test\ControllerTestCase {
         // Let's put back plain password
         $identity->password = $plainPassword;
 
-        // Inflate request with identity data
-        $r = new \OmegaUp\Request([
-            'usernameOrEmail' => $identity->username,
-            'password' => $identity->password
-        ]);
-
-        // Call the API
-        $response = \OmegaUp\Controllers\User::apiLogin($r);
+        try {
+            \OmegaUp\Controllers\User::apiLogin(new \OmegaUp\Request([
+                'usernameOrEmail' => $identity->username,
+                'password' => $identity->password
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidCredentialsException $e) {
+            $this->assertEquals('usernameOrPassIsWrong', $e->getMessage());
+        }
     }
 
     public function testDeleteTokenExpired() {

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -6,7 +6,7 @@
  * @author joemmanuel
  */
 
-class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
+class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Basic test for creating a problem
      */
@@ -372,8 +372,8 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertTrue($problemArtifacts->exists('statements/es.markdown'));
 
         // Verify we have the accents, lol
-        $markdown_contents = $problemArtifacts->get('statements/es.markdown');
-        if (strpos($markdown_contents, 'ó') === false) {
+        $markdownContents = $problemArtifacts->get('statements/es.markdown');
+        if (strpos($markdownContents, 'ó') === false) {
             $this->fail('ó not found when expected.');
         }
     }
@@ -415,15 +415,21 @@ class CreateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertTrue($problemArtifacts->exists('statements/bunny.jpg'));
 
         // Do image path checks in the markdown file
-        $markdown_contents = $problemArtifacts->get('statements/es.markdown');
-        $this->assertContains('![Saluda](bunny.jpg)', $markdown_contents);
+        $markdownContents = $problemArtifacts->get('statements/es.markdown');
+        $this->assertStringContainsString(
+            '![Saluda](bunny.jpg)',
+            $markdownContents
+        );
         // And the direct URL.
-        $this->assertContains(
+        $this->assertStringContainsString(
             "![Saluda]($imageAbsoluteUrl)",
-            $markdown_contents
+            $markdownContents
         );
         // And the unmodified, not found image.
-        $this->assertContains('![404](notfound.jpg)', $markdown_contents);
+        $this->assertStringContainsString(
+            '![404](notfound.jpg)',
+            $markdownContents
+        );
 
         // Check that the images are there.
         $response = \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([

--- a/frontend/tests/controllers/ProblemDeleteTest.php
+++ b/frontend/tests/controllers/ProblemDeleteTest.php
@@ -9,12 +9,13 @@
 class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Tests problem with submissions in a contest or a course can't be deleted anymore
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testProblemCanNotBeDeletedAfterSubmissionsInACourseOrContest() {
         // Get a user
-        ['user' => $userLogin, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $userLogin,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         // Get a problem
         $problemData = \OmegaUp\Test\Factories\Problem::createProblem(
@@ -34,7 +35,10 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Create our contestant
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $contestant,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         // Create a run
         $runData = \OmegaUp\Test\Factories\Run::createRun(
@@ -48,11 +52,18 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         $login = self::login($problemData['author']);
 
-        // Call API
-        $response = \OmegaUp\Controllers\Problem::apiDelete(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'problem_alias' => $problemData['request']['problem_alias'],
-        ]));
+        try {
+            \OmegaUp\Controllers\Problem::apiDelete(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals(
+                'problemHasBeenUsedInContestOrCourse',
+                $e->getMessage()
+            );
+        }
     }
 
     /**

--- a/frontend/tests/controllers/ProblemDetailsTest.php
+++ b/frontend/tests/controllers/ProblemDetailsTest.php
@@ -7,9 +7,6 @@
  */
 
 class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
-    /**
-     *
-     */
     public function testViewProblemInAContestDetailsValid() {
         // Get a contest
         $contestData = \OmegaUp\Test\Factories\Contest::createContest();
@@ -56,9 +53,9 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Assert data
-        $this->assertEquals($response['title'], $problemDAO->title);
-        $this->assertEquals($response['alias'], $problemDAO->alias);
-        $this->assertEquals($response['points'], 100);
+        $this->assertEquals($problemDAO->title, $response['title']);
+        $this->assertEquals($problemDAO->alias, $response['alias']);
+        $this->assertEquals(100, $response['points']);
         $this->assertEquals(
             $response['problemsetter']['username'],
             $authorIdentity->username
@@ -67,10 +64,13 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
             $response['problemsetter']['name'],
             $authorIdentity->name
         );
-        $this->assertEquals($response['source'], $problemDAO->source);
-        $this->assertContains('# Entrada', $response['statement']['markdown']);
-        $this->assertEquals($response['order'], $problemDAO->order);
-        $this->assertEquals($response['score'], 0);
+        $this->assertEquals($problemDAO->source, $response['source']);
+        $this->assertStringContainsString(
+            '# Entrada',
+            $response['statement']['markdown']
+        );
+        $this->assertEquals($problemDAO->order, $response['order']);
+        $this->assertEquals(0, $response['score']);
 
         // Default data
         $this->assertEquals(0, $problemDAO->visits);
@@ -121,7 +121,7 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
 
         // Assert data
-        $this->assertContains(
+        $this->assertStringContainsString(
             $expected_text,
             $response['statement']['markdown']
         );
@@ -134,11 +134,13 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         $this->internalViewProblemStatement('markdown', '# Entrada');
     }
 
-    /**
-     * @expectedException \OmegaUp\Exceptions\NotFoundException
-     */
     public function testViewProblemStatementInvalidType() {
-        $this->internalViewProblemStatement('not_html_or_markdown', '');
+        try {
+            $this->internalViewProblemStatement('not_html_or_markdown', '');
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotFoundException $e) {
+            $this->assertEquals('invalidStatementType', $e->getMessage());
+        }
     }
 
     public function testProblemDetailsNotInContest() {
@@ -173,8 +175,6 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * User can't see problem details
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testPrivateProblemDetailsOutsideOfContest() {
         // Get 1 problem public
@@ -185,18 +185,20 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
         // Get a user for our scenario
         ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
-        // Call api
         $login = self::login($identity);
-        $response = \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'problem_alias' => $problemData['request']['problem_alias'],
-        ]));
+        try {
+            \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('problemIsPrivate', $e->getMessage());
+        }
     }
 
     /**
      * Non-user can't see problem details
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testPrivateProblemDetailsAnonymousOutsideOfContest() {
         // Get 1 problem public
@@ -204,10 +206,14 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
             'visibility' => 0
         ]));
 
-        // Call api
-        $response = \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([
-            'problem_alias' => $problemData['request']['problem_alias'],
-        ]));
+        try {
+            \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([
+                'problem_alias' => $problemData['request']['problem_alias'],
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('problemIsPrivate', $e->getMessage());
+        }
     }
 
     /**
@@ -405,7 +411,7 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
                 'auth_token' => $login->auth_token,
                 'problem_alias' => $problemData['request']['problem_alias'],
             ]));
-            $this->assertContains(
+            $this->assertStringContainsString(
                 '`long long`',
                 $response['solution']['markdown']
             );
@@ -447,7 +453,7 @@ class ProblemDetailsTest extends \OmegaUp\Test\ControllerTestCase {
                 'auth_token' => $login->auth_token,
                 'problem_alias' => $problemData['request']['problem_alias'],
             ]));
-            $this->assertContains(
+            $this->assertStringContainsString(
                 '`long long`',
                 $response['solution']['markdown']
             );

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Description of ProblemList
+ * Description of ProblemListTest
  *
  * @author joemmanuel
  */
-class ProblemList extends \OmegaUp\Test\ControllerTestCase {
+class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Gets the list of problems
      */

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Description of UpdateProblem
+ * Description of ProblemUpdateTest
  *
  * @author joemmanuel
  */
 
-class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
+class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testProblemUpdateLanguages() {
         // Get a problem (with 'es' statements)
         $problemData = \OmegaUp\Test\Factories\Problem::createProblem(new \OmegaUp\Test\Factories\ProblemParams([
@@ -115,7 +115,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
             // Check update in statements
             $statement = $problemArtifacts->get('statements/es.markdown');
-            $this->assertContains('perímetro', $statement);
+            $this->assertStringContainsString('perímetro', $statement);
 
             $problemDistribSettings = json_decode(
                 $problemArtifacts->get('settings.distrib.json'),
@@ -160,7 +160,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
             // Check update in statements
             $statement = $problemArtifacts->get('statements/es.markdown');
-            $this->assertContains('perímetro', $statement);
+            $this->assertStringContainsString('perímetro', $statement);
 
             $problemDistribSettings = json_decode(
                 $problemArtifacts->get('settings.distrib.json'),
@@ -327,7 +327,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'statement' => $statement
         ]));
 
-        $this->assertEquals($response['status'], 'ok');
+        $this->assertEquals('ok', $response['status']);
 
         // Check statment contents
         $problemArtifacts = new \OmegaUp\ProblemArtifacts(
@@ -338,7 +338,10 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'statements/es.markdown'
         );
 
-        $this->assertContains($statement, $statementMarkdownContents);
+        $this->assertStringContainsString(
+            $statement,
+            $statementMarkdownContents
+        );
     }
 
     /**
@@ -357,7 +360,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'solution' => $solution
         ]));
 
-        $this->assertEquals($response['status'], 'ok');
+        $this->assertEquals('ok', $response['status']);
 
         // Check solution contents
         $response = \OmegaUp\Controllers\Problem::apiSolution(new \OmegaUp\Request([
@@ -365,7 +368,10 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'problem_alias' => $problemData['request']['problem_alias'],
         ]));
 
-        $this->assertContains($solution, $response['solution']['markdown']);
+        $this->assertStringContainsString(
+            $solution,
+            $response['solution']['markdown']
+        );
     }
 
     /**
@@ -390,7 +396,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'statement' => $statement
         ]));
 
-        $this->assertEquals($response['status'], 'ok');
+        $this->assertEquals('ok', $response['status']);
 
         // Check statment contents
         $problemArtifacts = new \OmegaUp\ProblemArtifacts(
@@ -449,7 +455,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Check statements still is the original one
         $statement = $problemArtifacts->get('statements/es.markdown');
-        $this->assertContains('# Entrada', $statement);
+        $this->assertStringContainsString('# Entrada', $statement);
 
         $this->assertEquals(0, $detourGrader->getGraderCallCount());
     }
@@ -493,8 +499,6 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Tests removed problem admin can't edit a problem anymore
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testUpdateProblemWithRemovedProblemAdmin() {
         // Get a problem
@@ -522,18 +526,18 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals('ok', $response['status']);
 
         //Call API
-        $newTitle = 'new title coadmin';
         $login = self::login($problemAdmin);
-        $response = \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'problem_alias' => $problemData['request']['problem_alias'],
-            'title' => $newTitle,
-            'message' => 'Non-admin powers',
-        ]));
-        $this->assertFalse($response['rejudged']);
-
-        // Verify data in DB
-        $problems = \OmegaUp\DAO\Problems::getByTitle($newTitle);
+        try {
+            \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'title' => 'new title coadmin',
+                'message' => 'Non-admin powers',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
@@ -597,7 +601,7 @@ class UpdateProblemTest extends \OmegaUp\Test\ControllerTestCase {
             ]));
             $this->fail('Should not have been able to see the problem');
         } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
-            $this->assertEquals($e->getMessage(), 'problemIsPrivate');
+            $this->assertEquals('problemIsPrivate', $e->getMessage());
         }
 
         // Promote to reviewer, can see the problem now.

--- a/frontend/tests/controllers/ProblemsForfeitedTest.php
+++ b/frontend/tests/controllers/ProblemsForfeitedTest.php
@@ -70,7 +70,10 @@ class ProblemsForfeitedTest extends \OmegaUp\Test\ControllerTestCase {
             'problem_alias' => $extraProblem['problem']->alias,
             'forfeit_problem' => true,
         ]));
-        $this->assertContains('`long long`', $response['solution']['markdown']);
+        $this->assertStringContainsString(
+            '`long long`',
+            $response['solution']['markdown']
+        );
         $this->assertTrue(
             \OmegaUp\DAO\ProblemsForfeited::isProblemForfeited(
                 $extraProblem['problem'],

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -488,16 +488,19 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
             $request
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             $problemData['problem']->title,
             $emailSender::$listEmails[0]['subject']
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             $problemData['author']->name,
             $emailSender::$listEmails[0]['body']
         );
-        $this->assertContains('qwert', $emailSender::$listEmails[0]['body']);
-        $this->assertContains(
+        $this->assertStringContainsString(
+            'qwert',
+            $emailSender::$listEmails[0]['body']
+        );
+        $this->assertStringContainsString(
             'something else',
             $emailSender::$listEmails[0]['body']
         );
@@ -1305,17 +1308,17 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         $newProblem[0] = \OmegaUp\DAO\Problems::getByAlias(
             $problemData[0]['request']['problem_alias']
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             2.971428571,
             $newProblem[0]->difficulty,
-            'Wrong difficulty.',
-            0.001
+            0.001,
+            'Wrong difficulty.'
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             2.2,
             $newProblem[0]->quality,
-            'Wrong quality.',
-            0.001
+            0.001,
+            'Wrong quality.'
         );
         $this->assertEquals(
             '[0, 0, 2, 2, 1]',
@@ -1331,13 +1334,18 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         $newProblem[2] = \OmegaUp\DAO\Problems::getByAlias(
             $problemData[2]['request']['problem_alias']
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             0,
             $newProblem[2]->difficulty,
-            'Wrong difficulty',
-            0.001
+            0.001,
+            'Wrong difficulty'
         );
-        $this->assertEquals(0, $newProblem[2]->quality, 'Wrong quality', 0.001);
+        $this->assertEqualsWithDelta(
+            0,
+            $newProblem[2]->quality,
+            0.001,
+            'Wrong quality'
+        );
 
         $tagArrayForProblem1 = \OmegaUp\DAO\ProblemsTags::getProblemTags(
             $newProblem[0],
@@ -1373,49 +1381,49 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
         $newProblem[0] = \OmegaUp\DAO\Problems::getByAlias(
             $problemData[0]['request']['problem_alias']
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             2.895384615,
             $newProblem[0]->difficulty,
-            'Wrong difficulty.',
-            0.001
+            0.001,
+            'Wrong difficulty.'
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             2.538378378,
             $newProblem[0]->quality,
-            'Wrong quality.',
-            0.001
+            0.001,
+            'Wrong quality.'
         );
 
         $newProblem[1] = \OmegaUp\DAO\Problems::getByAlias(
             $problemData[1]['request']['problem_alias']
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             3.446886447,
             $newProblem[1]->difficulty,
-            'Wrong difficulty.',
-            0.001
+            0.001,
+            'Wrong difficulty.'
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             0,
             $newProblem[1]->quality,
-            'Wrong quality.',
-            0.001
+            0.001,
+            'Wrong quality.'
         );
 
         $newProblem[2] = \OmegaUp\DAO\Problems::getByAlias(
             $problemData[2]['request']['problem_alias']
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             2.684981685,
             $newProblem[2]->difficulty,
-            'Wrong difficulty',
-            0.001
+            0.001,
+            'Wrong difficulty'
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             1.736164736,
             $newProblem[2]->quality,
-            'Wrong quality',
-            0.001
+            0.001,
+            'Wrong quality'
         );
 
         $tagArrayForProblem1 = \OmegaUp\DAO\ProblemsTags::getProblemTags(

--- a/frontend/tests/controllers/ResetCreateTest.php
+++ b/frontend/tests/controllers/ResetCreateTest.php
@@ -1,54 +1,65 @@
 <?php
 class ResetCreateTest extends \OmegaUp\Test\ControllerTestCase {
-    /**
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
-     */
     public function testShouldRequireEmailParameter() {
-        $r = new \OmegaUp\Request();
-        $response = \OmegaUp\Controllers\Reset::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Reset::apiCreate(new \OmegaUp\Request());
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterEmpty', $e->getMessage());
+            $this->assertEquals('email', $e->parameter);
+        }
     }
 
-    /**
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
-     */
     public function testShouldRefuseNotRegisteredEmailAddresses() {
-        $email = \OmegaUp\Test\Utils::createRandomString() . '@mail.com';
-        $r = new \OmegaUp\Request();
-        $response = \OmegaUp\Controllers\Reset::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Reset::apiCreate(new \OmegaUp\Request([
+                'email' => \OmegaUp\Test\Utils::createRandomString() . '@mail.com',
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('invalidUser', $e->getMessage());
+        }
     }
 
     public function testShouldRefuseUnverifiedUser() {
-        $message = null;
         try {
-            $user_data = \OmegaUp\Test\Factories\User::generateUser(false);
-            $r = new \OmegaUp\Request($user_data);
-            \OmegaUp\Controllers\Reset::apiCreate($r);
-        } catch (\OmegaUp\Exceptions\InvalidParameterException $expected) {
-            $message = $expected->getMessage();
+            $userData = \OmegaUp\Test\Factories\User::generateUser(false);
+            \OmegaUp\Controllers\Reset::apiCreate(
+                new \OmegaUp\Request(
+                    $userData
+                )
+            );
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('unverifiedUser', $e->getMessage());
         }
-        $this->assertEquals('unverifiedUser', $message);
     }
 
     public function testShouldRefuseMultipleRequestsInShortInterval() {
-        $user_data = \OmegaUp\Test\Factories\User::generateUser();
-        $r = new \OmegaUp\Request(['email' => $user_data['email']]);
-        $response = \OmegaUp\Controllers\Reset::apiCreate($r);
+        $userData = \OmegaUp\Test\Factories\User::generateUser();
+        $response = \OmegaUp\Controllers\Reset::apiCreate(new \OmegaUp\Request([
+            'email' => $userData['email'],
+        ]));
 
         try {
-            \OmegaUp\Controllers\Reset::apiCreate($r);
-        } catch (\OmegaUp\Exceptions\InvalidParameterException $expected) {
-            $message = $expected->getMessage();
+            \OmegaUp\Controllers\Reset::apiCreate(new \OmegaUp\Request([
+                'email' => $userData['email'],
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('passwordResetMinWait', $e->getMessage());
         }
-        $this->assertEquals('passwordResetMinWait', $message);
 
         // time travel
         $reset_sent_at = \OmegaUp\ApiUtils::getStringTime(
             \OmegaUp\Time::get() - PASSWORD_RESET_MIN_WAIT - 1
         );
-        $user = \OmegaUp\DAO\Users::findByEmail($user_data['email']);
+        $user = \OmegaUp\DAO\Users::findByEmail($userData['email']);
         $user->reset_sent_at = $reset_sent_at;
         \OmegaUp\DAO\Users::update($user);
 
-        \OmegaUp\Controllers\Reset::apiCreate($r);
+        \OmegaUp\Controllers\Reset::apiCreate(new \OmegaUp\Request([
+            'email' => $userData['email'],
+        ]));
     }
 }

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -185,10 +185,9 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals(ip2long('127.0.0.1'), $log->ip);
 
         if (!is_null($contest)) {
-            $this->assertEquals(
+            $this->assertEqualsWithDelta(
                 (\OmegaUp\Time::get() - $contest->start_time) / 60,
                 $run->penalty,
-                '',
                 0.5
             );
         }
@@ -308,8 +307,6 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Test a invalid submission to a private contest
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunPrivateContestWithUserNotRegistred() {
         $r = $this->setValidRequest(new \OmegaUp\Test\Factories\ContestParams([
@@ -317,14 +314,21 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
 
         // Create a second user not regitered to private contest
-        ['user' => $contestant2, 'identity' => $identity2] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $contestant2,
+            'identity' => $identity2,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         // Log in this second user
         $login = self::login($identity2);
         $r['auth_token'] = $login->auth_token;
 
-        // Call API
-        \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runNotEvenOpened', $e->getMessage());
+        }
     }
 
     /**
@@ -346,6 +350,7 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $this->fail(
                 'api should have not created run, because contest has not started yet.'
             );
+            $this->fail('Should have failed');
         } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
             $this->assertEquals('runNotInsideContest', $e->getMessage());
         }
@@ -354,8 +359,6 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Test that a user cannot submit once he has already submitted something
      * and the submissions gap time has not expired
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testInvalidRunInsideSubmissionsGap() {
         // Set the context
@@ -374,7 +377,12 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertRun($r, $response);
 
         // Send a second run. This one should fail
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runWaitGap', $e->getMessage());
+        }
     }
 
     /**
@@ -414,8 +422,6 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Test that grabbing a problem from a contest A and using it as
      * parameter of contest B does not work
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testInvalidContestProblemCombination() {
         // Set the context for the first contest
@@ -427,8 +433,13 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         // Mix problems
         $r2['problem_alias'] = $r1['problem_alias'];
 
-        // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r2);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r2);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterNotFound', $e->getMessage());
+            $this->assertEquals('problem_alias', $e->parameter);
+        }
     }
 
     /**
@@ -531,8 +542,6 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Admin is god, but even he is unable to submit even when contest has ended
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunWhenContestEndedForContestDirector() {
         $startTime = \OmegaUp\Time::get() - 60 * 60;
@@ -549,9 +558,12 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $r['auth_token'] = $login->auth_token;
 
         // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
-
-        $this->assertRun($r, $response);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runNotInsideContest', $e->getMessage());
+        }
     }
 
     /**
@@ -704,8 +716,6 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * User cannot send runs to a private problem, regardless of it being
      * in a contest
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunToPrivateProblemWhileInsideAPublicContest() {
         // Get a contest
@@ -727,22 +737,23 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         ['user' => $this->contestant, 'identity' => $this->contestantIdentity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($this->contestantIdentity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'contest_alias' => '', // Not inside a contest
-            'problem_alias' => $problemData['request']['problem_alias'],
-            'language' => 'c11-gcc',
-            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
-        ]);
 
-        // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'contest_alias' => '', // Not inside a contest
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'language' => 'c11-gcc',
+                'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('problemIsNotPublic', $e->getMessage());
+        }
     }
 
     /**
      * User should wait between consecutive runs.
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunsToPublicProblemInsideSubmissionGap() {
         $originalGap = \OmegaUp\Controllers\Run::$defaultSubmissionGap;
@@ -774,7 +785,12 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $this->assertRun($r, $response);
 
             // Call API
-            $response = \OmegaUp\Controllers\Run::apiCreate($r);
+            try {
+                \OmegaUp\Controllers\Run::apiCreate($r);
+                $this->fail('Should have failed');
+            } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+                $this->assertEquals('runWaitGap', $e->getMessage());
+            }
         } finally {
             \OmegaUp\Controllers\Run::$defaultSubmissionGap = $originalGap;
         }
@@ -797,15 +813,21 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Can't set both params at the same time
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testRunWithProblemsetIdAndContestAlias() {
         $r = $this->setValidRequest();
         $r['problemset_id'] = $this->contestData['contest']->problemset_id;
 
-        // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('incompatibleArgs', $e->getMessage());
+            $this->assertEquals(
+                'problemset_id and contest_alias',
+                $e->parameter
+            );
+        }
     }
 
     /**
@@ -822,22 +844,22 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Can't submit by a user that is not enrolled in a course.
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunInAssignmentFromNonStudent() {
         $r = $this->setUpAssignment();
         $login = self::login($this->non_student_identity);
         $r['auth_token'] = $login->auth_token;
 
-        // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runNotEvenOpened', $e->getMessage());
+        }
     }
 
     /**
      * Run from a student before assignment opens.
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunInAssignmentFromStudentBeforeStart() {
         $r = $this->setUpAssignment(10);
@@ -845,14 +867,16 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($this->studentIdentity);
         $r['auth_token'] = $login->auth_token;
 
-        // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runNotInsideContest', $e->getMessage());
+        }
     }
 
     /**
      * Run from a student after the deadline passed.
-     *
-     * @expectedException \OmegaUp\Exceptions\NotAllowedToSubmitException
      */
     public function testRunInAssignmentFromStudentAfterDeadline() {
         $r = $this->setUpAssignment();
@@ -873,13 +897,16 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($this->studentIdentity);
         $r['auth_token'] = $login->auth_token;
 
-        // Call API
-        $response = \OmegaUp\Controllers\Run::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\Run::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runNotInsideContest', $e->getMessage());
+        }
     }
 
     /**
      * Should not allow sending to banned public problems.
-     * @expectedException \OmegaUp\Exceptions\NotFoundException
      */
     public function testShouldNotAllowToSendPubliclyBannedProblems() {
         $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
@@ -894,18 +921,21 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
              'message' => 'public_banned',
         ]));
 
-        // Call API
-        \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
-             'auth_token' => $login->auth_token,
-             'problem_alias' => $problem->alias,
-             'language' => 'c11-gcc',
-             'source'   => "#include <stdio.h>\nint main() {printf(\"3\"); return 0; }",
-        ]));
+        try {
+            \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
+                 'auth_token' => $login->auth_token,
+                 'problem_alias' => $problem->alias,
+                 'language' => 'c11-gcc',
+                 'source'   => "#include <stdio.h>\nint main() {printf(\"3\"); return 0; }",
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotFoundException $e) {
+            $this->assertEquals('problemNotFound', $e->getMessage());
+        }
     }
 
      /**
      * Should not allow sending to privately banned problems.
-     * @expectedException \OmegaUp\Exceptions\NotFoundException
      */
     public function testShouldNotAllowToSendPrivatelyBannedProblems() {
         $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
@@ -920,13 +950,17 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
              'message' => 'private_banned',
         ]));
 
-        // Call API
-        \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
-             'auth_token' => $login->auth_token,
-             'problem_alias' => $problem->alias,
-             'language' => 'c11-gcc',
-             'source'   => "#include <stdio.h>\nint main() {printf(\"3\"); return 0; }",
-        ]));
+        try {
+            \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
+                 'auth_token' => $login->auth_token,
+                 'problem_alias' => $problem->alias,
+                 'language' => 'c11-gcc',
+                 'source'   => "#include <stdio.h>\nint main() {printf(\"3\"); return 0; }",
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotFoundException $e) {
+            $this->assertEquals('problemNotFound', $e->getMessage());
+        }
     }
 
     /**

--- a/frontend/tests/controllers/UserCreateTest.php
+++ b/frontend/tests/controllers/UserCreateTest.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * CreateUserTest
+ * UserCreateTest
  *
  * @author joemmanuel
  */
 
-class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
+class UserCreateTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Creates an omegaup user happily :)
      */
@@ -65,13 +65,10 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Try to create 2 users with same username, should fail.
-     *
-     * @expectedException \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
     public function testDuplicatedUsernames() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
 
-        // Inflate request
         $r = new \OmegaUp\Request([
             'username' => \OmegaUp\Test\Utils::createRandomString(),
             'password' => \OmegaUp\Test\Utils::createRandomString(),
@@ -80,19 +77,21 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
         ]);
 
         // Call API
-        $response = \OmegaUp\Controllers\User::apiCreate($r);
+        \OmegaUp\Controllers\User::apiCreate($r);
 
         // Randomize email again
         $r['email'] = \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com';
 
-        // Call api
-        $response = \OmegaUp\Controllers\User::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\User::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals('usernameInUse', $e->getMessage());
+        }
     }
 
     /**
      * Test create 2 users with same email (diff username) should fail
-     *
-     * @expectedException \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
     public function testDuplicatedEmails() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
@@ -111,65 +110,69 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
         // Randomize email again
         $r['username'] = \OmegaUp\Test\Utils::createRandomString();
 
-        // Call api
-        $response = \OmegaUp\Controllers\User::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\User::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\DuplicatedEntryInDatabaseException $e) {
+            $this->assertEquals('mailInUse', $e->getMessage());
+        }
     }
 
     /**
      * Creating a user without password
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testNoPassword() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
 
-        // Inflate request
-        $r = new \OmegaUp\Request([
-            'username' => \OmegaUp\Test\Utils::createRandomString(),
-            'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
-            'permission_key' => \OmegaUp\Controllers\User::$permissionKey
-        ]);
-
-        // Call API
-        $response = \OmegaUp\Controllers\User::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'username' => \OmegaUp\Test\Utils::createRandomString(),
+                'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterStringTooShort', $e->getMessage());
+            $this->assertEquals('password', $e->parameter);
+        }
     }
 
     /**
      * Creating a user without email
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testNoEmail() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
 
-        // Inflate request
-        $r = new \OmegaUp\Request([
-            'username' => \OmegaUp\Test\Utils::createRandomString(),
-            'password' => \OmegaUp\Test\Utils::createRandomString(),
-            'permission_key' => \OmegaUp\Controllers\User::$permissionKey
-        ]);
-
-        // Call API
-        $response = \OmegaUp\Controllers\User::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'username' => \OmegaUp\Test\Utils::createRandomString(),
+                'password' => \OmegaUp\Test\Utils::createRandomString(),
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterEmpty', $e->getMessage());
+            $this->assertEquals('email', $e->parameter);
+        }
     }
 
     /**
      * Create a user without username...
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
-    public function testNoUser() {
+    public function testNoUsername() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
 
-        // Inflate request
-        $r = new \OmegaUp\Request([
-            'password' => \OmegaUp\Test\Utils::createRandomString(),
-            'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
-            'permission_key' => \OmegaUp\Controllers\User::$permissionKey
-        ]);
-
-        // Call API
-        \OmegaUp\Controllers\User::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'password' => \OmegaUp\Test\Utils::createRandomString(),
+                'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterEmpty', $e->getMessage());
+            $this->assertEquals('username', $e->parameter);
+        }
     }
 
     /**
@@ -203,34 +206,32 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
 
     /**
      * Tests usernames with invalid chars. Exception is expected
-     *
-     * @expectedException \OmegaUp\Exceptions\InvalidParameterException
      */
     public function testUsernameWithInvalidChars() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
 
-        // Inflate request
-        $r = new \OmegaUp\Request([
-            'username' => 'ínvalid username',
-            'password' => \OmegaUp\Test\Utils::createRandomString(),
-            'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
-            'permission_key' => \OmegaUp\Controllers\User::$permissionKey
-        ]);
-
-        // Call API
-        $response = \OmegaUp\Controllers\User::apiCreate($r);
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'username' => 'ínvalid username',
+                'password' => \OmegaUp\Test\Utils::createRandomString(),
+                'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertEquals('parameterInvalidAlias', $e->getMessage());
+            $this->assertEquals('username', $e->parameter);
+        }
     }
 
     /**
      * Tests usernames with invalid chars. Exception is expected
-     *
      */
     public function testUsernameWithInvalidChar() {
         \OmegaUp\Controllers\User::$permissionKey = uniqid();
 
-        // Call API
         try {
-            $response = \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
                 'username' => 'invalid:username',
                 'password' => \OmegaUp\Test\Utils::createRandomString(),
                 'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
@@ -239,8 +240,8 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
 
             $this->fail('Expected because of the invalid group name');
         } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
-            // OK
             $this->assertEquals('parameterInvalidAlias', $e->getMessage());
+            $this->assertEquals('username', $e->parameter);
         }
     }
 
@@ -273,8 +274,6 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Admin can verify users only with username
      * Testing invalid username
-     *
-     * @expectedException \OmegaUp\Exceptions\NotFoundException
      */
     public function testUsernameVerificationByAdminInvalidUsername() {
         // Admin will verify $user
@@ -282,20 +281,26 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call api using admin
         $adminLogin = self::login($identityAdmin);
-        $response = \OmegaUp\Controllers\User::apiVerifyEmail(new \OmegaUp\Request([
-            'auth_token' => $adminLogin->auth_token,
-            'usernameOrEmail' => \OmegaUp\Test\Utils::createRandomString(),
-        ]));
+        try {
+            \OmegaUp\Controllers\User::apiVerifyEmail(new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'usernameOrEmail' => \OmegaUp\Test\Utils::createRandomString(),
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\NotFoundException $e) {
+            $this->assertEquals('userOrMailNotFound', $e->getMessage());
+        }
     }
 
     /**
      * Normal user trying to verify herself through the admin path
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testUsernameVerificationByAdminNotAdmin() {
         // User to be verified
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser(
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser(
             new \OmegaUp\Test\Factories\UserParams(['verify' => false])
         );
 
@@ -304,24 +309,35 @@ class CreateUserTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call api using admin
         $login = self::login($identity2);
-        $response = \OmegaUp\Controllers\User::apiVerifyEmail(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $identity->username,
-        ]));
+        try {
+            \OmegaUp\Controllers\User::apiVerifyEmail(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'usernameOrEmail' => $identity->username,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**
      * Normal user trying to backfill mailing list
-     *
-     * @expectedException \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public function testMailingListBackfillNotAdmin() {
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
-        $response = \OmegaUp\Controllers\User::apiMailingListBackfill(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-        ]));
+        try {
+            \OmegaUp\Controllers\User::apiMailingListBackfill(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertEquals('userNotAllowed', $e->getMessage());
+        }
     }
 
     /**

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -31,44 +31,44 @@ def update_problem_accepted_stats(cur: MySQLdb.cursors.BaseCursor) -> None:
     logging.info('Updating accepted stats for problems...')
     cur.execute('''
         UPDATE
-            Problems p
+            `Problems` AS `p`
         SET
-            p.accepted = (
+            `p`.accepted = (
                 SELECT
-                    COUNT(DISTINCT s.identity_id)
+                    COUNT(DISTINCT `s`.`identity_id`)
                 FROM
-                    Submissions s
+                    `Submissions` AS `s`
                 INNER JOIN
-                    Runs r
+                    `Runs` AS `r`
                 ON
-                    r.run_id = s.current_run_id
+                    `r`.run_id = `s`.current_run_id
                 INNER JOIN
-                    Identities i
+                    `Identities` AS `i`
                 ON
-                    i.identity_id = s.identity_id
+                    `i`.`identity_id` = `s`.`identity_id`
                 INNER JOIN
-                    Users u
+                    `Users` AS `u`
                 ON
-                    u.user_id = i.user_id
+                    `u`.`user_id` = `i`.`user_id`
                 WHERE
-                    s.problem_id = p.problem_id AND r.verdict = 'AC'
+                    `s`.`problem_id` = `p`.`problem_id` AND `r`.verdict = 'AC'
                     AND NOT EXISTS (
                         SELECT
-                            pf.problem_id, pf.user_id
+                            `pf`.`problem_id`, `pf`.`user_id`
                         FROM
-                            Problems_Forfeited pf
+                            `Problems_Forfeited` AS `pf`
                         WHERE
-                            pf.problem_id = p.problem_id AND
-                            pf.user_id = u.user_id
+                            `pf`.`problem_id` = `p`.`problem_id` AND
+                            `pf`.`user_id` = `u`.`user_id`
                     )
                     AND NOT EXISTS (
                         SELECT
-                            a.acl_id
+                            `a`.`acl_id`
                         FROM
-                            ACLs a
+                            `ACLs` AS `a`
                         WHERE
-                            a.acl_id = p.acl_id AND
-                            a.owner_id = u.user_id
+                            `a`.`acl_id` = `p`.`acl_id` AND
+                            `a`.`owner_id` = `u`.`user_id`
                     )
             );
     ''')
@@ -81,62 +81,64 @@ def update_user_rank(cur: MySQLdb.cursors.BaseCursor) -> Sequence[float]:
     logging.info('Updating user rank...')
     cur.execute('''
         SELECT
-            i.username,
-            i.name,
-            i.country_id,
-            i.state_id,
-            isc.school_id,
-            up.identity_id,
-            i.user_id,
-            COUNT(p.problem_id) problems_solved_count,
-            SUM(ROUND(100 / LOG(2, p.accepted+1) , 0)) score
+            `i`.`username`,
+            `i`.`name`,
+            `i`.`country_id`,
+            `i`.`state_id`,
+            `isc`.`school_id`,
+            `up`.`identity_id`,
+            `i`.`user_id`,
+            COUNT(`p`.`problem_id`) AS `problems_solved_count`,
+            SUM(ROUND(100 / LOG(2, `p`.`accepted` + 1) , 0)) AS `score`
         FROM
         (
             SELECT DISTINCT
-                s.identity_id,
-                s.problem_id
+                `s`.`identity_id`,
+                `s`.`problem_id`
             FROM
-                Submissions s
+                `Submissions` AS `s`
             INNER JOIN
-                Runs r
+                `Runs` AS `r`
             ON
-                r.run_id = s.current_run_id
+                `r`.run_id = `s`.current_run_id
             WHERE
-                r.verdict = 'AC' AND s.type = 'normal'
+                `r`.verdict = 'AC' AND `s`.type = 'normal'
         ) AS up
         INNER JOIN
-            Problems p ON p.problem_id = up.problem_id AND p.visibility > 0
+            `Problems` AS `p`
+        ON `p`.`problem_id` = up.`problem_id` AND `p`.visibility > 0
         INNER JOIN
-            Identities i ON i.identity_id = up.identity_id
+            `Identities` AS `i` ON `i`.`identity_id` = up.`identity_id`
         LEFT JOIN
-            Identities_Schools isc
+            `Identities_Schools` AS `isc`
         ON
-            isc.identity_school_id = i.current_identity_school_id
+            `isc`.`identity_school_id` = `i`.`current_identity_school_id`
         INNER JOIN
-            Users u ON u.user_id = i.user_id
+            `Users` AS `u` ON `u`.`user_id` = `i`.`user_id`
         WHERE
-            u.is_private = 0
+            `u`.`is_private` = 0
             AND NOT EXISTS (
                 SELECT
-                    pf.problem_id, pf.user_id
+                    `pf`.`problem_id`, `pf`.`user_id`
                 FROM
-                    Problems_Forfeited pf
+                    `Problems_Forfeited` AS `pf`
                 WHERE
-                    pf.problem_id = p.problem_id AND pf.user_id = u.user_id
+                    `pf`.`problem_id` = `p`.`problem_id` AND
+                    `pf`.`user_id` = `u`.`user_id`
             )
             AND NOT EXISTS (
                 SELECT
-                    a.acl_id
+                    `a`.`acl_id`
                 FROM
-                    ACLs a
+                    `ACLs` AS `a`
                 WHERE
-                    a.acl_id = p.acl_id AND
-                    a.owner_id = u.user_id
+                    `a`.`acl_id` = `p`.`acl_id` AND
+                    `a`.`owner_id` = `u`.`user_id`
             )
         GROUP BY
-            identity_id
+            `identity_id`
         ORDER BY
-            score DESC;
+            `score` DESC;
     ''')
     prev_score = None
     rank = 0
@@ -150,9 +152,10 @@ def update_user_rank(cur: MySQLdb.cursors.BaseCursor) -> Sequence[float]:
         prev_score = row['score']
         cur.execute('''
                     INSERT INTO
-                        User_Rank (user_id, rank, problems_solved_count, score,
-                                   username, name, country_id, state_id,
-                                   school_id)
+                        `User_Rank` (`user_id`, `rank`,
+                                     `problems_solved_count`, `score`,
+                                     `username`, `name`, `country_id`,
+                                     `state_id`, `school_id`)
                     VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s);''',
                     (row['user_id'], rank, row['problems_solved_count'],
                      row['score'], row['username'], row['name'],
@@ -180,7 +183,8 @@ def update_user_rank_cutoffs(cur: MySQLdb.cursors.BaseCursor,
         # cutoffs towards higher scores.
         cur.execute('''
                     INSERT INTO
-                        User_Rank_Cutoffs (score, percentile, classname)
+                        `User_Rank_Cutoffs` (`score`, `percentile`,
+                                             `classname`)
                     VALUES(%s, %s, %s);''',
                     (scores[int(len(scores) * cutoff.percentile)],
                      cutoff.percentile, cutoff.classname))
@@ -192,37 +196,37 @@ def update_school_rank(cur: MySQLdb.cursors.BaseCursor) -> None:
     logging.info('Updating school rank...')
     cur.execute('''
         SELECT
-            s.school_id,
-            SUM(ROUND(100 / LOG(2, distinct_school_problems.accepted+1), 0))
-            AS score
+            `s`.`school_id`,
+            SUM(ROUND(100 / LOG(2, `distinct_school_problems`.accepted+1), 0))
+            AS `score`
         FROM
-            Schools s
+            `Schools` AS `s`
         INNER JOIN
             (
                 SELECT
-                    su.school_id,
-                    p.accepted,
-                    MIN(su.time)
+                    `su`.`school_id`,
+                    `p`.accepted,
+                    MIN(`su`.time)
                 FROM
-                    Submissions su
+                    `Submissions` AS `su`
                 INNER JOIN
-                    Runs r ON r.run_id = su.current_run_id
+                    `Runs` AS `r` ON `r`.run_id = `su`.current_run_id
                 INNER JOIN
-                    Problems p ON p.problem_id = su.problem_id
+                    `Problems` AS `p` ON `p`.`problem_id` = `su`.`problem_id`
                 WHERE
-                    r.verdict = "AC"
-                    AND p.visibility >= 1
-                    AND su.school_id IS NOT NULL
+                    `r`.verdict = "AC"
+                    AND `p`.visibility >= 1
+                    AND `su`.`school_id` IS NOT NULL
                 GROUP BY
-                    su.school_id,
-                    su.problem_id
-            ) AS distinct_school_problems
+                    `su`.`school_id`,
+                    `su`.`problem_id`
+            ) AS `distinct_school_problems`
         ON
-            distinct_school_problems.school_id = s.school_id
+            `distinct_school_problems`.`school_id` = `s`.`school_id`
         GROUP BY
-            s.school_id
+            `s`.`school_id`
         ORDER BY
-            score DESC;
+            `score` DESC;
     ''')
     prev_score = None
     rank = 0
@@ -233,12 +237,12 @@ def update_school_rank(cur: MySQLdb.cursors.BaseCursor) -> None:
         prev_score = row['score']
         cur.execute('''
                         UPDATE
-                            Schools as s
+                            `Schools` AS `s`
                         SET
-                            s.score = %s,
-                            s.rank = %s
+                            `s`.`score` = %s,
+                            `s`.`rank` = %s
                         WHERE
-                            s.school_id = %s;
+                            `s`.`school_id` = %s;
                     ''',
                     (row['score'], rank, row['school_id']))
 


### PR DESCRIPTION
Este cambio:

* Hace que las pruebas sean compatibles con phpunit 8.5.2.
  - Deja de usar @expectedException porque eso arroja una advertencia
    nefasta.
  - Utiliza assertEqualsWithDelta() en vez de assertEquals().
  - Utiliza assertStringContainsString en vez de assertContains().
* Escapa más instancias de `Groups`.
* Escapa todas las columnas y tablas en update_ranks.py.