### PR TITLE
Dejando de usa la bandera 's' en RegExps

### DIFF
--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -312,11 +312,17 @@ export function markdownConverter(
         return `<pre><code${className}>${contents}</code></pre>`;
       };
       text = text.replace(
-        /^( {0,3})(`{3,})([^`\n]*)\n(.*?\n|) {0,3}\2`* *$/gms,
+        new RegExp(
+          '^( {0,3})(`{3,})([^`\\n]*)\\n((?:.|\\n)*?\\n|) {0,3}\\2`* *$',
+          'gm',
+        ),
         fencedCodeBlock,
       );
       return text.replace(
-        /^( {0,3})((?:~T){3,})(?!~)([^\n]*)\n(.*?\n|) {0,3}\2(?:~T)* *$/gms,
+        new RegExp(
+          '^( {0,3})((?:~T){3,})(?!~)([^\\n]*)\\n((.|\\n)*?\\n|) {0,3}\\2(?:~T)* *$',
+          'gm',
+        ),
         fencedCodeBlock,
       );
     },


### PR DESCRIPTION
Resulta que a Firefox no le gusta la bandera 's', que permite hacer
match de saltos de línea usando `.`. Lo bueno es que el workaround es
razonablemente sencillo.