### PR TITLE
Agregando un analizador para anotar los parámetros de cada API

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -5,6 +5,10 @@
 class Admin extends \OmegaUp\Controllers\Controller {
     /**
      * Get stats for an overall platform report.
+     *
+     * @omegaup-request-param mixed $end_time
+     * @omegaup-request-param mixed $start_time
+     *
      * @return array{report: array{acceptedSubmissions: int, activeSchools: int, activeUsers: array<string, int>, courses: int, omiCourse: array{attemptedUsers: int, completedUsers: int, passedUsers: int}}}
      */
     public static function apiPlatformReportStats(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/Authorization.php
+++ b/frontend/server/src/Controllers/Authorization.php
@@ -7,6 +7,10 @@
  */
 class Authorization extends \OmegaUp\Controllers\Controller {
     /**
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $username
+     *
      * @return array{has_solved: bool, is_admin: bool, can_view: bool, can_edit: bool}
      */
     public static function apiProblem(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/Badge.php
+++ b/frontend/server/src/Controllers/Badge.php
@@ -57,6 +57,8 @@ class Badge extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of badges owned by a certain user
      *
+     * @omegaup-request-param mixed $target_username
+     *
      * @return array{badges: list<Badge>}
      */
     public static function apiUserList(\OmegaUp\Request $r): array {
@@ -76,6 +78,8 @@ class Badge extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a the assignation timestamp of a badge
      * for current user.
+     *
+     * @omegaup-request-param mixed $badge_alias
      *
      * @return array{assignation_time: int|null}
      */
@@ -102,6 +106,8 @@ class Badge extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the number of owners and the first
      * assignation timestamp for a certain badge
+     *
+     * @omegaup-request-param mixed $badge_alias
      *
      * @return Badge
      */
@@ -130,6 +136,8 @@ class Badge extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $badge_alias
+     *
      * @return array{smartyProperties: array{badge_alias: string}, template: string}
      */
     public static function getDetailsForSmarty(\OmegaUp\Request $r) {

--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -25,6 +25,11 @@ class Clarification extends \OmegaUp\Controllers\Controller {
     /**
      * Creates a Clarification
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $message
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $username
+     *
      * @return array{clarification_id: int}
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
@@ -106,6 +111,8 @@ class Clarification extends \OmegaUp\Controllers\Controller {
     /**
      * API for getting a clarification
      *
+     * @omegaup-request-param mixed $clarification_id
+     *
      * @return array{message: string, answer: null|string, time: int, problem_id: int, problemset_id: int|null}
      */
     public static function apiDetails(\OmegaUp\Request $r) {
@@ -149,6 +156,10 @@ class Clarification extends \OmegaUp\Controllers\Controller {
 
     /**
      * Update a clarification
+     *
+     * @omegaup-request-param mixed $answer
+     * @omegaup-request-param mixed $clarification_id
+     * @omegaup-request-param mixed $message
      *
      * @return array{status: string}
      */

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -13,6 +13,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests
      *
+     * @omegaup-request-param mixed $active
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param mixed $participating
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $recommended
+     *
      * @return array{number_of_results: int, results: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>}
      */
     public static function apiList(\OmegaUp\Request $r): array {
@@ -221,6 +229,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Returns a list of contests where current user has admin rights (or is
      * the director).
      *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     *
      * @return array{contests: list<array{admission_mode: string, alias: string, finish_time: int, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int, title: string}>}
      */
     public static function apiAdminList(\OmegaUp\Request $r): array {
@@ -256,6 +267,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Callback to get contests list, depending on a given method
+     *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param mixed $query
      *
      * @param \OmegaUp\Request $r
      * @param Closure(int, int, int, null|string):list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}> $callbackUserFunction
@@ -294,6 +309,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests where current user is the director
      *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param mixed $query
+     *
      * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
      */
     public static function apiMyList(\OmegaUp\Request $r): array {
@@ -318,6 +337,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns a list of contests where current user is participating in
+     *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param mixed $query
      *
      * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: int, languages?: null|string, last_updated: int, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: int, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
      */
@@ -466,6 +489,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Get all the properties for smarty.
      *
+     * @omegaup-request-param null|string $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $is_practice
+     *
      * @return array{inContest?: bool, smartyProperties: array{needsBasicInformation?: bool, requestsUserInformation?: false, privacyStatement?: array{markdown: string, statementType: string, gitObjectId?: string}, payload?: array{shouldShowFirstAssociatedIdentityRunWarning: bool}}, template: string}
      */
     public static function getContestDetailsForSmarty(
@@ -577,6 +604,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param mixed $query
+     *
      * @return array{smartyProperties: array{payload: array{contests: array{current: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>, future: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>, participating?: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>, past: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>, public: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>, recommended_current: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>, recommended_past: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: int, last_updated: int, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: int, title: string, window_length: int|null}>}, isLogged: bool, query: string}}, template: string}
      */
     public static function getContestListDetailsForSmarty(
@@ -675,6 +706,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param mixed $query
+     *
      * @return array{smartyProperties: array{payload: array{contests: list<array{contest_id: int, problemset_id: int, acl_id?: int, title: string, description: string, original_finish_time?: \OmegaUp\Timestamp, start_time: int|null, finish_time: int|null, last_updated: int|null, window_length: null|int, rerun_id: int, admission_mode: string, alias: string, scoreboard?: int, points_decay_factor?: float, partial_score?: int, submissions_gap?: int, feedback?: string, penalty?: int, penalty_type?: string, penalty_calc_policy?: string, show_scoreboard_after?: int, urgent?: int, languages?: null|string, recommended: bool, scoreboard_url: string, scoreboard_url_admin: string}>}, privateContestsAlert: bool}, template: string}
      */
     public static function getContestListMineForSmarty(
@@ -800,6 +835,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Validate request of a details contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      * @throws \OmegaUp\Exceptions\PreconditionFailedException
      *
@@ -864,6 +902,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @return array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: int, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_scoreboard_after: bool, start_time: int, submissions_gap: int, title: string, window_length: int|null, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null}
      */
     public static function apiPublicDetails(\OmegaUp\Request $r): array {
@@ -940,6 +980,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @return array{status: string}
      */
     public static function apiRegisterForContest(\OmegaUp\Request $r): array {
@@ -963,6 +1005,12 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Joins a contest - explicitly adds a identity to a contest.
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $privacy_git_object_id
+     * @omegaup-request-param mixed $share_user_information
+     * @omegaup-request-param mixed $statement_type
+     * @omegaup-request-param mixed $token
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -1187,6 +1235,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * not start the current user into that contest. In order to participate
      * in the contest, \OmegaUp\Controllers\Contest::apiOpen() must be used.
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
+     *
      * @return array{admin?: bool, admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: int, languages: list<string>, needs_basic_information: bool, opened: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, scoreboard: int, show_scoreboard_after: bool, start_time: int, submissions_gap: int, submission_deadline?: int, title: string, window_length: int|null}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
@@ -1248,6 +1299,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * apiDetails in the sense that it does not attempt to calculate the
      * remaining time from the contest, or register the opened time.
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
+     *
      * @return array{admin: bool, admission_mode: string, alias: string, available_languages: array<string, string>, description: string, director: null|string, feedback: string, finish_time: int, languages: list<string>, needs_basic_information: bool, partial_score: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: int, submissions_gap: int, title: string, window_length: int|null}
      */
     public static function apiAdminDetails(\OmegaUp\Request $r): array {
@@ -1283,6 +1337,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns a report with all user activity for a contest.
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
      *
      * @return array{events: list<array{username: string, ip: int, time: int, classname?: string, alias?: string}>}
      */
@@ -1326,6 +1383,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Clone a contest
+     *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $title
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
@@ -1433,6 +1497,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $start_time
+     *
      * @return array{alias: string}
      */
     public static function apiCreateVirtual(\OmegaUp\Request $r): array {
@@ -1586,6 +1653,27 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Creates a new contest
      *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $basic_information
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $partial_score
+     * @omegaup-request-param mixed $penalty
+     * @omegaup-request-param mixed $penalty_calc_policy
+     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param mixed $points_decay_factor
+     * @omegaup-request-param mixed $problems
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $scoreboard
+     * @omegaup-request-param mixed $show_scoreboard_after
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $window_length
+     *
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      *
      * @return array{status: string}
@@ -1652,6 +1740,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Validates that Request contains expected data to create or update a contest
      * In case of update, everything is optional except the contest_alias
      * In case of error, this function throws.
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $penalty_calc_policy
+     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param mixed $problems
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $window_length
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
@@ -1837,6 +1939,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Validates that Request contains expected data to create a contest
      * In case of error, this function throws.
      *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $penalty_calc_policy
+     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param mixed $problems
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $window_length
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     private static function validateCreate(
@@ -1850,6 +1966,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Validates that Request contains expected data to update a contest
      * everything is optional except the contest_alias
      * In case of error, this function throws.
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $penalty_calc_policy
+     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param mixed $problems
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $window_length
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
@@ -1937,6 +2067,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the problems from a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @return array{problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>}
      */
     public static function apiProblems(\OmegaUp\Request $r): array {
@@ -1982,6 +2114,12 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Adds a problem to a contest
+     *
+     * @omegaup-request-param mixed $commit
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $order_in_contest
+     * @omegaup-request-param mixed $points
+     * @omegaup-request-param mixed $problem_alias
      *
      * @return array{status: string}
      */
@@ -2148,6 +2286,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Removes a problem from a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @return array{status: string}
      */
     public static function apiRemoveProblem(\OmegaUp\Request $r) {
@@ -2269,6 +2410,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Return a report of which runs would change due to a version change.
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $version
+     *
      * @return array{diff: list<array{guid: string, new_score: float|null, new_status: null|string, new_verdict: null|string, old_score: float|null, old_status: null|string, old_verdict: null|string, problemset_id: int|null, username: string}>}
      */
     public static function apiRunsDiff(\OmegaUp\Request $r): array {
@@ -2340,6 +2485,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * By default, any user can view details of public contests.
      * Only users added through this API can view private contests
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -2384,6 +2532,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Remove a user from a private contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @return array{status: string}
      */
     public static function apiRemoveUser(\OmegaUp\Request $r): array {
@@ -2413,6 +2564,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Adds an group to a contest
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -2467,6 +2621,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Removes a group from a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -2518,6 +2675,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Adds an admin to a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -2560,6 +2720,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Removes an admin from a contest
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $usernameOrEmail
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -2609,6 +2772,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Adds an group admin to a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -2654,6 +2820,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Removes a group admin from a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -2694,6 +2863,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Validate the Clarifications request
+     *
+     * @omegaup-request-param mixed $contest_alias
      */
     private static function validateClarifications(\OmegaUp\Request $r): \OmegaUp\DAO\VO\Contests {
         // Check contest_alias
@@ -2715,6 +2886,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get clarifications of a contest
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $rowcount
      *
      * @return array{clarifications: list<array{answer: null|string, author: string, clarification_id: int, message: string, problem_alias: string, public: bool, receiver: null|string, time: int}>}
      */
@@ -2749,6 +2924,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the Scoreboard events
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
      * @return array{events: list<array{country: null|string, delta: float, is_invited: bool, total: array{points: float, penalty: float}, name: null|string, username: string, problem: array{alias: string, points: float, penalty: float}}>}
@@ -2779,6 +2957,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns the Scoreboard
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
@@ -2863,6 +3044,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Gets the accomulative scoreboard for an array of contests
+     *
+     * @omegaup-request-param mixed $contest_aliases
+     * @omegaup-request-param mixed $contest_params
+     * @omegaup-request-param mixed $usernames_filter
      *
      * @return array{ranking: list<array{name: null|string, username: string, contests: array<string, array{points: float, penalty: float}>, total: array{points: float, penalty: float}}>}
      */
@@ -3035,6 +3220,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @return array{users: list<array{accepted: bool|null, admin?: array{username?: null|string}, country: null|string, last_update: \OmegaUp\Timestamp|null, request_time: \OmegaUp\Timestamp, username: string}>, contest_alias: string}
      */
     public static function apiRequests(\OmegaUp\Request $r): array {
@@ -3099,6 +3286,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $note
+     * @omegaup-request-param mixed $resolution
+     * @omegaup-request-param mixed $username
+     *
      * @return array{status: string}
      */
     public static function apiArbitrateRequest(\OmegaUp\Request $r): array {
@@ -3180,6 +3372,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns ALL identities participating in a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @return array{users: list<array{access_time: int|null, country_id: null|string, end_time: int|null, is_owner: int|null, username: string}>, groups: list<array{alias: string, name: string}>}
      */
     public static function apiUsers(\OmegaUp\Request $r): array {
@@ -3207,6 +3401,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns all contest administrators
+     *
+     * @omegaup-request-param mixed $contest_alias
      *
      * @return array{admins: list<array{role: string, username: string}>, group_admins: list<array{alias: string, name: string, role: string}>}
      */
@@ -3257,6 +3453,23 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Update a Contest
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $basic_information
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $penalty_calc_policy
+     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param mixed $problems
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $window_length
      *
      * @return array{status: string}
      */
@@ -3421,6 +3634,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Update Contest end time for an identity when window_length
      * option is turned on
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $end_time
+     * @omegaup-request-param mixed $username
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
      * @return array{status: string}
@@ -3511,6 +3728,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Validates runs API
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -3588,6 +3814,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns all runs for a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
+     *
      * @return array{runs: list<array{run_id: int, guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float, judged_by: null|string, time: int, submit_delay: int, type: null|string, username: string, alias: string, country_id: null|string, contest_alias: null|string}>}
      */
     public static function apiRuns(\OmegaUp\Request $r): array {
@@ -3660,6 +3895,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Stats of a contest
      *
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{total_runs: int, pending_runs: list<string>, max_wait_time: int, max_wait_time_guid: null|string, verdict_counts: array<string, int>, distribution: array<int, int>, size_of_bucket: float, total_points: float}
@@ -3676,6 +3913,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $contest_alias
+     *
      * @return array{smartyProperties: array{payload: array{alias: string, entity_type: string, total_runs: int, pending_runs: list<string>, max_wait_time: int, max_wait_time_guid: null|string, verdict_counts: array<string, int>, distribution: array<int, int>, size_of_bucket: float, total_points: float}}, template: string}
      */
     public static function getStatsDataForSmarty(\OmegaUp\Request $r) {
@@ -3796,6 +4035,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a detailed report of the contest. Only Admins can get the report
      *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $filterBy
+     *
      * @return array{finish_time: int|null, problems: list<array{alias: string, order: int}>, ranking: list<array{country: null|string, is_invited: bool, name: string|null, place?: int, problems: list<array{alias: string, penalty: float, percent: float, place?: int, points: float, run_details?: array{cases?: list<array{contest_score: float, max_score: float, meta: array{status: string}, name: string|null, out_diff: string, score: float, verdict: string}>, details: array{groups: list<array{cases: list<array{meta: array{memory: float, time: float, wall_time: float}}>}>}}, runs: int}>, total: array{penalty: float, points: float}, username: string}>, start_time: int, time: int, title: string}
      */
     private static function getContestReportDetails(\OmegaUp\Request $r): array {
@@ -3832,6 +4075,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Gets all details to show the report
      *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $filterBy
+     *
      * @return array{contestReport: list<array{country: null|string, is_invited: bool, name: null|string, place?: int, problems: list<array{alias: string, penalty: float, percent: float, place?: int, points: float, run_details?: array{cases?: list<array{contest_score: float, max_score: float, meta: array{status: string}, name: null|string, out_diff: string, score: float, verdict: string}>, details: array{groups: list<array{cases: list<array{meta: array{memory: float, time: float, wall_time: float}}>}>}}, runs: int}>, total: array{penalty: float, points: float}, username: string}>}
      */
     public static function getContestReportDetailsForSmarty(\OmegaUp\Request $r) {
@@ -3864,6 +4111,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Generates a CSV for contest report
+     *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $filterBy
      */
     public static function apiCsvReport(\OmegaUp\Request $r): void {
         $r->ensureIdentity();
@@ -4003,6 +4254,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         return $escapedRow;
     }
 
+    /**
+     * @omegaup-request-param mixed $contest_alias
+     */
     public static function apiDownload(\OmegaUp\Request $r): void {
         $r->ensureIdentity();
 
@@ -4030,6 +4284,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Given a contest_alias and user_id, returns the role of the user within
      * the context of a contest.
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
+     *
      * @return array{admin: bool}
      */
     public static function apiRole(\OmegaUp\Request $r): array {
@@ -4053,6 +4310,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Given a contest_alias, sets the recommended flag on/off.
      * Only omegaUp admins can call this API.
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $value
      *
      * @return array{status: string}
      */
@@ -4088,6 +4348,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Return users who participate in a contest, as long as contest admin
      * has chosen to ask for users information and contestants have
      * previously agreed to share their information.
+     *
+     * @omegaup-request-param mixed $contest_alias
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *

--- a/frontend/server/src/Controllers/Controller.php
+++ b/frontend/server/src/Controllers/Controller.php
@@ -17,6 +17,8 @@ class Controller {
      * This is to allow unauthenticated access to APIs that work for both
      * current authenticated user and a targeted user (via $r["username"])
      *
+     * @omegaup-request-param mixed $username
+     *
      * @param \OmegaUp\Request $r
      */
     protected static function authenticateOrAllowUnauthenticatedRequest(
@@ -38,6 +40,8 @@ class Controller {
      * user.
      *
      * Request must be authenticated before this function is called.
+     *
+     * @omegaup-request-param mixed $username
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      */
@@ -67,6 +71,8 @@ class Controller {
      * identity.
      *
      * Request must be authenticated before this function is called.
+     *
+     * @omegaup-request-param mixed $username
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      */
@@ -122,6 +128,7 @@ class Controller {
      *     it into the proper form that should be stored in $object. For example:
      *     function($value) { return gmdate('Y-m-d H:i:s', $value); }
      *
+     * @psalm-suppress RequestAccessNotALiteralString  This is the only function that's allowed to access parameters as a non-string literal.
      * @param \OmegaUp\Request $request
      * @param object $object
      * @param array<int|string, string|array{transform?: callable(mixed):mixed, important?: bool}> $properties

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -45,8 +45,17 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates request for creating a new Assignment
      *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $assignment_type
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
+     *
      * @param \OmegaUp\DAO\VO\Courses $course
      * @param \OmegaUp\DAO\VO\Assignments $assignment
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     private static function validateCreateAssignment(
@@ -113,6 +122,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Validates clone Courses
+     *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $name
      */
     private static function validateClone(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
@@ -123,7 +135,18 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates create Courses
      *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
+     *
      * @param \OmegaUp\Request $r
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
@@ -144,6 +167,16 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Validates update Courses
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
@@ -180,8 +213,18 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Validates basic information of a course
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param mixed $unlimited_duration
+     *
      * @param \OmegaUp\Request $r
      * @param bool $isUpdate
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
@@ -305,6 +348,11 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Clone a course
      *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $start_time
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      *
@@ -407,7 +455,21 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Create new course API
      *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $needs_basic_information
+     * @omegaup-request-param mixed $public
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param mixed $show_scoreboard
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
+     *
      * @return array{status: string}
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      */
@@ -590,6 +652,16 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * API to Create an assignment
      *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $assignment_type
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $publish_time_delay
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
+     *
      * @return array{status: string}
      */
     public static function apiCreateAssignment(\OmegaUp\Request $r): array {
@@ -628,6 +700,12 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Update an assignment
+     *
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
      *
      * @return array{status: 'ok'}
      */
@@ -739,6 +817,12 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Adds a problem to an assignment
      *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $commit
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $points
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @return array{status: 'ok'}
      */
     public static function apiAddProblem(\OmegaUp\Request $r): array {
@@ -813,6 +897,11 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $order
+     * @omegaup-request-param mixed $problems
+     *
      * @return array{status: string}
      */
     public static function apiUpdateProblemsOrder(\OmegaUp\Request $r): array {
@@ -884,6 +973,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $assignments
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{status: string}
      */
     public static function apiUpdateAssignmentsOrder(\OmegaUp\Request $r): array {
@@ -938,6 +1030,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @return array{identities: list<string>}
      */
     public static function apiGetProblemUsers(\OmegaUp\Request $r) {
@@ -983,6 +1078,10 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Remove a problem from an assignment
+     *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $problem_alias
      *
      * @return array{status: string}
      */
@@ -1068,7 +1167,10 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * List course assignments
      *
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{assignments: list<array{alias: string, assignment_type: string, description: string, finish_time: null|int, has_runs: bool, name: string, order: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: int}>}
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     public static function apiListAssignments(\OmegaUp\Request $r) {
@@ -1129,6 +1231,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Remove an assignment from a course
+     *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
      */
     public static function apiRemoveAssignment(\OmegaUp\Request $r): void {
         if (OMEGAUP_LOCKDOWN) {
@@ -1202,7 +1307,11 @@ class Course extends \OmegaUp\Controllers\Controller {
      * Returns courses for which the current user is an admin and
      * for in which the user is a student.
      *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     *
      * @return array{admin: list<array{alias: string, counts: array<string, int>, finish_time: int|null, name: string, start_time: int}>, public: list<array{alias: string, counts: array<string, int>, finish_time: int|null, name: string, start_time: int}>, student: list<array{alias: string, counts: array<string, int>, finish_time: int|null, name: string, start_time: int}>}
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     public static function apiListCourses(\OmegaUp\Request $r) {
@@ -1334,6 +1443,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * List students in a course
      *
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{students: list<array{name: null|string, progress: array<string, float>, username: string}>}
      */
     public static function apiListStudents(\OmegaUp\Request $r): array {
@@ -1366,6 +1477,10 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @return array{problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, submissions: int, title: string, version: string, visibility: int, visits: int, runs: list<array{guid: string, language: string, source?: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float|null, time: int, submit_delay: int}>}>}
      */
     public static function apiStudentProgress(\OmegaUp\Request $r): array {
@@ -1461,6 +1576,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns details of a given course
      *
+     * @omegaup-request-param mixed $alias
+     *
      * @return array{assignments: AssignmentProgress}
      */
     public static function apiMyProgress(\OmegaUp\Request $r): array {
@@ -1501,6 +1618,14 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Add Student to Course.
+     *
+     * @omegaup-request-param mixed $accept_teacher
+     * @omegaup-request-param mixed $accept_teacher_git_object_id
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $privacy_git_object_id
+     * @omegaup-request-param mixed $share_user_information
+     * @omegaup-request-param mixed $statement_type
+     * @omegaup-request-param mixed $usernameOrEmail
      *
      * @return array{status: string}
      */
@@ -1637,6 +1762,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Remove Student from Course
      *
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @return array{status: string}
      */
     public static function apiRemoveStudent(\OmegaUp\Request $r): array {
@@ -1692,6 +1820,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns all course administrators
      *
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{admins: list<array{role: string, username: string}>, group_admins: list<array{alias: string, name: string, role: string}>}
      */
     public static function apiAdmins(\OmegaUp\Request $r): array {
@@ -1720,6 +1850,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Adds an admin to a course
+     *
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $usernameOrEmail
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -1769,6 +1902,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Removes an admin from a course
+     *
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $usernameOrEmail
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -1833,6 +1969,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Adds an group admin to a course
      *
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $group
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -1881,6 +2020,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Removes a group admin from a course
+     *
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $group
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -1948,6 +2090,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $student
+     *
      * @return array{payload: array{course: array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: array{name: string, description: string, alias: string, publish_time_delay: ?int, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}[], school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: string|null}, students: array{name: null|string, progress: array<string, float>, username: string}[], student?: string}}
      */
     public static function getStudentsInformationForSmarty(
@@ -1994,6 +2139,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Refactor of apiIntroDetails in order to be called from php files and APIs
+     *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
      *
      * @return array{inContest: bool, smartyProperties: array{coursePayload?: array{alias: string, currentUsername: string, description: string, isFirstTimeAccess: bool, name: string, needsBasicInformation: bool, requestsUserInformation: string, shouldShowAcceptTeacher: bool, shouldShowResults: bool, statements: array{acceptTeacher: array{gitObjectId: null|string, markdown: string, statementType: string}, privacy: array{gitObjectId: null|string, markdown: null|string, statementType: null|string}}, userRegistrationAccepted?: bool|null, userRegistrationAnswered?: bool, userRegistrationRequested?: bool}, payload?: array{details?: array{alias: string, assignments?: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: int}>, basic_information_required: bool, description: string, finish_time?: int|null, is_admin?: bool, name: string, public?: bool, requests_user_information: string, school_id?: int|null, school_name?: null|string, show_scoreboard?: bool, start_time?: int, student_count?: int}, progress?: AssignmentProgress, shouldShowFirstAssociatedIdentityRunWarning?: bool}, showRanking?: bool}, template: string}
      */
@@ -2189,6 +2337,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{status: string}
      */
     public static function apiRegisterForCourse(\OmegaUp\Request $r): array {
@@ -2297,6 +2447,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns all details of a given Course
      *
+     * @omegaup-request-param mixed $alias
+     *
      * @return array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: list<array{name: string, description: string, alias: string, publish_time_delay: int|null, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: null|string}
      */
     public static function apiAdminDetails(\OmegaUp\Request $r): array {
@@ -2321,6 +2473,8 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns a report with all user activity for a course.
+     *
+     * @omegaup-request-param mixed $course_alias
      *
      * @return array{events: list<array{username: string, ip: int, time: int, classname?: string, alias?: string}>}
      */
@@ -2497,6 +2651,11 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns details of a given assignment
      *
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $username
+     *
      * @return array{name: null|string, description: null|string, assignment_type: null|string, start_time: int, finish_time: null|int, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, director: string, problemset_id: int, admin: bool}
      */
     public static function apiAssignmentDetails(\OmegaUp\Request $r): array {
@@ -2627,6 +2786,16 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns all runs for a course
      *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
+     *
      * @return array{runs: list<array{run_id: int, guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float, judged_by: null|string, time: int, submit_delay: int, type: null|string, username: string, alias: string, country_id: null|string, contest_alias: null|string}>}
      */
     public static function apiRuns(\OmegaUp\Request $r): array {
@@ -2669,7 +2838,18 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates runs API
      *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
+     *
      * @return array{assignment: \OmegaUp\DAO\VO\Assignments, problem: \OmegaUp\DAO\VO\Problems|null, identity: \OmegaUp\DAO\VO\Identities|null}
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
@@ -2766,6 +2946,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns details of a given course
      *
+     * @omegaup-request-param mixed $alias
+     *
      * @return array{name: string, description: string, alias: string, basic_information_required: bool, requests_user_information: string, assignments?: list<array{name: string, description: string, alias: string, publish_time_delay: int|null, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, school_id?: int|null, start_time?: int, finish_time?: int|null, is_admin?: bool, public?: bool, show_scoreboard?: bool, student_count?: int, school_name?: null|string}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
@@ -2801,6 +2983,17 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Edit Course contents
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param mixed $start_time
+     * @omegaup-request-param mixed $unlimited_duration
      *
      * @return array{status: string}
      */
@@ -2865,6 +3058,10 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Gets Scoreboard for an assignment
      *
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $token
+     *
      * @return array{finish_time: int|null, problems: list<array{alias: string, order: int}>, ranking: list<array{country: null|string, is_invited: bool, name: string|null, place?: int, problems: list<array{alias: string, penalty: float, percent: float, place?: int, points: float, run_details?: array{cases?: list<array{contest_score: float, max_score: float, meta: array{status: string}, name: string|null, out_diff: string, score: float, verdict: string}>, details: array{groups: list<array{cases: list<array{meta: array{memory: float, time: float, wall_time: float}}>}>}}, runs: int}>, total: array{penalty: float, points: float}, username: string}>, start_time: int, time: int, title: string}
      */
     public static function apiAssignmentScoreboard(\OmegaUp\Request $r): array {
@@ -2924,6 +3121,10 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the Scoreboard events
      *
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $token
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
      * @return array{events: list<array{country: null|string, delta: float, is_invited: bool, name: null|string, problem: array{alias: string, penalty: float, points: float}, total: array{penalty: float, points: float}, username: string}>}
@@ -2968,6 +3169,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Get Problems solved by users of a course
      *
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{user_problems: array<string, list<array{alias: string, title: string, username: string}>>}
      */
     public static function apiListSolvedProblems(\OmegaUp\Request $r): array {
@@ -2995,6 +3198,8 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get Problems unsolved by users of a course
+     *
+     * @omegaup-request-param mixed $course_alias
      *
      * @return array{user_problems: array<string, list<array{alias: string, title: string, username: string}>>}
      */

--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -55,7 +55,12 @@ class Group extends \OmegaUp\Controllers\Controller {
     /**
      * New group
      *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $name
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{status: string}
      */
     public static function apiCreate(\OmegaUp\Request $r) {
@@ -113,6 +118,9 @@ class Group extends \OmegaUp\Controllers\Controller {
     /**
      * Add identity to group
      *
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @param \OmegaUp\Request $r
      *
      * @return array{status: string}
@@ -159,6 +167,9 @@ class Group extends \OmegaUp\Controllers\Controller {
 
     /**
      * Remove user from group
+     *
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $usernameOrEmail
      *
      * @param \OmegaUp\Request $r
      *
@@ -226,6 +237,8 @@ class Group extends \OmegaUp\Controllers\Controller {
      * Returns a list of groups that match a partial name. This returns an
      * array instead of an object since it is used by typeahead.
      *
+     * @omegaup-request-param mixed $query
+     *
      * @param \OmegaUp\Request $r
      *
      * @return list<array{label: string, value: string}>
@@ -254,6 +267,8 @@ class Group extends \OmegaUp\Controllers\Controller {
 
     /**
      * Details of a group (scoreboards)
+     *
+     * @omegaup-request-param mixed $group_alias
      *
      * @param \OmegaUp\Request $r
      *
@@ -302,6 +317,8 @@ class Group extends \OmegaUp\Controllers\Controller {
     /**
      * Members of a group (usernames only).
      *
+     * @omegaup-request-param mixed $group_alias
+     *
      * @param \OmegaUp\Request $r
      *
      * @return array{identities: list<array{classname: string, country?: null|string, country_id?: null|string, name?: null|string, school?: null|string, school_id?: int|null, state?: null|string, state_id?: null|string, username: string}>}
@@ -329,6 +346,11 @@ class Group extends \OmegaUp\Controllers\Controller {
 
     /**
      * Create a scoreboard set to a group
+     *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $name
      *
      * @return array{status: string}
      */

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -75,6 +75,12 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
     /**
      * Add contest to a group scoreboard
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $only_ac
+     * @omegaup-request-param mixed $scoreboard_alias
+     * @omegaup-request-param mixed $weight
+     *
      * @param \OmegaUp\Request $r
      *
      * @return array{status: string}
@@ -121,6 +127,10 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
 
     /**
      * Add contest to a group scoreboard
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $scoreboard_alias
      *
      * @param \OmegaUp\Request $r
      *
@@ -170,6 +180,9 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
     /**
      * Details of a scoreboard. Returns a list with all contests that belong to
      * the given scoreboard_alias
+     *
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $scoreboard_alias
      *
      * @param \OmegaUp\Request $r
      *
@@ -257,6 +270,8 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
 
     /**
      * Details of a scoreboard
+     *
+     * @omegaup-request-param mixed $group_alias
      *
      * @return array{scoreboards: list<array{group_scoreboard_id: int, group_id: int, create_time: int, alias: string, name: string, description: string}>}
      */

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -67,6 +67,16 @@ class Identity extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Create an Identity API
      *
+     * @omegaup-request-param mixed $country_id
+     * @omegaup-request-param mixed $gender
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $identities
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $school_name
+     * @omegaup-request-param mixed $state_id
+     * @omegaup-request-param mixed $username
+     *
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      *
      * @return array{username: string}
@@ -169,6 +179,11 @@ class Identity extends \OmegaUp\Controllers\Controller {
 
     /**
      * Entry point for Create bulk Identities API
+     *
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $identities
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $username
      *
      * @return array{status: string}
      */
@@ -275,6 +290,12 @@ class Identity extends \OmegaUp\Controllers\Controller {
         ];
     }
 
+    /**
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $identities
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $username
+     */
     private static function validateGroupOwnership(\OmegaUp\Request $r): \OmegaUp\DAO\VO\Groups {
         $r->ensureIdentity();
         if (!\OmegaUp\Authorization::isGroupIdentityCreator($r->identity)) {
@@ -370,6 +391,16 @@ class Identity extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Update an Identity API
      *
+     * @omegaup-request-param mixed $country_id
+     * @omegaup-request-param mixed $gender
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $identities
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $original_username
+     * @omegaup-request-param mixed $school_name
+     * @omegaup-request-param mixed $state_id
+     * @omegaup-request-param mixed $username
+     *
      * @return array{status: string}
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
@@ -463,6 +494,12 @@ class Identity extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for change passowrd of an identity
      *
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $identities
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $username
+     *
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      *
      * @return array{status: string}
@@ -501,6 +538,11 @@ class Identity extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param mixed $identities
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $username
+     *
      * @param \OmegaUp\Request $r
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException

--- a/frontend/server/src/Controllers/Interview.php
+++ b/frontend/server/src/Controllers/Interview.php
@@ -4,6 +4,11 @@
 
 class Interview extends \OmegaUp\Controllers\Controller {
     /**
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param mixed $duration
+     * @omegaup-request-param mixed $title
+     *
      * @return array{status: string}
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
@@ -89,6 +94,9 @@ class Interview extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $interview_alias
+     * @omegaup-request-param mixed $usernameOrEmailsCSV
+     *
      * @return array{status: string}
      */
     public static function apiAddUsers(\OmegaUp\Request $r): array {
@@ -234,6 +242,8 @@ class Interview extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $interview_alias
+     *
      * @return array{description?: null|string, contest_alias?: null|string, problemset_id?: int|null, users?: list<array{user_id: int|null, username: string, access_time: \OmegaUp\Timestamp|null, email: null|string, opened_interview: bool, country: null|string}>, exists: bool}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
@@ -300,6 +310,9 @@ class Interview extends \OmegaUp\Controllers\Controller {
         ];
     }
 
+    /**
+     * @omegaup-request-param mixed $contest_alias
+     */
     public static function showIntro(\OmegaUp\Request $r): bool {
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['contest_alias'],

--- a/frontend/server/src/Controllers/Notification.php
+++ b/frontend/server/src/Controllers/Notification.php
@@ -25,6 +25,8 @@ class Notification extends \OmegaUp\Controllers\Controller {
     /**
      * Updates notifications as read in database
      *
+     * @omegaup-request-param mixed $notifications
+     *
      * @return array{status: string}
      */
     public static function apiReadNotifications(\OmegaUp\Request $r) {

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -58,6 +58,22 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a ProblemParams instance from the Request values.
      *
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
      */
     private static function convertRequestToProblemParams(
         \OmegaUp\Request $r,
@@ -284,6 +300,23 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Create a new problem
      *
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
+     *
      * @throws \OmegaUp\Exceptions\ApiException
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      *
@@ -401,6 +434,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Adds an admin to a problem
      *
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -448,6 +484,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Adds a group admin to a problem
      *
+     * @omegaup-request-param mixed $group
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -493,6 +532,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Adds a tag to a problem
+     *
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $public
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -563,6 +606,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Removes an admin from a problem
      *
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -616,6 +662,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Removes a group admin from a problem
      *
+     * @omegaup-request-param mixed $group
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -660,6 +709,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Removes a tag from a contest
+     *
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $problem_alias
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -710,6 +762,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Removes a problem whether user is the creator
      *
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -749,6 +803,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Returns all problem administrators
      *
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @return array{admins: list<array{role: string, username: string}>, group_admins: list<array{alias: string, name: string, role: string}>}
      */
     public static function apiAdmins(\OmegaUp\Request $r): array {
@@ -780,6 +836,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Returns every tag associated to a given problem.
      *
+     * @omegaup-request-param mixed $include_voted
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @return array{tags: list<array{name: string, public: bool}>}
      */
     public static function apiTags(\OmegaUp\Request $r): array {
@@ -807,6 +866,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Rejudge problem
+     *
+     * @omegaup-request-param mixed $problem_alias
      *
      * @throws \OmegaUp\Exceptions\ApiException
      *
@@ -876,8 +937,29 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Update problem contents
      *
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $message
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $redirect
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{rejudged: bool}
+     *
      * @throws \OmegaUp\Exceptions\ApiException
      */
     public static function apiUpdate(\OmegaUp\Request $r) {
@@ -1377,6 +1459,26 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Updates problem statement only
      *
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $message
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $statement
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
+     *
      * @throws \OmegaUp\Exceptions\ApiException
      *
      * @return array{status: string}
@@ -1446,6 +1548,26 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Updates problem solution only
+     *
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $message
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $solution
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
      *
      * @throws \OmegaUp\Exceptions\ApiException
      *
@@ -1863,6 +1985,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Problem Download API
      *
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @param \OmegaUp\Request $r
      *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
@@ -1989,6 +2113,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Entry point for Problem Details API
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param mixed $prevent_problemset_open
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $show_solvers
+     * @omegaup-request-param mixed $statement_type
      *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
@@ -2306,6 +2438,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the solution for a problem if conditions are satisfied.
      *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $forfeit_problem
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $statement_type
+     *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
      * @return array{exists: bool, solution?: array{language: string, markdown: string, images: array<string, string>}}
@@ -2398,6 +2537,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Problem Versions API
      *
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
@@ -2485,6 +2626,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Change the version of the problem.
+     *
+     * @omegaup-request-param mixed $commit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $update_published
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      * @throws \OmegaUp\Exceptions\NotFoundException
@@ -2657,6 +2802,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Return a report of which runs would change due to a version change.
      *
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $version
+     *
      * @return array{diff: list<array{username: string, guid: string, problemset_id: ?int, old_status: ?string, old_verdict: ?string, old_score: ?float, new_status: ?string, new_verdict: ?string, new_score: ?float}>}
      */
     public static function apiRunsDiff(\OmegaUp\Request $r): array {
@@ -2756,6 +2904,15 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Problem runs API
      *
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $show_all
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
+     *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
      * @return array{runs: list<array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float|null, time: int, submit_delay: int, alias: string, username: string, run_id?: int, judged_by?: null|string, type?: null|string, country_id?: null|string, contest_alias?: null|string}>}
@@ -2831,6 +2988,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Problem clarifications API
      *
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
      * @return array{clarifications: list<array{clarification_id: int, contest_alias: string, author: null|string, message: string, time: int, answer: null|string, public: bool}>}
@@ -2874,6 +3035,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Stats of a problem
      *
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{cases_stats: array<string, int>, pending_runs: list<array{guid: string}>, total_runs: int, verdict_counts: array<string, int>}
@@ -2895,6 +3058,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @return array{smartyProperties: array{payload: array{alias: string, entity_type: string, cases_stats: array<string, int>, pending_runs: list<array{guid: string}>, total_runs: int, verdict_counts: array<string, int>}}, template: string}
      */
     public static function getStatsDataForSmarty(\OmegaUp\Request $r) {
@@ -3055,6 +3220,20 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $difficulty_range
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $max_difficulty
+     * @omegaup-request-param mixed $min_difficulty
+     * @omegaup-request-param mixed $min_visibility
+     * @omegaup-request-param mixed $mode
+     * @omegaup-request-param mixed $only_karel
+     * @omegaup-request-param mixed $order_by
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $programming_languages
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $require_all_tags
+     * @omegaup-request-param mixed $some_tags
+     *
      * @return array{difficultyRange: array{0: int, 1: int}|null, keyword: string, language: string, minVisibility: int, mode: string, orderBy: string, page: int, programmingLanguages: list<string>, requireAllTags: bool, tags: list<string>}
      */
     private static function validateListParams(\OmegaUp\Request $r) {
@@ -3154,7 +3333,22 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * List of public and user's private problems
      *
-     * @param \OmegaUp\Request $r
+     * @omegaup-request-param mixed $difficulty_range
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $max_difficulty
+     * @omegaup-request-param mixed $min_difficulty
+     * @omegaup-request-param mixed $min_visibility
+     * @omegaup-request-param mixed $mode
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $only_karel
+     * @omegaup-request-param mixed $order_by
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $programming_languages
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $require_all_tags
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $some_tags
+     *
      * @return array{results: list<ProblemListItem>, total: int}
      */
     public static function apiList(\OmegaUp\Request $r) {
@@ -3289,6 +3483,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * Returns a list of problems where current user has admin rights (or is
      * the owner).
      *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     *
      * @return array{pagerItems: list<PageItem>, problems: list<array{tags: list<array{name: string, source: string}>}>}
      */
     public static function apiAdminList(\OmegaUp\Request $r): array {
@@ -3354,6 +3551,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of problems where current user is the owner
      *
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $rowcount
+     *
      * @return array{pagerItems: list<PageItem>, problems: list<array{tags: list<array{name: string, source: string}>}>}
      */
     public static function apiMyList(\OmegaUp\Request $r): array {
@@ -3414,6 +3615,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns the best score for a problem
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $statement_type
+     * @omegaup-request-param mixed $username
      *
      * @return array{score: float}
      */
@@ -3637,6 +3845,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param mixed $prevent_problemset_open
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $statement_type
+     *
      * @return array{smartyProperties: array{input_limit: string, karel_problem: bool, memory_limit: string, overall_wall_time_limit: string, payload: array{accepted: int, admin?: bool, alias: string, commit: string, creation_date: int, difficulty: float|null, email_clarifications: bool, histogram: array{difficulty: float, difficulty_histogram: null|string, quality: float, quality_histogram: null|string}, input_limit: int, languages: list<string>, order: string, points: float, preferred_language?: string, problemsetter?: array{creation_date: int, name: string, username: string}, quality_seal: bool, runs?: list<array{alias: string, contest_score: float|null, guid: string, language: string, memory: int, penalty: int, runtime: int, score: float, status: string, submit_delay: int, time: int, username: string, verdict: string}>, score: float, settings: array{cases: array<string, array{in: string, out: string, weight?: float}>, limits: array{ExtraWallTime?: int|string, MemoryLimit: int|string, OutputLimit?: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance?: float}}, shouldShowFirstAssociatedIdentityRunWarning?: bool, solution_status?: string, solvers?: list<array{language: string, memory: float, runtime: float, time: int, username: string}>, source?: string, statement: array{images: array<string, string>, language: string, markdown: string}, submissions: int, title: string, user: array{admin: bool, logged_in: bool, reviewer: bool}, version: string, visibility: int, visits: int}, points: float, problem_admin: bool, problem_alias: string, problemsetter: array{creation_date: int, name: string, username: string}|null, quality_payload: array{can_nominate_problem?: bool, dismissed: bool, dismissedBeforeAC?: bool, language?: string, nominated: bool, nominatedBeforeAC?: bool, problem_alias?: string, solved: bool, tried: bool}, nomination_payload: array{problem_alias: string, reviewer: bool, already_reviewed: bool}, solvers: list<array{language: string, memory: float, runtime: float, time: int, username: string}>, source: null|string, time_limit: string, title: string, quality_seal: bool, visibility: int}, template: string}
      */
     public static function getProblemDetailsForSmarty(
@@ -3810,6 +4025,22 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $difficulty_range
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $max_difficulty
+     * @omegaup-request-param mixed $min_difficulty
+     * @omegaup-request-param mixed $min_visibility
+     * @omegaup-request-param mixed $mode
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $only_karel
+     * @omegaup-request-param mixed $order_by
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $programming_languages
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $require_all_tags
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $some_tags
+     *
      * @return array{smartyProperties: array{payload: array{currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tags: list<string>}}, template: string}
      */
     public static function getProblemListForSmarty(
@@ -3906,6 +4137,29 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $message
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $redirect
+     * @omegaup-request-param mixed $request
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $statement-language
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
+     * @omegaup-request-param mixed $wmd-input-statement
+     *
      * @return array{IS_UPDATE: bool, LOAD_MATHJAX: bool, LOAD_PAGEDOWN: bool, STATUS_ERROR?: string, STATUS_SUCCESS?: null|string}
      */
     public static function getProblemEditDetailsForSmarty(
@@ -3996,6 +4250,25 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param mixed $extra_wall_time
+     * @omegaup-request-param mixed $input_limit
+     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param mixed $memory_limit
+     * @omegaup-request-param mixed $output_limit
+     * @omegaup-request-param mixed $overall_wall_time_limit
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $request
+     * @omegaup-request-param mixed $selected_tags
+     * @omegaup-request-param mixed $source
+     * @omegaup-request-param mixed $time_limit
+     * @omegaup-request-param mixed $title
+     * @omegaup-request-param mixed $update_published
+     * @omegaup-request-param mixed $validator
+     * @omegaup-request-param mixed $validator_time_limit
+     * @omegaup-request-param mixed $visibility
+     *
      * @return array{smartyProperties: array{ALIAS: string, EMAIL_CLARIFICATIONS: string, EXTRA_WALL_TIME: string, INPUT_LIMIT: string, LANGUAGES: string, MEMORY_LIMIT: string, OUTPUT_LIMIT: string, OVERALL_WALL_TIME_LIMIT: string, SELECTED_TAGS: string, SOURCE: string, TIME_LIMIT: string, TITLE: string, VALIDATOR: string, VALIDATOR_TIME_LIMIT: string, VISIBILITY: string}, template: string}
      */
     public static function getProblemNewForSmarty(
@@ -4171,6 +4444,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
         return [$minDifficulty, $maxDifficulty];
     }
 
+    /**
+     * @omegaup-request-param mixed $commit
+     * @omegaup-request-param mixed $filename
+     * @omegaup-request-param mixed $problem_alias
+     */
     public static function apiTemplate(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['problem_alias'],
@@ -4235,6 +4513,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problemDeployer->generateLibinteractiveTemplates($commit);
     }
 
+    /**
+     * @omegaup-request-param mixed $extension
+     * @omegaup-request-param mixed $object_id
+     * @omegaup-request-param mixed $problem_alias
+     */
     public static function apiImage(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['problem_alias'],
@@ -4305,6 +4588,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $idl
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $os
+     *
      * @return array{smartyProperties: array{error?: string, error_field?: string}, template: string}
      */
     public static function getLibinteractiveGenForSmarty(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/Problemset.php
+++ b/frontend/server/src/Controllers/Problemset.php
@@ -90,6 +90,16 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $interview_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $tokens
+     * @omegaup-request-param mixed $username
+     *
      * @return array{admin?: bool, admission_mode?: string, alias?: string, assignment_type?: null|string, contest_alias?: null|string, description?: null|string, director?: \OmegaUp\DAO\VO\Identities|null|string, exists?: bool, feedback?: string, finish_time?: null|int, languages?: list<string>, name?: null|string, needs_basic_information?: bool, opened?: bool, original_contest_alias?: null|string, original_problemset_id?: int|null, partial_score?: bool, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problems?: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter?: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, problemset_id?: int|null, requests_user_information?: string, scoreboard?: int, show_scoreboard_after?: bool, start_time?: int, submission_deadline?: int, submissions_gap?: int, title?: string, users?: list<array{access_time: \OmegaUp\Timestamp|null, country: null|string, email: null|string, opened_interview: bool, user_id: int|null, username: string}>, window_length?: int|null}
      */
     public static function apiDetails(\OmegaUp\Request $r) {
@@ -125,6 +135,14 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $tokens
+     *
      * @return array{finish_time?: int|null, problems?: list<array{alias: string, order: int}>, ranking?: list<array{country: null|string, is_invited: bool, name: null|string, place?: int, problems: list<array{alias: string, penalty: float, percent: float, place?: int, points: float, run_details?: array{cases?: list<array{contest_score: float, max_score: float, meta: array{status: string}, name: null|string, out_diff: string, score: float, verdict: string}>, details: array{groups: list<array{cases: list<array{meta: array{memory: float, time: float, wall_time: float}}>}>}}, runs: int}>, total: array{penalty: float, points: float}, username: string}>, start_time?: int, time?: int, title?: string}
      */
     public static function apiScoreboard(\OmegaUp\Request $r): array {
@@ -158,6 +176,14 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the Scoreboard events
      *
+     * @omegaup-request-param mixed $assignment
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $course
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $tokens
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
      * @return array{events: list<array{country: null|string, delta: float, is_invited: bool, total: array{points: float, penalty: float}, name: null|string, username: string, problem: array{alias: string, points: float, penalty: float}}>}
@@ -190,11 +216,13 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @param \OmegaUp\Request $r
-     * $r['tokens'][0] = invalid filter
-     * $r['tokens'][1] = Type of filter (all-events, user, contest, problemset, problem)
-     * $r['tokens'][2] = Id of entity ($tokens[2])
-     * $r['tokens'][3] = Token given by the filter
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $tokens
+     *
+     * @param \OmegaUp\Request $r $r['tokens'][0] = invalid filter $r['tokens'][1] = Type of filter (all-events, user, contest, problemset, problem) $r['tokens'][2] = Id of entity ($tokens[2]) $r['tokens'][3] = Token given by the filter
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -444,6 +444,10 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * A user that has already solved a problem can dismiss suggestions. The
      * `contents` field is empty.
      *
+     * @omegaup-request-param mixed $contents
+     * @omegaup-request-param mixed $nomination
+     * @omegaup-request-param mixed $problem_alias
+     *
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
      *
      * @return array{qualitynomination_id: int}
@@ -495,6 +499,11 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
 
     /**
      * Marks a nomination (only the demotion type supported for now) as resolved (approved or denied).
+     *
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $qualitynomination_id
+     * @omegaup-request-param mixed $rationale
+     * @omegaup-request-param mixed $status
      *
      * @return array{status: string}
      */
@@ -672,11 +681,12 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * assigned to $assignee (if non-null) or all nominations (if both
      * $nominator and $assignee are null).
      *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     *
      * @param \OmegaUp\Request $r         The request.
-     * @param int     $nominator The user id of the person that made the
-     *                           nomination.  May be null.
-     * @param int     $assignee  The user id of the person assigned to review
-     *                           nominations.  May be null.
+     * @param int     $nominator The user id of the person that made the nomination.  May be null.
+     * @param int     $assignee  The user id of the person assigned to review nominations.  May be null.
      *
      * @return array{nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: int, votes: list<array{time: int|null, user: array{name: null|string, username: string}, vote: int}>}|null>} The response.
      */
@@ -733,6 +743,9 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $rowcount
+     *
      * @return array{totalRows: int, nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: int, votes: list<array{time: int|null, user: array{name: null|string, username: string}, vote: int}>}|null>}
      */
     public static function apiList(\OmegaUp\Request $r) {
@@ -768,6 +781,9 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     /**
      * Displays the nominations that this user has been assigned.
      *
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $page_size
+     *
      * @param \OmegaUp\Request $r
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
@@ -787,6 +803,9 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $rowcount
+     *
      * @return array{totalRows: int, nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: int, votes: list<array{time: int|null, user: array{name: null|string, username: string}, vote: int}>}|null>}
      */
     public static function apiMyList(\OmegaUp\Request $r) {
@@ -821,8 +840,12 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * Displays the details of a nomination. The user needs to be either the
      * nominator or a member of the reviewer group.
      *
+     * @omegaup-request-param mixed $qualitynomination_id
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nomination_status: string, nominator: array{name: null|string, username: string}, original_contents?: array{source: null|string, statements: array<string, array{language: string, markdown: string, images: array<string, string>}>|\stdClass, tags?: list<array{source: string, name: string}>}, problem: array{alias: string, title: string}, qualitynomination_id: int, reviewer: bool, time: int, votes: list<array{time: int|null, user: array{name: null|string, username: string}, vote: int}>}
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
     public static function apiDetails(\OmegaUp\Request $r) {
@@ -922,6 +945,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $qualitynomination_id
+     *
      * @return array{smartyProperties: array{payload: array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nomination_status: string, nominator: array{name: null|string, username: string}, original_contents?: array{source: null|string, statements: mixed|\stdClass, tags?: list<array{source: string, name: string}>}, problem: array{alias: string, title: string}, qualitynomination_id: int, reviewer: bool, status: string, time: int, votes: list<array{time: int|null, user: array{name: null|string, username: string}, vote: int}>}}, template: string}
      */
     public static function getDetailsForSmarty(
@@ -950,6 +975,9 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details for the quality nomination's list
      * with pagination
+     *
+     * @omegaup-request-param mixed $length
+     * @omegaup-request-param mixed $page
      *
      * @return array{smartyProperties: array{payload: array{page: int, length: int, myView: bool}}, template: string}
      */
@@ -981,6 +1009,9 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details for the quality nomination's list
      * with pagination for a certain user
+     *
+     * @omegaup-request-param mixed $length
+     * @omegaup-request-param mixed $page
      *
      * @return array{smartyProperties: array{payload: array{page: int, length: int, myView: bool}}, template: string}
      */

--- a/frontend/server/src/Controllers/Reset.php
+++ b/frontend/server/src/Controllers/Reset.php
@@ -8,6 +8,8 @@ class Reset extends \OmegaUp\Controllers\Controller {
      * password. The first step consist of sending an email to the user with
      * instructions to reset he's password, if and only if the email is valid.
      *
+     * @omegaup-request-param mixed $email
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
      * @return array{message?: string, token?: string}
@@ -68,6 +70,8 @@ class Reset extends \OmegaUp\Controllers\Controller {
     /**
      * Creates a reset operation, support team members can generate a valid
      * token and then they can send it to end user
+     *
+     * @omegaup-request-param mixed $email
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
@@ -133,6 +137,11 @@ class Reset extends \OmegaUp\Controllers\Controller {
      * Updates the password of a given user, this is the second and last step
      * in order to reset the password. This operation is done if and only if
      * the correct parameters are suplied.
+     *
+     * @omegaup-request-param mixed $email
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $password_confirmation
+     * @omegaup-request-param mixed $reset_token
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
@@ -219,6 +228,9 @@ class Reset extends \OmegaUp\Controllers\Controller {
         ];
     }
 
+    /**
+     * @omegaup-request-param mixed $email
+     */
     private static function validateCreateRequest(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty($r['email'], 'email');
         $user = \OmegaUp\DAO\Users::findByEmail($r['email']);

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -76,8 +76,12 @@ class Run extends \OmegaUp\Controllers\Controller {
     public const STATUS = ['new', 'waiting', 'compiling', 'running', 'ready'];
 
     /**
-     *
      * Validates Create Run request
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
      *
      * @throws \OmegaUp\Exceptions\ApiException
      * @throws \OmegaUp\Exceptions\NotAllowedToSubmitException
@@ -323,6 +327,12 @@ class Run extends \OmegaUp\Controllers\Controller {
 
     /**
      * Create a new run
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $source
      *
      * @throws \Exception
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
@@ -572,6 +582,8 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * Get basic details of a run
      *
+     * @omegaup-request-param mixed $run_alias
+     *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
      * @return array{contest_score: float|null, memory: int, penalty: int, runtime: int, score: float, submit_delay: int, time: int}
@@ -631,6 +643,9 @@ class Run extends \OmegaUp\Controllers\Controller {
 
     /**
      * Re-sends a problem to Grader.
+     *
+     * @omegaup-request-param mixed $debug
+     * @omegaup-request-param mixed $run_alias
      *
      * @return array{status: string}
      */
@@ -693,6 +708,8 @@ class Run extends \OmegaUp\Controllers\Controller {
 
     /**
      * Disqualify a submission
+     *
+     * @omegaup-request-param mixed $run_alias
      *
      * @return array{status: string}
      */
@@ -767,6 +784,8 @@ class Run extends \OmegaUp\Controllers\Controller {
 
     /**
      * Gets the details of a run. Includes admin details if admin.
+     *
+     * @omegaup-request-param mixed $run_alias
      *
      * @return array{admin: bool, compile_error?: string, details?: array{compile_meta?: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups?: list<array{cases: list<array{contest_score: float, max_score: float, meta: array{verdict: string}, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score?: float, memory?: float, score: float, time?: float, verdict: string, wall_time?: float}, guid: string, judged_by?: string, language: string, logs?: string, source?: string}
      */
@@ -848,6 +867,8 @@ class Run extends \OmegaUp\Controllers\Controller {
      * Given the run alias, returns the source code and any compile errors if any
      * Used in the arena, any contestant can view its own codes and compile errors
      *
+     * @omegaup-request-param mixed $run_alias
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{compile_error?: string, details?: array{compile_meta?: array<string, array{memory: float, sys_time: float, time: float, verdict: string, wall_time: float}>, contest_score: float, groups?: list<array{cases: list<array{contest_score: float, max_score: float, meta: array{verdict: string}, name: string, score: float, verdict: string}>, contest_score: float, group: string, max_score: float, score: float}>, judged_by: string, max_score?: float, memory?: float, score: float, time?: float, verdict: string, wall_time?: float}, source: string}
@@ -922,6 +943,8 @@ class Run extends \OmegaUp\Controllers\Controller {
 
     /**
      * Given the run alias, returns a .zip file with all the .out files generated for a run.
+     *
+     * @omegaup-request-param mixed $run_alias
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
@@ -1238,6 +1261,9 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * Validator for List API
      *
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $username
+     *
      * @return array{problem: null|\OmegaUp\DAO\VO\Problems, identity: null|\OmegaUp\DAO\VO\Identities}
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
@@ -1296,6 +1322,14 @@ class Run extends \OmegaUp\Controllers\Controller {
 
     /**
      * Gets a list of latest runs overall
+     *
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
      *
      * @return array{runs: list<array{alias: string, contest_alias: null|string, contest_score: float|null, country_id: null|string, guid: string, judged_by: null|string, language: string, memory: int, penalty: int, run_id: int, runtime: int, score: float, submit_delay: int, time: int, type: null|string, username: string, verdict: string}>}
      */

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -11,6 +11,9 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of schools
      *
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $term
+     *
      * @return list<array{id: int, label: string, value: string}>
      */
     public static function apiList(\OmegaUp\Request $r) {
@@ -42,7 +45,11 @@ class School extends \OmegaUp\Controllers\Controller {
 
     /**
      * Returns the basic details for school
+     *
+     * @omegaup-request-param mixed $school_id
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{template: string, smartyProperties: array{details: array{school_id: int, school_name: string, ranking: int, country: array{id: string, name: string}|null, state_name: string|null}}}
      */
     public static function getSchoolProfileDetailsForSmarty(\OmegaUp\Request $r): array {
@@ -96,7 +103,12 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Api to create new school
      *
+     * @omegaup-request-param mixed $country_id
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $state_id
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{school_id: int}
      */
     public static function apiCreate(\OmegaUp\Request $r) {
@@ -157,7 +169,11 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Returns rank of best schools in last month
      *
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param mixed $school_id
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{coders: list<array{time: string, username: string, classname: string}>}
      */
     public static function apiSchoolCodersOfTheMonth(\OmegaUp\Request $r): array {
@@ -184,7 +200,11 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the number of solved problems on the last
      * months (including the current one)
+     *
+     * @omegaup-request-param mixed $school_id
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{distinct_problems_solved: list<array{month: int, problems_solved: int, year: int}>}
      */
     public static function apiMonthlySolvedProblemsCount(\OmegaUp\Request $r): array {
@@ -206,7 +226,10 @@ class School extends \OmegaUp\Controllers\Controller {
      * Returns the list of current students registered in a certain school
      * with the number of created problems, solved problems and organized contests.
      *
+     * @omegaup-request-param mixed $school_id
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{users: list<array{username: string, classname: string, created_problems: int, solved_problems: int, organized_contests: int}>}
      */
     public static function apiUsers(\OmegaUp\Request $r): array {
@@ -252,6 +275,9 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the historical rank of schools
      *
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $rowcount
+     *
      * @return array{rank: list<array{country_id: string|null, name: string, ranking: int|null, school_id: int, score: float}>, totalRows: int}
      */
     public static function apiRank(\OmegaUp\Request $r) {
@@ -277,6 +303,9 @@ class School extends \OmegaUp\Controllers\Controller {
 
     /**
      * Gets the details for historical rank of schools with pagination
+     *
+     * @omegaup-request-param mixed $length
+     * @omegaup-request-param mixed $page
      *
      * @return array{smartyProperties: array{schoolRankPayload: array{page: int, length: int, showHeader: bool}}, template: string}
      */
@@ -408,6 +437,8 @@ class School extends \OmegaUp\Controllers\Controller {
 
     /**
      * Selects a certain school as school of the month
+     *
+     * @omegaup-request-param mixed $school_id
      *
      * @return array{status: string}
      */

--- a/frontend/server/src/Controllers/Scoreboard.php
+++ b/frontend/server/src/Controllers/Scoreboard.php
@@ -10,6 +10,10 @@ class Scoreboard extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests
      *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $token
+     *
      * @return array{status: string}
      */
     public static function apiRefresh(\OmegaUp\Request $r) {

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -70,6 +70,9 @@ class Session extends \OmegaUp\Controllers\Controller {
         ];
     }
 
+    /**
+     * @omegaup-request-param null|string $auth_token
+     */
     private static function getAuthToken(\OmegaUp\Request $r): ?string {
         $sessionManager = self::getSessionManagerInstance();
         $authToken = null;
@@ -97,6 +100,8 @@ class Session extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param null|string $auth_token
+     *
      * @return array{valid: bool, email: ?string, user: ?\OmegaUp\DAO\VO\Users, identity: ?\OmegaUp\DAO\VO\Identities, auth_token: ?string, is_admin: bool}
      */
     public static function getCurrentSession(?\OmegaUp\Request $r = null): array {
@@ -137,6 +142,8 @@ class Session extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param null|string $auth_token
+     *
      * @return array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool}
      */
     private static function getCurrentSessionImpl(\OmegaUp\Request $r): array {
@@ -332,6 +339,8 @@ class Session extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param string $storeToken
+     *
      * @return array<string, string>
      */
     public static function apiGoogleLogin(\OmegaUp\Request $r): array {
@@ -441,9 +450,9 @@ class Session extends \OmegaUp\Controllers\Controller {
 
     /**
      * Does login for a user given username or email and password.
-     * Expects in request:
-     * usernameOrEmail
-     * password
+     *
+     * @omegaup-request-param string $password
+     * @omegaup-request-param string $usernameOrEmail
      */
     public static function nativeLogin(\OmegaUp\Request $r): string {
         \OmegaUp\Validators::validateStringNonEmpty($r['password'], 'password');

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -13,6 +13,10 @@ class Submission extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the latest submissions
      *
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $username
+     *
      * @return array{submissions: list<array{time: int, username: string, school_id: int|null, school_name: string|null, alias: string, title: string, language: string, verdict: string, runtime: int, memory: int}>, totalRows: int}
      */
     public static function apiLatestSubmissions(\OmegaUp\Request $r) {
@@ -61,6 +65,9 @@ class Submission extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details for the latest submissions with pagination
      *
+     * @omegaup-request-param mixed $length
+     * @omegaup-request-param mixed $page
+     *
      * @return array{smartyProperties: array{submissionsPayload: array{page: int, length: int, includeUser: bool}}, template: string}
      */
     public static function getLatestSubmissionsForSmarty(\OmegaUp\Request $r): array {
@@ -85,6 +92,10 @@ class Submission extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details for the latest submissions of
      * a certain user with pagination
+     *
+     * @omegaup-request-param mixed $length
+     * @omegaup-request-param mixed $page
+     * @omegaup-request-param mixed $username
      *
      * @return array{smartyProperties: array{submissionsPayload: array{page: int, length: int, includeUser: bool}}, template: string}
      */

--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -17,6 +17,9 @@ class Tag extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of tags
      *
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $term
+     *
      * @return list<array{name: string}>
      */
     public static function apiList(\OmegaUp\Request $r) {

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -386,6 +386,11 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Changes the password of a user
      *
+     * @omegaup-request-param mixed $old_password
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $permission_key
+     * @omegaup-request-param mixed $username
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
@@ -484,6 +489,9 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Verifies the user given its verification id
+     *
+     * @omegaup-request-param mixed $id
+     * @omegaup-request-param mixed $usernameOrEmail
      *
      * @param \OmegaUp\Request $r
      *
@@ -620,6 +628,15 @@ class User extends \OmegaUp\Controllers\Controller {
      * contest.
      * If the user does not exists, we create him.
      *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $change_password
+     * @omegaup-request-param mixed $id
+     * @omegaup-request-param mixed $old_password
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $permission_key
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @param \OmegaUp\Request $r
      * @param string $username
      * @param string $password
@@ -677,6 +694,17 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $change_password
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $contest_type
+     * @omegaup-request-param mixed $id
+     * @omegaup-request-param mixed $old_password
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $permission_key
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $usernameOrEmail
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array<string, string>
@@ -1299,6 +1327,10 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Get general user info
      *
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param mixed $omit_rank
+     * @omegaup-request-param mixed $username
+     *
      * @return array{birth_date?: int|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date?: int|null, gravatar_92?: null|string, hide_problem_tags?: bool|null, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{name?: null|string, problems_solved?: int|null, rank?: int|null}, scholar_degree?: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified?: bool|null}
      */
     public static function apiProfile(\OmegaUp\Request $r): array {
@@ -1393,6 +1425,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Gets verify status of a user
      *
+     * @omegaup-request-param mixed $email
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
@@ -1428,6 +1462,8 @@ class User extends \OmegaUp\Controllers\Controller {
      * - last password change request
      * - verify status
      *
+     * @omegaup-request-param mixed $email
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
@@ -1455,7 +1491,11 @@ class User extends \OmegaUp\Controllers\Controller {
      * day of the current month. If there's no coder of the month for the given
      * date, calculate it and save it.
      *
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param mixed $date
+     *
      * @param \OmegaUp\Request $r
+     *
      * @return array{coderinfo: array{birth_date: int|null, country: null|string, country_id: null|string, email: null|string, gender: null|string, graduation_date: int|null, gravatar_92: string, hide_problem_tags: bool|null, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool}|null}
      */
     public static function apiCoderOfTheMonth(\OmegaUp\Request $r) {
@@ -1530,6 +1570,9 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the list of coders of the month
      *
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param mixed $date
+     *
      * @return array{coders: list<array{username: string, country_id: string, gravatar_32: string, date: string, classname: string}>}
      */
     public static function apiCoderOfTheMonthList(\OmegaUp\Request $r): array {
@@ -1557,6 +1600,9 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Selects coder of the month for next month.
+     *
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param mixed $username
      *
      * @return array{status: 'ok'}
      */
@@ -1661,6 +1707,9 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Get the results for this user in a given interview
      *
+     * @omegaup-request-param mixed $interview
+     * @omegaup-request-param mixed $username
+     *
      * @param \OmegaUp\Request $r
      *
      * @return array{user_verified: bool, interview_url: string, name_or_username: null|string, opened_interview: bool, finished: bool}
@@ -1711,6 +1760,11 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get Contests which a certain user has participated in
+     *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $username
      *
      * @return array{contests: array<string, array{data: array{alias: string, title: string, start_time: int, finish_time: int, last_updated: int}, place: int|null}>}
      */
@@ -1869,6 +1923,9 @@ class User extends \OmegaUp\Controllers\Controller {
      * Gets a list of users. This returns an array instead of an object since
      * it is used by typeahead.
      *
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $term
+     *
      * @return list<UserListItem>
      */
     public static function apiList(\OmegaUp\Request $r): array {
@@ -1935,6 +1992,9 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Update basic user profile info when logged with fb/gool
      *
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $username
+     *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
      * @return array{status: string}
@@ -1992,6 +2052,19 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Update user profile
+     *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $birth_date
+     * @omegaup-request-param mixed $country_id
+     * @omegaup-request-param mixed $gender
+     * @omegaup-request-param mixed $graduation_date
+     * @omegaup-request-param mixed $locale
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param mixed $scholar_degree
+     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param mixed $school_name
+     * @omegaup-request-param mixed $state_id
+     * @omegaup-request-param mixed $username
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
@@ -2272,6 +2345,12 @@ class User extends \OmegaUp\Controllers\Controller {
      * If no username provided: Gets the top N users who have solved more problems
      * If username provided: Gets rank for username provided
      *
+     * @omegaup-request-param null|string $auth_token
+     * @omegaup-request-param mixed $filter
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param mixed $username
+     *
      * @return array{rank: int|list<array{classname: string, country_id: null|string, name: null|string, problems_solved: int, ranking: int, score: float, user_id: int, username: string}>, total?: int, name?: string, problems_solved?: int}
      */
     public static function apiRankByProblemsSolved(\OmegaUp\Request $r): array {
@@ -2418,6 +2497,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Updates the main email of the current user
      *
+     * @omegaup-request-param mixed $email
+     *
      * @param \OmegaUp\Request $r
      *
      * @return array{status: string}
@@ -2511,6 +2592,14 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * This API does not need authentication to be used. This allows to track
      * contest updates with an access token.
+     *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_admin
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $filter
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $tokens
      *
      * @return array{user: null|string, admin: bool, problem_admin: list<string>, contest_admin: list<string>, problemset_admin: list<int>}
      */
@@ -2705,6 +2794,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Adds the role to the user.
      *
+     * @omegaup-request-param mixed $role
+     *
      * @return array{status: string}
      */
     public static function apiAddRole(\OmegaUp\Request $r): array {
@@ -2731,6 +2822,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Removes the role from the user.
      *
+     * @omegaup-request-param mixed $role
+     *
      * @return array{status: string}
      */
     public static function apiRemoveRole(\OmegaUp\Request $r): array {
@@ -2756,6 +2849,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Adds the identity to the group.
      *
+     * @omegaup-request-param mixed $group
+     *
      * @return array{status: string}
      */
     public static function apiAddGroup(\OmegaUp\Request $r): array {
@@ -2780,6 +2875,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Removes the user to the group.
      *
+     * @omegaup-request-param mixed $group
+     *
      * @return array{status: string}
      */
     public static function apiRemoveGroup(\OmegaUp\Request $r): array {
@@ -2800,6 +2897,9 @@ class User extends \OmegaUp\Controllers\Controller {
         ];
     }
 
+    /**
+     * @omegaup-request-param mixed $experiment
+     */
     private static function validateAddRemoveExperiment(\OmegaUp\Request $r): void {
         /** @var \OmegaUp\DAO\VO\Identities $r->identity */
         if (
@@ -2829,6 +2929,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Adds the experiment to the user.
      *
+     * @omegaup-request-param mixed $experiment
+     *
      * @return array{status: string}
      */
     public static function apiAddExperiment(\OmegaUp\Request $r): array {
@@ -2851,6 +2953,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Removes the experiment from the user.
+     *
+     * @omegaup-request-param mixed $experiment
      *
      * @return array{status: string}
      */
@@ -2988,6 +3092,10 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Keeps a record of a user who accepts the privacy policy
      *
+     * @omegaup-request-param mixed $privacy_git_object_id
+     * @omegaup-request-param mixed $statement_type
+     * @omegaup-request-param mixed $username
+     *
      * @param \OmegaUp\Request $r
      *
      * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
@@ -3037,6 +3145,9 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Associates an identity to the logged user given the username
+     *
+     * @omegaup-request-param mixed $password
+     * @omegaup-request-param mixed $username
      *
      * @param \OmegaUp\Request $r
      *
@@ -3152,6 +3263,10 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Prepare all the properties to be sent to the rank table view via smarty
      *
+     * @omegaup-request-param mixed $filter
+     * @omegaup-request-param mixed $length
+     * @omegaup-request-param mixed $page
+     *
      * @return array{smartyProperties: array{rankTablePayload: array{availableFilters: array{country?: null|string, school?: null|string, state?: null|string}, filter: string, isIndex: false, isLogged: bool, length: int, page: int}}, template: string}
      */
     public static function getRankDetailsForSmarty(\OmegaUp\Request $r) {
@@ -3223,6 +3338,9 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param mixed $date
+     *
      * @return array{smartyProperties: array{payload: array{coderOfTheMonthData: array{all: array{birth_date: int|null, classname: string, country: string, country_id: null|string, email: null|string, gender: null|string, graduation_date: int|null, gravatar_92: string, hide_problem_tags: bool|null, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool}|null, female: array{birth_date: int|null, classname: string, country: string, country_id: null|string, email: null|string, gender: null|string, graduation_date: int|null, gravatar_92: string, hide_problem_tags: bool|null, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool}|null}, currentUserInfo: array{username?: string}, enableSocialMediaResources: true, rankTable: array{rank: list<array{classname: string, country_id: null|string, name: null|string, problems_solved: int, ranking: int, score: float, user_id: int, username: string}>, total: int}, runsChartPayload: array{date: list<string>, total: list<int>}, schoolOfTheMonthData: array{country_id: null|string, name: string, school_id: int}|null, schoolRank: list<array{name: string, ranking: int, school_id: int, school_of_the_month_id: int, score: float}>, upcomingContests: array{number_of_results: int, results: list<array{alias: string, title: string}>}}}, template: string}
      */
     public static function getIndexDetailsForSmarty(\OmegaUp\Request $r) {
@@ -3299,6 +3417,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Prepare all the properties to be sent to the rank table view via smarty
+     *
+     * @omegaup-request-param mixed $category
      *
      * @return array{smartyProperties: array{payload: array{codersOfCurrentMonth: list<array{username: string, country_id: string, gravatar_32: string, date: string, classname: string}>, codersOfPreviousMonth: list<array{username: string, country_id: string, gravatar_32: string, date: string, classname: string}>, candidatesToCoderOfTheMonth: list<mixed>, isMentor: bool, category: string, options?: array{canChooseCoder: bool, coderIsSelected: bool}}}, template: string}
      */

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -1,0 +1,494 @@
+<?php
+
+namespace OmegaUp\Psalm;
+
+class RequestParamChecker implements
+    \Psalm\Plugin\Hook\AfterExpressionAnalysisInterface,
+    \Psalm\Plugin\Hook\AfterMethodCallAnalysisInterface,
+    \Psalm\Plugin\Hook\AfterClassLikeAnalysisInterface {
+    /**
+     * @var array<string, array<string, RequestParamDescription>>
+     */
+    private static $methodTypeMapping = [];
+
+    /**
+     * @var array<string, array<string, RequestParamDescription>>
+     */
+    private static $parsedMethodTypeMapping = [];
+
+    /**
+     * @var array<string, array<string, true>>
+     */
+    private static $methodCallGraph = [];
+
+    /**
+     * Called for every Request property fetch.
+     *
+     * @param \Psalm\FileManipulation[] $fileReplacements
+     *
+     * @return null|false
+     */
+    private static function processRequestPropertyFetch(
+        \PhpParser\Node\Expr\ArrayDimFetch $expr,
+        \Psalm\Context $context,
+        \Psalm\StatementsSource $statementsSource,
+        \Psalm\Codebase $codebase,
+        array &$fileReplacements = []
+    ) {
+        $varType = $statementsSource->getNodeTypeProvider()->getType(
+            $expr->var
+        );
+        if (is_null($varType)) {
+            return null;
+        }
+        $foundRequest = false;
+        foreach ($varType->getAtomicTypes() as $typeName => $type) {
+            if (
+                $type instanceof \Psalm\Type\Atomic\TNamedObject &&
+                $type->value == 'OmegaUp\\Request'
+            ) {
+                $foundRequest = true;
+                break;
+            }
+        }
+        if (!$foundRequest) {
+            return null;
+        }
+        if (!$expr->dim instanceof \PhpParser\Node\Scalar\String_) {
+            if (
+                \Psalm\IssueBuffer::accepts(
+                    new RequestAccessNotALiteralString(
+                        'Request array access not a literal string',
+                        new \Psalm\CodeLocation($statementsSource, $expr)
+                    ),
+                    $statementsSource->getSuppressedIssues()
+                )
+            ) {
+                return false;
+            }
+            return null;
+        }
+        if (is_null($context->calling_function_id)) {
+            throw new \Exception('Should never happen');
+        }
+        $functionId = strtolower($context->calling_function_id);
+        if (!array_key_exists($functionId, self::$methodTypeMapping)) {
+            self::$methodTypeMapping[$functionId] = [];
+        }
+        self::$methodTypeMapping[$functionId][$expr->dim->value] = new RequestParamDescription(
+            \Psalm\Type::getMixed(),
+            $expr->dim->value
+        );
+        return null;
+    }
+
+    /**
+     * Called after a statement has been checked
+     *
+     * @param \Psalm\FileManipulation[] $fileReplacements
+     *
+     * @return null|false
+     */
+    public static function afterExpressionAnalysis(
+        \PhpParser\Node\Expr $expr,
+        \Psalm\Context $context,
+        \Psalm\StatementsSource $statementsSource,
+        \Psalm\Codebase $codebase,
+        array &$fileReplacements = []
+    ) {
+        if (
+            $context->parent !== 'OmegaUp\\Controllers\\Controller' &&
+            $context->self !== 'OmegaUp\\Controllers\\Controller'
+        ) {
+            return null;
+        }
+        if ($expr instanceof \PhpParser\Node\Expr\ArrayDimFetch) {
+            return self::processRequestPropertyFetch(
+                $expr,
+                $context,
+                $statementsSource,
+                $codebase,
+                $fileReplacements
+            );
+        }
+
+        return null;
+    }
+
+    private static function processClass(
+        \PhpParser\Node\Stmt\ClassLike $classStmt,
+        string $className
+    ): void {
+        foreach ($classStmt->stmts as $methodStmt) {
+            if (!$methodStmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+                continue;
+            }
+            $functionId = strtolower(
+                "{$className}::{$methodStmt->name->name}"
+            );
+            if (array_key_exists($functionId, self::$parsedMethodTypeMapping)) {
+                continue;
+            }
+            self::$parsedMethodTypeMapping[$functionId] = [];
+
+            $docblock = $methodStmt->getDocComment();
+            if (is_null($docblock)) {
+                continue;
+            }
+
+            $parsedDocComment = \Psalm\DocComment::parse($docblock->getText());
+            if (isset($parsedDocComment['specials']['omegaup-request-param'])) {
+                foreach (
+                    $parsedDocComment['specials']['omegaup-request-param'] as $requestParam
+                ) {
+                    if (
+                        preg_match(
+                            '/^([^$]+)\s+\$([_a-zA-Z]\S*)\s*(\S.*)?$/',
+                            $requestParam,
+                            $matches,
+                            PREG_UNMATCHED_AS_NULL
+                        ) !== 1
+                    ) {
+                        continue;
+                    }
+                    /** @var array{0: string, 1: string, 2: string, 3: ?string} $matches */
+                    [
+                        $_,
+                        $annotationType,
+                        $annotationVariable,
+                        $annotationDescription,
+                    ] = $matches;
+                    self::$parsedMethodTypeMapping[$functionId][$annotationVariable] = (
+                        new RequestParamDescription(
+                            \Psalm\Type::parseString($annotationType),
+                            $annotationVariable,
+                            $annotationDescription
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<string, RequestParamDescription>
+     */
+    private static function getDocBlockReturnTypes(
+        string $functionId,
+        \Psalm\Codebase $codebase
+    ) {
+        if (array_key_exists($functionId, self::$parsedMethodTypeMapping)) {
+            return self::$parsedMethodTypeMapping[$functionId];
+        }
+        $methodId = new \Psalm\Internal\MethodIdentifier(
+            ...explode('::', $functionId)
+        );
+        /** @psalm-suppress InternalMethod This code also appears in the examples, so it should be fine. */
+        $methodStorage = $codebase->methods->getStorage($methodId);
+        if (is_null($methodStorage->location)) {
+            return [];
+        }
+        $statements = $codebase->getStatementsForFile(
+            $methodStorage->location->file_path
+        );
+        $finder = new \PhpParser\NodeFinder();
+        /** @var \PhpParser\Node\Stmt\ClassLike $classStmt */
+        foreach (
+            $finder->find(
+                $statements,
+                function (\PhpParser\Node $node): bool {
+                    return $node instanceof \PhpParser\Node\Stmt\ClassLike;
+                }
+            ) as $classStmt
+        ) {
+            self::processClass(
+                $classStmt,
+                $methodId->fq_class_name
+            );
+        }
+        if (!array_key_exists($functionId, self::$parsedMethodTypeMapping)) {
+            return [];
+        }
+        return self::$parsedMethodTypeMapping[$functionId];
+    }
+
+    /**
+     * @param  \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $expr
+     * @param  \Psalm\FileManipulation[] $fileReplacements
+     *
+     * @return void
+     */
+    public static function afterMethodCallAnalysis(
+        $expr,
+        string $methodId,
+        string $appearingMethodId,
+        string $declaringMethodId,
+        \Psalm\Context $context,
+        \Psalm\StatementsSource $statementsSource,
+        \Psalm\Codebase $codebase,
+        array &$fileReplacements = [],
+        \Psalm\Type\Union &$returnTypeCandidate = null
+    ) {
+        if (is_null($context->calling_function_id)) {
+            // Not being called form within a function-like.
+            return;
+        }
+        $functionId = strtolower($context->calling_function_id);
+        if (!array_key_exists($functionId, self::$methodCallGraph)) {
+            self::$methodCallGraph[$functionId] = [];
+        }
+        self::$methodCallGraph[$functionId][strtolower(
+            $appearingMethodId
+        )] = true;
+
+        if (
+            !array_key_exists(
+                strtolower($appearingMethodId),
+                self::$methodTypeMapping
+            )
+        ) {
+            return;
+        }
+        if (!array_key_exists($functionId, self::$methodTypeMapping)) {
+            self::$methodTypeMapping[$functionId] = [];
+        }
+        self::$methodTypeMapping[$functionId] = array_merge(
+            self::$methodTypeMapping[$functionId],
+            self::$methodTypeMapping[strtolower($appearingMethodId)]
+        );
+    }
+
+    /**
+     * Called after a statement has been checked
+     *
+     * @param \Psalm\FileManipulation[] $fileReplacements
+     *
+     * @return null|false
+     */
+    public static function afterStatementAnalysis(
+        \PhpParser\Node\Stmt\ClassLike $classStmt,
+        \Psalm\Storage\ClassLikeStorage $classLikeStorage,
+        \Psalm\StatementsSource $statementsSource,
+        \Psalm\Codebase $codebase,
+        array &$fileReplacements = []
+    ) {
+        if (is_null($classLikeStorage->location)) {
+            return null;
+        }
+
+        // First go through all the methods in this class, parsing the doc
+        // comment for each and saving its parsed representation to
+        // self::$parsedMethodTypeMapping.
+        self::processClass($classStmt, $classLikeStorage->name);
+
+        $fileContents = $codebase->getFileContents(
+            $classLikeStorage->location->file_name
+        );
+        foreach ($classStmt->stmts as $methodStmt) {
+            if (!$methodStmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+                continue;
+            }
+            $functionId = strtolower(
+                "{$classLikeStorage->name}::{$methodStmt->name->name}"
+            );
+
+            $hasRequestArgument = false;
+            foreach ($methodStmt->params as $param) {
+                if ($param->type instanceof \PhpParser\Node\NullableType) {
+                    $type = $param->type->type;
+                } else {
+                    $type = $param->type;
+                }
+                if (is_null($type)) {
+                    continue;
+                }
+                if ($type->getAttribute('resolvedName') == 'OmegaUp\\Request') {
+                    $hasRequestArgument = true;
+                    break;
+                }
+            }
+
+            $docblock = $methodStmt->getDocComment();
+            $parsedDocComment = \Psalm\DocComment::parse(
+                !is_null($docblock) ?
+                $docblock->getText() :
+                '/** */'
+            );
+            $docblockStart = (
+                !is_null($docblock) ?
+                $docblock->getFilePos() :
+                intval(
+                    $methodStmt->getAttribute(
+                        'startFilePos'
+                    )
+                )
+            );
+            $docblockEnd = $functionStart = intval(
+                $methodStmt->getAttribute(
+                    'startFilePos'
+                )
+            );
+            $precedingNewlinePos = strrpos(
+                $fileContents,
+                "\n",
+                $docblockEnd - strlen($fileContents)
+            );
+
+            if ($precedingNewlinePos === false) {
+                $indentation = '';
+            } else {
+                $firstLine = substr(
+                    $fileContents,
+                    $precedingNewlinePos + 1,
+                    $docblockEnd - $precedingNewlinePos
+                );
+                $indentation = str_replace(ltrim($firstLine), '', $firstLine);
+            }
+
+            if (
+                !isset(self::$methodTypeMapping[$functionId]) ||
+                // Methods that do not have an \OmegaUp\Request argument don't
+                // need the annotations.
+                !$hasRequestArgument
+            ) {
+                $expected = [];
+            } else {
+                $expected = self::$methodTypeMapping[$functionId];
+
+                // Now go through the callgraph, parsing any unvisited methods if needed.
+                foreach (self::$methodCallGraph[$functionId] ?? [] as $calleeMethodId => $_) {
+                    foreach (
+                        self::getDocBlockReturnTypes(
+                            $calleeMethodId,
+                            $codebase
+                        ) as $_ => $requestParam
+                    ) {
+                        if (array_key_exists($requestParam->name, $expected)) {
+                            // TODO(lhchavez): Merge the descriptions and types.
+                            continue;
+                        }
+                        $expected[$requestParam->name] = $requestParam;
+                    }
+                }
+                ksort($expected);
+            }
+            $modified = false;
+            $missing = [];
+            foreach ($expected as $key => $_) {
+                $missing[$key] = true;
+            }
+            foreach (self::$parsedMethodTypeMapping[$functionId] ?? [] as $_ => $requestParam) {
+                if (!isset($expected[$requestParam->name])) {
+                    // This is one property that is not expected and needs
+                    // to be removed.
+                    $modified = true;
+                    continue;
+                }
+                unset($missing[$requestParam->name]);
+                if (!is_null($requestParam->description)) {
+                    $expected[$requestParam->name]->description = $requestParam->description;
+                }
+                if (
+                    $expected[$requestParam->name]->type->isMixed() &&
+                    $requestParam->type->isMixed()
+                ) {
+                    continue;
+                }
+                if (
+                    !$expected[$requestParam->name]->type->isMixed() &&
+                    $requestParam->type->isMixed()
+                ) {
+                    $modified = true;
+                }
+                // The type in the annotation is more specific than what we
+                // found. Trust the annotator.
+                $expected[$requestParam->name]->type = $requestParam->type;
+            }
+
+            if (!$modified && empty($missing)) {
+                continue;
+            }
+
+            unset($parsedDocComment['specials']['omegaup-request-param']);
+            if (!empty($expected)) {
+                $parsedDocComment['specials'] = [
+                    'omegaup-request-param' => array_map(
+                        function (RequestParamDescription $description): string {
+                            return strval($description);
+                        },
+                        array_values($expected)
+                    ),
+                ] + $parsedDocComment['specials'];
+            }
+
+            if ($codebase->alter_code) {
+                $fileReplacements[] = new \Psalm\FileManipulation(
+                    $docblockStart,
+                    $docblockEnd,
+                    \Psalm\DocComment::render($parsedDocComment, $indentation)
+                );
+                continue;
+            }
+            if (
+                \Psalm\IssueBuffer::accepts(
+                    new MismatchingDocblockOmegaUpRequestParamAnnotation(
+                        (
+                        'Mismatched dockblock annotations for ' .
+                        "{$classLikeStorage->name}::{$methodStmt->name->name}: Wanted:\n\n" .
+                        \Psalm\DocComment::render($parsedDocComment, '')
+                        ),
+                        new \Psalm\CodeLocation(
+                            $statementsSource,
+                            $methodStmt,
+                            null,
+                            true
+                        )
+                    ),
+                    $statementsSource->getSuppressedIssues(),
+                    true
+                )
+            ) {
+                // do nothing
+            }
+        }
+    }
+}
+
+class RequestParamDescription {
+    /** @var \Psalm\Type\Union */
+    public $type;
+
+    /**
+     * @var string
+     * @readonly
+     */
+    public $name;
+
+    /**
+     * @var null|string
+     */
+    public $description;
+
+    public function __construct(
+        \Psalm\Type\Union $type,
+        string $name,
+        ?string $description = null
+    ) {
+        $this->type = $type;
+        $this->name = $name;
+        $this->description = $description;
+    }
+
+    public function __toString(): string {
+        if (is_null($this->description)) {
+            return "{$this->type} \${$this->name}";
+        }
+        return "{$this->type} \${$this->name} {$this->description}";
+    }
+}
+
+class RequestAccessNotALiteralString extends \Psalm\Issue\PluginIssue {
+}
+
+class MismatchingDocblockOmegaUpRequestParamAnnotation extends \Psalm\Issue\PluginIssue {
+}

--- a/frontend/tests/phpunit.xml
+++ b/frontend/tests/phpunit.xml
@@ -15,6 +15,7 @@
 				<directory>../server/cmd/</directory>
 				<directory>../server/libs/third_party/</directory>
 				<directory>../server/libs/dao/base/</directory>
+				<directory>../server/src/Psalm/</directory>
 			</exclude>
 		</whitelist>
 	</filter>

--- a/psalm.xml
+++ b/psalm.xml
@@ -30,4 +30,8 @@
        <file name="frontend/server/libs/third_party/stubs/phpunit.php" />
        <file name="frontend/server/libs/third_party/stubs/smarty.php" />
     </stubs>
+
+    <plugins>
+        <plugin filename="frontend/server/src/Psalm/RequestParamChecker.php" />
+    </plugins>
 </psalm>


### PR DESCRIPTION
Este cambio agrega un plugin de Psalm para asegurarnos de que cada
método del API (o más correctamente, cada método que recibe un parámetro
de tipo \OmegaUp\Request y que luego accede a las propiedades de éste)
esté declarando sus parámetros en el docblock del método.

Por ahora, reporta todos los argumentos como `mixed`, pero la idea es
que poco a poco vamos a poder usar el hecho de que casi todos los APIs
usan validadores, y usando la información de éstos podemos tener mejores
cotas alrededor de qué tipos se esperan.