### PR TITLE
Usando el nuevo charset utf8mb4 en MySQL

### DIFF
--- a/frontend/server/src/MySQLConnection.php
+++ b/frontend/server/src/MySQLConnection.php
@@ -89,8 +89,11 @@ class MySQLConnection {
             );
         }
         $this->_connection->autocommit(false);
-        $this->_connection->set_charset('utf8');
-        $this->_connection->query('SET NAMES "utf8";', MYSQLI_STORE_RESULT);
+        $this->_connection->set_charset('utf8mb4');
+        $this->_connection->query(
+            'SET NAMES "utf8mb4" COLLATE "utf8mb4_unicode_ci";',
+            MYSQLI_STORE_RESULT
+        );
     }
 
     /**


### PR DESCRIPTION
Este cambio hace que use utilice el conjunto de caracteres `utf8mb4` y
su ordenamiento `utf8mb4_unicode_ci`. Esto es en preparación para la
migración a MySQL 8.

Fixes: #3561