### PR TITLE
Restaurando id="content" que fue eliminado por error

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -101,6 +101,7 @@
 			{$ERROR_MESSAGE}
 		</div>
 		{/if}
+		</div>
 	{/if}
 	{include file='status.tpl' inline}
 {/if}

--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -94,10 +94,13 @@
 	{else}
 		{include file='common.navbar.tpl' headerPayload=[] inline}
 	{/if}
-	{if (!isset($inArena) || !$inArena) && isset($ERROR_MESSAGE)}
+	{if (!isset($inArena) || !$inArena)}
+		<div id="content">
+		{if isset($ERROR_MESSAGE)}
 		<div class="alert alert-danger">
 			{$ERROR_MESSAGE}
 		</div>
+		{/if}
 	{/if}
 	{include file='status.tpl' inline}
 {/if}


### PR DESCRIPTION
# Descripción

Cuando removí `mainmenu.tpl`, eliminé también `div#content`. Esto hacía que en desarrollo todo se descuadre.


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
