### PR TITLE
Haciendo más robusta la validación de lenguajes

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1924,12 +1924,19 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // languages is always optional
         if (!empty($r['languages'])) {
-            foreach ($r['languages'] as $language) {
-                \OmegaUp\Validators::validateOptionalInEnum(
-                    $language,
-                    'languages',
-                    array_keys(\OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES)
-                );
+            if (is_string($r['languages'])) {
+                $r['languages'] = explode(',', $r['languages']);
+            }
+            if (is_array($r['languages'])) {
+                foreach ($r['languages'] as $language) {
+                    \OmegaUp\Validators::validateOptionalInEnum(
+                        $language,
+                        'languages',
+                        array_keys(
+                            \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                        )
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Este cambio hace que si se crea/actualiza un concurso con soporte de
límite de lenguajes, no produzca un error a veces.