### PR TITLE
Cambiar algunos CSS a que sean asíncronos

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -46,34 +46,34 @@
 		<!-- Latest compiled and minified JavaScript -->
 		<script src="{version_hash src="/third_party/bootstrap-3.4.1/js/bootstrap.min.js"}" defer></script>
 		<!-- Bootstrap datepicker plugin from http://www.eyecon.ro/bootstrap-datepicker/ -->
-		<link rel="stylesheet" href="/third_party/css/bootstrap-datepicker.css">
+		<link rel="stylesheet" href="/third_party/css/bootstrap-datepicker.css" media="print" onload="this.media='all'">
 		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datepicker.js"}" defer></script>
 		<!-- typeahead plugin from https://github.com/twitter/typeahead.js -->
 		<script type="text/javascript" src="{version_hash src="/third_party/js/typeahead.jquery.min.js"}" defer></script>
 		<!-- Bootstrap datetimepicker plugin from http://www.malot.fr/bootstrap-datetimepicker/demo.php -->
-		<link rel="stylesheet" href="/third_party/css/bootstrap-datetimepicker.css">
+		<link rel="stylesheet" href="/third_party/css/bootstrap-datetimepicker.css" media="print" onload="this.media='all'">
 		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datetimepicker.min.js"}" defer></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.es.js"}" defer></script>
 		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js"}" defer></script>
 
 {if isset($inArena) && $inArena}
-		<link rel="stylesheet" type="text/css" href="{version_hash src="/ux/arena.css"}" />
+		<link rel="stylesheet" type="text/css" href="{version_hash src="/ux/arena.css"}">
 {else}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/css/style.css"}">
 		<!-- Bootstrap table plugin from https://github.com/wenzhixin/bootstrap-table/releases -->
 		<script src="{version_hash src="/third_party/js/bootstrap-table.min.js"}" defer></script>
-		<link rel="stylesheet" href="/third_party/css/bootstrap-table.min.css">
+		<link rel="stylesheet" href="/third_party/css/bootstrap-table.min.css" media="print" onload="this.media='all'">
 {/if}
-		<link rel="stylesheet" type="text/css" href="{version_hash src="/css/common.css"}" />
+		<link rel="stylesheet" type="text/css" href="{version_hash src="/css/common.css"}">
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/css/dist/omegaup_styles.css"}">
-		<link rel="stylesheet" type="text/css" href="{version_hash src="/third_party/wenk/demo/wenk.min.css"}" />
+		<link rel="stylesheet" type="text/css" href="{version_hash src="/third_party/wenk/demo/wenk.min.css"}"  media="print" onload="this.media='all'">
 		<link rel="shortcut icon" href="/favicon.ico" />
 
 {if isset($LOAD_PAGEDOWN) && $LOAD_PAGEDOWN}
 	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Converter.js"}" defer></script>
 	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Sanitizer.js"}" defer></script>
 	<script type="text/javascript" src="{version_hash src="/third_party/js/pagedown/Markdown.Editor.js"}" defer></script>
-	<link rel="stylesheet" type="text/css" href="/css/markdown-editor-widgets.css" />
+	<link rel="stylesheet" type="text/css" href="/css/markdown-editor-widgets.css"  media="print" onload="this.media='all'">
 {/if}
 {if !empty($ENABLED_EXPERIMENTS)}
 		<script type="text/plain" id="omegaup-enabled-experiments">{','|implode:$ENABLED_EXPERIMENTS}</script>


### PR DESCRIPTION
# Descripción

Cambia algunos CSS que no son esenciales para la página a que se carguen de modo asíncrono.
Utiliza el truco que explican aquí: https://www.filamentgroup.com/lab/load-css-simpler/

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.