### PR TITLE
Hacer que los scripts de webpack sean 'defer' tambien

### DIFF
--- a/frontend/smarty_plugins/compiler.js_include.php
+++ b/frontend/smarty_plugins/compiler.js_include.php
@@ -41,7 +41,7 @@ function smarty_compiler_js_include(
         // if the content changes.
         $generatedPath = __DIR__ . "/../www/{$filename}";
         $hash = substr(sha1(file_get_contents($generatedPath)), 0, 6);
-        $generatedPaths[] = "<script src=\"{$filename}?ver={$hash}\" type=\"text/javascript\"></script>";
+        $generatedPaths[] = "<script src=\"{$filename}?ver={$hash}\" type=\"text/javascript\" defer></script>";
     }
     return implode('', $generatedPaths);
 }

--- a/frontend/templates/contest.new.form.tpl
+++ b/frontend/templates/contest.new.form.tpl
@@ -166,5 +166,5 @@
 	</div>
 </div>
 <script type="text/javascript" src="/third_party/js/bootstrap-select.min.js"></script>
-<script type="text/javascript" src="{version_hash src="/js/contest.new.form.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/contest.new.form.js"}" defer></script>
 <link rel="stylesheet" href="/third_party/css/bootstrap-select.min.css">

--- a/frontend/templates/contest.new.tpl
+++ b/frontend/templates/contest.new.tpl
@@ -3,6 +3,6 @@
 
 {include file='contest.new.form.tpl' inline}
 
-<script type="text/javascript" src="{version_hash src="/js/contest.new.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/contest.new.js"}" defer></script>
 
 {include file='footer.tpl' inline}

--- a/frontend/templates/course.details.tpl
+++ b/frontend/templates/course.details.tpl
@@ -1,6 +1,6 @@
 {include file='head.tpl' navbarSection='schools' headerPayload=$headerPayload htmlTitle="{#courseDetails#}" inline}
 
-<script src="{version_hash src="/js/course.js"}"></script>
+<script src="{version_hash src="/js/course.js"}" defer></script>
 
 <script type="text/html" id="assignments-list">
 <h3 data-bind="text: header"></h3>

--- a/frontend/templates/group.edit.scoreboards.tpl
+++ b/frontend/templates/group.edit.scoreboards.tpl
@@ -1,4 +1,4 @@
-<script src="{version_hash src="/js/alias.generate.js"}"></script>
+<script src="{version_hash src="/js/alias.generate.js"}" defer></script>
 
 <div class="panel panel-primary">
 	<div class="panel-body">

--- a/frontend/templates/group.edit.tpl
+++ b/frontend/templates/group.edit.tpl
@@ -2,7 +2,7 @@
 {include file='head.tpl' navbarSection='contests' headerPayload=$headerPayload htmlTitle="{#omegaupTitleGroupsEdit#}" inline}
 
 <span id="form-data" data-name="groups" data-page="edit" data-alias="{$smarty.get.group}"></span>
