### PR TITLE
Usando PHPUnit 8.5.2

### DIFF
--- a/frontend/tests/BadgesTestCase.php
+++ b/frontend/tests/BadgesTestCase.php
@@ -22,7 +22,7 @@ class BadgesTestCase extends \OmegaUp\Test\ControllerTestCase {
      */
     private $originalFileUploader;
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         \OmegaUp\Time::setTimeForTesting(null);
         \OmegaUp\Test\Utils::CleanupDb();
@@ -32,7 +32,7 @@ class BadgesTestCase extends \OmegaUp\Test\ControllerTestCase {
         );
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
         \OmegaUp\FileHandler::setFileUploaderForTesting(
             $this->originalFileUploader

--- a/frontend/tests/ControllerTestCase.php
+++ b/frontend/tests/ControllerTestCase.php
@@ -12,7 +12,7 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
     /** @var \Logger|null */
     private static $logObj = null;
 
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
 
         $scriptFilename = __DIR__ . '/controllers/gitserver-start.sh ' .
@@ -26,7 +26,7 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
         }
     }
 
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void {
         parent::tearDownAfterClass();
         $scriptFilename = __DIR__ . '/controllers/gitserver-stop.sh';
         exec($scriptFilename, $output, $returnVar);
@@ -41,7 +41,7 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
     /**
      * setUp function gets executed before each test (thanks to phpunit)
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         \OmegaUp\Controllers\User::$sendEmailOnVerify = false;
         \OmegaUp\Controllers\Session::setCookieOnRegisterSessionForTesting(
@@ -64,7 +64,7 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
     /**
      * tearDown function gets executed after each test (thanks to phpunit)
      */
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
         self::logout();
     }
@@ -398,45 +398,6 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
         }
 
         self::$logObj->info('[INFO] ' . $message);
-    }
-
-    /**
-     * Compatibility with PHPUnit 8.5.2.
-     */
-    public static function assertStringContainsString(
-        string $needle,
-        string $haystack,
-        string $message = ''
-    ): void {
-        if (strpos($haystack, $needle) !== false) {
-            return;
-        }
-        if (empty($message)) {
-            $message = \sprintf('"%s" contains "%s"', $haystack, $needle);
-        }
-        self::fail("failed asserting that {$message}");
-    }
-
-    /**
-     * Asserts that two variables are equal (with delta).
-     * Compatibility with PHPUnit 8.5.2.
-     *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     */
-    public static function assertEqualsWithDelta(
-        $expected,
-        $actual,
-        float $delta,
-        string $message = ''
-    ): void {
-        if ($expected == $actual) {
-            return;
-        }
-        if (abs($expected - $actual) <= $delta) {
-            return;
-        }
-        self::assertEquals($expected, $actual, $message);
     }
 }
 

--- a/frontend/tests/controllers/CourseCreateTest.php
+++ b/frontend/tests/controllers/CourseCreateTest.php
@@ -4,7 +4,7 @@ class CourseCreateTest extends \OmegaUp\Test\ControllerTestCase {
     private static $curator = null;
     private static $curatorIdentity = null;
 
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
 
         $curatorGroup = \OmegaUp\DAO\Groups::findByAlias(

--- a/frontend/tests/controllers/CourseListTest.php
+++ b/frontend/tests/controllers/CourseListTest.php
@@ -6,7 +6,7 @@
  */
 
 class CourseListTest extends \OmegaUp\Test\ControllerTestCase {
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithNAssignmentsPerType(
             ['homework' => 3, 'test' => 2]

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -15,7 +15,7 @@ stage_install() {
 	pip3 install --user mysqlclient
 
 	curl -sSfL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit \
-		https://phar.phpunit.de/phpunit-6.5.9.phar
+		https://phar.phpunit.de/phpunit-8.5.2.phar
 	composer install
 
 	install_omegaup_gitserver


### PR DESCRIPTION
Este cambio migra las pruebas para usar PHPUnit 8.5.2, que es compatible
con PHP 7.2 y 7.4. PHP 7.4 es la versión de PHP que viene instalada en
Ubuntu Focal.