### PR TITLE
Corrigiendo el tipo de `validateNumber`, `validateOptionalNumber`

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -42,21 +42,21 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 20);
         $activeContests = isset($r['active'])
-            ? \OmegaUp\DAO\Enum\ActiveStatus::getIntValue($r['active'])
+            ? \OmegaUp\DAO\Enum\ActiveStatus::getIntValue(intval($r['active']))
             : \OmegaUp\DAO\Enum\ActiveStatus::ALL;
         // If the parameter was not set, the default should be ALL which is
         // a number and should pass this check.
         \OmegaUp\Validators::validateNumber($activeContests, 'active');
         $recommended = isset($r['recommended'])
             ? \OmegaUp\DAO\Enum\RecommendedStatus::getIntValue(
-                $r['recommended']
+                intval($r['recommended'])
             )
             : \OmegaUp\DAO\Enum\RecommendedStatus::ALL;
         // Same as above.
         \OmegaUp\Validators::validateNumber($recommended, 'recommended');
         $participating = isset($r['participating'])
             ? \OmegaUp\DAO\Enum\ParticipatingStatus::getIntValue(
-                $r['participating']
+                intval($r['participating'])
             )
             : \OmegaUp\DAO\Enum\ParticipatingStatus::NO;
         \OmegaUp\Validators::validateOptionalInEnum(

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3114,7 +3114,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         return [
             'mode' => strval($r['mode']),
-            'page' => $r['page'],
+            'page' => intval($r['page']),
             'orderBy' => strval($r['order_by']),
             'language' => strval($r['language']),
             'tags' => $tags,

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -522,7 +522,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             'qualitynomination_id'
         );
         $qualitynomination = \OmegaUp\DAO\QualityNominations::getByPK(
-            $r['qualitynomination_id']
+            intval($r['qualitynomination_id'])
         );
         if (is_null($qualitynomination)) {
             throw new \OmegaUp\Exceptions\NotFoundException(

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -413,7 +413,7 @@ class Validators {
      *
      * @param mixed  $parameter
      * @param string $parameterName
-     * @psalm-assert int $parameter
+     * @psalm-assert numeric $parameter
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     public static function validateNumber(
@@ -435,7 +435,7 @@ class Validators {
      *
      * @param mixed  $parameter
      * @param string $parameterName
-     * @psalm-assert int $parameter
+     * @psalm-assert numeric|null $parameter
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     public static function validateOptionalNumber(


### PR DESCRIPTION
Este cambio hace que los validadores numéricos aseveren que el parámetro
es `numeric` (o `numeric|null`) en vez de `int`.