### PR TITLE
Haciendo posible conectarse a la base de datos de Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Ignore objects
 *.o
-bin/mysql-connector-java-5.1.29.jar
 
 # Ignore temporary files
 *~
@@ -109,3 +108,4 @@ frontend/www/docs/pas
 
 # Ignore omegaup.db
 omegaup.db
+.my.cnf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,11 @@ services:
       - '3306'
     volumes:
       - 'dbdata:/var/lib/mysql'
+    ports:
+      - target: 3306
+        published: 13306
+        protocol: tcp
+        mode: host
 
 volumes:
   dbdata:

--- a/stuff/database_utils.py
+++ b/stuff/database_utils.py
@@ -28,8 +28,16 @@ def quote(s):
 
 def default_config_file() -> Optional[str]:
     '''Returns the default config file path for MySQL.'''
-    for candidate_path in (os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
-                           '/etc/mysql/conf.d/mysql_password.cnf'):
+    for candidate_path in (
+            # ${OMEGAUP_ROOT}/.my.cnf
+            os.path.join(
+                os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), '..')),
+                '.my.cnf'),
+            # ~/.my.cnf
+            os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
+            '/etc/mysql/conf.d/mysql_password.cnf',
+    ):
         if os.path.isfile(candidate_path):
             return candidate_path
     return None
@@ -39,7 +47,7 @@ def authentication(*, config_file=default_config_file(), username=None,
                    password=None):
     '''Computes the authentication arguments for mysql binaries.'''
     if config_file and os.path.isfile(config_file):
-        return ['--defaults-extra-file=%s' % quote(config_file)]
+        return ['--defaults-file=%s' % quote(config_file)]
     assert username
     args = ['--user=%s' % quote(username)]
     if password:

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -21,10 +21,13 @@ RUN apt update -y && \
 
 RUN curl -sL https://phar.phpunit.de/phpunit-6.5.9.phar -o /usr/bin/phpunit
 RUN chmod +x /usr/bin/phpunit
-RUN mkdir -p /etc/omegaup/frontend
+
+RUN curl -sL https://getcomposer.org/download/1.10.1/composer.phar -o /usr/bin/composer
+RUN chmod +x /usr/bin/composer
 
 RUN useradd --create-home --shell=/bin/bash ubuntu
 
+RUN mkdir -p /etc/omegaup/frontend
 RUN mkdir -p /var/log/omegaup && chown -R ubuntu /var/log/omegaup
 RUN mkdir -p /var/log/supervisor && chown -R ubuntu /var/log/supervisor
 

--- a/stuff/docker/etc/supervisor/supervisord.conf
+++ b/stuff/docker/etc/supervisor/supervisord.conf
@@ -15,7 +15,15 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:db-migrate]
-command=/opt/omegaup/stuff/db-migrate.py migrate
+command=/opt/omegaup/stuff/db-migrate.py --mysql-config-file=/home/ubuntu/.my.cnf migrate
+autorestart=unexpected
+startsecs=0
+exitcodes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:composer-install]
+command=/usr/bin/composer install
 autorestart=unexpected
 startsecs=0
 exitcodes=0

--- a/stuff/lib/db.py
+++ b/stuff/lib/db.py
@@ -19,8 +19,16 @@ import MySQLdb.connections
 
 def default_config_file_path() -> Optional[str]:
     '''Try to autodetect the config file path.'''
-    for candidate_path in (os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
-                           '/etc/mysql/conf.d/mysql_password.cnf'):
+    for candidate_path in (
+            # ${OMEGAUP_ROOT}/.my.cnf
+            os.path.join(
+                os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), '..', '..')),
+                '.my.cnf'),
+            # ~/.my.cnf
+            os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
+            '/etc/mysql/conf.d/mysql_password.cnf',
+    ):
         if os.path.isfile(candidate_path):
             return candidate_path
     return None


### PR DESCRIPTION
Este cambio hace que si se está corriendo en Docker, sea posible
establecer conexión con la base de datos. Esto require que exista un
archivo `.my.cnf` en el directorio `omegaup`.