### PR TITLE
Arreglando falla al actualizar el modo de visualización de un problema

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1094,9 +1094,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         // Update the Problem object
         $valueProperties = [
-            'visibility' => [
-                'important' => true,
-            ],
+            'visibility',
             'title',
             'inputLimit' => [
                 'alias' => 'input_limit',
@@ -3551,6 +3549,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'MemoryLimit' => '256MiB',
                     'OutputLimit' => '10KiB',
                     'OverallWallTimeLimit' => '5s',
+                    'TimeLimit' => '30s',
                 ];
             }
             $problemSettings['validator']['limits']['TimeLimit'] = "{$params->validatorTimeLimit}ms";

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -249,34 +249,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             );
         }
         \OmegaUp\Validators::validateNumberInRange(
-            $params->validatorTimeLimit,
-            'validator_time_limit',
-            0,
-            null,
-            $isRequired
-        );
-        \OmegaUp\Validators::validateNumberInRange(
-            $params->overallWallTimeLimit,
-            'overall_wall_time_limit',
-            0,
-            60000,
-            $isRequired
-        );
-        \OmegaUp\Validators::validateNumberInRange(
-            $params->extraWallTime,
-            'extra_wall_time',
-            0,
-            5000,
-            $isRequired
-        );
-        \OmegaUp\Validators::validateNumberInRange(
-            $params->outputLimit,
-            'output_limit',
-            0,
-            null,
-            $isRequired
-        );
-        \OmegaUp\Validators::validateNumberInRange(
             $params->inputLimit,
             'input_limit',
             0,
@@ -1136,17 +1108,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'order',
             'languages',
         ];
-        $importantChanges = $params->updateValueParams(
-            $problem,
-            $valueProperties
-        );
+        $params->updateValueParams($problem, $valueProperties);
         $problem->languages = $languages ?: $problem->languages;
 
         $response = [
             'rejudged' => false,
         ];
 
-        // No needed when visibility changes
         $problemSettings = self::getProblemSettingsDistrib(
             $problem,
             $problem->commit
@@ -1178,11 +1146,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $operation = \OmegaUp\ProblemDeployer::UPDATE_CASES;
             }
             if (
-                (
-                    $operation !== \OmegaUp\ProblemDeployer::UPDATE_SETTINGS ||
-                    $settingsUpdated
-                ) &&
-                !$importantChanges
+                $operation !== \OmegaUp\ProblemDeployer::UPDATE_SETTINGS ||
+                $settingsUpdated
             ) {
                 $problemDeployer = new \OmegaUp\ProblemDeployer(
                     $problem->alias,
@@ -3561,12 +3526,18 @@ class Problem extends \OmegaUp\Controllers\Controller {
         array &$problemSettings,
         \OmegaUp\ProblemParams $params
     ): void {
-        $problemSettings['limits']['ExtraWallTime'] = "{$params->extraWallTime}ms";
+        if (!is_null($params->extraWallTime)) {
+            $problemSettings['limits']['ExtraWallTime'] = "{$params->extraWallTime}ms";
+        }
         if (!is_null($params->memoryLimit)) {
             $problemSettings['limits']['MemoryLimit'] = "{$params->memoryLimit}KiB";
         }
-        $problemSettings['limits']['OutputLimit'] = "{$params->outputLimit}";
-        $problemSettings['limits']['OverallWallTimeLimit'] = "{$params->overallWallTimeLimit}ms";
+        if (!is_null($params->outputLimit)) {
+            $problemSettings['limits']['OutputLimit'] = "{$params->outputLimit}";
+        }
+        if (!is_null($params->memoryLimit)) {
+            $problemSettings['limits']['OverallWallTimeLimit'] = "{$params->overallWallTimeLimit}ms";
+        }
         if (!is_null($params->timeLimit)) {
             $problemSettings['limits']['TimeLimit'] = "{$params->timeLimit}ms";
         }
@@ -3580,7 +3551,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'MemoryLimit' => '256MiB',
                     'OutputLimit' => '10KiB',
                     'OverallWallTimeLimit' => '5s',
-                    'TimeLimit' => '30s',
                 ];
             }
             $problemSettings['validator']['limits']['TimeLimit'] = "{$params->validatorTimeLimit}ms";

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -191,6 +191,42 @@ class ProblemParams {
                 $isRequired
             );
         }
