### PR TITLE
Moviendo las cadenas de traducción a su propio módulo

### DIFF
--- a/frontend/www/js/omegaup/activity/feed.js
+++ b/frontend/www/js/omegaup/activity/feed.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import activity_Feed from '../components/activity/Feed.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/admin/roles.js
+++ b/frontend/www/js/omegaup/admin/roles.js
@@ -1,5 +1,8 @@
 import user_Roles from '../components/admin/Roles.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/admin/support.js
+++ b/frontend/www/js/omegaup/admin/support.js
@@ -1,5 +1,8 @@
 import admin_Support from '../components/admin/Support.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/admin/user.js
+++ b/frontend/www/js/omegaup/admin/user.js
@@ -1,5 +1,8 @@
 import admin_User from '../components/admin/User.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -1,4 +1,5 @@
-import { OmegaUp, T } from '../omegaup';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
 import API from '../api.js';
 import * as api from '../api_transitional';
 import ArenaAdmin from './admin_arena.js';

--- a/frontend/www/js/omegaup/arena/contest_list.js
+++ b/frontend/www/js/omegaup/arena/contest_list.js
@@ -1,4 +1,7 @@
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import arena_ContestList from '../components/arena/ContestList.vue';
 

--- a/frontend/www/js/omegaup/arena/qualitynomination_demotionpopup.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_demotionpopup.js
@@ -1,4 +1,6 @@
-import { API, OmegaUp, UI } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 import qualitynomination_demotionPopup from '../components/qualitynomination/DemotionPopup.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/arena/qualitynomination_popup.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_popup.js
@@ -1,4 +1,7 @@
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import qualitynomination_Popup from '../components/qualitynomination/Popup.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/arena/qualitynomination_qualityreview.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_qualityreview.js
@@ -1,4 +1,6 @@
-import { API, UI, OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 import qualitynomination_ReviewerPopup from '../components/qualitynomination/ReviewerPopup.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/arena/virtual.js
+++ b/frontend/www/js/omegaup/arena/virtual.js
@@ -1,4 +1,7 @@
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import arena_virtual from '../components/arena/Virtual.vue';
 

--- a/frontend/www/js/omegaup/badge/details.js
+++ b/frontend/www/js/omegaup/badge/details.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import badge_Details from '../components/badge/Details.vue';
-import { OmegaUp, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/badge/list.js
+++ b/frontend/www/js/omegaup/badge/list.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import badge_List from '../components/badge/List.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/coderofthemonth/index.js
+++ b/frontend/www/js/omegaup/coderofthemonth/index.js
@@ -1,4 +1,7 @@
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import coderofthemonth_List from '../components/coderofthemonth/List.vue';
 

--- a/frontend/www/js/omegaup/common/footer.js
+++ b/frontend/www/js/omegaup/common/footer.js
@@ -1,5 +1,6 @@
 import common_Footer from '../components/common/Footer.vue';
-import { OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/common/index.js
+++ b/frontend/www/js/omegaup/common/index.js
@@ -1,5 +1,7 @@
 import common_Index from '../components/common/Index.vue';
-import { UI, OmegaUp, T } from '../omegaup';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import UI from '../ui.js';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/common/navbar.js
+++ b/frontend/www/js/omegaup/common/navbar.js
@@ -1,7 +1,9 @@
 import common_Navbar from '../components/common/Navbar.vue';
+import { OmegaUp } from '../omegaup';
 import * as api from '../api_transitional';
 import API from '../api.js';
-import { UI, OmegaUp, T } from '../omegaup';
+import T from '../lang';
+import UI from '../ui.js';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/common/runs_chart.js
+++ b/frontend/www/js/omegaup/common/runs_chart.js
@@ -1,4 +1,5 @@
-import { OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
 import Vue from 'vue';
 import { Chart } from 'highcharts-vue';
 

--- a/frontend/www/js/omegaup/common/stats.js
+++ b/frontend/www/js/omegaup/common/stats.js
@@ -1,6 +1,9 @@
 import common_Stats from '../components/common/Stats.vue';
 import Vue from 'vue';
-import { API, OmegaUp, T, UI } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
+import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {
   Highcharts.setOptions({ global: { useUTC: false } });

--- a/frontend/www/js/omegaup/components/DatePicker.vue
+++ b/frontend/www/js/omegaup/components/DatePicker.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
-import { T } from '../omegaup.js';
+import T from '../lang';
 import UI from '../ui.js';
 import '../../../third_party/js/bootstrap-datepicker.js';
 

--- a/frontend/www/js/omegaup/components/DateTimePicker.vue
+++ b/frontend/www/js/omegaup/components/DateTimePicker.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
-import { T } from '../omegaup.js';
+import T from '../lang';
 import UI from '../ui.js';
 import '../../../third_party/js/bootstrap-datetimepicker.min.js';
 import '../../../third_party/js/locales/bootstrap-datetimepicker.es.js';

--- a/frontend/www/js/omegaup/components/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/GridPaginator.vue
@@ -65,7 +65,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { T } from '../omegaup';
+import T from '../lang';
 import { LinkableResource } from '../types.ts';
 
 interface SortOption {

--- a/frontend/www/js/omegaup/components/RankTable.vue
+++ b/frontend/www/js/omegaup/components/RankTable.vue
@@ -119,7 +119,8 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import { T, OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
 import UI from '../ui.js';
 import Autocomplete from './Autocomplete.vue';
 import CountryFlag from './CountryFlag.vue';

--- a/frontend/www/js/omegaup/components/activity/Feed.vue
+++ b/frontend/www/js/omegaup/components/activity/Feed.vue
@@ -151,7 +151,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import user_Username from '../user/Username.vue';
 

--- a/frontend/www/js/omegaup/components/activity/SubmissionsList.vue
+++ b/frontend/www/js/omegaup/components/activity/SubmissionsList.vue
@@ -57,7 +57,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 interface CourseProblems {
   [user: string]: omegaup.Problem[];

--- a/frontend/www/js/omegaup/components/admin/Roles.vue
+++ b/frontend/www/js/omegaup/components/admin/Roles.vue
@@ -42,7 +42,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component({})
 export default class AdminRoles extends Vue {

--- a/frontend/www/js/omegaup/components/admin/Support.vue
+++ b/frontend/www/js/omegaup/components/admin/Support.vue
@@ -127,7 +127,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component({})

--- a/frontend/www/js/omegaup/components/admin/User.vue
+++ b/frontend/www/js/omegaup/components/admin/User.vue
@@ -70,7 +70,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component({})
 export default class User extends Vue {

--- a/frontend/www/js/omegaup/components/arena/CodeView.vue
+++ b/frontend/www/js/omegaup/components/arena/CodeView.vue
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import { codemirror } from 'vue-codemirror-lite';
 

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -192,7 +192,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import contest_FilteredList from '../contest/FilteredList.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/arena/NavbarAssignments.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarAssignments.vue
@@ -42,7 +42,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class ArenaNavbarAssignments extends Vue {

--- a/frontend/www/js/omegaup/components/arena/NavbarMiniranking.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarMiniranking.vue
@@ -63,7 +63,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import user_Username from '../user/Username.vue';
 @Component({
   components: {

--- a/frontend/www/js/omegaup/components/arena/NavbarProblems.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarProblems.vue
@@ -58,7 +58,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class ArenaNavbarProblems extends Vue {

--- a/frontend/www/js/omegaup/components/arena/RunDetails.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.vue
@@ -135,7 +135,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import arena_CodeView from './CodeView.vue';
 
 interface GroupVisibility {

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -153,7 +153,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/arena/Virtual.vue
+++ b/frontend/www/js/omegaup/components/arena/Virtual.vue
@@ -51,7 +51,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import DateTimePicker from '../DateTimePicker.vue';
 

--- a/frontend/www/js/omegaup/components/badge/Badge.vue
+++ b/frontend/www/js/omegaup/components/badge/Badge.vue
@@ -38,7 +38,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import 'v-tooltip/dist/v-tooltip.css';
 import { VTooltip } from 'v-tooltip';
 
@@ -50,14 +51,12 @@ import { VTooltip } from 'v-tooltip';
 export default class Badge extends Vue {
   @Prop() badge!: omegaup.Badge;
 
-  T = T;
-
   get name(): string {
-    return this.T[`badge_${this.badge.badge_alias}_name`];
+    return T[`badge_${this.badge.badge_alias}_name`];
   }
 
   get description(): string {
-    return this.T[`badge_${this.badge.badge_alias}_description`];
+    return T[`badge_${this.badge.badge_alias}_description`];
   }
 
   get iconUrl(): string {

--- a/frontend/www/js/omegaup/components/badge/Details.vue
+++ b/frontend/www/js/omegaup/components/badge/Details.vue
@@ -90,7 +90,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/badge/List.vue
+++ b/frontend/www/js/omegaup/components/badge/List.vue
@@ -40,7 +40,8 @@ a.badges-link {
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import Badge from '../badge/Badge.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/coderofthemonth/CoderOfTheMonth.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/CoderOfTheMonth.vue
@@ -31,7 +31,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import user_Username from '../user/Username.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/coderofthemonth/List.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/List.vue
@@ -105,7 +105,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import user_Username from '../user/Username.vue';
 import country_Flag from '../CountryFlag.vue';
 

--- a/frontend/www/js/omegaup/components/coderofthemonth/Notice.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/Notice.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/common/Footer.vue
+++ b/frontend/www/js/omegaup/components/common/Footer.vue
@@ -58,9 +58,7 @@
           <li>
             <a
               href="https://github.com/omegaup/omegaup/issues/new"
-              v-on:click="
-                $event.target.href = reportAnIssueURL(T.reportAnIssueTemplate)
-              "
+              v-on:click="$event.target.href = reportAnIssueURL()"
               target="_blank"
               rel="nofollow"
               v-if="!omegaUpLockDown && isLoggedIn"
@@ -217,7 +215,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import { reportAnIssueURL } from '../../errors';
 
 @Component

--- a/frontend/www/js/omegaup/components/common/GraderBadge.vue
+++ b/frontend/www/js/omegaup/components/common/GraderBadge.vue
@@ -32,7 +32,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component({})

--- a/frontend/www/js/omegaup/components/common/GraderStatus.vue
+++ b/frontend/www/js/omegaup/components/common/GraderStatus.vue
@@ -64,7 +64,8 @@ ul {
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component({})

--- a/frontend/www/js/omegaup/components/common/Index.vue
+++ b/frontend/www/js/omegaup/components/common/Index.vue
@@ -70,7 +70,8 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Chart } from 'highcharts-vue';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import common_Welcome from './Welcome.vue';
 import common_SocialMedia from './SocialMedia.vue';
 import common_RecomendedMaterial from './RecomendedMaterial.vue';

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -387,7 +387,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import notifications_List from '../notification/List.vue';
 import notifications_Clarifications from '../notification/Clarifications.vue';
 import common_GraderStatus from '../common/GraderStatus.vue';

--- a/frontend/www/js/omegaup/components/common/Paginator.vue
+++ b/frontend/www/js/omegaup/components/common/Paginator.vue
@@ -19,7 +19,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import { types } from '../../api_types';
 
 @Component

--- a/frontend/www/js/omegaup/components/common/RecomendedMaterial.vue
+++ b/frontend/www/js/omegaup/components/common/RecomendedMaterial.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class RecomendedMaterial extends Vue {

--- a/frontend/www/js/omegaup/components/common/Requests.vue
+++ b/frontend/www/js/omegaup/components/common/Requests.vue
@@ -53,7 +53,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class Requests extends Vue {

--- a/frontend/www/js/omegaup/components/common/SocialMedia.vue
+++ b/frontend/www/js/omegaup/components/common/SocialMedia.vue
@@ -29,7 +29,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class SocialMedia extends Vue {

--- a/frontend/www/js/omegaup/components/common/Stats.vue
+++ b/frontend/www/js/omegaup/components/common/Stats.vue
@@ -14,7 +14,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import { Chart } from 'highcharts-vue';
 

--- a/frontend/www/js/omegaup/components/common/Welcome.vue
+++ b/frontend/www/js/omegaup/components/common/Welcome.vue
@@ -28,7 +28,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class Welcome extends Vue {

--- a/frontend/www/js/omegaup/components/contest/AddProblem.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblem.vue
@@ -128,7 +128,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 import problem_Versions from '../problem/Versions.vue';

--- a/frontend/www/js/omegaup/components/contest/Admins.vue
+++ b/frontend/www/js/omegaup/components/contest/Admins.vue
@@ -55,7 +55,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 import user_Username from '../user/Username.vue';

--- a/frontend/www/js/omegaup/components/contest/Clone.vue
+++ b/frontend/www/js/omegaup/components/contest/Clone.vue
@@ -53,7 +53,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import DateTime from '../DateTimePicker.vue';
 

--- a/frontend/www/js/omegaup/components/contest/ContestList.vue
+++ b/frontend/www/js/omegaup/components/contest/ContestList.vue
@@ -172,7 +172,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component({})

--- a/frontend/www/js/omegaup/components/contest/Contestant.vue
+++ b/frontend/www/js/omegaup/components/contest/Contestant.vue
@@ -88,7 +88,8 @@
 <script lang="ts">
 import { Vue, Component, Emit, Prop } from 'vue-property-decorator';
 
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 import DateTimePicker from '../DateTimePicker.vue';

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -161,7 +161,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, OmegaUp, T } from '../../omegaup';
+import { omegaup, OmegaUp } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import contest_AddProblem from './AddProblem.vue';
 import contest_Admins from './Admins.vue';

--- a/frontend/www/js/omegaup/components/contest/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/contest/FilteredList.vue
@@ -91,7 +91,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/contest/GroupAdmins.vue
+++ b/frontend/www/js/omegaup/components/contest/GroupAdmins.vue
@@ -46,7 +46,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 

--- a/frontend/www/js/omegaup/components/contest/Groups.vue
+++ b/frontend/www/js/omegaup/components/contest/Groups.vue
@@ -39,7 +39,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 

--- a/frontend/www/js/omegaup/components/contest/Links.vue
+++ b/frontend/www/js/omegaup/components/contest/Links.vue
@@ -51,7 +51,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component({})
 export default class Links extends Vue {

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -244,7 +244,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import DateTimePicker from '../DateTimePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/contest/Publish.vue
+++ b/frontend/www/js/omegaup/components/contest/Publish.vue
@@ -33,7 +33,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component({})
 export default class Publish extends Vue {

--- a/frontend/www/js/omegaup/components/contest/Report.vue
+++ b/frontend/www/js/omegaup/components/contest/Report.vue
@@ -75,7 +75,8 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 interface ContestReport {

--- a/frontend/www/js/omegaup/components/contest/ScoreboardMerge.vue
+++ b/frontend/www/js/omegaup/components/contest/ScoreboardMerge.vue
@@ -99,7 +99,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component({})

--- a/frontend/www/js/omegaup/components/contest/Upcoming.vue
+++ b/frontend/www/js/omegaup/components/contest/Upcoming.vue
@@ -17,7 +17,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class Upcoming extends Vue {

--- a/frontend/www/js/omegaup/components/course/AddStudents.vue
+++ b/frontend/www/js/omegaup/components/course/AddStudents.vue
@@ -85,7 +85,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 

--- a/frontend/www/js/omegaup/components/course/Administrators.vue
+++ b/frontend/www/js/omegaup/components/course/Administrators.vue
@@ -153,7 +153,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 

--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
@@ -157,7 +157,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import DateTimePicker from '../DateTimePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/AssignmentList.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentList.vue
@@ -131,7 +131,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class CourseAssignmentList extends Vue {

--- a/frontend/www/js/omegaup/components/course/Clone.vue
+++ b/frontend/www/js/omegaup/components/course/Clone.vue
@@ -57,7 +57,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import DatePicker from '../DatePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/CourseDetails.vue
+++ b/frontend/www/js/omegaup/components/course/CourseDetails.vue
@@ -182,7 +182,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { OmegaUp, omegaup, T } from '../../omegaup';
+import { OmegaUp, omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import { types } from '../../api_types';
 

--- a/frontend/www/js/omegaup/components/course/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/course/FilteredList.vue
@@ -78,7 +78,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -232,7 +232,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import DatePicker from '../DatePicker.vue';
 

--- a/frontend/www/js/omegaup/components/course/Intro.vue
+++ b/frontend/www/js/omegaup/components/course/Intro.vue
@@ -69,7 +69,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 interface Statement {

--- a/frontend/www/js/omegaup/components/course/List.vue
+++ b/frontend/www/js/omegaup/components/course/List.vue
@@ -30,7 +30,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import course_FilteredList from './FilteredList.vue';
 

--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -180,7 +180,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import Autocomplete from '../Autocomplete.vue';
 

--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -48,7 +48,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import AsyncComputedPlugin from 'vue-async-computed';
 import AsyncComputed from 'vue-async-computed-decorator';
 import JSZip from 'jszip';

--- a/frontend/www/js/omegaup/components/course/ViewStudent.vue
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.vue
@@ -90,7 +90,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/group/GroupList.vue
+++ b/frontend/www/js/omegaup/components/group/GroupList.vue
@@ -43,7 +43,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class GroupList extends Vue {

--- a/frontend/www/js/omegaup/components/group/Identities.vue
+++ b/frontend/www/js/omegaup/components/group/Identities.vue
@@ -70,7 +70,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -118,7 +118,8 @@ label {
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import user_Username from '../user/Username.vue';
 import identity_Edit from '../identity/Edit.vue';

--- a/frontend/www/js/omegaup/components/identity/ChangePassword.vue
+++ b/frontend/www/js/omegaup/components/identity/ChangePassword.vue
@@ -78,9 +78,9 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 
-@Component({})
+@Component
 export default class IdentityChangePassword extends Vue {
   @Prop() username!: string;
 

--- a/frontend/www/js/omegaup/components/identity/Edit.vue
+++ b/frontend/www/js/omegaup/components/identity/Edit.vue
@@ -122,7 +122,8 @@
 
 <script lang="ts">
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import * as iso3166 from '@/third_party/js/iso-3166-2.js/iso3166.min.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/notification/Clarifications.vue
+++ b/frontend/www/js/omegaup/components/notification/Clarifications.vue
@@ -134,7 +134,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class Clarifications extends Vue {

--- a/frontend/www/js/omegaup/components/notification/List.vue
+++ b/frontend/www/js/omegaup/components/notification/List.vue
@@ -73,7 +73,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import Notification from './Notification.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/notification/Notification.vue
+++ b/frontend/www/js/omegaup/components/notification/Notification.vue
@@ -58,15 +58,13 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component
 export default class Notification extends Vue {
   @Prop() notification!: omegaup.Notification;
-
-  T = T;
-  UI = UI;
 
   get iconUrl(): string {
     switch (this.notification.contents.type) {
@@ -80,8 +78,8 @@ export default class Notification extends Vue {
   get text(): string {
     switch (this.notification.contents.type) {
       case 'badge':
-        return this.UI.formatString(this.T.notificationNewBadge, {
-          badgeName: this.T[`badge_${this.notification.contents.badge}_name`],
+        return UI.formatString(T.notificationNewBadge, {
+          badgeName: T[`badge_${this.notification.contents.badge}_name`],
         });
       default:
         return '';
@@ -89,7 +87,7 @@ export default class Notification extends Vue {
   }
 
   get date() {
-    return this.UI.formatDate(this.notification.timestamp);
+    return UI.formatDate(this.notification.timestamp);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/Feedback.vue
+++ b/frontend/www/js/omegaup/components/problem/Feedback.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import problemHistogram from './Histogram.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/problem/FinderWizard.vue
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.vue
@@ -166,7 +166,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 // https://binarcode.github.io/vue-form-wizard/
 import { FormWizard, TabContent } from 'vue-form-wizard';
 import 'vue-form-wizard/dist/vue-form-wizard.min.css';

--- a/frontend/www/js/omegaup/components/problem/Histogram.vue
+++ b/frontend/www/js/omegaup/components/problem/Histogram.vue
@@ -164,7 +164,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class ProblemHistogram extends Vue {
@@ -177,25 +177,23 @@ export default class ProblemHistogram extends Vue {
   get tags(): string[] {
     return this.type === 'quality'
       ? [
-          this.T.qualityFormQualityVeryGood,
-          this.T.qualityFormQualityGood,
-          this.T.qualityFormQualityFair,
-          this.T.qualityFormQualityBad,
-          this.T.qualityFormQualityVeryBad,
+          T.qualityFormQualityVeryGood,
+          T.qualityFormQualityGood,
+          T.qualityFormQualityFair,
+          T.qualityFormQualityBad,
+          T.qualityFormQualityVeryBad,
         ]
       : [
-          this.T.qualityFormDifficultyVeryEasy,
-          this.T.qualityFormDifficultyEasy,
-          this.T.qualityFormDifficultyMedium,
-          this.T.qualityFormDifficultyHard,
-          this.T.qualityFormDifficultyVeryHard,
+          T.qualityFormDifficultyVeryEasy,
+          T.qualityFormDifficultyEasy,
+          T.qualityFormDifficultyMedium,
+          T.qualityFormDifficultyHard,
+          T.qualityFormDifficultyVeryHard,
         ];
   }
 
   get title(): string {
-    return this.type === 'quality'
-      ? this.T.wordsQuality
-      : this.T.wordsDifficulty;
+    return this.type === 'quality' ? T.wordsQuality : T.wordsDifficulty;
   }
 
   get customHistogram(): number[] {

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -134,7 +134,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import { types } from '../../api_types';
 import UI from '../../ui.js';
 import common_Paginator from '../common/Paginator.vue';

--- a/frontend/www/js/omegaup/components/problem/Mine.vue
+++ b/frontend/www/js/omegaup/components/problem/Mine.vue
@@ -122,7 +122,8 @@
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import common_Paginator from '../common/Paginator.vue';
-import { omegaup, T } from '../../omegaup.js';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import { types } from '../../api_types';
 
 @Component({

--- a/frontend/www/js/omegaup/components/problem/Solution.vue
+++ b/frontend/www/js/omegaup/components/problem/Solution.vue
@@ -56,7 +56,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/problem/StatementEdit.vue
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.vue
@@ -83,7 +83,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/problem/Versions.vue
+++ b/frontend/www/js/omegaup/components/problem/Versions.vue
@@ -169,7 +169,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 interface RunsDiff {

--- a/frontend/www/js/omegaup/components/qualitynomination/DemotionPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/DemotionPopup.vue
@@ -130,7 +130,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/qualitynomination/Details.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/Details.vue
@@ -108,7 +108,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 interface QualityNominationContents {
   original: string;

--- a/frontend/www/js/omegaup/components/qualitynomination/List.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.vue
@@ -78,7 +78,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/qualitynomination/Popup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/Popup.vue
@@ -228,7 +228,7 @@ label.tag-select:hover {
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 interface ProblemTag {

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
@@ -70,7 +70,7 @@
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import Popup from './Popup.vue';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component({

--- a/frontend/www/js/omegaup/components/schools/Chart.vue
+++ b/frontend/www/js/omegaup/components/schools/Chart.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 export default {

--- a/frontend/www/js/omegaup/components/schools/Intro.vue
+++ b/frontend/www/js/omegaup/components/schools/Intro.vue
@@ -64,7 +64,7 @@ body {
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import { T } from '../../omegaup';
+import T from '../../lang';
 
 @Component({})
 export default class Intro extends Vue {

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -95,7 +95,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import CountryFlag from '../CountryFlag.vue';
 import SchoolChart from './Chart.vue';

--- a/frontend/www/js/omegaup/components/schools/Rank.vue
+++ b/frontend/www/js/omegaup/components/schools/Rank.vue
@@ -91,7 +91,8 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import CountryFlag from '../CountryFlag.vue';
 

--- a/frontend/www/js/omegaup/components/schools/SchoolOfTheMonth.vue
+++ b/frontend/www/js/omegaup/components/schools/SchoolOfTheMonth.vue
@@ -147,7 +147,8 @@ table.school-of-the-month-table > tbody > tr > td {
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import country_Flag from '../CountryFlag.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/submissions/List.vue
+++ b/frontend/www/js/omegaup/components/submissions/List.vue
@@ -178,7 +178,8 @@ table.submissions-table > tbody > tr > td {
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 import UserName from '../user/Username.vue';
 import Autocomplete from '../Autocomplete.vue';

--- a/frontend/www/js/omegaup/components/user/BasicEdit.vue
+++ b/frontend/www/js/omegaup/components/user/BasicEdit.vue
@@ -65,7 +65,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/user/BasicInfo.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInfo.vue
@@ -112,7 +112,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import user_Username from './Username.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/user/Charts.vue
+++ b/frontend/www/js/omegaup/components/user/Charts.vue
@@ -47,7 +47,8 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { Chart } from 'highcharts-vue';
 import * as Highcharts from 'highcharts';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 interface Data {

--- a/frontend/www/js/omegaup/components/user/EmailEdit.vue
+++ b/frontend/www/js/omegaup/components/user/EmailEdit.vue
@@ -39,7 +39,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class UserEmailEdit extends Vue {

--- a/frontend/www/js/omegaup/components/user/ManageIdentities.vue
+++ b/frontend/www/js/omegaup/components/user/ManageIdentities.vue
@@ -70,7 +70,8 @@ th.align-right {
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 
 @Component
 export default class UserManageIdentities extends Vue {

--- a/frontend/www/js/omegaup/components/user/PrivacyPolicy.vue
+++ b/frontend/www/js/omegaup/components/user/PrivacyPolicy.vue
@@ -31,7 +31,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { T } from '../../omegaup';
+import T from '../../lang';
 import UI from '../../ui.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/user/Profile.vue
+++ b/frontend/www/js/omegaup/components/user/Profile.vue
@@ -118,7 +118,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, T } from '../../omegaup';
+import { omegaup } from '../../omegaup';
+import T from '../../lang';
 import { Chart } from 'highcharts-vue';
 import user_BasicInfo from './BasicInfo.vue';
 import user_Username from './Username.vue';

--- a/frontend/www/js/omegaup/contest/edit.js
+++ b/frontend/www/js/omegaup/contest/edit.js
@@ -1,4 +1,7 @@
-import { OmegaUp, UI, API, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import contest_Edit from '../components/contest/Edit.vue';
 

--- a/frontend/www/js/omegaup/contest/list.js
+++ b/frontend/www/js/omegaup/contest/list.js
@@ -1,5 +1,8 @@
 import contest_ContestList from '../components/contest/ContestList.vue';
-import { API, OmegaUp, UI, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import * as CSV from '../../../third_party/js/csv.js/csv.js';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/contest/list_participant.js
+++ b/frontend/www/js/omegaup/contest/list_participant.js
@@ -1,5 +1,6 @@
 import contest_List from '../components/contest/ContestList.vue';
-import { OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/contest/report.js
+++ b/frontend/www/js/omegaup/contest/report.js
@@ -1,5 +1,5 @@
 import contest_Report from '../components/contest/Report.vue';
-import { OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/contest/scoreboardmerge.js
+++ b/frontend/www/js/omegaup/contest/scoreboardmerge.js
@@ -1,5 +1,7 @@
 import contest_ScoreboardMerge from '../components/contest/ScoreboardMerge.vue';
-import { UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import UI from '../ui.js';
 import * as api from '../api_transitional';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/details.js
+++ b/frontend/www/js/omegaup/course/details.js
@@ -1,5 +1,8 @@
 import course_Details from '../components/course/CourseDetails.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -5,7 +5,10 @@ import course_AssignmentList from '../components/course/AssignmentList.vue';
 import course_Form from '../components/course/Form.vue';
 import course_ProblemList from '../components/course/ProblemList.vue';
 import course_Clone from '../components/course/Clone.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import Sortable from 'sortablejs';
 

--- a/frontend/www/js/omegaup/course/intro.js
+++ b/frontend/www/js/omegaup/course/intro.js
@@ -1,4 +1,6 @@
-import { API, UI, OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 import course_Intro from '../components/course/Intro.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/list.js
+++ b/frontend/www/js/omegaup/course/list.js
@@ -1,5 +1,8 @@
 import course_List from '../components/course/List.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/course/new.js
+++ b/frontend/www/js/omegaup/course/new.js
@@ -1,5 +1,8 @@
 import course_Form from '../components/course/Form.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/course/scoreboard.js
+++ b/frontend/www/js/omegaup/course/scoreboard.js
@@ -1,5 +1,7 @@
 import { Arena } from '../arena/arena.js';
-import { API, UI, OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(

--- a/frontend/www/js/omegaup/course/student.js
+++ b/frontend/www/js/omegaup/course/student.js
@@ -1,5 +1,8 @@
 import course_ViewStudent from '../components/course/ViewStudent.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/course/students.js
+++ b/frontend/www/js/omegaup/course/students.js
@@ -1,5 +1,8 @@
 import course_ViewProgress from '../components/course/ViewProgress.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/course/submissions_list.js
+++ b/frontend/www/js/omegaup/course/submissions_list.js
@@ -1,5 +1,8 @@
 import course_SubmissionsList from '../components/activity/SubmissionsList.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 let course_alias = /\/course\/([^\/]+)\/list\/?/.exec(

--- a/frontend/www/js/omegaup/errors.ts
+++ b/frontend/www/js/omegaup/errors.ts
@@ -1,13 +1,15 @@
+import T from './lang';
+
 const _errors: Array<any> = [];
 
 export function addError(error: any): void {
   _errors.push(error);
 }
 
-export function reportAnIssueURL(reportAnIssueTemplate: string): string {
+export function reportAnIssueURL(): string {
   // Not using UI.formatString() to avoid creating a circular
   // dependency.
-  const issueBody = reportAnIssueTemplate
+  const issueBody = T.reportAnIssueTemplate
     .replace(
       '%(userAgent)',
       window && window.navigator ? window.navigator.userAgent : '(null)',

--- a/frontend/www/js/omegaup/group/identities.js
+++ b/frontend/www/js/omegaup/group/identities.js
@@ -1,5 +1,8 @@
 import group_Identities from '../components/group/Identities.vue';
-import { API, OmegaUp, UI, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import * as CSV from '../../../third_party/js/csv.js/csv.js';
 

--- a/frontend/www/js/omegaup/group/list.js
+++ b/frontend/www/js/omegaup/group/list.js
@@ -1,5 +1,5 @@
 import group_GroupList from '../components/group/GroupList.vue';
-import { OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/group/members.js
+++ b/frontend/www/js/omegaup/group/members.js
@@ -1,5 +1,8 @@
 import group_Members from '../components/group/Members.vue';
-import { OmegaUp, UI, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
+import UI from '../ui.js';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/lang.ts
+++ b/frontend/www/js/omegaup/lang.ts
@@ -1,0 +1,27 @@
+import * as lang_en from './lang.en';
+import * as lang_es from './lang.es';
+import * as lang_pt from './lang.pt';
+import * as lang_pseudo from './lang.pseudo';
+
+const T = (function() {
+  const head =
+    (document && document.querySelector && document.querySelector('head')) ||
+    null;
+
+  switch ((head && head.dataset && head.dataset.locale) || 'es') {
+    case 'pseudo':
+      return lang_pseudo.default;
+
+    case 'pt':
+      return lang_pt.default;
+
+    case 'en':
+      return lang_en.default;
+
+    case 'es':
+    default:
+      return lang_es.default;
+  }
+})();
+
+export { T as default };

--- a/frontend/www/js/omegaup/notification/list.js
+++ b/frontend/www/js/omegaup/notification/list.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import notifications_List from '../components/notification/List.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -1,5 +1,6 @@
-import { Experiments, EventListenerList, OmegaUp, T, UI } from './omegaup.ts';
+import { Experiments, EventListenerList, OmegaUp, UI } from './omegaup.ts';
 import API from './api.js';
+import T from './lang';
 export { API, EventListenerList, Experiments, OmegaUp, T, UI };
 
 if (

--- a/frontend/www/js/omegaup/omegaup.ts
+++ b/frontend/www/js/omegaup/omegaup.ts
@@ -1,8 +1,3 @@
-import * as lang_en from './lang.en';
-import * as lang_es from './lang.es';
-import * as lang_pt from './lang.pt';
-import * as lang_pseudo from './lang.pseudo';
-
 import UI from './ui.js';
 import * as api from './api_transitional';
 import * as errors from './errors';
@@ -67,28 +62,6 @@ export class EventListenerList {
     this.listenerList.push(listener);
   }
 }
-
-// Translation strings.
-export const T = (function() {
-  const head =
-    (document && document.querySelector && document.querySelector('head')) ||
-    null;
-
-  switch ((head && head.dataset && head.dataset.locale) || 'es') {
-    case 'pseudo':
-      return lang_pseudo.default;
-
-    case 'pt':
-      return lang_pt.default;
-
-    case 'en':
-      return lang_en.default;
-
-    case 'es':
-    default:
-      return lang_es.default;
-  }
-})();
 
 export namespace omegaup {
   export interface Selectable<T> {

--- a/frontend/www/js/omegaup/problem/edit.js
+++ b/frontend/www/js/omegaup/problem/edit.js
@@ -1,7 +1,9 @@
 import Vue from 'vue';
 import problem_Versions from '../components/problem/Versions.vue';
 import problem_StatementEdit from '../components/problem/StatementEdit.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/problem/feedback.js
+++ b/frontend/www/js/omegaup/problem/feedback.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import problem_Feedback from '../components/problem/Feedback.vue';
-import { OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/problem/list.js
+++ b/frontend/www/js/omegaup/problem/list.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import problem_List from '../components/problem/List.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/problem/mine.js
+++ b/frontend/www/js/omegaup/problem/mine.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import problem_Mine from '../components/problem/Mine.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', () => {

--- a/frontend/www/js/omegaup/problem/solution.js
+++ b/frontend/www/js/omegaup/problem/solution.js
@@ -1,4 +1,6 @@
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 import problem_Solution from '../components/problem/Solution.vue';
 import Vue from 'vue';

--- a/frontend/www/js/omegaup/qualitynomination/details.js
+++ b/frontend/www/js/omegaup/qualitynomination/details.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import qualitynomination_Details from '../components/qualitynomination/Details.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/qualitynomination/list.js
+++ b/frontend/www/js/omegaup/qualitynomination/list.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import qualitynomination_List from '../components/qualitynomination/List.vue';
-import { API, UI, OmegaUp } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/ranktable.js
+++ b/frontend/www/js/omegaup/ranktable.js
@@ -1,6 +1,6 @@
 import rank_table from './components/RankTable.vue';
 import Vue from 'vue';
-import { OmegaUp } from './omegaup.js';
+import { OmegaUp } from './omegaup';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(

--- a/frontend/www/js/omegaup/schools/intro.js
+++ b/frontend/www/js/omegaup/schools/intro.js
@@ -1,6 +1,9 @@
 import Vue from 'vue';
 import schools_Intro from '../components/schools/Intro.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 
 OmegaUp.on('ready', function() {
   var viewProgress = new Vue({

--- a/frontend/www/js/omegaup/schools/profile.js
+++ b/frontend/www/js/omegaup/schools/profile.js
@@ -1,5 +1,7 @@
 import Vue from 'vue';
-import { API, OmegaUp, UI } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 import school_Profile from '../components/schools/Profile.vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/schools/rank.js
+++ b/frontend/www/js/omegaup/schools/rank.js
@@ -1,5 +1,8 @@
 import schools_Rank from '../components/schools/Rank.vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/schools/schoolofthemonth.js
+++ b/frontend/www/js/omegaup/schools/schoolofthemonth.js
@@ -1,4 +1,7 @@
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 import Vue from 'vue';
 import schoolOfTheMonth from '../components/schools/SchoolOfTheMonth.vue';
 

--- a/frontend/www/js/omegaup/submissions/list.js
+++ b/frontend/www/js/omegaup/submissions/list.js
@@ -1,5 +1,7 @@
 import Vue from 'vue';
-import { API, OmegaUp, UI } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
 import submissions_List from '../components/submissions/List.vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -1,5 +1,5 @@
 import API from './api.js';
-import { T } from './omegaup.js';
+import T from './lang';
 import * as moment from 'moment';
 
 let UI = {

--- a/frontend/www/js/omegaup/user/basicedit.js
+++ b/frontend/www/js/omegaup/user/basicedit.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import user_BasicEdit from '../components/user/BasicEdit.vue';
-import { OmegaUp, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
 
 OmegaUp.on('ready', function() {
   let basicEdit = new Vue({

--- a/frontend/www/js/omegaup/user/emailedit.js
+++ b/frontend/www/js/omegaup/user/emailedit.js
@@ -1,6 +1,7 @@
 import user_EmailEdit from '../components/user/EmailEdit.vue';
 import Vue from 'vue';
-import { OmegaUp, UI } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/user/manage_identities.js
+++ b/frontend/www/js/omegaup/user/manage_identities.js
@@ -1,6 +1,9 @@
 import user_ManageIdentities from '../components/user/ManageIdentities.vue';
 import Vue from 'vue';
-import { API, UI, OmegaUp, T } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import API from '../api.js';
+import UI from '../ui.js';
+import T from '../lang';
 
 OmegaUp.on('ready', function() {
   let manageIdentities = new Vue({

--- a/frontend/www/js/omegaup/user/privacy_policy.js
+++ b/frontend/www/js/omegaup/user/privacy_policy.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import user_Privacy_Policy from '../components/user/PrivacyPolicy.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/user/profile.js
+++ b/frontend/www/js/omegaup/user/profile.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import user_Profile from '../components/user/Profile.vue';
-import { OmegaUp, T, API } from '../omegaup.js';
+import { OmegaUp } from '../omegaup';
+import T from '../lang';
+import API from '../api.js';
 import UI from '../ui.js';
 
 OmegaUp.on('ready', function() {


### PR DESCRIPTION
Este cambio hace que `omegaup.ts` deje de exportar `T`. En vez, ahora `T`
se exporta desde `lang.ts`.