### PR TITLE
Desplegando el log de PHP cuando se ejecuta mediante Docker

### DIFF
--- a/stuff/docker/etc/supervisor/supervisord.conf
+++ b/stuff/docker/etc/supervisor/supervisord.conf
@@ -26,3 +26,8 @@ stderr_logfile_maxbytes=0
 command=/usr/bin/yarn-dev.sh
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:omegaup-log]
+command=/usr/bin/tail --follow --retry /tmp/omegaup.log
+stdout_logfile=/dev/stderr
+stdout_logfile_maxbytes=0


### PR DESCRIPTION
Este cambio agrega un proceso que despliega el log de PHP en la salida
de supervisord, que se despliega a su vez en la salida de
`docker-compose`.