+        if (isset($params['validator_time_limit'])) {
+            \OmegaUp\Validators::validateNumberInRange(
+                $params['validator_time_limit'],
+                'validator_time_limit',
+                /*$lowerBound=*/ 0,
+                /*$uppperBound=*/ null,
+                $isRequired
+            );
+        }
+        if (isset($params['overall_wall_time_limit'])) {
+            \OmegaUp\Validators::validateNumberInRange(
+                $params['overall_wall_time_limit'],
+                'overall_wall_time_limit',
+                /*$lowerBound=*/ 0,
+                /*$uppperBound=*/ 60000,
+                $isRequired
+            );
+        }
+        if (isset($params['extra_wall_time'])) {
+            \OmegaUp\Validators::validateNumberInRange(
+                $params['extra_wall_time'],
+                'extra_wall_time',
+                /*$lowerBound=*/ 0,
+                /*$uppperBound=*/ 5000,
+                $isRequired
+            );
+        }
+        if (isset($params['output_limit'])) {
+            \OmegaUp\Validators::validateNumberInRange(
+                $params['output_limit'],
+                'output_limit',
+                /*$lowerBound=*/ 0,
+                /*$uppperBound=*/ null,
+                $isRequired
+            );
+        }
 
         $this->problemAlias = $params['problem_alias'];
         $this->title = $params['title'] ?? null;
@@ -206,11 +242,11 @@ class ProblemParams {
         $this->source = $params['source'] ?? null;
         $this->validator = $params['validator'] ?? null;
         $this->timeLimit = $params['time_limit'] ?? null;
-        $this->validatorTimeLimit = $params['validator_time_limit'] ?? 1000;
-        $this->overallWallTimeLimit = $params['overall_wall_time_limit'] ?? 60000;
-        $this->extraWallTime = $params['extra_wall_time'] ?? 0;
+        $this->validatorTimeLimit = $params['validator_time_limit'] ?? null;
+        $this->overallWallTimeLimit = $params['overall_wall_time_limit'] ?? null;
+        $this->extraWallTime = $params['extra_wall_time'] ?? null;
         $this->memoryLimit = $params['memory_limit'] ?? null;
-        $this->outputLimit = $params['output_limit'] ?? 10240;
+        $this->outputLimit = $params['output_limit'] ?? null;
         $this->inputLimit = $params['input_limit'] ?? null;
         $this->emailClarifications = $params['email_clarifications'] ?? null;
         $this->order = $params['order'] ?? 'normal';

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -247,7 +247,7 @@ class ProblemParams {
         $this->extraWallTime = $params['extra_wall_time'] ?? null;
         $this->memoryLimit = $params['memory_limit'] ?? null;
         $this->outputLimit = $params['output_limit'] ?? null;
-        $this->inputLimit = $params['input_limit'] ?? null;
+        $this->inputLimit = $params['input_limit'] ?? 10240;
         $this->emailClarifications = $params['email_clarifications'] ?? null;
         $this->order = $params['order'] ?? 'normal';
     }

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -122,13 +122,13 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $inputLimit;
 
     /**
      * @readonly
-     * @var bool
+     * @var bool|null
      */
     public $emailClarifications;
 
@@ -211,8 +211,8 @@ class ProblemParams {
         $this->extraWallTime = $params['extra_wall_time'] ?? 0;
         $this->memoryLimit = $params['memory_limit'] ?? null;
         $this->outputLimit = $params['output_limit'] ?? 10240;
-        $this->inputLimit = $params['input_limit'] ?? 10240;
-        $this->emailClarifications = $params['email_clarifications'] ?? false;
+        $this->inputLimit = $params['input_limit'] ?? null;
+        $this->emailClarifications = $params['email_clarifications'] ?? null;
         $this->order = $params['order'] ?? 'normal';
     }
 

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -92,19 +92,19 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $validatorTimeLimit;
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $overallWallTimeLimit;
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $extraWallTime;
 
@@ -116,7 +116,7 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var int
+     * @var int|null
      */
     public $outputLimit;
 

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -760,8 +760,8 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals(60000, $problemParams->overallWallTimeLimit);
         $this->assertEquals(0, $problemParams->extraWallTime);
         $this->assertEquals(10240, $problemParams->outputLimit);
-        $this->assertEquals(10240, $problemParams->inputLimit);
-        $this->assertFalse($problemParams->emailClarifications);
+        $this->assertEquals(null, $problemParams->inputLimit);
+        $this->assertEquals(null, $problemParams->emailClarifications);
 
         // New object with custom values
         $titleAlias = \OmegaUp\Test\Utils::createRandomString();

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -760,7 +760,7 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals(null, $problemParams->overallWallTimeLimit);
         $this->assertEquals(null, $problemParams->extraWallTime);
         $this->assertEquals(null, $problemParams->outputLimit);
-        $this->assertEquals(null, $problemParams->inputLimit);
+        $this->assertEquals(10240, $problemParams->inputLimit);
         $this->assertEquals(null, $problemParams->emailClarifications);
 
         // New object with custom values
@@ -784,5 +784,68 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $problemParams->overallWallTimeLimit
         );
         $this->assertTrue($problemParams->emailClarifications);
