### PR TITLE
Refactor de Requests.vue para que se pueda utilizar en cursos y concursos

### DIFF
--- a/frontend/www/js/omegaup/api.d.ts
+++ b/frontend/www/js/omegaup/api.d.ts
@@ -121,11 +121,6 @@ declare namespace omegaup {
     submissions_gap?: number;
   }
 
-  interface ContestAdmin {
-    username: string;
-    role: string;
-  }
-
   export interface ContestGroup {
     alias: string;
     name: string;
@@ -270,13 +265,13 @@ declare namespace omegaup {
     country_id?: string;
   }
 
-  export interface IdentityContestRequest {
+  export interface IdentityRequest {
     username: string;
     country: string;
     request_time: Date;
     last_update: Date;
     accepted: boolean;
-    admin?: ContestAdmin;
+    admin?: UserRole;
   }
 
   interface Languages {

--- a/frontend/www/js/omegaup/components/common/Requests.vue
+++ b/frontend/www/js/omegaup/components/common/Requests.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="panel panel-primary" v-if="requests.length != 0">
+  <div class="panel panel-primary" v-if="requests.length !== 0">
     <div class="panel-body">
       {{ T.pendingRegistrations }}
     </div>
@@ -11,7 +11,7 @@
           <th>{{ T.requestDate }}</th>
           <th>{{ T.currentStatus }}</th>
           <th>{{ T.lastUpdate }}</th>
-          <th>{{ T.contestAdduserAddContestant }}</th>
+          <th>{{ textAddParticipant }}</th>
         </tr>
       </thead>
       <tbody>
@@ -19,18 +19,16 @@
           <td>{{ request.username }}</td>
           <td>{{ request.country }}</td>
           <td>{{ request.request_time }}</td>
-          <td v-if="request.last_update == null">{{ T.wordsPending }}</td>
-          <td v-else-if="request.accepted == 'true' || request.accepted == '1'">
+          <td v-if="request.last_update === null">{{ T.wordsPending }}</td>
+          <td v-else-if="request.accepted === true">
             {{ T.wordAccepted }}
           </td>
           <td v-else="">{{ T.wordsDenied }}</td>
-          <td v-if="request.last_update != null">
+          <td v-if="request.last_update !== null">
             {{ request.last_update }} ({{ request.admin.username }})
           </td>
           <td v-else=""></td>
-          <td
-            v-if="request.accepted != 'true' &amp;&amp; request.accepted != '1'"
-          >
+          <td v-if="request.accepted === false">
             <button
               class="close"
               style="color:red"
@@ -58,9 +56,10 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { T } from '../../omegaup.js';
 import omegaup from '../../api.js';
 
-@Component({})
+@Component
 export default class Requests extends Vue {
-  @Prop() data!: omegaup.IdentityContestRequest[];
+  @Prop() data!: omegaup.IdentityRequest[];
+  @Prop() textAddParticipant!: string;
 
   T = T;
   requests = this.data;

--- a/frontend/www/js/omegaup/components/common/Requests.vue
+++ b/frontend/www/js/omegaup/components/common/Requests.vue
@@ -20,7 +20,7 @@
           <td>{{ request.country }}</td>
           <td>{{ request.request_time }}</td>
           <td v-if="request.last_update === null">{{ T.wordsPending }}</td>
-          <td v-else-if="request.accepted === true">
+          <td v-else-if="request.accepted">
             {{ T.wordAccepted }}
           </td>
           <td v-else="">{{ T.wordsDenied }}</td>
@@ -28,7 +28,7 @@
             {{ request.last_update }} ({{ request.admin.username }})
           </td>
           <td v-else=""></td>
-          <td v-if="request.accepted === false">
+          <td v-if="!request.accepted">
             <button
               class="close"
               style="color:red"

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -54,38 +54,63 @@
         <omegaup-contest-new-form
           v-bind:data="contest"
           v-bind:update="true"
-          v-on:emit-update-contest="newFormComponent =&gt; $emit('update-contest', newFormComponent)"
+          v-on:emit-update-contest="
+            newFormComponent => $emit('update-contest', newFormComponent)
+          "
         ></omegaup-contest-new-form>
       </div>
       <div class="tab-pane active problems" v-if="showTab === 'problems'">
         <omegaup-contest-add-problem
           v-bind:contest-alias="contest.alias"
           v-bind:data="problems"
-          v-on:emit-add-problem="addProblemComponent =&gt; $emit('add-problem', addProblemComponent)"
-          v-on:emit-change-alias="(addProblemComponent, newProblemAlias) =&gt; $emit('get-versions', newProblemAlias, addProblemComponent)"
-          v-on:emit-remove-problem="addProblemComponent =&gt; $emit('remove-problem', addProblemComponent)"
-          v-on:emit-runs-diff="(addProblemComponent, versions, selectedCommit) =&gt; $emit('runs-diff', addProblemComponent, versions, selectedCommit)"
+          v-on:emit-add-problem="
+            addProblemComponent => $emit('add-problem', addProblemComponent)
+          "
+          v-on:emit-change-alias="
+            (addProblemComponent, newProblemAlias) =>
+              $emit('get-versions', newProblemAlias, addProblemComponent)
+          "
+          v-on:emit-remove-problem="
+            addProblemComponent => $emit('remove-problem', addProblemComponent)
+          "
+          v-on:emit-runs-diff="
+            (addProblemComponent, versions, selectedCommit) =>
+              $emit('runs-diff', addProblemComponent, versions, selectedCommit)
+          "
         >
         </omegaup-contest-add-problem>
       </div>
       <div class="tab-pane active" v-if="showTab === 'publish'">
         <omegaup-contest-publish
           v-bind:data="contest"
-          v-on:emit-update-admission-mode="publishComponent =&gt; $emit('update-admission-mode', publishComponent)"
+          v-on:emit-update-admission-mode="
+            publishComponent => $emit('update-admission-mode', publishComponent)
+          "
         ></omegaup-contest-publish>
       </div>
       <div class="tab-pane active contestants" v-if="showTab === 'contestants'">
         <omegaup-contest-contestant
           v-bind:contest="contest"
           v-bind:data="users"
-          v-on:emit-add-user="contestantComponent =&gt; $emit('add-user', contestantComponent)"
-          v-on:emit-remove-user="contestantComponent =&gt; $emit('remove-user', contestantComponent)"
-          v-on:emit-save-end-time="selected =&gt; $emit('save-end-time', selected)"
+          v-on:emit-add-user="
+            contestantComponent => $emit('add-user', contestantComponent)
+          "
+          v-on:emit-remove-user="
+            contestantComponent => $emit('remove-user', contestantComponent)
+          "
+          v-on:emit-save-end-time="selected => $emit('save-end-time', selected)"
         ></omegaup-contest-contestant>
         <omegaup-contest-requests
           v-bind:data="requests"
-          v-on:emit-accept-request="(requestsComponent, username) =&gt; $emit('accept-request', requestsComponent, username)"
-          v-on:emit-deny-request="(requestsComponent, username) =&gt; $emit('deny-request', requestsComponent, username)"
+          v-bind:text-add-participant="T.contestAdduserAddContestant"
+          v-on:emit-accept-request="
+            (requestsComponent, username) =>
+              $emit('accept-request', requestsComponent, username)
+          "
+          v-on:emit-deny-request="
+            (requestsComponent, username) =>
+              $emit('deny-request', requestsComponent, username)
+          "
         ></omegaup-contest-requests>
         <omegaup-contest-groups
           v-bind:data="groups"
@@ -101,13 +126,23 @@
       <div class="tab-pane active" v-if="showTab === 'admins'">
         <omegaup-contest-admins
           v-bind:data="admins"
-          v-on:emit-add-admin="addAdminComponent =&gt; $emit('add-admin', addAdminComponent)"
-          v-on:emit-remove-admin="addAdminComponent =&gt; $emit('remove-admin', addAdminComponent)"
+          v-on:emit-add-admin="
+            addAdminComponent => $emit('add-admin', addAdminComponent)
+          "
+          v-on:emit-remove-admin="
+            addAdminComponent => $emit('remove-admin', addAdminComponent)
+          "
         ></omegaup-contest-admins>
         <omegaup-contest-group-admins
           v-bind:data="groupAdmins"
-          v-on:emit-add-group-admin="groupAdminsComponent =&gt; $emit('add-group-admin', groupAdminsComponent)"
-          v-on:emit-remove-group-admin="groupAdminsComponent =&gt; $emit('remove-group-admin', groupAdminsComponent)"
+          v-on:emit-add-group-admin="
+            groupAdminsComponent =>
+              $emit('add-group-admin', groupAdminsComponent)
+          "
+          v-on:emit-remove-group-admin="
+            groupAdminsComponent =>
+              $emit('remove-group-admin', groupAdminsComponent)
+          "
         ></omegaup-contest-group-admins>
       </div>
       <div class="tab-pane active" v-if="showTab === 'links'">
@@ -115,7 +150,9 @@
       </div>
       <div class="tab-pane active" v-if="showTab === 'clone'">
         <omegaup-contest-clone
-          v-on:emit-clone="cloneComponent =&gt; $emit('clone-contest', cloneComponent)"
+          v-on:emit-clone="
+            cloneComponent => $emit('clone-contest', cloneComponent)
+          "
         ></omegaup-contest-clone>
       </div>
     </div>
@@ -131,7 +168,7 @@ import contest_AddProblem from './AddProblem.vue';
 import contest_Admins from './Admins.vue';
 import contest_Clone from './Clone.vue';
 import contest_Contestant from './Contestant.vue';
-import contest_Requests from './Requests.vue';
+import common_Requests from '../common/Requests.vue';
 import contest_Groups from './Groups.vue';
 import contest_GroupAdmins from './GroupAdmins.vue';
 import contest_Links from './Links.vue';
@@ -139,11 +176,11 @@ import contest_NewForm from './NewForm.vue';
 import contest_Publish from './Publish.vue';
 
 interface ContestEdit {
-  admins: omegaup.ContestAdmin[];
+  admins: omegaup.UserRole[];
   contest: omegaup.Contest;
   groupAdmins: omegaup.ContestGroupAdmin[];
   problems: omegaup.Problem[];
-  requests: omegaup.IdentityContestRequest[];
+  requests: omegaup.IdentityRequest[];
   users: omegaup.IdentityContest[];
   groups: omegaup.ContestGroup[];
 }
@@ -154,7 +191,7 @@ interface ContestEdit {
     'omegaup-contest-admins': contest_Admins,
     'omegaup-contest-clone': contest_Clone,
     'omegaup-contest-contestant': contest_Contestant,
-    'omegaup-contest-requests': contest_Requests,
+    'omegaup-contest-requests': common_Requests,
     'omegaup-contest-groups': contest_Groups,
     'omegaup-contest-group-admins': contest_GroupAdmins,
     'omegaup-contest-links': contest_Links,


### PR DESCRIPTION
# Descripción

Se mueve el componente `Requests.vue` al directorio `common` para que se 
pueda utilizar tanto para concursos, como para cursos cuando se libere la 
funcionalidad.

Part of: #3013 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