-<script src="{version_hash src="/js/groups.js"}"></script>
+<script src="{version_hash src="/js/groups.js"}" defer></script>
 
 <ul class="nav nav-tabs nav-justified" id="sections">
 	<li class="active"><a href="#members" data-toggle="tab">{#groupEditMembers#}</a></li>

--- a/frontend/templates/group.new.tpl
+++ b/frontend/templates/group.new.tpl
@@ -6,8 +6,8 @@
 {/if}
 
 <span id="form-data" data-name="groups" data-page="new"></span>
-<script src="{version_hash src="/js/alias.generate.js"}"></script>
-<script src="{version_hash src="/js/groups.js"}"></script>
+<script src="{version_hash src="/js/alias.generate.js"}" defer></script>
+<script src="{version_hash src="/js/groups.js"}" defer></script>
 
 <div class="panel panel-primary">
 	{if $IS_UPDATE != 1}

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -32,7 +32,7 @@
 {/if}
 
 {if isset($jsfile)}
-		<script type="text/javascript" src="{$jsfile}"></script>
+		<script type="text/javascript" src="{$jsfile}" defer></script>
 {/if}
 {if isset($LOAD_MATHJAX) && $LOAD_MATHJAX}
 		<script type="text/javascript" src="{version_hash src="/js/mathjax-config.js"}" defer></script>

--- a/frontend/templates/index.tpl
+++ b/frontend/templates/index.tpl
@@ -4,6 +4,6 @@
 {js_include entrypoint="common_index" async}
 <div id="common-index"></div>
 
-<script type="text/javascript" src="{version_hash src="/js/index.js"}" async></script>
+<script type="text/javascript" src="{version_hash src="/js/index.js"}" defer></script>
 
 {include file='footer.tpl' inline}

--- a/frontend/templates/interviews.arena.intro.tpl
+++ b/frontend/templates/interviews.arena.intro.tpl
@@ -52,6 +52,6 @@
 		</div><!-- row -->
 	</div><!-- panel panel-default -->
 
-<script src="{version_hash src="/js/interviews.arena.intro.js"}"></script>
+<script src="{version_hash src="/js/interviews.arena.intro.js"}" defer></script>
 {include file='footer.tpl' inline}
 

--- a/frontend/templates/interviews.edit.tpl
+++ b/frontend/templates/interviews.edit.tpl
@@ -179,6 +179,6 @@
 
 </div>
 
-<script type="text/javascript" src="{version_hash src="/js/interviews.edit.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/interviews.edit.js"}" defer></script>
 {include file='footer.tpl' inline}
 

--- a/frontend/templates/interviews.list.tpl
+++ b/frontend/templates/interviews.list.tpl
@@ -1,7 +1,7 @@
 {include file='head.tpl' htmlTitle="{#interviewList#}" inline}
 
 <span id="form-data" data-name="interviews" data-page="new"></span>
-<script src="{version_hash src="/js/alias.generate.js"}"></script>
+<script src="{version_hash src="/js/alias.generate.js"}" defer></script>
 
 <div class="panel panel-primary">
 	<div class="panel-heading">
@@ -54,6 +54,6 @@
 	</table>
 </div>
 
-<script type="text/javascript" src="{version_hash src="/js/interviews.list.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/interviews.list.js"}" defer></script>
 {include file='footer.tpl' inline}
 

--- a/frontend/templates/interviews.results.tpl
+++ b/frontend/templates/interviews.results.tpl
@@ -20,8 +20,7 @@
 {include file='arena.runs.tpl' show_pager=true show_points=true show_user=true show_problem=true show_rejudge=true show_details=true inline}
 </div>
 
-<script type="text/javascript" src="{version_hash src="/js/omegaup/arena/arena.js"}"></script>
-
-<script type="text/javascript" src="{version_hash src="/js/interviews.results.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/omegaup/arena/arena.js"}" defer></script>
+<script type="text/javascript" src="{version_hash src="/js/interviews.results.js"}" defer></script>
 {include file='footer.tpl' inline}
 

--- a/frontend/templates/login.password.recover.tpl
+++ b/frontend/templates/login.password.recover.tpl
@@ -15,5 +15,5 @@
 		</div>
 	</div>
 </div>
-<script type='text/javascript' src="{version_hash src="/js/reset.js"}" ></script>
+<script type='text/javascript' src="{version_hash src="/js/reset.js"}" defer></script>
 {include file='footer.tpl' inline}

--- a/frontend/templates/login.password.reset.tpl
+++ b/frontend/templates/login.password.reset.tpl
@@ -21,5 +21,5 @@
 		</div>
 	</div>
 </div>
-<script type='text/javascript' src="{version_hash src="/js/reset.js"}" ></script>
+<script type='text/javascript' src="{version_hash src="/js/reset.js"}" defer></script>
 {include file='footer.tpl' inline}

--- a/frontend/templates/login.tpl
+++ b/frontend/templates/login.tpl
@@ -113,7 +113,7 @@
 	</div>
 </div>
 
-<script type="text/javascript" src="{version_hash src="/js/login.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/login.js"}" defer></script>
 {if $GOOGLECLIENTID != ""}
 <script src="https://apis.google.com/js/platform.js?onload=renderButton" async defer></script>
 {/if}

--- a/frontend/templates/logout.tpl
+++ b/frontend/templates/logout.tpl
@@ -1,6 +1,6 @@
 {include file='head.tpl' recaptchaFile='https://www.google.com/recaptcha/api.js' htmlTitle="{#omegaupTitleLogout#}" inline}
 
-<script type="text/javascript" src="{version_hash src="/js/logout.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/logout.js"}" defer></script>
 {if $GOOGLECLIENTID != ""}
 <script src="https://apis.google.com/js/platform.js" async defer></script>
 {else}

--- a/frontend/templates/problem.edit.form.tpl
+++ b/frontend/templates/problem.edit.form.tpl
@@ -1,4 +1,4 @@
-<script src="{version_hash src="/js/problem.edit.form.js"}" type="text/javascript"></script>
+<script src="{version_hash src="/js/problem.edit.form.js"}" type="text/javascript" defer></script>
 
 <div class="panel panel-primary">
 	{if $IS_UPDATE eq false}

--- a/frontend/templates/problem.mine.tpl
+++ b/frontend/templates/problem.mine.tpl
@@ -61,5 +61,5 @@
     </tbody>
   </table>
 </div>
-<script type="text/javascript" src="{version_hash src="/js/problem.mine.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/problem.mine.js"}" defer></script>
 {include file='footer.tpl' inline}

--- a/frontend/templates/problem.new.tpl
+++ b/frontend/templates/problem.new.tpl
@@ -2,5 +2,5 @@
 {include file='head.tpl' navbarSection='problems' headerPayload=$headerPayload htmlTitle="{#omegaupTitleProblemNew#}" inline}
 {include file='problem.edit.form.tpl' new='true' tags=$SELECTED_TAGS|json_encode inline}
 <span id="form-data" data-name="problems"></span>
-<script src="{version_hash src="/js/alias.generate.js"}"></script>
+<script src="{version_hash src="/js/alias.generate.js"}" defer></script>
 {include file='footer.tpl' inline}

--- a/frontend/templates/problem_search_bar.tpl
+++ b/frontend/templates/problem_search_bar.tpl
@@ -54,4 +54,4 @@
 		</div>
 	</form>
 </div>
-<script type="text/javascript" src="{version_hash src="/js/problem_search_bar.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/problem_search_bar.js"}" defer></script>

--- a/frontend/templates/redaccion.tpl
+++ b/frontend/templates/redaccion.tpl
@@ -1,7 +1,7 @@
 {include file='head.tpl' htmlTitle="{#omegaupTitleRedaccion#}" inline}
-<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}"></script>
-<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}"></script>
-<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}" defer></script>
+<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}" defer></script>
+<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}" defer></script>
 <link rel="stylesheet" type="text/css" href="/css/markdown-editor-widgets.css" />
 
 <div class="post">
