### PR TITLE
Mejorando el error que se emite cuando se llama un API inexistente

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -90,8 +90,21 @@ class ApiCaller {
      * Handles main API workflow. All HTTP API calls start here.
      */
     public static function httpEntryPoint(): string {
-        $r = self::createRequest();
-        return self::render(self::call($r), $r);
+        try {
+            $r = self::createRequest();
+            $response = self::call($r);
+        } catch (\OmegaUp\Exceptions\ApiException $apiException) {
+            $r = null;
+            $response = $apiException->asResponseArray();
+            self::$log->error($apiException);
+            if (
+                extension_loaded('newrelic') &&
+                $apiException->getCode() == 500
+            ) {
+                newrelic_notice_error(strval($apiException));
+            }
+        }
+        return self::render($response, $r);
     }
 
     /**


### PR DESCRIPTION
Este cambio hace que si alguien intenta llamar un API inválida, se
regresa 404 en vez de 500.

Fixes: #3527