### PR TITLE
Convirtiendo casi todo ui.js a TypeScript

### DIFF
--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -549,6 +549,7 @@ export function apiCall<
         .then(data => {
           if (!responseOk) {
             addError(data);
+            console.error(data);
             reject(data);
             return;
           }
@@ -561,6 +562,7 @@ export function apiCall<
         .catch(err => {
           const errorData = { status: 'error', error: err };
           addError(errorData);
+          console.error(errorData);
           reject(errorData);
         });
     });

--- a/frontend/www/js/omegaup/activity/feed.js
+++ b/frontend/www/js/omegaup/activity/feed.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import activity_Feed from '../components/activity/Feed.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   let match = /\/([^\/]+)\/([^\/]+)\/activity\/?.*/.exec(

--- a/frontend/www/js/omegaup/admin/roles.js
+++ b/frontend/www/js/omegaup/admin/roles.js
@@ -1,7 +1,7 @@
 import user_Roles from '../components/admin/Roles.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/admin/support.js
+++ b/frontend/www/js/omegaup/admin/support.js
@@ -1,7 +1,7 @@
 import admin_Support from '../components/admin/Support.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/admin/user.js
+++ b/frontend/www/js/omegaup/admin/user.js
@@ -1,7 +1,7 @@
 import admin_User from '../components/admin/User.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/api.js
+++ b/frontend/www/js/omegaup/api.js
@@ -1,4 +1,3 @@
-import UI from './ui.js';
 import * as types from './types.ts';
 import { OmegaUp } from './omegaup';
 import * as api from './api_transitional';

--- a/frontend/www/js/omegaup/api_transitional.ts
+++ b/frontend/www/js/omegaup/api_transitional.ts
@@ -46,6 +46,7 @@ export function apiCall<
         .then(data => {
           if (!responseOk) {
             addError(data);
+            console.error(data);
             reject(data);
             return;
           }
@@ -58,6 +59,7 @@ export function apiCall<
         .catch(err => {
           const errorData = { status: 'error', error: err };
           addError(errorData);
+          console.error(errorData);
           reject(errorData);
         });
     });

