### PR TITLE
Mostrando los candidatos a escuela del mes y acomodando otra función

### DIFF
--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -325,7 +325,7 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Gets all the information to be sent to smarty for the tabs
      * of School of the Month
-     * @return array{template: string, smartyProperties: array{schoolOfTheMonthPayload: array{candidatesToSchoolOfTheMonth: list<array{school_id: int, name: string, country_id: string, score: float}>, schoolsOfPreviousMonths: list<array{school_id: int, name: string, country_id: string, time: string}>, schoolsOfCurrentMonth: list<array{school_id: int, rank: int, name: string, country_id: string}>, isMentor: bool, options?: array{canChooseSchool: bool, schoolIsSelected: bool}}}}
+     * @return array{template: string, smartyProperties: array{schoolOfTheMonthPayload: array{candidatesToSchoolOfTheMonth: list<array{name: string, rank: int, school_id: int, score: float}>, schoolsOfPreviousMonths: list<array{school_id: int, name: string, country_id: string, time: string}>, schoolsOfCurrentMonth: list<array{school_id: int, rank: int, name: string, country_id: string}>, isMentor: bool, options?: array{canChooseSchool: bool, schoolIsSelected: bool}}}}
      */
     public static function getSchoolOfTheMonthDetailsForSmarty(\OmegaUp\Request $r): array {
         try {
@@ -351,9 +351,7 @@ class School extends \OmegaUp\Controllers\Controller {
                     'schoolsOfCurrentMonth' => \OmegaUp\DAO\SchoolOfTheMonth::getMonthlyList(
                         $currentDate
                     ),
-                    'candidatesToSchoolOfTheMonth' => self::getTopSchoolsOfTheMonth(
-                        /* rowcount */ 100
-                    ),
+                    'candidatesToSchoolOfTheMonth' => \OmegaUp\DAO\SchoolOfTheMonth::getCandidatesToSchoolOfTheMonth(),
                     'isMentor' => $isMentor,
                 ],
             ],
@@ -389,7 +387,7 @@ class School extends \OmegaUp\Controllers\Controller {
      */
     public static function getSchoolOfTheMonth(string $date = null): array {
         $firstDay = self::getCurrentMonthFirstDay($date);
-        $schoolsOfTheMonth = \OmegaUp\DAO\SchoolOfTheMonth::getByTimeAndSelected(
+        $schoolsOfTheMonth = \OmegaUp\DAO\SchoolOfTheMonth::getByTime(
             $firstDay
         );
 

--- a/frontend/tests/controllers/SchoolOfTheMonthTest.php
+++ b/frontend/tests/controllers/SchoolOfTheMonthTest.php
@@ -267,11 +267,19 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             SchoolsFactory::createSchool(),
             SchoolsFactory::createSchool(),
         ];
+        $today = date('Y-m-d', \OmegaUp\Time::get());
+
+        $previousMonth = date_create($today);
+        date_add(
+            $previousMonth,
+            date_interval_create_from_date_string(
+                '-1 month'
+            )
+        );
+        $runDate = date_format($previousMonth, 'Y-m-d');
 
         self::setUpSchoolsRuns($schoolsData);
-
-        // TODO(https://github.com/omegaup/omegaup/issues/3438): Remove this.
-        return;
+        \OmegaUp\Test\Utils::runUpdateRanks($runDate);
 
         // API should return school1
         $response = \OmegaUp\Controllers\School::getSchoolOfTheMonth();


### PR DESCRIPTION
# Descripción

Este es un avance más para la restauración del rank mensual de escuelas.

Part of: #3438 

# Comentarios

@lhchavez  si hay código que eliminar, me dices. También me parece que podríamos restaurar la consulta que determina la cantidad de problemas resueltos por escuela en  los últimos 6 meses.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