@@ -17,7 +17,7 @@
 	<div id="wmd-button-bar"></div><button id="reset-statement">Restaurar</button>
 	<textarea class="wmd-input" id="wmd-input"></textarea>
 </div>
-<script type="text/javascript" src="{version_hash src="/js/redaccion.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/redaccion.js"}" defer></script>
 <div style='clear: both;'></div>
 </div>
 </div>

--- a/frontend/templates/status.tpl
+++ b/frontend/templates/status.tpl
@@ -20,4 +20,4 @@
 	</div>
 {/if}
 
-<script type="text/javascript" src="{version_hash src="/js/status.dismiss.js"}"></script>
+<script type="text/javascript" src="{version_hash src="/js/status.dismiss.js"}" defer></script>

--- a/frontend/templates/user.edit.tpl
+++ b/frontend/templates/user.edit.tpl
@@ -195,5 +195,5 @@
 		{/block}
 	</div>
 
-	<script type="text/javascript" src="{version_hash src="/js/user.edit.js"}"></script>
+	<script type="text/javascript" src="{version_hash src="/js/user.edit.js"}" defer></script>
 {/block}


### PR DESCRIPTION
# Descripción

Más de lo mismo. Cambiar otros scripts a `defer`. Esta vez los scripts producidos por Webpack que se incluyen via `js_include`.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
