### PR TITLE
Usando el formato anterior de los timestamps para la lista de envíos

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -139,7 +139,7 @@
     </tfoot>
     <tbody v-for="run in filteredRuns">
       <tr>
-        <td>{{ time.formatDateTimeLocal(run.time) }}</td>
+        <td>{{ time.formatTimestamp(run.time) }}</td>
         <td>
           <acronym v-bind:title="run.guid">{{
             run.guid.substring(0, 8)

--- a/frontend/www/js/omegaup/time.test.js
+++ b/frontend/www/js/omegaup/time.test.js
@@ -40,6 +40,16 @@ describe('omegaup.Time', function() {
     });
   });
 
+  describe('formatTimestamp', function() {
+    const expectedValue = '2010-01-01 11:22:33';
+
+    it('Should format timestamps correctly', function() {
+      expect(
+        omegaup.Time.formatTimestamp(new Date('2010-01-01 11:22:33')),
+      ).toEqual(expectedValue);
+    });
+  });
+
   describe('parseDuration', function() {
     it('Should handle valid inputs', function() {
       expect(omegaup.Time.parseDuration('0')).toEqual(0);

--- a/frontend/www/js/omegaup/time.ts
+++ b/frontend/www/js/omegaup/time.ts
@@ -1,6 +1,6 @@
-import T from './lang';
-
 import * as moment from 'moment';
+
+import T from './lang';
 
 let momentInitialized: boolean = false;
 
@@ -68,7 +68,8 @@ export function formatDateLocal(date: Date): string {
 
 export function parseDateLocal(dateString: string): Date {
   // The expected format is yyyy-MM-dd in the local timezone. Date.parse()
-  // will use UTC if given a timestamp with that format, instead of the local timezone.
+  // will use UTC if given a timestamp with that format, instead of the local
+  // timezone.
   const result = new Date();
   const matches = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
   if (matches !== null) {
@@ -121,6 +122,15 @@ export function formatDateTime(date: Date): string {
 
 export function formatDate(date: Date): string {
   return date.toLocaleDateString(T.locale);
+}
+
+export function formatTimestamp(date: Date): string {
+  return `${formatDateLocal(date)} ${String(date.getHours()).padStart(
+    2,
+    '0',
+  )}:${String(date.getMinutes()).padStart(2, '0')}:${String(
+    date.getSeconds(),
+  ).padStart(2, '0')}`;
 }
 
 export function parseDuration(str: string): number | null {


### PR DESCRIPTION
Este cambio despliega los timestamps de los envíos usando el formato
anterior, que era `YYYY-mm-dd HH:MM:SS`.