### PR TITLE
Quitando el cierre de la etiqueta div#content

### DIFF
--- a/frontend/templates/head.tpl
+++ b/frontend/templates/head.tpl
@@ -101,7 +101,6 @@
 			{$ERROR_MESSAGE}
 		</div>
 		{/if}
-		</div>
 	{/if}
 	{include file='status.tpl' inline}
 {/if}


### PR DESCRIPTION
# Descripción

Lastimosamente, si le dejo el cierre de etiqueta, rompe todo. Está hecho para quedarse abierto y que se rellene con lo que viene después.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
