### PR TITLE
Creando un script externo para validar los tipos de MySQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ frontend/tests/controllers/templates/
 frontend/tests/omegaup.db
 frontend/tests/ui/results/
 omegaup_test.log
+coverage.xml
 
 # Ignore runtime and test stuff
 test-env

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -2,7 +2,8 @@ FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update -y && \
-    apt install --no-install-recommends -y curl ca-certificates gnupg2 && \
+    apt install --no-install-recommends -y openjdk-11-jre-headless curl \
+        ca-certificates gnupg2 xz-utils && \
     /usr/sbin/update-ca-certificates && \
     apt autoremove -y && \
     apt clean
@@ -19,11 +20,14 @@ RUN apt update -y && \
     apt autoremove -y && \
     apt clean
 
-RUN curl -sL https://phar.phpunit.de/phpunit-6.5.9.phar -o /usr/bin/phpunit
+RUN curl -sL https://phar.phpunit.de/phpunit-8.5.2.phar -o /usr/bin/phpunit
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar
 RUN chmod +x /usr/bin/phpunit
 
 RUN curl -sL https://getcomposer.org/download/1.10.1/composer.phar -o /usr/bin/composer
 RUN chmod +x /usr/bin/composer
+
+RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.8/omegaup-gitserver.tar.xz | tar xJ -C /
 
 RUN useradd --create-home --shell=/bin/bash ubuntu
 

--- a/stuff/mysql_types.sh
+++ b/stuff/mysql_types.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+# Check that all the Psalm type annotations are consistent with what MySQL
+# returns.
+
+OMEGAUP_ROOT=$(/usr/bin/git rev-parse --show-toplevel)
+
+phpunit --bootstrap "${OMEGAUP_ROOT}/frontend/tests/bootstrap.php" \
+	--configuration="${OMEGAUP_ROOT}/frontend/tests/phpunit.xml" \
+	--coverage-clover="${OMEGAUP_ROOT}/coverage.xml" \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers"
+mv "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.1"
+phpunit --bootstrap "${OMEGAUP_ROOT}/frontend/tests/bootstrap.php" \
+	--configuration="${OMEGAUP_ROOT}/frontend/tests/phpunit.xml" \
+	"${OMEGAUP_ROOT}/frontend/tests/badges"
+mv "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.2"
+cat "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.1" \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.2" > \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log"
+python3 "${OMEGAUP_ROOT}/stuff/process_mysql_return_types.py" \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log"

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -34,22 +34,8 @@ stage_before_script() {
 }
 
 stage_script() {
-	phpunit --bootstrap frontend/tests/bootstrap.php \
-		--configuration=frontend/tests/phpunit.xml \
-		--coverage-clover=coverage.xml \
-		frontend/tests/controllers
-	mv frontend/tests/controllers/mysql_types.log \
-		frontend/tests/controllers/mysql_types.log.1
-	phpunit --bootstrap frontend/tests/bootstrap.php \
-		--configuration=frontend/tests/phpunit.xml \
-		frontend/tests/badges
-	mv frontend/tests/controllers/mysql_types.log \
-		frontend/tests/controllers/mysql_types.log.2
-	cat frontend/tests/controllers/mysql_types.log.1 \
-		frontend/tests/controllers/mysql_types.log.2 > \
-		frontend/tests/controllers/mysql_types.log
-	python3 stuff/process_mysql_return_types.py \
-		frontend/tests/controllers/mysql_types.log
+	./stuff/mysql_types.sh
+
 	python3 stuff/policy-tool.py --database=omegaup-test validate
 	if [[ "${UBUNTU}" == "focal" ]]; then
 		python3 stuff/database_schema.py --database=omegaup-test validate --all < /dev/null


### PR DESCRIPTION
Este cambio hace que se pueda correr la prueba que actualmente sólo
ocurre en Travis desde la VM. Esto debería evitar un roundtrip a Travis
sólo para correr esto.