### PR TITLE
Estabilizando Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       dockerfile: ./Dockerfile.dev-php
       context: ./stuff/docker/
-    image: omegaup/dev-php:latest
+    image: omegaup/dev-php:20200407
     restart: always
     volumes:
       - type: bind
@@ -27,7 +27,7 @@ services:
     build:
       dockerfile: ./Dockerfile.gitserver
       context: ./stuff/docker/
-    image: omegaup/dev-gitserver:latest
+    image: omegaup/dev-gitserver:20200407
     restart: always
     depends_on:
       - mysql
@@ -42,7 +42,7 @@ services:
     build:
       dockerfile: ./Dockerfile.broadcaster
       context: ./stuff/docker/
-    image: omegaup/dev-broadcaster:latest
+    image: omegaup/dev-broadcaster:20200407
     restart: always
     depends_on:
       - mysql
@@ -55,7 +55,7 @@ services:
     build:
       dockerfile: ./Dockerfile.grader
       context: ./stuff/docker/
-    image: omegaup/dev-grader:latest
+    image: omegaup/dev-grader:20200407
     restart: always
     depends_on:
       - mysql
@@ -69,7 +69,7 @@ services:
     build:
       dockerfile: ./Dockerfile.runner
       context: ./stuff/docker/
-    image: omegaup/dev-runner:latest
+    image: omegaup/dev-runner:20200407
     restart: always
     depends_on:
       - grader

--- a/stuff/docker/Dockerfile.broadcaster
+++ b/stuff/docker/Dockerfile.broadcaster
@@ -1,11 +1,11 @@
 FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && \
-    apt install --no-install-recommends -y curl ca-certificates xz-utils && \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y curl ca-certificates xz-utils && \
     /usr/sbin/update-ca-certificates && \
-    apt autoremove -y && \
-    apt clean
+    apt-get autoremove -y && \
+    apt-get clean
 
 RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.1.29/omegaup-backend.tar.xz | tar xJ -C /
 RUN mkdir -p /etc/omegaup/broadcaster

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -1,24 +1,24 @@
 FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && \
-    apt install --no-install-recommends -y openjdk-11-jre-headless curl \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y openjdk-11-jre-headless curl \
         ca-certificates gnupg2 xz-utils && \
     /usr/sbin/update-ca-certificates && \
-    apt autoremove -y && \
-    apt clean
+    apt-get autoremove -y && \
+    apt-get clean
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 
-RUN apt update -y && \
-    apt install --no-install-recommends -y \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
         php7.4-fpm php7.4-curl php7.4-mysql php7.4-sqlite3 php7.4-zip \
         php7.4-mbstring php7.4-json php7.4-opcache php7.4-xml nginx git \
         yarn nodejs supervisor python3-requests python3-mysqldb \
         mysql-client-core-8.0 sudo wait-for-it && \
-    apt autoremove -y && \
-    apt clean
+    apt-get autoremove -y && \
+    apt-get clean
 
 RUN curl -sL https://phar.phpunit.de/phpunit-8.5.2.phar -o /usr/bin/phpunit
 RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar

--- a/stuff/docker/Dockerfile.gitserver
+++ b/stuff/docker/Dockerfile.gitserver
@@ -1,12 +1,12 @@
 FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && \
-    apt install --no-install-recommends -y \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
         curl ca-certificates xz-utils openjdk-11-jre-headless wait-for-it && \
     /usr/sbin/update-ca-certificates && \
-    apt autoremove -y && \
-    apt clean
+    apt-get autoremove -y && \
+    apt-get clean
 
 RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.8/omegaup-gitserver.tar.xz | tar xJ -C /
 RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar

--- a/stuff/docker/Dockerfile.grader
+++ b/stuff/docker/Dockerfile.grader
@@ -1,12 +1,12 @@
 FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && \
-    apt install --no-install-recommends -y \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
         curl ca-certificates xz-utils openjdk-11-jre-headless wait-for-it && \
     /usr/sbin/update-ca-certificates && \
-    apt autoremove -y && \
-    apt clean
+    apt-get autoremove -y && \
+    apt-get clean
 
 RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.1.29/omegaup-backend.tar.xz | tar xJ -C /
 RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar

--- a/stuff/docker/Dockerfile.runner
+++ b/stuff/docker/Dockerfile.runner
@@ -1,12 +1,12 @@
 FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update -y && \
-    apt install --no-install-recommends -y curl ca-certificates xz-utils \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y curl ca-certificates xz-utils \
         wait-for-it && \
     /usr/sbin/update-ca-certificates && \
-    apt autoremove -y && \
-    apt clean
+    apt-get autoremove -y && \
+    apt-get clean
 
 RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.1.29/omegaup-runner.tar.xz | tar xJ -C /
 RUN mkdir -p /etc/omegaup/runner

--- a/stuff/docker/usr/bin/developer-environment.sh
+++ b/stuff/docker/usr/bin/developer-environment.sh
@@ -25,6 +25,8 @@ fi
 if ! /opt/omegaup/stuff/db-migrate.py --mysql-config-file=/home/ubuntu/.my.cnf exists ; then
   mysql --defaults-file=/home/ubuntu/.my.cnf \
     -e "CREATE USER IF NOT EXISTS 'omegaup'@'localhost' IDENTIFIED BY 'omegaup';"
+  mysql --defaults-file=/home/ubuntu/.my.cnf \
+    -e 'GRANT ALL PRIVILEGES ON `omegaup-test`.* TO "omegaup"@"%";'
   /opt/omegaup/stuff/bootstrap-environment.py \
     --mysql-config-file=/home/ubuntu/.my.cnf \
     --purge --verbose --root-url=http://localhost:8000/


### PR DESCRIPTION
Este cambio hace que Docker ya se pueda correr sin el `--build`. A
partir de ahora, cada que se desee hacer un cambio en los archivos de
`stuff/docker`, hay que re-construir los contenedores y volverlos a
subir a Docker Hub.