### PR TITLE
Renombrando la tabla `Groups` a `Groups_`

### DIFF
--- a/frontend/database/139_rename_groups.sql
+++ b/frontend/database/139_rename_groups.sql
@@ -1,0 +1,1 @@
+RENAME TABLE `Groups` TO `Groups_`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -225,7 +225,7 @@ CREATE TABLE `Courses` (
   KEY `fk_cg_student_group_id` (`group_id`),
   KEY `school_id` (`school_id`),
   CONSTRAINT `fk_ca_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`),
-  CONSTRAINT `fk_cg_student_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups` (`group_id`),
+  CONSTRAINT `fk_cg_student_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups_` (`group_id`),
   CONSTRAINT `fk_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Un curso/clase que un maestro da.';
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -263,14 +263,14 @@ CREATE TABLE `Group_Roles` (
   KEY `group_id` (`group_id`),
   KEY `role_id` (`role_id`),
   KEY `acl_id` (`acl_id`),
-  CONSTRAINT `fk_gr_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups` (`group_id`),
+  CONSTRAINT `fk_gr_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups_` (`group_id`),
   CONSTRAINT `fk_gr_role_id` FOREIGN KEY (`role_id`) REFERENCES `Roles` (`role_id`),
   CONSTRAINT `fk_gra_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Establece los roles que se pueden dar a los grupos.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Groups` (
+CREATE TABLE `Groups_` (
   `group_id` int NOT NULL AUTO_INCREMENT,
   `acl_id` int NOT NULL,
   `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -298,7 +298,7 @@ CREATE TABLE `Groups_Identities` (
   KEY `fk_gipc_privacystatement_consent_id` (`privacystatement_consent_id`),
   CONSTRAINT `fk_gii_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_gipc_privacystatement_consent_id` FOREIGN KEY (`privacystatement_consent_id`) REFERENCES `PrivacyStatement_Consent_Log` (`privacystatement_consent_id`),
-  CONSTRAINT `fk_gu_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups` (`group_id`)
+  CONSTRAINT `fk_gu_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups_` (`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -313,7 +313,7 @@ CREATE TABLE `Groups_Scoreboards` (
   PRIMARY KEY (`group_scoreboard_id`),
   UNIQUE KEY `groups_scoreboards_alias` (`alias`),
   KEY `group_id` (`group_id`),
-  CONSTRAINT `fk_gs_user_id` FOREIGN KEY (`group_id`) REFERENCES `Groups` (`group_id`)
+  CONSTRAINT `fk_gs_user_id` FOREIGN KEY (`group_id`) REFERENCES `Groups_` (`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -21,16 +21,16 @@ abstract class Groups {
     /**
      * Actualizar registros.
      *
-     * @param \OmegaUp\DAO\VO\Groups $Groups El objeto de tipo Groups a actualizar.
+     * @param \OmegaUp\DAO\VO\Groups $Groups_ El objeto de tipo Groups a actualizar.
      *
      * @return int Número de filas afectadas
      */
     final public static function update(
-        \OmegaUp\DAO\VO\Groups $Groups
+        \OmegaUp\DAO\VO\Groups $Groups_
     ): int {
         $sql = '
             UPDATE
-                `Groups`
+                `Groups_`
             SET
                 `acl_id` = ?,
                 `create_time` = ?,
@@ -43,17 +43,17 @@ abstract class Groups {
                 );';
         $params = [
             (
-                is_null($Groups->acl_id) ?
+                is_null($Groups_->acl_id) ?
                 null :
-                intval($Groups->acl_id)
+                intval($Groups_->acl_id)
             ),
             \OmegaUp\DAO\DAO::toMySQLTimestamp(
-                $Groups->create_time
+                $Groups_->create_time
             ),
-            $Groups->alias,
-            $Groups->name,
-            $Groups->description,
-            intval($Groups->group_id),
+            $Groups_->alias,
+            $Groups_->name,
+            $Groups_->description,
+            intval($Groups_->group_id),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
@@ -74,14 +74,14 @@ abstract class Groups {
     ): ?\OmegaUp\DAO\VO\Groups {
         $sql = '
             SELECT
-                `Groups`.`group_id`,
-                `Groups`.`acl_id`,
-                `Groups`.`create_time`,
-                `Groups`.`alias`,
-                `Groups`.`name`,
-                `Groups`.`description`
+                `Groups_`.`group_id`,
+                `Groups_`.`acl_id`,
+                `Groups_`.`create_time`,
+                `Groups_`.`alias`,
+                `Groups_`.`name`,
+                `Groups_`.`description`
             FROM
-                `Groups`
+                `Groups_`
             WHERE
                 (
                     `group_id` = ?
@@ -108,24 +108,24 @@ abstract class Groups {
      * Si no puede encontrar el registro a eliminar,
      * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
      *
-     * @param \OmegaUp\DAO\VO\Groups $Groups El
+     * @param \OmegaUp\DAO\VO\Groups $Groups_ El
      * objeto de tipo \OmegaUp\DAO\VO\Groups a eliminar
      *
      * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
      * encuentra el objeto a eliminar en la base de datos.
      */
     final public static function delete(
-        \OmegaUp\DAO\VO\Groups $Groups
+        \OmegaUp\DAO\VO\Groups $Groups_
     ): void {
         $sql = '
             DELETE FROM
-                `Groups`
+                `Groups_`
             WHERE
                 (
                     `group_id` = ?
                 );';
         $params = [
-            $Groups->group_id
+            $Groups_->group_id
         ];
 
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
@@ -161,14 +161,14 @@ abstract class Groups {
     ): array {
         $sql = '
             SELECT
-                `Groups`.`group_id`,
-                `Groups`.`acl_id`,
-                `Groups`.`create_time`,
-                `Groups`.`alias`,
-                `Groups`.`name`,
-                `Groups`.`description`
+                `Groups_`.`group_id`,
+                `Groups_`.`acl_id`,
+                `Groups_`.`create_time`,
+                `Groups_`.`alias`,
+                `Groups_`.`name`,
+                `Groups_`.`description`
             FROM
-                `Groups`
+                `Groups_`
         ';
         if (!is_null($orden)) {
             $sql .= (
@@ -204,7 +204,7 @@ abstract class Groups {
      * contenidos del objeto {@link \OmegaUp\DAO\VO\Groups}
      * suministrado.
      *
-     * @param \OmegaUp\DAO\VO\Groups $Groups El
+     * @param \OmegaUp\DAO\VO\Groups $Groups_ El
      * objeto de tipo {@link \OmegaUp\DAO\VO\Groups}
      * a crear.
      *
@@ -212,11 +212,11 @@ abstract class Groups {
      *             filas afectadas.
      */
     final public static function create(
-        \OmegaUp\DAO\VO\Groups $Groups
+        \OmegaUp\DAO\VO\Groups $Groups_
     ): int {
         $sql = '
             INSERT INTO
-                `Groups` (
+                `Groups_` (
                     `acl_id`,
                     `create_time`,
                     `alias`,
@@ -231,23 +231,23 @@ abstract class Groups {
                 );';
         $params = [
             (
-                is_null($Groups->acl_id) ?
+                is_null($Groups_->acl_id) ?
                 null :
-                intval($Groups->acl_id)
+                intval($Groups_->acl_id)
             ),
             \OmegaUp\DAO\DAO::toMySQLTimestamp(
-                $Groups->create_time
+                $Groups_->create_time
             ),
-            $Groups->alias,
-            $Groups->name,
-            $Groups->description,
+            $Groups_->alias,
+            $Groups_->name,
+            $Groups_->description,
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
         if ($affectedRows == 0) {
             return 0;
         }
-        $Groups->group_id = (
+        $Groups_->group_id = (
             \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
         );
 

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -95,7 +95,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                 INNER JOIN (
                     SELECT g.group_id
                     FROM Groups_Identities gi
-                    INNER JOIN `Groups` AS g ON g.group_id = gi.group_id
+                    INNER JOIN `Groups_` AS g ON g.group_id = gi.group_id
                     WHERE gi.identity_id = ?
                 ) gg
                 ON c.group_id = gg.group_id
@@ -134,7 +134,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                     pr.alias as assignment_alias,
                     pr.assignment_score
                 FROM
-                    `Groups` AS g
+                    `Groups_` AS g
                 INNER JOIN Groups_Identities gi
                     ON g.group_id = ? AND g.group_id = gi.group_id
                 INNER JOIN Identities i

--- a/frontend/server/src/DAO/GroupRoles.php
+++ b/frontend/server/src/DAO/GroupRoles.php
@@ -22,7 +22,7 @@ class GroupRoles extends \OmegaUp\DAO\Base\GroupRoles {
             FROM
                 Group_Roles gr
             INNER JOIN
-                `Groups` AS g ON g.group_id = gr.group_id
+                `Groups_` AS g ON g.group_id = gr.group_id
             WHERE
                 gr.role_id = ? AND gr.acl_id IN (?, ?);';
         $params = [
@@ -68,7 +68,7 @@ class GroupRoles extends \OmegaUp\DAO\Base\GroupRoles {
             INNER JOIN
                 Group_Roles gr ON gr.acl_id = p.acl_id
             INNER JOIN
-                `Groups` AS g ON g.group_id = gr.group_id
+                `Groups_` AS g ON g.group_id = gr.group_id
             WHERE
                 p.problemset_id = ? AND
                 gr.role_id = ?;

--- a/frontend/server/src/DAO/Groups.php
+++ b/frontend/server/src/DAO/Groups.php
@@ -15,7 +15,7 @@ namespace OmegaUp\DAO;
  */
 class Groups extends \OmegaUp\DAO\Base\Groups {
     public static function findByAlias(string $alias): ?\OmegaUp\DAO\VO\Groups {
-        $sql = 'SELECT `g`.* FROM `Groups` AS `g` WHERE `g`.`alias` = ? LIMIT 1;';
+        $sql = 'SELECT `g`.* FROM `Groups_` AS `g` WHERE `g`.`alias` = ? LIMIT 1;';
         $params = [$alias];
         /** @var array{acl_id: int, alias: string, create_time: string, description: null|string, group_id: int, name: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
@@ -29,7 +29,7 @@ class Groups extends \OmegaUp\DAO\Base\Groups {
      * @return \OmegaUp\DAO\VO\Groups[]
      */
     public static function SearchByName(string $name) {
-        $sql = "SELECT `g`.* FROM `Groups` AS `g` WHERE `g`.`name` LIKE CONCAT('%', ?, '%') LIMIT 10;";
+        $sql = "SELECT `g`.* FROM `Groups_` AS `g` WHERE `g`.`name` LIKE CONCAT('%', ?, '%') LIMIT 10;";
         $args = [$name];
 
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $args);
@@ -41,7 +41,7 @@ class Groups extends \OmegaUp\DAO\Base\Groups {
     }
 
     public static function getByName(string $name): ?\OmegaUp\DAO\VO\Groups {
-        $sql = 'SELECT `g`.* FROM `Groups` AS `g` WHERE `g`.`name` = ? LIMIT 1;';
+        $sql = 'SELECT `g`.* FROM `Groups_` AS `g` WHERE `g`.`name` = ? LIMIT 1;';
 
         /** @var array{acl_id: int, alias: string, create_time: string, description: null|string, group_id: int, name: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$name]);
@@ -71,7 +71,7 @@ class Groups extends \OmegaUp\DAO\Base\Groups {
                 g.name,
                 g.group_id
             FROM
-                `Groups` AS g
+                `Groups_` AS g
             INNER JOIN
                 ACLs AS a ON a.acl_id = g.acl_id
             LEFT JOIN

--- a/frontend/server/src/DAO/UserRoles.php
+++ b/frontend/server/src/DAO/UserRoles.php
@@ -179,7 +179,7 @@ class UserRoles extends \OmegaUp\DAO\Base\UserRoles {
             FROM
                 Groups_Identities gi
             INNER JOIN
-                `Groups` AS g ON gi.group_id = g.group_id
+                `Groups_` AS g ON gi.group_id = g.group_id
             WHERE
                 gi.identity_id = ? AND g.name LIKE '%omegaup:%';";
         $params = [

--- a/frontend/server/src/DAO/VO/Groups.php
+++ b/frontend/server/src/DAO/VO/Groups.php
@@ -10,7 +10,7 @@
 namespace OmegaUp\DAO\VO;
 
 /**
- * Value Object class for table `Groups`.
+ * Value Object class for table `Groups_`.
  *
  * @access public
  */

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -253,7 +253,7 @@ class Utils {
 
             // Tables with special entries.
             \OmegaUp\MySQLConnection::getInstance()->Execute(
-                'DELETE FROM `Groups` WHERE `alias` NOT LIKE "%:%";'
+                'DELETE FROM `Groups_` WHERE `alias` NOT LIKE "%:%";'
             );
 
             // The format of the question changed from this id


### PR DESCRIPTION
Este cambio renombra la tabla `Groups` a `Groups_`, porque el primero es
una palabra reservada en MySQL 8 y Amazon RDS se rehúsa a actualizar la
versión de MySQL de 5.7 a 8 bajo esas circunstancias.

Part of: #3557