### PR TITLE
Mueve los JS y CSS de date[time]picker a donde se requieren

### DIFF
--- a/frontend/templates/contest.new.form.tpl
+++ b/frontend/templates/contest.new.form.tpl
@@ -165,6 +165,13 @@
 		</form>
 	</div>
 </div>
+
+<!-- Bootstrap datetimepicker plugin from http://www.malot.fr/bootstrap-datetimepicker/demo.php -->
+<link rel="stylesheet" href="/third_party/css/bootstrap-datetimepicker.css">
+<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datetimepicker.min.js"}" defer></script>
+<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.es.js"}" defer></script>
+<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js"}" defer></script>
+
 <script type="text/javascript" src="/third_party/js/bootstrap-select.min.js"></script>
 <script type="text/javascript" src="{version_hash src="/js/contest.new.form.js"}" defer></script>
 <link rel="stylesheet" href="/third_party/css/bootstrap-select.min.css">

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -45,16 +45,8 @@
 		<link rel="stylesheet" href="/third_party/bootstrap-3.4.1/css/bootstrap.min.css">
 		<!-- Latest compiled and minified JavaScript -->
 		<script src="{version_hash src="/third_party/bootstrap-3.4.1/js/bootstrap.min.js"}" defer></script>
-		<!-- Bootstrap datepicker plugin from http://www.eyecon.ro/bootstrap-datepicker/ -->
-		<link rel="stylesheet" href="/third_party/css/bootstrap-datepicker.css">
-		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datepicker.js"}" defer></script>
 		<!-- typeahead plugin from https://github.com/twitter/typeahead.js -->
 		<script type="text/javascript" src="{version_hash src="/third_party/js/typeahead.jquery.min.js"}" defer></script>
-		<!-- Bootstrap datetimepicker plugin from http://www.malot.fr/bootstrap-datetimepicker/demo.php -->
-		<link rel="stylesheet" href="/third_party/css/bootstrap-datetimepicker.css">
-		<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datetimepicker.min.js"}" defer></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.es.js"}" defer></script>
-		<script type="text/javascript" src="{version_hash src="/third_party/js/locales/bootstrap-datetimepicker.pt-BR.js"}" defer></script>
 
 {if isset($inArena) && $inArena}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/ux/arena.css"}" />

--- a/frontend/templates/user.edit.tpl
+++ b/frontend/templates/user.edit.tpl
@@ -195,5 +195,8 @@
 		{/block}
 	</div>
 
+	<!-- Bootstrap datepicker plugin from http://www.eyecon.ro/bootstrap-datepicker/ -->
+	<link rel="stylesheet" href="/third_party/css/bootstrap-datepicker.css">
+	<script type="text/javascript" src="{version_hash src="/third_party/js/bootstrap-datepicker.js"}" defer></script>
 	<script type="text/javascript" src="{version_hash src="/js/user.edit.js"}" defer></script>
 {/block}

--- a/frontend/www/js/omegaup/components/DatePicker.vue
+++ b/frontend/www/js/omegaup/components/DatePicker.vue
@@ -14,6 +14,7 @@
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
 import { T } from '../omegaup.js';
 import UI from '../ui.js';
+import '../../../third_party/js/bootstrap-datepicker.js';
 
 @Component
 export default class DatePicker extends Vue {
@@ -29,7 +30,7 @@ export default class DatePicker extends Vue {
   mounted() {
     if ((this.$el as HTMLInputElement).type === 'text') {
       // Even though we declared the input as having date type,
-      // browsers that don't support it will silently change the type to ext'.
+      // browsers that don't support it will silently change the type to text.
       // In that case, use the bootstrap datepicker.
       this.mountedFallback();
     }
@@ -67,3 +68,7 @@ export default class DatePicker extends Vue {
   }
 }
 </script>
+
+<style>
+@import '../../../third_party/css/bootstrap-datepicker.css';
+</style>

--- a/frontend/www/js/omegaup/components/DateTimePicker.vue
+++ b/frontend/www/js/omegaup/components/DateTimePicker.vue
@@ -16,6 +16,9 @@
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
 import { T } from '../omegaup.js';
 import UI from '../ui.js';
+import '../../../third_party/js/bootstrap-datetimepicker.min.js';
+import '../../../third_party/js/locales/bootstrap-datetimepicker.es.js';
+import '../../../third_party/js/locales/bootstrap-datetimepicker.pt-BR.js';
 
 @Component
 export default class DateTimePicker extends Vue {
@@ -35,7 +38,7 @@ export default class DateTimePicker extends Vue {
   public mounted() {
     if ((this.$el as HTMLInputElement).type === 'text') {
       // Even though we declared the input as having datetime-local type,
-      // browsers that don't support it will silently change the type to ext'.
+      // browsers that don't support it will silently change the type to text.
       // In that case, use the bootstrap datetimepicker.
       this.mountedFallback();
     }
@@ -94,3 +97,7 @@ export default class DateTimePicker extends Vue {
   }
 }
 </script>
+
+<style>
+@import '../../../third_party/css/bootstrap-datetimepicker.css';
+</style>


### PR DESCRIPTION
# Descripción

Segundo intento de limpiar un poco el CSS y ahora también JS de `date[time]picker`.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
