### PR TITLE
Evitando un error en la consola

### DIFF
--- a/frontend/www/js/omegaup/components/activity/SubmissionsList.vue
+++ b/frontend/www/js/omegaup/components/activity/SubmissionsList.vue
@@ -73,7 +73,7 @@ export default class ActivitySubmissionsList extends Vue {
   @Prop() unsolvedProblems!: CourseProblems;
 
   T = T;
-  static readonly NUM_COLUMNS = 3;
+  readonly NUM_COLUMNS = 3;
 
   get groupedSolvedProblems(): GroupedCourseProblems {
     return this.groupElements(this.solvedProblems);
@@ -87,14 +87,8 @@ export default class ActivitySubmissionsList extends Vue {
     let groups: GroupedCourseProblems = {};
     for (let user in elements) {
       groups[user] = [];
-      for (
-        let i = 0;
-        i < elements[user].length;
-        i += ActivitySubmissionsList.NUM_COLUMNS
-      ) {
-        groups[user].push(
-          elements[user].slice(i, i + ActivitySubmissionsList.NUM_COLUMNS),
-        );
+      for (let i = 0; i < elements[user].length; i += this.NUM_COLUMNS) {
+        groups[user].push(elements[user].slice(i, i + this.NUM_COLUMNS));
       }
     }
     return groups;


### PR DESCRIPTION
Este cambio hace que SubmissionList.NUM_COLUMNS sea una propiedad en la
instancia, evitando un error en la consola de errores.