### PR TITLE
Arreglando las pruebas de los badges

### DIFF
--- a/frontend/badges/updatedUser/query.sql
+++ b/frontend/badges/updatedUser/query.sql
@@ -5,7 +5,7 @@ FROM
 INNER JOIN
     `Users` AS `u` ON `i`.`user_id` = `u`.`user_id`
 INNER JOIN
-	`Identities_Schools` AS `is` ON `i`.`current_identity_school_id` = `is`.`identity_school_id`
+    `Identities_Schools` AS `is` ON `i`.`current_identity_school_id` = `is`.`identity_school_id`
 INNER JOIN
     `Schools` AS `s` ON `s`.`school_id` = `is`.`school_id`
 WHERE

--- a/frontend/badges/updatedUser/test.json
+++ b/frontend/badges/updatedUser/test.json
@@ -4,10 +4,10 @@
         {
             "type": "apicalls",
             "apicalls": [
-                {    
+                {
                     "username": "admintest",
                     "password": "testtesttest",
-                    "requests": [          
+                    "requests": [
                         {
                             "api": "\\OmegaUp\\Controllers\\User::apiCreate",
                             "params": {
@@ -48,7 +48,7 @@
                                 "name": "usuario verificado",
                                 "gender": "male",
                                 "school_name": "ITSF",
-                                "scholar_degree": "bachelors", 
+                                "scholar_degree": "bachelors",
                                 "graduation_date": "2020-03-03",
                                 "birth_date": "1996-02-02",
                                 "locale": "es",
@@ -73,7 +73,7 @@
                                 "username": "test_user_2",
                                 "name": "usuario verificado dos",
                                 "school_name": "ITSF",
-                                "scholar_degree": "bachelors", 
+                                "scholar_degree": "bachelors",
                                 "graduation_date": "2020-03-03",
                                 "birth_date": "1996-02-02",
                                 "locale": "es",
@@ -89,6 +89,6 @@
         }
     ],
     "expectedResults": [
-        "test_user_0 "
+        "test_user_0"
     ]
 }

--- a/frontend/tests/BadgesTestCase.php
+++ b/frontend/tests/BadgesTestCase.php
@@ -25,7 +25,7 @@ class BadgesTestCase extends \OmegaUp\Test\ControllerTestCase {
     public function setUp(): void {
         parent::setUp();
         \OmegaUp\Time::setTimeForTesting(null);
-        \OmegaUp\Test\Utils::CleanupDb();
+        \OmegaUp\Test\Utils::cleanupFilesAndDB();
         $this->originalFileUploader = \OmegaUp\FileHandler::getfileUploader();
         \OmegaUp\FileHandler::setFileUploaderForTesting(
             $this->createFileUploaderMock()


### PR DESCRIPTION
Este cambio:

* Hace que las pruebas de todos los badges use un dataProvider de
  PHPUnit, para que los errores se muestren mejor.
* Mejora la forma en la que se muestran los errores, usando
  aseveraciones en vez de arrojar excepciones.
* Agrega una aseveración para asegurarnos que el usuario especificado
  exista en la base de datos.
* Elimina un espacio en blanco que estaba causando que una de las
  pruebas fallara al no encontrar un usuario.