### PR TITLE
Agregando font-family al navbar por consistencia

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -367,6 +367,7 @@
     margin-right: auto;
     padding-left: 0;
     padding-right: 0;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
     @media (max-width: 991px) {
       width: 100% !important;


### PR DESCRIPTION
# Descripción

Se agrega un el font-family en el navbar para que siempre se muestre la misma
fuente sin importar en que vista nos encontremos.

Faltaba probar con Firefox en Ubuntu. En este navegador si pude reproducir la
falla.

Antes:
![image](https://user-images.githubusercontent.com/3230352/76673592-f93b8900-657c-11ea-9ecc-c5c26231f2a2.png)

Despues:
![image](https://user-images.githubusercontent.com/3230352/76673650-6fd88680-657d-11ea-9730-88feba8ff781.png)

Fixes: #2797 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