+    }
+
+    public function testCreateProblemWithDefaultValues() {
+        // Create our contestant
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+
+        $login = self::login($identity);
+        $title = \OmegaUp\Test\Utils::createRandomString();
+        $problemAlias = substr(
+            preg_replace(
+                '/[^a-zA-Z0-9_-]/',
+                '',
+                str_replace(' ', '-', $title)
+            ),
+            0,
+            32
+        );
+
+        /** @var array<string, array{tmp_name: string}> $_FILES */
+        $_FILES['problem_contents']['tmp_name'] = OMEGAUP_TEST_RESOURCES_ROOT . 'testproblem.zip';
+
+        \OmegaUp\FileHandler::setFileUploaderForTesting(
+            $this->createFileUploaderMock()
+        );
+
+        \OmegaUp\Controllers\Problem::apiCreate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'title' => $title,
+            'problem_alias' => $problemAlias,
+            'source' => 'yo',
+        ]));
+
+        $response = \OmegaUp\Controllers\Problem::apiDetails(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemAlias,
+            ])
+        );
+
+        $this->assertEquals(10240, $response['input_limit']);
+        {
+            $problemArtifacts = new \OmegaUp\ProblemArtifacts($problemAlias);
+            $problemSettings = json_decode(
+                $problemArtifacts->get(
+                    'settings.json'
+                )
+            );
+
+            $this->assertEquals('1s', $problemSettings->Limits->TimeLimit);
+            $this->assertEquals('0s', $problemSettings->Limits->ExtraWallTime);
+            $this->assertEquals(
+                \Omegaup\Controllers\Problem::parseSize('64MiB'),
+                $problemSettings->Limits->MemoryLimit
+            );
+            $this->assertEquals(
+                \Omegaup\Controllers\Problem::parseSize('10240KiB'),
+                $problemSettings->Limits->OutputLimit
+            );
+            $this->assertEquals(
+                '30s',
+                $problemSettings->Limits->OverallWallTimeLimit
+            );
+        }
     }
 }

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -756,10 +756,10 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
             \OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS,
             $problemParams->updatePublished
         );
