### PR TITLE
Actualizando `Update_Run_Counts`

### DIFF
--- a/frontend/database/142_update_run_counts.sql
+++ b/frontend/database/142_update_run_counts.sql
@@ -1,0 +1,18 @@
+DELIMITER $$
+ALTER EVENT `Update_Run_Counts`
+ON SCHEDULE EVERY 1 DAY STARTS NOW()
+DO BEGIN
+   REPLACE INTO
+       `Run_Counts` (`date`, `total`, `ac_count`)
+   SELECT
+       CURDATE() AS `date`,
+       COUNT(*) AS `total`,
+       IFNULL(SUM(IF(`r`.`verdict` = 'AC', 1, 0)), 0) AS `ac_count`
+   FROM
+       `Submissions` AS `s`
+   INNER JOIN
+       `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
+   WHERE
+       `s`.`time` <= CURDATE();
+END$$
+DELIMITER ;

--- a/frontend/database/1_initial_schema.sql
+++ b/frontend/database/1_initial_schema.sql
@@ -1068,7 +1068,7 @@ CREATE EVENT `Update_Run_Counts`
 ON SCHEDULE EVERY 1 DAY STARTS NOW()
 DO BEGIN
    INSERT INTO
-       Run_Counts (date, total, ac_count)
+       Run_Counts (`date`, total, ac_count)
    SELECT
        CURDATE(),
        COUNT(*) AS total,
@@ -1076,7 +1076,7 @@ DO BEGIN
    FROM
        Runs
    WHERE
-       time <= CURDATE();
+       `time` <= CURDATE();
 END$$
 DELIMITER ;
 


### PR DESCRIPTION
Este cambio hace que el evento que actualiza `Run_Counts` funcione
después de haber separado los envíos de las evaluaciones.

Fixes: #3587