### PR TITLE
Usando la nueva ruta de configuración para MySQL

### DIFF
--- a/stuff/database_utils.py
+++ b/stuff/database_utils.py
@@ -9,6 +9,7 @@ import os
 import shlex
 import subprocess
 import tempfile
+from typing import Optional
 
 
 _MYSQL_BINARY = '/usr/bin/mysql'
@@ -25,9 +26,13 @@ def quote(s):
     return pipes.quote(s)
 
 
-def default_config_file():
+def default_config_file() -> Optional[str]:
     '''Returns the default config file path for MySQL.'''
-    return os.path.join(os.getenv('HOME') or '.', '.my.cnf')
+    for candidate_path in (os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
+                           '/etc/mysql/conf.d/mysql_password.cnf'):
+        if os.path.isfile(candidate_path):
+            return candidate_path
+    return None
 
 
 def authentication(*, config_file=default_config_file(), username=None,

--- a/stuff/lib/db.py
+++ b/stuff/lib/db.py
@@ -11,17 +11,26 @@ import argparse
 import configparser
 import getpass
 import os
+from typing import Optional
 
 import MySQLdb
 import MySQLdb.connections
 
 
+def default_config_file_path() -> Optional[str]:
+    '''Try to autodetect the config file path.'''
+    for candidate_path in (os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
+                           '/etc/mysql/conf.d/mysql_password.cnf'):
+        if os.path.isfile(candidate_path):
+            return candidate_path
+    return None
+
+
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     '''Add DB-related arguments to `parser`'''
     db_args = parser.add_argument_group('DB Access')
-    db_args.add_argument('--mysql-config-file',
-                         default=os.path.join(os.getenv('HOME') or '.',
-                                              '.my.cnf'),
+    db_args.add_argument('--mysql-config-file', type=str,
+                         default=default_config_file_path(),
                          help='.my.cnf file that stores credentials')
     db_args.add_argument('--host', type=str, help='MySQL host',
                          default='localhost')


### PR DESCRIPTION
Este cambio permite usar el archivo creado por Puppet para evitar tener
que escribir la contraseña en consola al momento de ejecutar los
scripts.