--- a/frontend/www/js/omegaup/arena/admin_arena.js
+++ b/frontend/www/js/omegaup/arena/admin_arena.js
@@ -1,6 +1,6 @@
 import API from '../api.js';
 import * as api from '../api_transitional';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 export default class ArenaAdmin {
   constructor(arena) {

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -12,7 +12,7 @@ import arena_Navbar_Problems from '../components/arena/NavbarProblems.vue';
 import arena_Navbar_Assignments from '../components/arena/NavbarAssignments.vue';
 import arena_Navbar_Miniranking from '../components/arena/NavbarMiniranking.vue';
 import common_Navbar from '../components/common/Navbar.vue';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import Vue from 'vue';
 import * as ko from 'knockout';
 import * as secureBindingsProvider from 'knockout-secure-binding';

--- a/frontend/www/js/omegaup/arena/contest_list.js
+++ b/frontend/www/js/omegaup/arena/contest_list.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import arena_ContestList from '../components/arena/ContestList.vue';

--- a/frontend/www/js/omegaup/arena/qualitynomination_demotionpopup.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_demotionpopup.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import qualitynomination_demotionPopup from '../components/qualitynomination/DemotionPopup.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/arena/qualitynomination_popup.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_popup.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import qualitynomination_Popup from '../components/qualitynomination/Popup.vue';
 import Vue from 'vue';

--- a/frontend/www/js/omegaup/arena/qualitynomination_qualityreview.js
+++ b/frontend/www/js/omegaup/arena/qualitynomination_qualityreview.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import qualitynomination_ReviewerPopup from '../components/qualitynomination/ReviewerPopup.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/arena/virtual.js
+++ b/frontend/www/js/omegaup/arena/virtual.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import arena_virtual from '../components/arena/Virtual.vue';

--- a/frontend/www/js/omegaup/badge/details.js
+++ b/frontend/www/js/omegaup/badge/details.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import badge_Details from '../components/badge/Details.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/badge/list.js
+++ b/frontend/www/js/omegaup/badge/list.js
@@ -3,7 +3,7 @@ import badge_List from '../components/badge/List.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/coderofthemonth/index.js
+++ b/frontend/www/js/omegaup/coderofthemonth/index.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import coderofthemonth_List from '../components/coderofthemonth/List.vue';

--- a/frontend/www/js/omegaup/common/index.js
+++ b/frontend/www/js/omegaup/common/index.js
@@ -1,7 +1,7 @@
 import common_Index from '../components/common/Index.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/common/navbar.js
+++ b/frontend/www/js/omegaup/common/navbar.js
@@ -3,7 +3,7 @@ import { OmegaUp } from '../omegaup';
 import * as api from '../api_transitional';
 import API from '../api.js';
 import T from '../lang';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/common/stats.js
+++ b/frontend/www/js/omegaup/common/stats.js
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   Highcharts.setOptions({ global: { useUTC: false } });

--- a/frontend/www/js/omegaup/components/DatePicker.vue
+++ b/frontend/www/js/omegaup/components/DatePicker.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
 import T from '../lang';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import '../../../third_party/js/bootstrap-datepicker.js';
 
 @Component

--- a/frontend/www/js/omegaup/components/DateTimePicker.vue
+++ b/frontend/www/js/omegaup/components/DateTimePicker.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
 import T from '../lang';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import '../../../third_party/js/bootstrap-datetimepicker.min.js';
 import '../../../third_party/js/locales/bootstrap-datetimepicker.es.js';
 import '../../../third_party/js/locales/bootstrap-datetimepicker.pt-BR.js';

--- a/frontend/www/js/omegaup/components/RankTable.vue
+++ b/frontend/www/js/omegaup/components/RankTable.vue
@@ -121,7 +121,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import Autocomplete from './Autocomplete.vue';
 import CountryFlag from './CountryFlag.vue';
 import user_Username from './user/Username.vue';

--- a/frontend/www/js/omegaup/components/activity/Feed.vue
+++ b/frontend/www/js/omegaup/components/activity/Feed.vue
@@ -153,7 +153,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import user_Username from '../user/Username.vue';
 
 interface Mapping {

--- a/frontend/www/js/omegaup/components/admin/Support.vue
+++ b/frontend/www/js/omegaup/components/admin/Support.vue
@@ -128,7 +128,7 @@
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class AdminSupport extends Vue {

--- a/frontend/www/js/omegaup/components/arena/CodeView.vue
+++ b/frontend/www/js/omegaup/components/arena/CodeView.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import { codemirror } from 'vue-codemirror-lite';
 
 const languageModeMap: {

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -155,7 +155,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class ArenaScoreboard extends Vue {

--- a/frontend/www/js/omegaup/components/arena/Virtual.vue
+++ b/frontend/www/js/omegaup/components/arena/Virtual.vue
@@ -52,7 +52,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import DateTimePicker from '../DateTimePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/badge/Details.vue
+++ b/frontend/www/js/omegaup/components/badge/Details.vue
@@ -92,7 +92,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class BadgeDetails extends Vue {

--- a/frontend/www/js/omegaup/components/coderofthemonth/Notice.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/Notice.vue
@@ -7,7 +7,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class CoderOfTheMonthNotice extends Vue {

--- a/frontend/www/js/omegaup/components/common/GraderBadge.vue
+++ b/frontend/www/js/omegaup/components/common/GraderBadge.vue
@@ -32,8 +32,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import T from '../../lang';
-import UI from '../../ui.js';
 
 @Component
 export default class GraderCountBadge extends Vue {

--- a/frontend/www/js/omegaup/components/common/GraderStatus.vue
+++ b/frontend/www/js/omegaup/components/common/GraderStatus.vue
@@ -66,7 +66,7 @@ ul {
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class GraderStatus extends Vue {

--- a/frontend/www/js/omegaup/components/common/Stats.vue
+++ b/frontend/www/js/omegaup/components/common/Stats.vue
@@ -16,7 +16,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import { Chart } from 'highcharts-vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/contest/AddProblem.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblem.vue
@@ -130,7 +130,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 import problem_Versions from '../problem/Versions.vue';
 

--- a/frontend/www/js/omegaup/components/contest/Admins.vue
+++ b/frontend/www/js/omegaup/components/contest/Admins.vue
@@ -57,7 +57,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 import user_Username from '../user/Username.vue';
 

--- a/frontend/www/js/omegaup/components/contest/Clone.vue
+++ b/frontend/www/js/omegaup/components/contest/Clone.vue
@@ -54,7 +54,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import DateTime from '../DateTimePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/contest/ContestList.vue
+++ b/frontend/www/js/omegaup/components/contest/ContestList.vue
@@ -174,7 +174,7 @@
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class List extends Vue {

--- a/frontend/www/js/omegaup/components/contest/Contestant.vue
+++ b/frontend/www/js/omegaup/components/contest/Contestant.vue
@@ -90,7 +90,7 @@ import { Vue, Component, Emit, Prop } from 'vue-property-decorator';
 
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 import DateTimePicker from '../DateTimePicker.vue';
 import user_Username from '../user/Username.vue';

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -163,7 +163,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup, OmegaUp } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import contest_AddProblem from './AddProblem.vue';
 import contest_Admins from './Admins.vue';
 import contest_Clone from './Clone.vue';

--- a/frontend/www/js/omegaup/components/contest/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/contest/FilteredList.vue
@@ -93,7 +93,7 @@
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class FilteredList extends Vue {

--- a/frontend/www/js/omegaup/components/contest/GroupAdmins.vue
+++ b/frontend/www/js/omegaup/components/contest/GroupAdmins.vue
@@ -48,7 +48,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/contest/Groups.vue
+++ b/frontend/www/js/omegaup/components/contest/Groups.vue
@@ -41,7 +41,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/contest/Report.vue
+++ b/frontend/www/js/omegaup/components/contest/Report.vue
@@ -77,7 +77,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 interface ContestReport {
   country?: string;

--- a/frontend/www/js/omegaup/components/contest/ScoreboardMerge.vue
+++ b/frontend/www/js/omegaup/components/contest/ScoreboardMerge.vue
@@ -101,7 +101,7 @@
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class ScoreboardMerge extends Vue {

--- a/frontend/www/js/omegaup/components/course/AddStudents.vue
+++ b/frontend/www/js/omegaup/components/course/AddStudents.vue
@@ -87,7 +87,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/Administrators.vue
+++ b/frontend/www/js/omegaup/components/course/Administrators.vue
@@ -155,7 +155,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/CourseDetails.vue
+++ b/frontend/www/js/omegaup/components/course/CourseDetails.vue
@@ -184,7 +184,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { OmegaUp, omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import { types } from '../../api_types';
 
 @Component

--- a/frontend/www/js/omegaup/components/course/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/course/FilteredList.vue
@@ -80,7 +80,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class CourseFilteredList extends Vue {

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -234,7 +234,7 @@
 import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import DatePicker from '../DatePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/Intro.vue
+++ b/frontend/www/js/omegaup/components/course/Intro.vue
@@ -70,7 +70,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 interface Statement {
   [name: string]: {

--- a/frontend/www/js/omegaup/components/course/List.vue
+++ b/frontend/www/js/omegaup/components/course/List.vue
@@ -32,7 +32,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import course_FilteredList from './FilteredList.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -182,7 +182,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import Autocomplete from '../Autocomplete.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/course/ViewStudent.vue
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.vue
@@ -92,7 +92,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class CourseViewStudent extends Vue {

--- a/frontend/www/js/omegaup/components/group/Identities.vue
+++ b/frontend/www/js/omegaup/components/group/Identities.vue
@@ -72,7 +72,7 @@
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class Identities extends Vue {

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -120,7 +120,7 @@ label {
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import user_Username from '../user/Username.vue';
 import identity_Edit from '../identity/Edit.vue';
 import identity_ChangePassword from '../identity/ChangePassword.vue';

--- a/frontend/www/js/omegaup/components/notification/Notification.vue
+++ b/frontend/www/js/omegaup/components/notification/Notification.vue
@@ -60,7 +60,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class Notification extends Vue {

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -137,7 +137,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import { types } from '../../api_types';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import common_Paginator from '../common/Paginator.vue';
 import problem_FinderWizard from './FinderWizard.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Solution.vue
+++ b/frontend/www/js/omegaup/components/problem/Solution.vue
@@ -57,7 +57,7 @@
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class ProblemSolution extends Vue {

--- a/frontend/www/js/omegaup/components/problem/StatementEdit.vue
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.vue
@@ -85,7 +85,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class ProblemStatementEdit extends Vue {

--- a/frontend/www/js/omegaup/components/problem/Versions.vue
+++ b/frontend/www/js/omegaup/components/problem/Versions.vue
@@ -171,7 +171,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 interface RunsDiff {
   guid: string;

--- a/frontend/www/js/omegaup/components/qualitynomination/DemotionPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/DemotionPopup.vue
@@ -131,7 +131,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class QualityNominationDemotionPopup extends Vue {

--- a/frontend/www/js/omegaup/components/qualitynomination/List.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.vue
@@ -80,7 +80,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class QualityNominationList extends Vue {

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
@@ -71,7 +71,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import Popup from './Popup.vue';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component({
   components: {

--- a/frontend/www/js/omegaup/components/schools/Chart.vue
+++ b/frontend/www/js/omegaup/components/schools/Chart.vue
@@ -6,7 +6,7 @@
 
 <script>
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 export default {
   props: {

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -97,7 +97,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import CountryFlag from '../CountryFlag.vue';
 import SchoolChart from './Chart.vue';
 import GridPaginator from '../GridPaginator.vue';

--- a/frontend/www/js/omegaup/components/schools/Rank.vue
+++ b/frontend/www/js/omegaup/components/schools/Rank.vue
@@ -93,7 +93,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import CountryFlag from '../CountryFlag.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/submissions/List.vue
+++ b/frontend/www/js/omegaup/components/submissions/List.vue
@@ -180,7 +180,7 @@ table.submissions-table > tbody > tr > td {
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 import UserName from '../user/Username.vue';
 import Autocomplete from '../Autocomplete.vue';
 

--- a/frontend/www/js/omegaup/components/user/BasicEdit.vue
+++ b/frontend/www/js/omegaup/components/user/BasicEdit.vue
@@ -66,7 +66,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class UserBasicEdit extends Vue {

--- a/frontend/www/js/omegaup/components/user/Charts.vue
+++ b/frontend/www/js/omegaup/components/user/Charts.vue
@@ -49,7 +49,7 @@ import { Chart } from 'highcharts-vue';
 import * as Highcharts from 'highcharts';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 interface Data {
   runs: omegaup.RunInfo[];

--- a/frontend/www/js/omegaup/components/user/PrivacyPolicy.vue
+++ b/frontend/www/js/omegaup/components/user/PrivacyPolicy.vue
@@ -32,7 +32,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import UI from '../../ui.js';
+import * as UI from '../../ui';
 
 @Component
 export default class UserPrivacyPolicy extends Vue {

--- a/frontend/www/js/omegaup/contest/edit.js
+++ b/frontend/www/js/omegaup/contest/edit.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import contest_Edit from '../components/contest/Edit.vue';

--- a/frontend/www/js/omegaup/contest/list.js
+++ b/frontend/www/js/omegaup/contest/list.js
@@ -1,7 +1,7 @@
 import contest_ContestList from '../components/contest/ContestList.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import * as CSV from '../../../third_party/js/csv.js/csv.js';
 import Vue from 'vue';

--- a/frontend/www/js/omegaup/contest/scoreboardmerge.js
+++ b/frontend/www/js/omegaup/contest/scoreboardmerge.js
@@ -1,7 +1,7 @@
 import contest_ScoreboardMerge from '../components/contest/ScoreboardMerge.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import * as api from '../api_transitional';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/details.js
+++ b/frontend/www/js/omegaup/course/details.js
@@ -1,7 +1,7 @@
 import course_Details from '../components/course/CourseDetails.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -7,7 +7,7 @@ import course_ProblemList from '../components/course/ProblemList.vue';
 import course_Clone from '../components/course/Clone.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import Sortable from 'sortablejs';

--- a/frontend/www/js/omegaup/course/intro.js
+++ b/frontend/www/js/omegaup/course/intro.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import course_Intro from '../components/course/Intro.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/list.js
+++ b/frontend/www/js/omegaup/course/list.js
@@ -1,7 +1,7 @@
 import course_List from '../components/course/List.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/new.js
+++ b/frontend/www/js/omegaup/course/new.js
@@ -1,7 +1,7 @@
 import course_Form from '../components/course/Form.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/scoreboard.js
+++ b/frontend/www/js/omegaup/course/scoreboard.js
@@ -1,7 +1,7 @@
 import { Arena } from '../arena/arena.js';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(

--- a/frontend/www/js/omegaup/course/student.js
+++ b/frontend/www/js/omegaup/course/student.js
@@ -1,7 +1,7 @@
 import course_ViewStudent from '../components/course/ViewStudent.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/students.js
+++ b/frontend/www/js/omegaup/course/students.js
@@ -1,7 +1,7 @@
 import course_ViewProgress from '../components/course/ViewProgress.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/course/submissions_list.js
+++ b/frontend/www/js/omegaup/course/submissions_list.js
@@ -1,7 +1,7 @@
 import course_SubmissionsList from '../components/activity/SubmissionsList.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/group/identities.js
+++ b/frontend/www/js/omegaup/group/identities.js
@@ -1,7 +1,7 @@
 import group_Identities from '../components/group/Identities.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import * as CSV from '../../../third_party/js/csv.js/csv.js';

--- a/frontend/www/js/omegaup/group/members.js
+++ b/frontend/www/js/omegaup/group/members.js
@@ -2,7 +2,7 @@ import group_Members from '../components/group/Members.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -1,0 +1,435 @@
+import T from './lang';
+
+export type ProblemSettings = any;
+
+declare namespace Markdown {
+  export type ImageMapping = {
+    [url: string]: string;
+  };
+
+  export interface Hooks {
+    chain: (eventName: string, callback: any) => void;
+  }
+
+  export interface Converter {
+    hooks: Markdown.Hooks;
+    _settings?: ProblemSettings;
+    _imageMapping?: Markdown.ImageMapping;
+
+    makeHtml: (markdown: string) => string;
+    makeHtmlWithImages: (
+      markdown: string,
+      imageMapping: Markdown.ImageMapping,
+      settings: ProblemSettings,
+    ) => string;
+  }
+
+  function getSanitizingConverter(): Markdown.Converter;
+}
+
+export function markdownConverter(
+  options: {
+    preview?: boolean;
+    settings?: ProblemSettings;
+    imageMapping?: Markdown.ImageMapping;
+  } = {},
+) {
+  // Map of templates.
+  const templates: { [key: string]: string } = {};
+  if (options.preview) {
+    templates['libinteractive:download'] =
+      '<code class="libinteractive-download">' +
+      '<i class="glyphicon glyphicon-download-alt"></i></code>';
+  } else {
+    templates[
+      'libinteractive:download'
+    ] = `<div class="libinteractive-download panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          ${T.libinteractiveTitle}
+          <a class="libinteractive-help" target="_blank" href="/libinteractive/${T.locale}/contest/"><span class="glyphicon glyphicon-question-sign"></span></a>
+        </h3>
+      </div>
+      <div class="panel-body">
+        <form role="form">
+          <div class="form-horizontal">
+            <div class="form-group">
+              <div class="col-sm-10">
+                <label class="col-sm-2 control-label">${T.libinteractiveOs}</label>
+                <select class="form-control download-os">
+                  <option value="unix">Linux/Mac OS X</option>
+                  <option value="windows">Windows</option>
+                </select>
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="col-sm-10">
+                <label class="col-sm-2 control-label">${T.libinteractiveLanguage}</label>
+                <select class="form-control download-lang">
+                  <option value="c" selected="selected">C</option>
+                  <option value="cpp">C++</option>
+                  <option value="java">Java</option>
+                  <option value="py">Python</option>
+                  <option value="pas">Pascal</option>
+                </select>
+              </div>
+            </div>
+            <div class="form-group">
+              <strong class="col-sm-2 control-label">${T.libinteractiveFilename}</strong>
+              <div class="col-sm-10">
+                <span class="libinteractive-interface-name"></span>.<span class="libinteractive-extension">c</span>
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="col-sm-offset-2 col-sm-10">
+                <button type="submit" class="btn btn-primary active">
+                  ${T.libinteractiveDownload}
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>`;
+  }
+
+  const converter = Markdown.getSanitizingConverter();
+  const whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|figure|figcaption|code|i|table|tbody|thead|tr|th(?: align="\w+")?|td(?: align="\w+")?|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
+  const imageWhitelist = new RegExp(
+    '^<img\\ssrc="data:image/[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$',
+    'i',
+  );
+
+  converter.hooks.chain(
+    'isValidTag',
+    (tag: string): boolean =>
+      tag.match(whitelist) != null || tag.match(imageWhitelist) != null,
+  );
+
+  // These two functions are adapted from Markdown.Converter.js. They are
+  // needed to support images with some special characters in their name.
+  const escapeCharacters = (
+    text: string,
+    charsToEscape: string,
+    afterBackslash: boolean = false,
+    doNotEscapeTildeAndDollar: boolean = false,
+  ): string => {
+    // First we have to escape the escape characters so that
+    // we can build a character class out of them
+    let regexString = `([${charsToEscape.replace(/([\[\]\\])/g, '\\$1')}])`;
+
+    if (afterBackslash) {
+      regexString = `\\\\${regexString}`;
+    }
+
+    const regex = new RegExp(regexString, 'g');
+    if (!doNotEscapeTildeAndDollar) {
+      text = text.replace(/~/g, '~T').replace(/\$/g, '~D');
+    }
+    return text.replace(regex, (wholeMatch, m1) => `~E${m1.charCodeAt(0)}E`);
+  };
+  const unescapeCharacters = (text: string): string => {
+    //
+    // Swap back in all the special characters we've hidden.
+    //
+    return text
+      .replace(/~E(\d+)E/g, (wholeMatch: string, m1: string): string => {
+        const charCodeToReplace = parseInt(m1);
+        return String.fromCharCode(charCodeToReplace);
+      })
+      .replace(/~D/g, '$')
+      .replace(/~T/g, '~');
+  };
+
+  converter.hooks.chain('postSpanGamut', (text: string): string => {
+    // Templates.
+    text = text.replace(
+      /^\s*\{\{([a-z0-9_:]+)\}\}\s*$/g,
+      (wholematch: string, m1: string): string => {
+        if (templates.hasOwnProperty(m1)) {
+          return templates[m1];
+        }
+        return (
+          '<strong style="color: red">Unrecognized template name: ' +
+          m1 +
+          '</strong>'
+        );
+      },
+    );
+    // Images.
+    const imageMapping: Markdown.ImageMapping =
+      converter._imageMapping || options.imageMapping || {};
+    text = text.replace(
+      /<img src="([^"]+)"\s*([^>]+)>/g,
+      (wholeMatch: string, url: string, attributes: string): string => {
+        url = unescapeCharacters(url);
+        if (url.indexOf('/') != -1 || !imageMapping.hasOwnProperty(url)) {
+          return wholeMatch;
+        }
+        return `<img src="${escapeCharacters(
+          imageMapping[url],
+          '*_',
+        )}" ${attributes}>`;
+      },
+    );
+    // Figures.
+    text = text.replace(
+      /^\s*<img src="([^"]+)"\s*([^>]+)\s+title="([^"]+)"\s*\/>\s*$/g,
+      (wholeMatch: string, url: string, attributes: string, title: string) =>
+        `<figure><img src="${url}" ${attributes} />` +
+        `<figcaption>${title}</figcaption></figure>`,
+    );
+    return text;
+  });
+  converter.hooks.chain(
+    'postNormalization',
+    (text: string, blockGamut: (text: string) => string): string => {
+      // Sample I/O table.
+      let settings = converter._settings || options.settings || { cases: {} };
+      return text.replace(
+        /^( {0,3}\|\| *(?:input|examplefile) *\n(?:.|\n)+?\n) {0,3}\|\| *end *\n/gm,
+        (whole: string, inner: string): string => {
+          var matches = inner.split(
+            / {0,3}\|\| *(examplefile|input|output|description) *\n/,
+          );
+          var result = '';
+          var description_column = false;
+          for (var i = 1; i < matches.length; i += 2) {
+            if (matches[i] == 'description') {
+              description_column = true;
+              break;
+            }
+          }
+          result += '<thead><tr>';
+          result += `<th>${T.wordsInput}</th>`;
+          result += `<th>${T.wordsOutput}</th>`;
+          if (description_column) {
+            result += `<th>${T.wordsDescription}</th>`;
+          }
+          result += '</tr></thead>';
+          var first_row = true;
+          var columns = 0;
+          result += '<tbody>';
+          for (var i = 1; i < matches.length; i += 2) {
+            if (matches[i] == 'description') {
+              result += '<td>' + blockGamut(matches[i + 1]) + '</td>';
+              columns++;
+            } else {
+              if (matches[i] == 'input' || matches[i] == 'examplefile') {
+                if (!first_row) {
+                  while (columns < (description_column ? 3 : 2)) {
+                    result += '<td></td>';
+                    columns++;
+                  }
+                  result += '</tr>';
+                }
+                first_row = false;
+                result += '<tr>';
+                columns = 0;
+              }
+
+              if (matches[i] == 'examplefile') {
+                let exampleFilename = matches[i + 1].trim();
+                let exampleFile = {
+                  in: `{{examples/${exampleFilename}.in}}`,
+                  out: `{{examples/${exampleFilename}.out}}`,
+                };
+                if (settings.cases.hasOwnProperty(exampleFilename)) {
+                  exampleFile = settings.cases[exampleFilename];
+                }
+                result += `<td><pre>${exampleFile['in'].replace(
+                  /\s+$/,
+                  '',
+                )}</pre></td>`;
+                result += `<td><pre>${exampleFile.out.replace(
+                  /\s+$/,
+                  '',
+                )}</pre></td>`;
+                columns += 2;
+              } else {
+                result += `<td><pre>${escapeCharacters(
+                  matches[i + 1]
+                    .replace(/\s+$/, '')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;'),
+                  ' \t*_{}[]()<>#+=.!|`-',
+                  /*afterBackslash=*/ false,
+                  /*doNotEscapeTildeAnDollar=*/ true,
+                )}</pre></td>`;
+                columns++;
+              }
+            }
+          }
+          while (columns < (description_column ? 3 : 2)) {
+            result += '<td></td>';
+            columns++;
+          }
+          result += '</tr></tbody>';
+
+          return '<table class="sample_io">\n' + result + '\n</table>\n';
+        },
+      );
+    },
+  );
+  converter.hooks.chain(
+    'preBlockGamut',
+    (
+      text: string,
+      blockGamut: (text: string) => string,
+      spanGamut: (text: string) => string,
+    ): string => {
+      // GitHub-flavored fenced code blocks
+      const fencedCodeBlock = (
+        whole: string,
+        indentation: string,
+        fence: string,
+        infoString: string,
+        contents: string,
+      ) => {
+        contents = contents
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+        if (indentation != '') {
+          let lines = [];
+          let stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
+          for (let line of contents.split('\n')) {
+            lines.push(line.replace(stripPrefix, ''));
+          }
+          contents = escapeCharacters(
+            lines.join('\n'),
+            ' \t*_{}[]()<>#+=.!|`-',
+            /*afterBackslash=*/ false,
+            /*doNotEscapeTildeAnDollar=*/ true,
+          );
+        }
+        let className = '';
+        infoString = infoString.trim();
+        if (infoString != '') {
+          className = ` class="language-${infoString.split(/\s+/)[0]}"`;
+        }
+        return `<pre><code${className}>${contents}</code></pre>`;
+      };
+      text = text.replace(
+        /^( {0,3})(`{3,})([^`\n]*)\n(.*?\n|) {0,3}\2`* *$/gms,
+        fencedCodeBlock,
+      );
+      return text.replace(
+        /^( {0,3})((?:~T){3,})(?!~)([^\n]*)\n(.*?\n|) {0,3}\2(?:~T)* *$/gms,
+        fencedCodeBlock,
+      );
+    },
+  );
+  converter.hooks.chain(
+    'preBlockGamut',
+    (
+      text: string,
+      blockGamut: (text: string) => string,
+      spanGamut: (text: string) => string,
+    ): string => {
+      // GitHub-flavored Markdown table.
+      return text.replace(
+        /^ {0,3}\|[^\n]*\|[ \t]*(\n {0,3}\|[^\n]*\|[ \t]*)+$/gm,
+        (whole: string, inner: string): string => {
+          let cells = whole
+            .trim()
+            .split('\n')
+            .map((line: string) => {
+              const m = line.match(/(\\\||[^|])+/g);
+              if (!m) return '';
+              return m.map((value: string) =>
+                value.trim().replace(/\\\|/g, '|'),
+              );
+            });
+
+          // The header row must match the delimiter row in the number of
+          // cells. If not, a table will not be recognized.
+          if (cells.length < 2) {
+            return whole;
+          }
+
+          const header = cells[0];
+          const delimiter = cells[1];
+          const alignment = [];
+          if (header.length != delimiter.length) {
+            return whole;
+          }
+          cells = cells.slice(2);
+
+          // The delimiter row consists of cells whose only content are
+          // hyphens (-), and optionally, a leading or trailing colon (:),
+          // or
+          // both, to indicate left, right, or center alignment
+          // respectively.
+          for (let i = 0; i < delimiter.length; i++) {
+            if (!delimiter[i].match(/^:?-+:?$/)) {
+              return whole;
+            }
+            if (
+              delimiter[i][0] == ':' &&
+              delimiter[i][delimiter[i].length - 1] == ':'
+            ) {
+              alignment.push('center');
+            } else if (delimiter[i][delimiter[i].length - 1] == ':') {
+              alignment.push('right');
+            } else {
+              alignment.push('');
+            }
+          }
+
+          const alignedTag = (tagName: string, align: string) =>
+            '<' + tagName + (align ? ` align="${align}"` : '') + '>';
+
+          let text = '<table>\n';
+          text += '<thead>\n';
+          text += '<tr>\n';
+          for (let i = 0; i < header.length; i++) {
+            text +=
+              alignedTag('th', alignment[i]) + spanGamut(header[i]) + '</th>\n';
+          }
+          text += '</tr>\n';
+          text += '</thead>\n';
+          if (cells.length) {
+            text += '<tbody>\n';
+            for (let i = 0; i < cells.length; i++) {
+              text += '<tr>\n';
+              const row = cells[i];
+              for (let j = 0; j < Math.min(alignment.length, row.length); j++) {
+                text +=
+                  alignedTag('td', alignment[j]) +
+                  spanGamut(row[j]) +
+                  '</td>\n';
+              }
+              for (let j = row.length; j < alignment.length; j++) {
+                text += alignedTag('td', alignment[j]) + '</td>\n';
+              }
+              text += '</tr>\n';
+            }
+            text += '</tbody>\n';
+          }
+          text += '</table>\n';
+
+          return text;
+        },
+      );
+    },
+  );
+
+  converter.makeHtmlWithImages = (
+    markdown: string,
+    imageMapping: Markdown.ImageMapping,
+    settings: ProblemSettings,
+  ): string => {
+    try {
+      converter._imageMapping = imageMapping;
+      converter._settings = settings;
+      return converter.makeHtml(markdown);
+    } finally {
+      delete converter._imageMapping;
+      delete converter._settings;
+    }
+  };
+
+  return converter;
+}

--- a/frontend/www/js/omegaup/notification/list.js
+++ b/frontend/www/js/omegaup/notification/list.js
@@ -3,7 +3,7 @@ import notifications_List from '../components/notification/List.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   let notificationsList = new Vue({

--- a/frontend/www/js/omegaup/omegaup.js
+++ b/frontend/www/js/omegaup/omegaup.js
@@ -1,5 +1,6 @@
-import { Experiments, EventListenerList, OmegaUp, UI } from './omegaup.ts';
+import { Experiments, EventListenerList, OmegaUp } from './omegaup.ts';
 import API from './api.js';
+import * as UI from './ui.js';
 import T from './lang';
 export { API, EventListenerList, Experiments, OmegaUp, T, UI };
 

--- a/frontend/www/js/omegaup/omegaup.ts
+++ b/frontend/www/js/omegaup/omegaup.ts
@@ -1,8 +1,6 @@
-import UI from './ui.js';
+import * as ui from './ui_transitional';
 import * as api from './api_transitional';
 import * as errors from './errors';
-
-export { UI };
 
 // This is the JavaScript version of the frontend's Experiments class.
 export class Experiments {
@@ -696,7 +694,7 @@ export namespace omegaup {
             this._notify('ready');
           }
         })
-        .catch(UI.apiError);
+        .catch(ui.apiError);
     }
 
     _notify(eventName: string): void {

--- a/frontend/www/js/omegaup/problem/edit.js
+++ b/frontend/www/js/omegaup/problem/edit.js
@@ -4,7 +4,7 @@ import problem_StatementEdit from '../components/problem/StatementEdit.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   var chosenLanguage = null;

--- a/frontend/www/js/omegaup/problem/feedback.js
+++ b/frontend/www/js/omegaup/problem/feedback.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import problem_Feedback from '../components/problem/Feedback.vue';
 import { OmegaUp } from '../omegaup';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/problem/list.js
+++ b/frontend/www/js/omegaup/problem/list.js
@@ -3,7 +3,7 @@ import problem_List from '../components/problem/List.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/problem/mine.js
+++ b/frontend/www/js/omegaup/problem/mine.js
@@ -3,7 +3,7 @@ import problem_Mine from '../components/problem/Mine.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', () => {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/problem/solution.js
+++ b/frontend/www/js/omegaup/problem/solution.js
@@ -1,7 +1,7 @@
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import problem_Solution from '../components/problem/Solution.vue';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/qualitynomination/details.js
+++ b/frontend/www/js/omegaup/qualitynomination/details.js
@@ -3,7 +3,7 @@ import qualitynomination_Details from '../components/qualitynomination/Details.v
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   let payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/qualitynomination/list.js
+++ b/frontend/www/js/omegaup/qualitynomination/list.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import qualitynomination_List from '../components/qualitynomination/List.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/ranktable.js
+++ b/frontend/www/js/omegaup/ranktable.js
@@ -1,6 +1,7 @@
 import rank_table from './components/RankTable.vue';
 import Vue from 'vue';
 import { OmegaUp } from './omegaup';
+import * as ui from './ui_transitional';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(
@@ -61,5 +62,5 @@ OmegaUp.on('ready', function() {
         },
       });
     })
-    .catch(UI.apiError);
+    .catch(ui.apiError);
 });

--- a/frontend/www/js/omegaup/schools/intro.js
+++ b/frontend/www/js/omegaup/schools/intro.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import schools_Intro from '../components/schools/Intro.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/schools/profile.js
+++ b/frontend/www/js/omegaup/schools/profile.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import school_Profile from '../components/schools/Profile.vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/schools/rank.js
+++ b/frontend/www/js/omegaup/schools/rank.js
@@ -1,7 +1,7 @@
 import schools_Rank from '../components/schools/Rank.vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/schools/schoolofthemonth.js
+++ b/frontend/www/js/omegaup/schools/schoolofthemonth.js
@@ -1,6 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 import Vue from 'vue';
 import schoolOfTheMonth from '../components/schools/SchoolOfTheMonth.vue';

--- a/frontend/www/js/omegaup/submissions/list.js
+++ b/frontend/www/js/omegaup/submissions/list.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import submissions_List from '../components/submissions/List.vue';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/time.ts
+++ b/frontend/www/js/omegaup/time.ts
@@ -1,0 +1,154 @@
+import T from './lang';
+
+import * as moment from 'moment';
+
+let momentInitialized: boolean = false;
+
+export function formatDelta(delta: number): string {
+  if (!momentInitialized) {
+    moment.locale(T.locale);
+    momentInitialized = true;
+  }
+
+  let months = delta / (30 * 24 * 60 * 60 * 1000);
+  if (months >= 1.0) {
+    return moment(delta + Date.now())
+      .endOf()
+      .fromNow();
+  }
+
+  let days = Math.floor(delta / (24 * 60 * 60 * 1000));
+  delta -= days * (24 * 60 * 60 * 1000);
+  let hours = Math.floor(delta / (60 * 60 * 1000));
+  delta -= hours * (60 * 60 * 1000);
+  let minutes = Math.floor(delta / (60 * 1000));
+  delta -= minutes * (60 * 1000);
+  let seconds = Math.floor(delta / 1000);
+
+  let clock = '';
+
+  if (days > 0) {
+    clock += `${days}:`;
+  }
+  clock += `${String(hours).padStart(2, '0')}:`;
+  clock += `${String(minutes).padStart(2, '0')}:`;
+  clock += `${String(seconds).padStart(2, '0')}`;
+
+  return clock;
+}
+
+export function toDDHHMM(durationSeconds: number): string {
+  const days = Math.floor(durationSeconds / 86400);
+  const hours = Math.floor((durationSeconds - days * 86400) / 3600);
+  const minutes = Math.floor(
+    (durationSeconds - days * 86400 - hours * 3600) / 60,
+  );
+  const seconds = durationSeconds - days * 86400 - hours * 3600 - minutes * 60;
+
+  let time = '';
+  if (days > 0) time += `${days}d `;
+  return `${time}${String(hours).padStart(2, '0')}h ${String(minutes).padStart(
+    2,
+    '0',
+  )}m`;
+}
+
+export function formatDateLocal(date: Date): string {
+  // The expected format is yyyy-MM-dd in the local timezone, which is
+  // why we cannot use date.toISOSTring().
+  return (
+    String(date.getFullYear()).padStart(4, '0') +
+    '-' +
+    // Months in JavaScript start at 0.
+    String(date.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(date.getDate()).padStart(2, '0')
+  );
+}
+
+export function parseDateLocal(dateString: string): Date {
+  // The expected format is yyyy-MM-dd in the local timezone. Date.parse()
+  // will use UTC if given a timestamp with that format, instead of the local timezone.
+  const result = new Date();
+  const matches = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
+  if (matches !== null) {
+    result.setFullYear(Number.parseInt(matches[1], 10));
+    // Months in JavaScript start at 0.
+    result.setMonth(Number.parseInt(matches[2], 10) - 1);
+    result.setDate(Number.parseInt(matches[3], 10));
+  }
+  result.setHours(0);
+  result.setMinutes(0);
+  result.setSeconds(0);
+  result.setMilliseconds(0);
+  return result;
+}
+
+export function formatDateTimeLocal(date: Date): string {
+  // The expected format is yyyy-MM-ddTHH:MM in the local timezone, which
+  // is why we cannot use date.toISOSTring().
+  return (
+    formatDateLocal(date) +
+    'T' +
+    String(date.getHours()).padStart(2, '0') +
+    ':' +
+    String(date.getMinutes()).padStart(2, '0')
+  );
+}
+
+export function parseDateTimeLocal(dateString: string): Date {
+  // The expected format is yyyy-MM-ddTHH:MM in the local timezone.
+  // Date.parse() will use UTC if given a timestamp with that format, instead
+  // of the local timezone.
+  const result = new Date();
+  const matches = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(dateString);
+  if (matches !== null) {
+    result.setFullYear(Number.parseInt(matches[1], 10));
+    // Months in JavaScript start at 0.
+    result.setMonth(Number.parseInt(matches[2], 10) - 1);
+    result.setDate(Number.parseInt(matches[3], 10));
+    result.setHours(Number.parseInt(matches[4], 10));
+    result.setMinutes(Number.parseInt(matches[5], 10));
+  }
+  result.setSeconds(0);
+  result.setMilliseconds(0);
+  return result;
+}
+
+export function formatDateTime(date: Date): string {
+  return date.toLocaleString(T.locale);
+}
+
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString(T.locale);
+}
+
+export function parseDuration(str: string): number | null {
+  let duration: number = 0;
+  const durationRegexp = new RegExp(
+    '(\\d+(?:\\.\\d+)?)(ns|us|µs|ms|s|m|h)?',
+    'g',
+  );
+  const factor: { [suffix: string]: number } = {
+    h: 3600000.0,
+    m: 60000.0,
+    s: 1000.0,
+    ms: 1.0,
+    us: 0.001,
+    µs: 0.001,
+    ns: 0.000001,
+  };
+  let lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+  while ((match = durationRegexp.exec(str)) !== null) {
+    if (match.index != lastIndex) {
+      return null;
+    }
+    lastIndex += match[0].length;
+    duration += parseFloat(match[1]) * factor[match[2] || 's'];
+  }
+  if (lastIndex != str.length) {
+    return null;
+  }
+  return Math.round(duration);
+}

--- a/frontend/www/js/omegaup/ui.d.ts
+++ b/frontend/www/js/omegaup/ui.d.ts
@@ -1,49 +1,20 @@
-declare namespace omegaup {
-  export interface UI {
-    apiError: () => void;
-    buildURLQuery: (queryParameters: { [key: string]: string }) => string;
-    info: (message: string) => void;
-    error: (message: string) => void;
-    escape: (s: string) => string;
-    formatDate: (date: Date) => string;
-    formatDateTime: (date: Date) => string;
-    formatDateLocal: (date: Date) => string;
-    parseDateLocal: (dateString: string) => Date;
-    formatDateTimeLocal: (date: Date) => string;
-    parseDateTimeLocal: (dateString: string) => Date;
-    formatString: (
-      template: string,
-      values: { [key: string]: string },
-    ) => string;
-    groupTypeahead: (
-      elem: HTMLElement,
-      cb: (event: HTMLEvent, val: any) => void,
-    ) => void;
-    isVirtual: (contest: omegaup.Contest) => boolean;
-    markdownConverter: (options?: MarkdownConverterOptions) => Converter;
-    navigateTo: (url: string) => void;
-    problemTypeahead: (
-      elem: HTMLElement,
-      cb: (event: HTMLEvent, val: any) => void,
-    ) => void;
-    schoolTypeahead: (
-      elem: any,
-      cb: (event: HTMLEvent, val: any) => void,
-    ) => void;
-    userTypeahead: (
-      elem: HTMLElement,
-      cb: (event: HTMLEvent, val: any) => void,
-    ) => void;
-  }
+export * from './ui_transitional';
+export * from './time';
+export * from './markdown';
 
-  interface MarkdownConverterOptions {
-    preview: boolean;
-  }
-
-  interface Converter {
-    makeHtml: (text: string) => string;
-  }
-}
-
-declare let UI: omegaup.UI;
-export default UI;
+export function groupTypeahead(
+  elem: HTMLElement,
+  cb: (event: HTMLEvent, val: any) => void,
+): void;
+export function problemTypeahead(
+  elem: HTMLElement,
+  cb: (event: HTMLEvent, val: any) => void,
+): void;
+export function schoolTypeahead(
+  elem: any,
+  cb: (event: HTMLEvent, val: any) => void,
+): void;
+export function userTypeahead(
+  elem: HTMLElement,
+  cb: (event: HTMLEvent, val: any) => void,
+): void;

--- a/frontend/www/js/omegaup/ui.js
+++ b/frontend/www/js/omegaup/ui.js
@@ -1,1020 +1,194 @@
-import API from './api.js';
 import T from './lang';
-import * as moment from 'moment';
-
-let UI = {
-  momentInitialized: false,
-
-  navigateTo: function(url) {
-    window.location = url;
-  },
-
-  escape: function(s) {
-    if (typeof s !== 'string') return '';
-    return s
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-  },
-
-  buildURLQuery: function(queryParameters) {
-    return Object.entries(queryParameters)
-      .map(([key, value]) => {
-        const encodedKey = encodeURIComponent(key);
-        if (Array.isArray(value)) {
-          return value
-            .map(entry => `${encodedKey}[]=` + encodeURIComponent(entry))
-            .join('&');
-        }
-        return `${encodedKey}=` + encodeURIComponent(value);
-      })
-      .join('&');
-  },
-
-  formatDelta: function(delta) {
-    if (!UI.momentInitialized) {
-      moment.locale(T.locale);
-      UI.momentInitialized = true;
-    }
-
-    let months = delta / (30 * 24 * 60 * 60 * 1000);
-    if (months >= 1.0) {
-      return moment(delta + Date.now())
-        .endOf()
-        .fromNow();
-    }
-
-    let days = Math.floor(delta / (24 * 60 * 60 * 1000));
-    delta -= days * (24 * 60 * 60 * 1000);
-    let hours = Math.floor(delta / (60 * 60 * 1000));
-    delta -= hours * (60 * 60 * 1000);
-    let minutes = Math.floor(delta / (60 * 1000));
-    delta -= minutes * (60 * 1000);
-    let seconds = Math.floor(delta / 1000);
-
-    let clock = '';
-
-    if (days > 0) {
-      clock += days + ':';
-    }
-    if (hours < 10) clock += '0';
-    clock += hours + ':';
-    if (minutes < 10) clock += '0';
-    clock += minutes + ':';
-    if (seconds < 10) clock += '0';
-    clock += seconds;
-
-    return clock;
-  },
-
-  isVirtual: function(contest) {
-    return contest.rerun_id > 0;
-  },
-
-  contestTitle: function(contest) {
-    if (UI.isVirtual(contest)) {
-      return UI.formatString(T.virtualContestSuffix, { title: contest.title });
-    }
-    return contest.title;
-  },
-
-  rankingUsername: function(rank) {
-    let username = rank.username;
-    if (rank.name != rank.username) username += ` (${UI.escape(rank.name)})`;
-    if (rank.virtual)
-      username = UI.formatString(T.virtualSuffix, { username: username });
-    return username;
-  },
-
-  formatString: function(template, values) {
-    const re = new RegExp('%\\(([^!)]+)(?:!([^)]+))?\\)', 'g');
-    return template.replace(re, (match, key, modifier) => {
-      if (!values.hasOwnProperty(key)) {
-        // If the array does not provide a replacement for the key, just return
-        // the original substring.
-        return match;
-      }
-      let replacement = values[key];
-      if (modifier === 'date') {
-        replacement = UI.formatDate(new Date(replacement * 1000));
-      } else if (modifier === 'timestamp') {
-        replacement = UI.formatDateTime(new Date(replacement * 1000));
-      }
-      return replacement;
-    });
-  },
-
-  contestUpdated: function(data, contestAlias) {
-    if (data.status != 'ok') {
-      UI.error(data.error || 'error');
-      return;
-    }
-    UI.success(
-      T.contestEditContestEdited +
-        ' <a href="/arena/' +
-        contestAlias +
-        '">' +
-        T.contestEditGoToContest +
-        '</a>',
-    );
-  },
-
-  displayStatus: function(message, type) {
-    if ($('#status .message').length == 0) {
-      console.error('Showing warning but there is no status div');
-    }
-
-    // Just in case this needs to be displayed but the UI wasn't set up yet.
-    $('#loading').hide();
-    $('#root').show();
-
-    $('#status .message').html(message);
-    const statusElement = $('#status');
-    let statusCounter = parseInt(statusElement.attr('data-counter') || '0');
-    if (statusCounter % 2 == 1) {
-      statusCounter++;
-    }
-    statusElement
-      .removeClass('alert-success alert-info alert-warning alert-danger')
-      .addClass(type)
-      .addClass('animating')
-      .attr('data-counter', statusCounter + 1)
-      .slideDown({
-        complete: function() {
-          statusElement
-            .removeClass('animating')
-            .attr('data-counter', statusCounter + 2);
-          if (type == 'alert-success') {
-            setTimeout(() => {
-              UI.dismissNotifications(statusCounter + 2);
-            }, 5000);
-          }
-        },
-      });
-  },
-
-  error: function(message) {
-    UI.displayStatus(message, 'alert-danger');
-  },
-
-  info: function(message) {
-    UI.displayStatus(message, 'alert-info');
-  },
-
-  success: function(message) {
-    UI.displayStatus(message, 'alert-success');
-  },
-
-  warning: function(message) {
-    UI.displayStatus(message, 'alert-warning');
-  },
-
-  apiError: function(response) {
-    UI.error(
-      response.hasOwnProperty('payload')
-        ? UI.formatString(response.error, response.payload)
-        : ((response && response.error) || 'error').toString(),
-    );
-  },
-
-  ignoreError: function(response) {},
-
-  dismissNotifications: function(originalStatusCounter) {
-    const statusElement = $('#status');
-    let statusCounter = parseInt(statusElement.attr('data-counter') || '0');
-    if (
-      typeof originalStatusCounter == 'number' &&
-      statusCounter > originalStatusCounter
-    ) {
-      // This status has already been dismissed.
-      return;
-    }
-    if (statusCounter % 2 == 1) {
-      statusCounter++;
-    }
-    statusElement
-      .addClass('animating')
-      .attr('data-counter', statusCounter + 1)
-      .slideUp({
-        complete: function() {
-          statusElement
-            .removeClass('animating')
-            .attr('data-counter', statusCounter + 2);
-        },
-      });
-  },
-
-  prettyPrintJSON: function(json) {
-    return UI.syntaxHighlight(JSON.stringify(json, undefined, 4) || '');
-  },
-
-  syntaxHighlight: function(json) {
-    var jsonRE = /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g;
-    json = json
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-    return json.replace(jsonRE, function(match) {
-      var cls = 'number';
-      if (/^"/.test(match)) {
-        if (/:$/.test(match)) {
-          cls = 'key';
-        } else {
-          cls = 'string';
-        }
-      } else if (/true|false/.test(match)) {
-        cls = 'boolean';
-      } else if (/null/.test(match)) {
-        cls = 'null';
-      }
-      return '<span class="' + cls + '">' + match + '</span>';
-    });
-  },
-
-  columnName: function(idx) {
-    var name = String.fromCharCode('A'.charCodeAt(0) + (idx % 26));
-    while (idx >= 26) {
-      idx = (idx / 26) | 0;
-      idx--;
-      name = String.fromCharCode('A'.charCodeAt(0) + (idx % 26)) + name;
-    }
-    return name;
-  },
-
-  typeaheadWrapper: function(f) {
-    let lastRequest = null;
-    let pendingRequest = false;
-    function wrappedCall(query, syncResults, asyncResults) {
-      if (pendingRequest) {
-        lastRequest = arguments;
-        return;
-      }
-      pendingRequest = true;
-      f({ query: query })
-        .then(data => asyncResults(data.results || data))
-        .catch(UI.ignoreError)
-        .finally(() => {
-          pendingRequest = false;
-
-          // If there is a pending request, send it out now.
-          if (!lastRequest) return;
-          let currentRequest = lastRequest;
-          lastRequest = null;
-          wrappedCall(...currentRequest);
-        });
-    }
-    return wrappedCall;
-  },
-
-  typeahead: function(elem, searchFn, cb) {
-    cb =
-      cb ||
-      function(event, val) {
-        $(event.target).val(val.value);
-      };
-    elem
-      .typeahead(
-        {
-          minLength: 2,
-          highlight: true,
-        },
-        {
-          source: UI.typeaheadWrapper(searchFn),
-          async: true,
-          limit: 100,
-          display: 'label',
-          templates: {
-            suggestion: function(val) {
-              return UI.formatString(
-                '<div data-value="%(value)">%(label)</div>',
-                val,
-              );
-            },
-          },
-        },
-      )
-      .on('typeahead:select', cb)
-      .on('typeahead:autocomplete', cb)
-      .trigger('change');
-  },
-
-  problemTypeahead: function(elem, cb) {
-    cb =
-      cb ||
-      function(event, val) {
-        $(event.target).val(val.alias);
-      };
-    elem
-      .typeahead(
-        {
-          minLength: 3,
-          highlight: false,
-        },
-        {
-          source: UI.typeaheadWrapper(API.Problem.list),
-          async: true,
-          display: 'alias',
-          templates: {
-            suggestion: function(val) {
-              return UI.formatString(
-                '<div data-value="%(alias)"><strong>%(title)</strong> (%(alias))</div>',
-                val,
-              );
-            },
-          },
-        },
-      )
-      .on('typeahead:select', cb)
-      .on('typeahead:autocomplete', cb)
-      .trigger('change');
-  },
-
-  problemContestTypeahead: function(elem, problemList, cb) {
-    var substringMatcher = function(query, cb) {
-      var matches, substringRegex;
-
-      // an array that will be populated with substring matches
-      matches = [];
-
-      // regex used to determine if a string contains the substring `query`
-      substringRegex = new RegExp(query, 'i');
-
-      // iterate through the pool of strings and for any string that
-      // contains the substring `query`, add it to the `matches` array
-      $.each(problemList, function(i, problem) {
-        if (substringRegex.test(problem.alias)) {
-          matches.push(problem);
-        }
-      });
-
-      cb(matches);
-    };
-
-    cb =
-      cb ||
-      function(event, val) {
-        $(event.target).val(val.alias);
-      };
-
-    elem
-      .typeahead(
-        {
-          minLength: 3,
-          highlight: false,
-        },
-        {
-          source: substringMatcher,
-          async: true,
-          display: 'alias',
-          templates: {
-            suggestion: function(val) {
-              return UI.formatString(
-                '<div data-value="%(alias)">%(alias)</div>',
-                val,
-              );
-            },
-          },
-        },
-      )
-      .on('typeahead:select', cb)
-      .on('typeahead:autocomplete', cb);
-  },
-
-  schoolTypeahead: function(elem, cb) {
-    cb =
-      cb ||
-      function(event, val) {
-        $(event.target).val(val.value);
-      };
-    elem
-      .typeahead(
-        {
-          minLength: 2,
-          highlight: true,
-        },
-        {
-          source: UI.typeaheadWrapper(API.School.list),
-          async: true,
-          limit: 10,
-          display: 'label',
-          templates: {
-            empty: T.schoolToBeAdded,
-            suggestion: function(val) {
-              return UI.formatString(
-                '<div data-value="%(value)">%(label)</div>',
-                val,
-              );
-            },
-          },
-        },
-      )
-      .on('typeahead:select', cb)
-      .on('typeahead:autocomplete', cb);
-  },
-
-  userTypeahead: function(elem, cb) {
-    UI.typeahead(elem, API.User.list, cb);
-  },
-
-  groupTypeahead: function(elem, cb) {
-    UI.typeahead(elem, API.Group.list, cb);
-  },
-
-  getProfileLink: function(username) {
-    return '<a href="/profile/' + username + '" >' + username + '</a>';
-  },
-
-  toDDHHMM: function(duration) {
-    var sec_num = parseInt(duration, 10);
-    var days = Math.floor(sec_num / 86400);
-    var hours = Math.floor((sec_num - days * 86400) / 3600);
-    var minutes = Math.floor((sec_num - days * 86400 - hours * 3600) / 60);
-    var seconds = sec_num - days * 86400 - hours * 3600 - minutes * 60;
-
-    if (minutes < 10) {
-      minutes = '0' + minutes;
-    }
-    if (seconds < 10) {
-      seconds = '0' + seconds;
-    }
-
-    var time = '';
-    if (days > 0) time += days + 'd ';
-    return time + hours + 'h ' + minutes + 'm';
-  },
-
-  getFlag: function(country) {
-    if (!country) {
-      return '';
-    }
-    return (
-      ' <img src="/media/flags/' +
-      country.toLowerCase() +
-      '.png" width="16" height="11" title="' +
-      country +
-      '" />'
-    );
-  },
-
-  formatDateLocal: function(date) {
-    // The expected format is yyyy-MM-dd in the local timezone, which is
-    // why we cannot use date.toISOSTring().
-    return (
-      String(date.getFullYear()).padStart(4, '0') +
-      '-' +
-      // Months in JavaScript start at 0.
-      String(date.getMonth() + 1).padStart(2, '0') +
-      '-' +
-      String(date.getDate()).padStart(2, '0')
-    );
-  },
-
-  parseDateLocal: function(dateString) {
-    // The expected format is yyyy-MM-dd in the local timezone. Date.parse()
-    // will use UTC if given a timestamp with that format, instead of the local timezone.
-    const result = new Date();
-    const matches = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
-    if (matches !== null) {
-      result.setFullYear(Number.parseInt(matches[1], 10));
-      // Months in JavaScript start at 0.
-      result.setMonth(Number.parseInt(matches[2], 10) - 1);
-      result.setDate(Number.parseInt(matches[3], 10));
-    }
-    result.setHours(0);
-    result.setMinutes(0);
-    result.setSeconds(0);
-    result.setMilliseconds(0);
-    return result;
-  },
-
-  formatDateTimeLocal: function(date) {
-    // The expected format is yyyy-MM-ddTHH:MM in the local timezone, which
-    // is why we cannot use date.toISOSTring().
-    return (
-      UI.formatDateLocal(date) +
-      'T' +
-      String(date.getHours()).padStart(2, '0') +
-      ':' +
-      String(date.getMinutes()).padStart(2, '0')
-    );
-  },
-
-  parseDateTimeLocal: function(dateString) {
-    // The expected format is yyyy-MM-ddTHH:MM in the local timezone.
-    // Date.parse() will use UTC if given a timestamp with that format, instead
-    // of the local timezone.
-    const result = new Date();
-    const matches = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(
-      dateString,
-    );
-    if (matches !== null) {
-      result.setFullYear(Number.parseInt(matches[1], 10));
-      // Months in JavaScript start at 0.
-      result.setMonth(Number.parseInt(matches[2], 10) - 1);
-      result.setDate(Number.parseInt(matches[3], 10));
-      result.setHours(Number.parseInt(matches[4], 10));
-      result.setMinutes(Number.parseInt(matches[5], 10));
-    }
-    result.setSeconds(0);
-    result.setMilliseconds(0);
-    return result;
-  },
-
-  formatDateTime: function(date) {
-    return date.toLocaleString(T.locale);
-  },
-
-  formatDate: function(date) {
-    return date.toLocaleDateString(T.locale);
-  },
-
-  parseDuration: function(str) {
-    let duration = 0;
-    const durationRegexp = new RegExp(
-      '(\\d+(?:\\.\\d+)?)(ns|us|µs|ms|s|m|h)?',
-      'g',
-    );
-    const factor = {
-      h: 3600000.0,
-      m: 60000.0,
-      s: 1000.0,
-      ms: 1.0,
-      us: 0.001,
-      µs: 0.001,
-      ns: 0.000001,
-    };
-    let lastIndex = 0;
-    let match = null;
-    while ((match = durationRegexp.exec(str)) !== null) {
-      if (match.index != lastIndex) {
-        return null;
-      }
-      lastIndex += match[0].length;
-      duration += parseFloat(match[1]) * factor[match[2] || 's'];
-    }
-    if (lastIndex != str.length) {
-      return null;
-    }
-    return Math.round(duration);
-  },
-
-  copyToClipboard: function(value) {
-    let tempInput = document.createElement('textarea');
-
-    tempInput.style = 'position: absolute; left: -1000px; top: -1000px';
-    tempInput.value = value;
-
-    document.body.appendChild(tempInput);
-
-    try {
-      tempInput.select(); // refactor-lint-disable
-      document.execCommand('copy');
-    } finally {
-      document.body.removeChild(tempInput);
-    }
-  },
-
-  renderSampleToClipboardButton: function() {
-    document
-      .querySelectorAll('.sample_io > tbody > tr > td:first-of-type')
-      .forEach(function(item, index) {
-        let preElement = item.querySelector('pre');
-        if (!preElement) {
-          // This can only happen if a user messed up with the markdown of a
-          // problem.
-          return;
-        }
-        let inputValue = preElement.innerHTML;
-
-        let clipboardButton = document.createElement('button');
-        clipboardButton.title = T.copySampleCaseTooltip;
-        clipboardButton.className = 'glyphicon glyphicon-copy clipboard';
-
-        clipboardButton.addEventListener('click', function(event) {
-          event.preventDefault();
-          event.stopPropagation();
-          UI.copyToClipboard(inputValue);
-        });
-
-        item.appendChild(clipboardButton);
-      });
-  },
-
-  markdownConverter: function(options) {
-    options = options || {};
-
-    // Map of templates.
-    var templates = {};
-    if (options.preview) {
-      templates['libinteractive:download'] =
-        '<code class="libinteractive-download">' +
-        '<i class="glyphicon glyphicon-download-alt"></i></code>';
-    } else {
-      templates[
-        'libinteractive:download'
-      ] = `<div class="libinteractive-download panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">
-            ${T.libinteractiveTitle}
-            <a class="libinteractive-help" target="_blank" href="/libinteractive/${T.locale}/contest/"><span class="glyphicon glyphicon-question-sign"></span></a>
-          </h3>
-        </div>
-        <div class="panel-body">
-          <form role="form">
-            <div class="form-horizontal">
-              <div class="form-group">
-                <div class="col-sm-10">
-                  <label class="col-sm-2 control-label">${T.libinteractiveOs}</label>
-                  <select class="form-control download-os">
-                    <option value="unix">Linux/Mac OS X</option>
-                    <option value="windows">Windows</option>
-                  </select>
-                </div>
-              </div>
-              <div class="form-group">
-                <div class="col-sm-10">
-                  <label class="col-sm-2 control-label">${T.libinteractiveLanguage}</label>
-                  <select class="form-control download-lang">
-                    <option value="c" selected="selected">C</option>
-                    <option value="cpp">C++</option>
-                    <option value="java">Java</option>
-                    <option value="py">Python</option>
-                    <option value="pas">Pascal</option>
-                  </select>
-                </div>
-              </div>
-              <div class="form-group">
-                <strong class="col-sm-2 control-label">${T.libinteractiveFilename}</strong>
-                <div class="col-sm-10">
-                  <span class="libinteractive-interface-name"></span>.<span class="libinteractive-extension">c</span>
-                </div>
-              </div>
-              <div class="form-group">
-                <div class="col-sm-offset-2 col-sm-10">
-                  <button type="submit" class="btn btn-primary active">
-                    ${T.libinteractiveDownload}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>`;
-    }
-
-    let converter = Markdown.getSanitizingConverter();
-    let whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|figure|figcaption|code|i|table|tbody|thead|tr|th(?: align="\w+")?|td(?: align="\w+")?|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
-    let imageWhitelist = new RegExp(
-      '^<img\\ssrc="data:image/[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$',
-      'i',
-    );
-
-    converter.hooks.chain('isValidTag', function(tag) {
-      return tag.match(whitelist) || tag.match(imageWhitelist);
-    });
-
-    // These two functions are adapted from Markdown.Converter.js. They are
-    // needed to support images with some special characters in their name.
-    function escapeCharacters(
-      text,
-      charsToEscape,
-      afterBackslash,
-      doNotEscapeTildeAndDollar,
-    ) {
-      // First we have to escape the escape characters so that
-      // we can build a character class out of them
-      const regexString = `([${charsToEscape.replace(/([\[\]\\])/g, '\\$1')}])`;
-
-      if (afterBackslash) {
-        regexString = `\\\\${regexString}`;
-      }
-
-      const regex = new RegExp(regexString, 'g');
-      if (!doNotEscapeTildeAndDollar) {
-        text = text.replace(/~/g, '~T').replace(/\$/g, '~D');
-      }
-      return text.replace(regex, (wholeMatch, m1) => `~E${m1.charCodeAt(0)}E`);
-    }
-    function unescapeCharacters(text) {
-      //
-      // Swap back in all the special characters we've hidden.
-      //
-      return text
-        .replace(/~E(\d+)E/g, function(wholeMatch, m1) {
-          const charCodeToReplace = parseInt(m1);
-          return String.fromCharCode(charCodeToReplace);
-        })
-        .replace(/~D/g, '$')
-        .replace(/~T/g, '~');
-    }
-
-    converter.hooks.chain('postSpanGamut', function(text) {
-      // Templates.
-      text = text.replace(/^\s*\{\{([a-z0-9_:]+)\}\}\s*$/g, function(
-        wholematch,
-        m1,
-      ) {
-        if (templates.hasOwnProperty(m1)) {
-          return templates[m1];
-        }
-        return (
-          '<strong style="color: red">Unrecognized template name: ' +
-          m1 +
-          '</strong>'
-        );
-      });
-      // Images.
-      let imageMapping = converter._imageMapping || options.imageMapping || {};
-      text = text.replace(/<img src="([^"]+)"\s*([^>]+)>/g, function(
-        wholeMatch,
-        url,
-        attributes,
-      ) {
-        url = unescapeCharacters(url);
-        if (url.indexOf('/') != -1 || !imageMapping.hasOwnProperty(url)) {
-          return wholeMatch;
-        }
-        return `<img src="${escapeCharacters(
-          imageMapping[url],
-          '*_',
-        )}" ${attributes}>`;
-      });
-      // Figures.
-      text = text.replace(
-        /^\s*<img src="([^"]+)"\s*([^>]+)\s+title="([^"]+)"\s*\/>\s*$/g,
-        function(wholeMatch, url, attributes, title) {
-          return (
-            `<figure><img src="${url}" ${attributes} />` +
-            `<figcaption>${title}</figcaption></figure>`
-          );
-        },
-      );
-      return text;
-    });
-    converter.hooks.chain('postNormalization', function(text, blockGamut) {
-      // Sample I/O table.
-      let settings = converter._settings || options.settings || { cases: {} };
-      return text.replace(
-        /^( {0,3}\|\| *(?:input|examplefile) *\n(?:.|\n)+?\n) {0,3}\|\| *end *\n/gm,
-        function(whole, inner) {
-          var matches = inner.split(
-            / {0,3}\|\| *(examplefile|input|output|description) *\n/,
-          );
-          var result = '';
-          var description_column = false;
-          for (var i = 1; i < matches.length; i += 2) {
-            if (matches[i] == 'description') {
-              description_column = true;
-              break;
-            }
-          }
-          result += '<thead><tr>';
-          result += `<th>${T.wordsInput}</th>`;
-          result += `<th>${T.wordsOutput}</th>`;
-          if (description_column) {
-            result += `<th>${T.wordsDescription}</th>`;
-          }
-          result += '</tr></thead>';
-          var first_row = true;
-          var columns = 0;
-          result += '<tbody>';
-          for (var i = 1; i < matches.length; i += 2) {
-            if (matches[i] == 'description') {
-              result += '<td>' + blockGamut(matches[i + 1]) + '</td>';
-              columns++;
-            } else {
-              if (matches[i] == 'input' || matches[i] == 'examplefile') {
-                if (!first_row) {
-                  while (columns < (description_column ? 3 : 2)) {
-                    result += '<td></td>';
-                    columns++;
-                  }
-                  result += '</tr>';
-                }
-                first_row = false;
-                result += '<tr>';
-                columns = 0;
-              }
-
-              if (matches[i] == 'examplefile') {
-                let exampleFilename = matches[i + 1].trim();
-                let exampleFile = {
-                  in: `{{examples/${exampleFilename}.in}}`,
-                  out: `{{examples/${exampleFilename}.out}}`,
-                };
-                if (settings.cases.hasOwnProperty(exampleFilename)) {
-                  exampleFile = settings.cases[exampleFilename];
-                }
-                result += `<td><pre>${exampleFile['in'].replace(
-                  /\s+$/,
-                  '',
-                )}</pre></td>`;
-                result += `<td><pre>${exampleFile.out.replace(
-                  /\s+$/,
-                  '',
-                )}</pre></td>`;
-                columns += 2;
-              } else {
-                result += `<td><pre>${escapeCharacters(
-                  matches[i + 1]
-                    .replace(/\s+$/, '')
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;'),
-                  ' \t*_{}[]()<>#+=.!|`-',
-                  /*afterBackslash=*/ false,
-                  /*doNotEscapeTildeAnDollar=*/ true,
-                )}</pre></td>`;
-                columns++;
-              }
-            }
-          }
-          while (columns < (description_column ? 3 : 2)) {
-            result += '<td></td>';
-            columns++;
-          }
-          result += '</tr></tbody>';
-
-          return '<table class="sample_io">\n' + result + '\n</table>\n';
-        },
-      );
-    });
-    converter.hooks.chain('preBlockGamut', function(
-      text,
-      blockGamut,
-      spanGamut,
-    ) {
-      // GitHub-flavored fenced code blocks
-      function fencedCodeBlock(
-        whole,
-        indentation,
-        fence,
-        infoString,
-        contents,
-      ) {
-        contents = contents.replace(/&/g, '&amp;');
-        contents = contents.replace(/</g, '&lt;');
-        contents = contents.replace(/>/g, '&gt;');
-        if (indentation != '') {
-          let lines = [];
-          let stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
-          for (let line of contents.split('\n')) {
-            lines.push(line.replace(stripPrefix, ''));
-          }
-          contents = escapeCharacters(
-            lines.join('\n'),
-            ' \t*_{}[]()<>#+=.!|`-',
-            /*afterBackslash=*/ false,
-            /*doNotEscapeTildeAnDollar=*/ true,
-          );
-        }
-        let className = '';
-        infoString = infoString.trim();
-        if (infoString != '') {
-          className = ` class="language-${infoString.split(/\s+/)[0]}"`;
-        }
-        return `<pre><code${className}>${contents}</code></pre>`;
-      }
-      text = text.replace(
-        /^( {0,3})(`{3,})([^`\n]*)\n(.*?\n|) {0,3}\2`* *$/gms,
-        fencedCodeBlock,
-      );
-      return text.replace(
-        /^( {0,3})((?:~T){3,})(?!~)([^\n]*)\n(.*?\n|) {0,3}\2(?:~T)* *$/gms,
-        fencedCodeBlock,
-      );
-    });
-    converter.hooks.chain('preBlockGamut', function(
-      text,
-      blockGamut,
-      spanGamut,
-    ) {
-      // GitHub-flavored Markdown table.
-      return text.replace(
-        /^ {0,3}\|[^\n]*\|[ \t]*(\n {0,3}\|[^\n]*\|[ \t]*)+$/gm,
-        function(whole, inner) {
-          var cells = whole
-            .trim()
-            .split('\n')
-            .map(function(line) {
-              return line.match(/(\\\||[^|])+/g).map(function(value) {
-                return value.trim().replace(/\\\|/g, '|');
-              });
-            });
-
-          // The header row must match the delimiter row in the number of
-          // cells. If not, a table will not be recognized.
-          if (cells.length < 2) {
-            return whole;
-          }
-
-          var header = cells[0];
-          var delimiter = cells[1];
-          var alignment = [];
-          if (header.length != delimiter.length) {
-            return whole;
-          }
-          cells = cells.slice(2);
-
-          // The delimiter row consists of cells whose only content are
-          // hyphens (-), and optionally, a leading or trailing colon (:),
-          // or
-          // both, to indicate left, right, or center alignment
-          // respectively.
-          for (var i = 0; i < delimiter.length; i++) {
-            if (!delimiter[i].match(/^:?-+:?$/)) {
-              return whole;
-            }
-            if (
-              delimiter[i][0] == ':' &&
-              delimiter[i][delimiter[i].length - 1] == ':'
-            ) {
-              alignment.push('center');
-            } else if (delimiter[i][delimiter[i].length - 1] == ':') {
-              alignment.push('right');
-            } else {
-              alignment.push('');
-            }
-          }
-
-          function alignedTag(tagName, align) {
-            return (
-              '<' + tagName + (align ? ' align="' + align + '"' : '') + '>'
-            );
-          }
-
-          var text = '<table>\n';
-          text += '<thead>\n';
-          text += '<tr>\n';
-          for (var i = 0; i < header.length; i++) {
-            text +=
-              alignedTag('th', alignment[i]) + spanGamut(header[i]) + '</th>\n';
-          }
-          text += '</tr>\n';
-          text += '</thead>\n';
-          if (cells.length) {
-            text += '<tbody>\n';
-            for (var i = 0; i < cells.length; i++) {
-              text += '<tr>\n';
-              var row = cells[i];
-              for (var j = 0; j < Math.min(alignment.length, row.length); j++) {
-                text +=
-                  alignedTag('td', alignment[j]) +
-                  spanGamut(row[j]) +
-                  '</td>\n';
-              }
-              for (var j = row.length; j < alignment.length; j++) {
-                text += alignedTag('td', alignment[j]) + '</td>\n';
-              }
-              text += '</tr>\n';
-            }
-            text += '</tbody>\n';
-          }
-          text += '</table>\n';
-
-          return text;
-        },
-      );
-    });
-
-    converter.makeHtmlWithImages = function(markdown, imageMapping, settings) {
-      try {
-        converter._imageMapping = imageMapping;
-        converter._settings = settings;
-        return converter.makeHtml(markdown);
-      } finally {
-        delete converter._imageMapping;
-        delete converter._settings;
-      }
-    };
-
-    return converter;
-  },
-
-  reportEvent: function(category, action, label) {
-    if (typeof ga !== 'function') {
-      return;
-    }
-    ga('send', 'event', category, action, label);
-  },
-};
-
-export { UI as default };
-
-$(document).ajaxError(function(e, xhr, settings, exception) {
-  if (xhr.status == 499 || xhr.readyState != 4) {
-    // If we cancel the connection, let's just swallow the error since
-    // the user is not going to see it.
+import API from './api.js';
+
+import {
+  escape as escapeString,
+  formatString,
+  error,
+  success,
+  ignoreError,
+} from './ui_transitional';
+export * from './ui_transitional';
+export * from './time';
+export * from './markdown';
+
+export function rankingUsername(rank) {
+  let username = rank.username;
+  if (!!rank.name && rank.name != rank.username)
+    username += ` (${escapeString(rank.name)})`;
+  if (rank.virtual)
+    username = formatString(T.virtualSuffix, { username: username });
+  return username;
+}
+
+export function contestUpdated(data, contestAlias) {
+  if (data.status != 'ok') {
+    error(data.error || 'error');
     return;
   }
-  try {
-    var responseText = xhr.responseText;
-    var response = {};
-    if (responseText) {
-      response = JSON.parse(responseText);
+  success(
+    T.contestEditContestEdited +
+      ` <a href="/arena/${contestAlias}">${T.contestEditGoToContest}</a>`,
+  );
+}
+
+export function typeaheadWrapper(searchFn) {
+  let lastRequest = null;
+  let pendingRequest = false;
+  function wrappedCall(query, syncResults, asyncResults) {
+    if (pendingRequest) {
+      lastRequest = arguments;
+      return;
     }
-    console.error(settings.url, xhr.status, response.error, response);
-  } catch (e) {
-    console.error(settings.url, xhr.status, xhr.responseText);
+    pendingRequest = true;
+    searchFn({ query: query })
+      .then(data => asyncResults(data.results || data))
+      .catch(ignoreError)
+      .finally(() => {
+        pendingRequest = false;
+
+        // If there is a pending request, send it out now.
+        if (!lastRequest) return;
+        let currentRequest = lastRequest;
+        lastRequest = null;
+        wrappedCall(...currentRequest);
+      });
   }
-});
+  return wrappedCall;
+}
+
+export function typeahead(elem, searchFn, cb) {
+  if (!cb) {
+    cb = (event, val) => $(event.target).val(val.value);
+  }
+  elem
+    .typeahead(
+      {
+        minLength: 2,
+        highlight: true,
+      },
+      {
+        source: typeaheadWrapper(searchFn),
+        async: true,
+        limit: 100,
+        display: 'label',
+        templates: {
+          suggestion: val => {
+            return formatString(
+              '<div data-value="%(value)">%(label)</div>',
+              val,
+            );
+          },
+        },
+      },
+    )
+    .on('typeahead:select', cb)
+    .on('typeahead:autocomplete', cb)
+    .trigger('change');
+}
+
+export function problemTypeahead(elem, cb) {
+  if (!cb) {
+    cb = (event, val) => $(event.target).val(val.alias);
+  }
+  elem
+    .typeahead(
+      {
+        minLength: 3,
+        highlight: false,
+      },
+      {
+        source: typeaheadWrapper(API.Problem.list),
+        async: true,
+        display: 'alias',
+        templates: {
+          suggestion: val => {
+            return formatString(
+              '<div data-value="%(alias)"><strong>%(title)</strong> (%(alias))</div>',
+              val,
+            );
+          },
+        },
+      },
+    )
+    .on('typeahead:select', cb)
+    .on('typeahead:autocomplete', cb)
+    .trigger('change');
+}
+
+export function problemContestTypeahead(elem, problemList, cb) {
+  const substringMatcher = (query, syncResults) => {
+    // regex used to determine if a string contains the query substring.
+    const substringRegex = new RegExp(query, 'i');
+
+    // Filter out the results that contain the query substring.
+    syncResults(
+      problemList.filter(problem => substringRegex.test(problem.alias)),
+    );
+  };
+
+  if (!cb) {
+    cb = (event, problem) => $(event.target).val(problem.alias);
+  }
+
+  elem
+    .typeahead(
+      {
+        minLength: 3,
+        highlight: false,
+      },
+      {
+        source: substringMatcher,
+        async: true,
+        display: 'alias',
+        templates: {
+          suggestion: val => {
+            return formatString(
+              '<div data-value="%(alias)">%(alias)</div>',
+              val,
+            );
+          },
+        },
+      },
+    )
+    .on('typeahead:select', cb)
+    .on('typeahead:autocomplete', cb);
+}
+
+export function schoolTypeahead(elem, cb) {
+  if (!cb) {
+    cb = (event, val) => $(event.target).val(val.value);
+  }
+  elem
+    .typeahead(
+      {
+        minLength: 2,
+        highlight: true,
+      },
+      {
+        source: typeaheadWrapper(API.School.list),
+        async: true,
+        limit: 10,
+        display: 'label',
+        templates: {
+          empty: T.schoolToBeAdded,
+          suggestion: val => {
+            return formatString(
+              '<div data-value="%(value)">%(label)</div>',
+              val,
+            );
+          },
+        },
+      },
+    )
+    .on('typeahead:select', cb)
+    .on('typeahead:autocomplete', cb);
+}
+
+export function userTypeahead(elem, cb) {
+  typeahead(elem, API.User.list, cb);
+}
+
+export function groupTypeahead(elem, cb) {
+  typeahead(elem, API.Group.list, cb);
+}

--- a/frontend/www/js/omegaup/ui_transitional.ts
+++ b/frontend/www/js/omegaup/ui_transitional.ts
@@ -1,0 +1,270 @@
+import API from './api.js';
+import { types } from './api_types';
+import * as api from './api_transitional';
+import T from './lang';
+import { formatDate, formatDateTime } from './time';
+import { omegaup } from './omegaup';
+
+export function navigateTo(url: Location): void {
+  window.location = url;
+}
+
+function escapeString(s: string): string {
+  if (typeof s !== 'string') return '';
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export { escapeString as escape };
+
+export function buildURLQuery(queryParameters: {
+  [key: string]: string;
+}): string {
+  return Object.entries(queryParameters)
+    .map(([key, value]) => {
+      const encodedKey = encodeURIComponent(key);
+      if (Array.isArray(value)) {
+        return value
+          .map(entry => `${encodedKey}[]=${encodeURIComponent(entry)}`)
+          .join('&');
+      }
+      return `${encodedKey}=${encodeURIComponent(value)}`;
+    })
+    .join('&');
+}
+
+export function isVirtual(contest: omegaup.Contest): boolean {
+  return !!contest.rerun_id && contest.rerun_id > 0;
+}
+
+export function contestTitle(contest: omegaup.Contest): string {
+  if (isVirtual(contest)) {
+    return formatString(T.virtualContestSuffix, {
+      title: contest.title,
+    });
+  }
+  return contest.title;
+}
+
+export function formatString(
+  template: string,
+  values: { [key: string]: string | number },
+): string {
+  const re = new RegExp('%\\(([^!)]+)(?:!([^)]+))?\\)', 'g');
+  return template.replace(re, (match, key, modifier) => {
+    if (!values.hasOwnProperty(key)) {
+      // If the array does not provide a replacement for the key, just return
+      // the original substring.
+      return match;
+    }
+    const replacement = values[key];
+    if (modifier === 'date' && typeof replacement === 'number') {
+      return formatDate(new Date(replacement * 1000));
+    }
+    if (modifier === 'timestamp' && typeof replacement === 'number') {
+      return formatDateTime(new Date(replacement * 1000));
+    }
+    return String(replacement);
+  });
+}
+
+export function displayStatus(message: string, type: string): void {
+  if ($('#status .message').length == 0) {
+    console.error('Showing warning but there is no status div');
+  }
+
+  // Just in case this needs to be displayed but the UI wasn't set up yet.
+  $('#loading').hide();
+  $('#root').show();
+
+  $('#status .message').html(message);
+  const statusElement = $('#status');
+  let statusCounter = parseInt(statusElement.attr('data-counter') || '0');
+  if (statusCounter % 2 == 1) {
+    statusCounter++;
+  }
+  statusElement
+    .removeClass('alert-success alert-info alert-warning alert-danger')
+    .addClass(type)
+    .addClass('animating')
+    .attr('data-counter', statusCounter + 1)
+    .slideDown({
+      complete: () => {
+        statusElement
+          .removeClass('animating')
+          .attr('data-counter', statusCounter + 2);
+        if (type == 'alert-success') {
+          setTimeout(() => {
+            dismissNotifications(statusCounter + 2);
+          }, 5000);
+        }
+      },
+    });
+}
+
+export function error(message: string): void {
+  displayStatus(message, 'alert-danger');
+}
+
+export function info(message: string): void {
+  displayStatus(message, 'alert-info');
+}
+
+export function success(message: string): void {
+  displayStatus(message, 'alert-success');
+}
+
+export function warning(message: string): void {
+  displayStatus(message, 'alert-warning');
+}
+
+export function apiError(response: { error?: string; payload?: any }): void {
+  error(
+    response.error && response.payload
+      ? formatString(response.error, response.payload)
+      : (response.error || 'error').toString(),
+  );
+}
+
+export function ignoreError(response: {
+  error?: string;
+  payload?: any;
+}): void {}
+
+export function dismissNotifications(originalStatusCounter: number): void {
+  const statusElement = $('#status');
+  let statusCounter = parseInt(statusElement.attr('data-counter') || '0');
+  if (
+    typeof originalStatusCounter == 'number' &&
+    statusCounter > originalStatusCounter
+  ) {
+    // This status has already been dismissed.
+    return;
+  }
+  if (statusCounter % 2 == 1) {
+    statusCounter++;
+  }
+  statusElement
+    .addClass('animating')
+    .attr('data-counter', statusCounter + 1)
+    .slideUp({
+      complete: () => {
+        statusElement
+          .removeClass('animating')
+          .attr('data-counter', statusCounter + 2);
+      },
+    });
+}
+
+type JSONType = any;
+
+export function prettyPrintJSON(json: JSONType): string {
+  return syntaxHighlight(JSON.stringify(json, undefined, 4) || '');
+}
+
+export function syntaxHighlight(json: JSONType): string {
+  const jsonRE = /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g;
+  return json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(jsonRE, (match: string) => {
+      let cls = 'number';
+      if (/^"/.test(match)) {
+        if (/:$/.test(match)) {
+          cls = 'key';
+        } else {
+          cls = 'string';
+        }
+      } else if (/true|false/.test(match)) {
+        cls = 'boolean';
+      } else if (/null/.test(match)) {
+        cls = 'null';
+      }
+      return `<span class="${cls}">${match}</span>`;
+    });
+}
+
+export function columnName(idx: number): string {
+  let name = String.fromCharCode('A'.charCodeAt(0) + (idx % 26));
+  while (idx >= 26) {
+    idx = (idx / 26) | 0;
+    idx--;
+    name = String.fromCharCode('A'.charCodeAt(0) + (idx % 26)) + name;
+  }
+  return name;
+}
+
+export function getProfileLink(username: string): string {
+  return `<a href="/profile/${username}" >${username}</a>`;
+}
+
+export function getFlag(country: string): string {
+  if (!country) {
+    return '';
+  }
+  return ` <img src="/media/flags/${country.toLowerCase()}.png" width="16" height="11" title="${country}" />`;
+}
+
+export function copyToClipboard(value: string): void {
+  const tempInput = document.createElement('textarea');
+
+  tempInput.style.position = 'absolute';
+  tempInput.style.left = '-1000px';
+  tempInput.style.top = '-1000px';
+  tempInput.value = value;
+
+  document.body.appendChild(tempInput);
+
+  try {
+    tempInput.select(); // refactor-lint-disable
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(tempInput);
+  }
+}
+
+export function renderSampleToClipboardButton(): void {
+  document
+    .querySelectorAll('.sample_io > tbody > tr > td:first-of-type')
+    .forEach(function(item, index) {
+      const preElement = item.querySelector('pre');
+      if (!preElement) {
+        // This can only happen if a user messed up with the markdown of a
+        // problem.
+        return;
+      }
+      const inputValue = preElement.innerHTML;
+
+      const clipboardButton = document.createElement('button');
+      clipboardButton.title = T.copySampleCaseTooltip;
+      clipboardButton.className = 'glyphicon glyphicon-copy clipboard';
+
+      clipboardButton.addEventListener('click', (event: Event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        copyToClipboard(inputValue);
+      });
+
+      item.appendChild(clipboardButton);
+    });
+}
+
+declare global {
+  interface Window {
+    ga?: (command: string, ...fields: any[]) => void;
+  }
+}
+
+export function reportEvent(
+  category: string,
+  action?: string,
+  label?: string,
+): void {
+  if (typeof window.ga !== 'function') {
+    return;
+  }
+  window.ga('send', 'event', category, action, label);
+}

--- a/frontend/www/js/omegaup/user/emailedit.js
+++ b/frontend/www/js/omegaup/user/emailedit.js
@@ -1,7 +1,7 @@
 import user_EmailEdit from '../components/user/EmailEdit.vue';
 import Vue from 'vue';
 import { OmegaUp } from '../omegaup';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/user/manage_identities.js
+++ b/frontend/www/js/omegaup/user/manage_identities.js
@@ -2,7 +2,7 @@ import user_ManageIdentities from '../components/user/ManageIdentities.vue';
 import Vue from 'vue';
 import { OmegaUp } from '../omegaup';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 import T from '../lang';
 
 OmegaUp.on('ready', function() {

--- a/frontend/www/js/omegaup/user/privacy_policy.js
+++ b/frontend/www/js/omegaup/user/privacy_policy.js
@@ -3,7 +3,7 @@ import user_Privacy_Policy from '../components/user/PrivacyPolicy.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);

--- a/frontend/www/js/omegaup/user/profile.js
+++ b/frontend/www/js/omegaup/user/profile.js
@@ -3,7 +3,7 @@ import user_Profile from '../components/user/Profile.vue';
 import { OmegaUp } from '../omegaup';
 import T from '../lang';
 import API from '../api.js';
-import UI from '../ui.js';
+import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
   const payload = JSON.parse(document.getElementById('payload').innerText);


### PR DESCRIPTION
Este cambio hace que casi todo ui.js esté escrito en TypeScript. Faltan
algunas cosas que no supe cómo tipificar. Notablemente, todos los
wrappers de typeahead() son bastante complicados :S

De paso se dividen las responsabilidades de ui.ts en tres archivos:

a) `ui_transitional.ts` (nombre provisional, se renombrará a `ui.ts` una
   vez que la migración termine): Contiene todo lo referente a
   manipulación de interfaz y escapamiento.
b) `time.ts`: Todo lo referente a parseo / despliegue de tiempos, fechas
   e intervalos.
c) 'markdown.ts': Todo lo referente a Markdown.

Una vez que se puedan tipificar todas las cosas de typeahead, eso va a
pertenecer a un archivo `typeahead.ts`.