### PR TITLE
Evitando que el Navbar se muestre al doble de alto que lo habitual

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -149,7 +149,7 @@
               class="dropdown-toggle user-dropdown"
               data-toggle="dropdown"
               href="#"
-              ><img v-bind:src="header.gravatarURL51"/>
+              ><img class="user-avatar" v-bind:src="header.gravatarURL51"/>
               <span class="username" v-bind:title="header.currentUsername">{{
                 header.currentUsername
               }}</span>
@@ -252,8 +252,8 @@
     }
 
     img {
-      width: 51px;
-      height: 51px;
+      width: 50px;
+      height: 50px;
       margin-right: 10px;
     }
   }
@@ -346,6 +346,30 @@
   .container {
     @media (max-width: 991px) {
       max-width: 100% !important;
+    }
+  }
+
+  .user-avatar {
+    @media (max-width: 827px) {
+      display: none !important;
+    }
+  }
+
+  .username {
+    @media (max-width: 991px) {
+      display: none !important;
+    }
+  }
+
+  .grader-count {
+    @media (max-width: 991px) {
+      display: none !important;
+    }
+  }
+
+  .navbar-right .caret {
+    @media (max-width: 827px) {
+      margin: 23px 4px 23px 4px;
     }
   }
 

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -149,7 +149,7 @@
               class="dropdown-toggle user-dropdown"
               data-toggle="dropdown"
               href="#"
-              ><img class="user-avatar" v-bind:src="header.gravatarURL51"/>
+              ><img v-bind:src="header.gravatarURL51"/>
               <span class="username" v-bind:title="header.currentUsername">{{
                 header.currentUsername
               }}</span>
@@ -349,12 +349,6 @@
     }
   }
 
-  .user-avatar {
-    @media (max-width: 827px) {
-      display: none !important;
-    }
-  }
-
   .username {
     @media (max-width: 991px) {
       display: none !important;
@@ -364,12 +358,6 @@
   .grader-count {
     @media (max-width: 991px) {
       display: none !important;
-    }
-  }
-
-  .navbar-right .caret {
-    @media (max-width: 827px) {
-      margin: 23px 4px 23px 4px;
     }
   }
 


### PR DESCRIPTION
# Descripción

Se agregan algunas `media-queries` en los elementos del `navbar-right` para
que se oculten cuando la resolución del ancho de la pantalla está entre los
769px y 869px.

![NavBar](https://user-images.githubusercontent.com/3230352/76555945-3ceba100-645e-11ea-8588-dd21e1406f15.gif)


Fixes: #2797 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.