### PR TITLE
Moviendo el import de Typeahead a typeahead.js

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -48,8 +48,6 @@
 		<!-- Latest compiled and minified JavaScript -->
 		<script src="{version_hash src="/third_party/bootstrap-3.4.1/js/bootstrap.min.js"}" defer></script>
 {/if}
-		<!-- typeahead plugin from https://github.com/twitter/typeahead.js -->
-		<script type="text/javascript" src="{version_hash src="/third_party/js/typeahead.jquery.min.js"}" defer></script>
 
 {if isset($inArena) && $inArena}
 		<link rel="stylesheet" type="text/css" href="{version_hash src="/ux/arena.css"}" />

--- a/frontend/www/js/omegaup/typeahead.js
+++ b/frontend/www/js/omegaup/typeahead.js
@@ -2,6 +2,8 @@ import T from './lang';
 import API from './api';
 import * as ui from './ui';
 
+import '../../third_party/js/typeahead.jquery.js';
+
 export function typeaheadWrapper(searchFn) {
   let lastRequest = null;
   let pendingRequest = false;

--- a/frontend/www/third_party/js/typeahead.jquery.js
+++ b/frontend/www/third_party/js/typeahead.jquery.js
@@ -5,11 +5,7 @@
  */
 
 (function(root, factory) {
-    if (typeof define === "function" && define.amd) {
-        define("typeahead.js", [ "jquery" ], function(a0) {
-            return factory(a0);
-        });
-    } else if (typeof exports === "object") {
+    if (typeof exports === "object") {
         module.exports = factory(global.jQuery);
     } else {
         factory(jQuery);

--- a/stuff/webpack/tests.ejs
+++ b/stuff/webpack/tests.ejs
@@ -26,10 +26,12 @@
 		<script type="text/javascript" src="/third_party/js/pagedown/Markdown.Sanitizer.js"></script>
 
 		<!-- specs -->
-		<script type="text/javascript" src="/js/omegaup/omegaup.test.js" defer></script>
-		<script type="text/javascript" src="/js/omegaup/ui.test.js" defer></script>
-		<script type="text/javascript" src="/js/omegaup/arena/arena.test.js" defer></script>
 		<script type="text/javascript" src="/js/omegaup/arena/admin_arena.test.js" defer></script>
+		<script type="text/javascript" src="/js/omegaup/arena/arena.test.js" defer></script>
+		<script type="text/javascript" src="/js/omegaup/markdown.test.js" defer></script>
+		<script type="text/javascript" src="/js/omegaup/omegaup.test.js" defer></script>
+		<script type="text/javascript" src="/js/omegaup/time.test.js" defer></script>
+		<script type="text/javascript" src="/js/omegaup/ui.test.js" defer></script>
 	</head>
 	<body>
 	</body>


### PR DESCRIPTION
Este cambio hace que Typeahead ya no se cargue de manera global, sino
únicamente cuando es necesario.