-        $this->assertEquals(1000, $problemParams->validatorTimeLimit);
-        $this->assertEquals(60000, $problemParams->overallWallTimeLimit);
-        $this->assertEquals(0, $problemParams->extraWallTime);
-        $this->assertEquals(10240, $problemParams->outputLimit);
+        $this->assertEquals(null, $problemParams->validatorTimeLimit);
+        $this->assertEquals(null, $problemParams->overallWallTimeLimit);
+        $this->assertEquals(null, $problemParams->extraWallTime);
+        $this->assertEquals(null, $problemParams->outputLimit);
         $this->assertEquals(null, $problemParams->inputLimit);
         $this->assertEquals(null, $problemParams->emailClarifications);
 

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -1717,7 +1717,6 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
                 )
             );
         }
-
         // But visibility mode has changed
         $response = \OmegaUp\Controllers\Problem::apiDetails(
             new \OmegaUp\Request([
@@ -1726,5 +1725,67 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
             ])
         );
         $this->assertEquals(0, $response['visibility']);
+
+        // Updated problem setttings and visibility
+        $newTimeLimit = 3000;
+        $newExtraWallTime = 200;
+        $newMemoryLimit = 8000;
+        $newOutputLimit = 2560;
+        $newOverallWallTimeLimit = 15000;
+        \OmegaUp\Controllers\Problem::apiUpdate(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'problem_alias' => $problemAlias,
+            'visibility' => 1,
+            'time_limit' => $newTimeLimit,
+            'extra_wall_time' => $newExtraWallTime,
+            'memory_limit' => $newMemoryLimit,
+            'output_limit' => $newOutputLimit,
+            'overall_wall_time_limit' => $newOverallWallTimeLimit,
+            'message' => 'Visibility updated to private',
+        ]));
+
+        // Verify problem settings were not modified.
+        {
+            $problemArtifacts = new \OmegaUp\ProblemArtifacts($problemAlias);
+            $problemSettings = json_decode(
+                $problemArtifacts->get(
+                    'settings.json'
+                )
+            );
+            $this->assertEquals(
+                $newTimeLimit,
+                \Omegaup\Controllers\Problem::parseDuration(
+                    $problemSettings->Limits->TimeLimit
+                )
+            );
+            $this->assertEquals(
+                $newExtraWallTime,
+                \Omegaup\Controllers\Problem::parseDuration(
+                    $problemSettings->Limits->ExtraWallTime
+                )
+            );
+            $this->assertEquals(
+                $newMemoryLimit,
+                $problemSettings->Limits->MemoryLimit / 1024
+            );
+            $this->assertEquals(
+                $newOutputLimit,
+                $problemSettings->Limits->OutputLimit
+            );
+            $this->assertEquals(
+                $newOverallWallTimeLimit,
+                \Omegaup\Controllers\Problem::parseDuration(
+                    $problemSettings->Limits->OverallWallTimeLimit
+                )
+            );
+        }
+        // But visibility mode has changed
+        $response = \OmegaUp\Controllers\Problem::apiDetails(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'problem_alias' => $problemAlias,
+            ])
+        );
+        $this->assertEquals(1, $response['visibility']);
     }
 }

--- a/frontend/www/js/problem.mine.js
+++ b/frontend/www/js/problem.mine.js
@@ -68,7 +68,6 @@
           omegaup.API.Problem.update({
             problem_alias: alias,
             visibility: isPublic ? 1 : 0,
-            only_visibility: true,
             message: isPublic ? 'private -> public' : 'public -> private',
           })
             .then(resolve)

--- a/frontend/www/js/problem.mine.js
+++ b/frontend/www/js/problem.mine.js
@@ -68,6 +68,7 @@
           omegaup.API.Problem.update({
             problem_alias: alias,
             visibility: isPublic ? 1 : 0,
+            only_visibility: true,
             message: isPublic ? 'private -> public' : 'public -> private',
           })
             .then(resolve)


### PR DESCRIPTION
# Descripción

Se arregla la falla que existía al actualizar el modo de visibilidad de un problema.
Al cambiar este campo, se regresaban al valor por defecto algunos campos que 
ya habían sido previamente modificados. 

Ahora se manda una bandera al API que sólo se modificará la visualización. 

Fixes: #3521 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.