### PR TITLE
Reduciendo el tamaño de la página en lista de problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -50,7 +50,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     ];
 
     // Number of rows shown in problems list
-    const PAGE_SIZE = 1000;
+    const PAGE_SIZE = 100;
 
     /**
      * Returns a ProblemParams instance from the Request values.

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1085,6 +1085,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($identity);
         $request = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
+            'rowcount' => 1000,
         ]);
         // Call apiList to define the number of problems and pages
         $apiListResponse = \OmegaUp\Controllers\Problem::apiList($request);
@@ -1113,7 +1114,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
                 $problems[] = $problem['alias'];
             }
         }
-        // Asserting the number of non-repeated problems isthe same than the total
+        // Asserting the number of non-repeated problems is the same than the total
         $this->assertEquals(
             count(
                 array_unique(


### PR DESCRIPTION
# Descripción

Reduciendo el número de problemas mostrados por página en la vista de 
Lista de Problemas. Antes se estaban mandando 1000 registros, ahora
sólo se muestran 100.

Fixes: #3531

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.