### PR TITLE
Permitiendo que las pruebas de Selenium corran en Firefox

### DIFF
--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -86,8 +86,9 @@ class Driver:  # pylint: disable=too-many-instance-attributes
     '''Wraps the state needed to run a test.'''
 
     # pylint: disable=too-many-arguments
-    def __init__(self, browser, wait, url, worker_id, options):
+    def __init__(self, browser, browser_name, wait, url, worker_id, options):
         self.browser = browser
+        self.browser_name = browser_name
         self.wait = wait
         self._worker_id = worker_id
         self._next_id = 0
@@ -621,7 +622,8 @@ def driver(request, browser_name):
                              poll_frequency=0.1)
 
         try:
-            yield Driver(browser, wait, request.config.option.url,
+            yield Driver(browser, browser_name, wait,
+                         request.config.option.url,
                          os.environ.get('PYTEST_XDIST_WORKER', 'w0'),
                          request.config.option)
         finally:

--- a/frontend/tests/ui/test_smoke.py
+++ b/frontend/tests/ui/test_smoke.py
@@ -46,14 +46,16 @@ def test_js_errors(driver):
     with util.assert_no_js_errors(driver):
         driver.browser.execute_script('console.log("foo");')
 
-    with util.assert_js_errors(driver, expected_messages=('bar', )):
-        driver.browser.execute_script('console.error("bar");')
+    if driver.browser_name != 'firefox':
+        # Firefox does not support this.
+        with util.assert_js_errors(driver, expected_messages=('bar', )):
+            driver.browser.execute_script('console.error("bar");')
 
-    with util.assert_no_js_errors(driver):
-        # Within an asset_js_error() context manager, messages should not be
-        # bubbled up.
-        with util.assert_js_errors(driver, expected_messages=('baz', )):
-            driver.browser.execute_script('console.error("baz");')
+        with util.assert_no_js_errors(driver):
+            # Within an asset_js_error() context manager, messages should not
+            # be bubbled up.
+            with util.assert_js_errors(driver, expected_messages=('baz', )):
+                driver.browser.execute_script('console.error("baz");')
 
 
 @util.no_javascript_errors()


### PR DESCRIPTION
Este cambio hace que las pruebas de Selenium pasen correctamente en
Firefox.