### PR TITLE
Actualizando la configuración de Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - '6060'
 
   mysql:
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     environment:
       MYSQL_DATABASE: 'omegaup'

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -16,7 +16,7 @@ RUN apt update -y && \
         php7.2-fpm php7.2-curl php7.2-mysql php7.2-sqlite3 php7.2-zip \
         php7.2-mbstring php7.2-json php7.2-opcache php7.2-xml nginx git \
         yarn nodejs supervisor python3-requests python3-mysqldb \
-        mysql-client-core-5.7 sudo && \
+        mysql-client-core-5.7 sudo wait-for-it && \
     apt autoremove -y && \
     apt clean
 
@@ -45,4 +45,4 @@ WORKDIR /opt/omegaup
 
 EXPOSE 8000
 
-CMD [ "/usr/bin/supervisord" ]
+CMD ["wait-for-it", "grader:11302", "gitserver:33861", "mysql:3306", "--", "/usr/bin/supervisord"]

--- a/stuff/docker/Dockerfile.gitserver
+++ b/stuff/docker/Dockerfile.gitserver
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y && \
     apt install --no-install-recommends -y \
-        curl ca-certificates xz-utils openjdk-11-jre-headless && \
+        curl ca-certificates xz-utils openjdk-11-jre-headless wait-for-it && \
     /usr/sbin/update-ca-certificates && \
     apt autoremove -y && \
     apt clean
@@ -23,4 +23,4 @@ COPY ./etc/omegaup/gitserver/* /etc/omegaup/gitserver/
 USER ubuntu
 WORKDIR /var/lib
 
-CMD ["/usr/bin/omegaup-gitserver"]
+CMD ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-gitserver"]

--- a/stuff/docker/Dockerfile.grader
+++ b/stuff/docker/Dockerfile.grader
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y && \
     apt install --no-install-recommends -y \
-        curl ca-certificates xz-utils openjdk-11-jre-headless && \
+        curl ca-certificates xz-utils openjdk-11-jre-headless wait-for-it && \
     /usr/sbin/update-ca-certificates && \
     apt autoremove -y && \
     apt clean
@@ -22,4 +22,4 @@ COPY ./etc/omegaup/grader/* /etc/omegaup/grader/
 USER ubuntu
 WORKDIR /var/lib
 
-CMD ["/usr/bin/omegaup-grader"]
+CMD ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-grader"]

--- a/stuff/docker/Dockerfile.runner
+++ b/stuff/docker/Dockerfile.runner
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y && \
-    apt install --no-install-recommends -y curl ca-certificates xz-utils && \
+    apt install --no-install-recommends -y curl ca-certificates xz-utils \
+        wait-for-it && \
     /usr/sbin/update-ca-certificates && \
     apt autoremove -y && \
     apt clean
@@ -20,4 +21,4 @@ COPY ./etc/omegaup/runner/* /etc/omegaup/runner/
 USER ubuntu
 WORKDIR /var/lib
 
-CMD ["/usr/bin/omegaup-runner", "-noop-sandbox"]
+CMD ["wait-for-it", "grader:11302", "--", "/usr/bin/omegaup-runner", "-noop-sandbox"]

--- a/stuff/docker/etc/supervisor/supervisord.conf
+++ b/stuff/docker/etc/supervisor/supervisord.conf
@@ -14,6 +14,14 @@ command=/usr/sbin/php-fpm7.2 --nodaemonize
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+[program:db-migrate]
+command=/opt/omegaup/stuff/db-migrate.py migrate
+autorestart=unexpected
+startsecs=0
+exitcodes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:yarn-run]
 command=/usr/bin/yarn-dev.sh
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
Este cambio actualiza la base de datos a MySQL 8 y usa
[`wait-for-it`](https://github.com/vishnubob/wait-for-it) para esperar a
que los demás contenedores estén listos para evitar errores.