### PR TITLE
Agregando un adaptador para convertir las fechas al reloj local

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3596,7 +3596,7 @@ Get basic details of a run
 | `runtime`       | `number` |
 | `score`         | `number` |
 | `submit_delay`  | `number` |
-| `time`          | `number` |
+| `time`          | `Date`   |
 
 # School
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -586,7 +586,7 @@ class Run extends \OmegaUp\Controllers\Controller {
      *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
-     * @return array{contest_score: float|null, memory: int, penalty: int, runtime: int, score: float, submit_delay: int, time: int}
+     * @return array{contest_score: float|null, memory: int, penalty: int, runtime: int, score: float, submit_delay: int, time: \OmegaUp\Timestamp}
      */
     public static function apiStatus(\OmegaUp\Request $r): array {
         // Get the user who is calling this API
@@ -621,7 +621,7 @@ class Run extends \OmegaUp\Controllers\Controller {
                 'status', 'verdict', 'runtime', 'penalty', 'memory', 'score', 'contest_score',
             ])
         );
-        $filtered['time'] = intval($filtered['time']);
+        $filtered['time'] = new \OmegaUp\Timestamp(intval($filtered['time']));
         $filtered['score'] = round(floatval($filtered['score']), 4);
         $filtered['runtime'] = intval($filtered['runtime']);
         $filtered['penalty'] = intval($filtered['penalty']);

--- a/frontend/www/js/omegaup/api_transitional.ts
+++ b/frontend/www/js/omegaup/api_transitional.ts
@@ -888,9 +888,14 @@ export const Run = {
   source: apiCall<messages.RunSourceRequest, messages.RunSourceResponse>(
     '/api/run/source/',
   ),
-  status: apiCall<messages.RunStatusRequest, messages.RunStatusResponse>(
-    '/api/run/status/',
-  ),
+  status: apiCall<
+    messages.RunStatusRequest,
+    messages._RunStatusServerResponse,
+    messages.RunStatusResponse
+  >('/api/run/status/', x => {
+    x.time = ((x: number) => new Date(x * 1000))(x.time);
+    return x;
+  }),
 };
 
 export const School = {

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2063,6 +2063,7 @@ export namespace messages {
     source: string;
   };
   export type RunStatusRequest = { [key: string]: any };
+  export type _RunStatusServerResponse = any;
   export type RunStatusResponse = {
     contest_score?: number;
     memory: number;
@@ -2070,7 +2071,7 @@ export namespace messages {
     runtime: number;
     score: number;
     submit_delay: number;
-    time: number;
+    time: Date;
   };
 
   // School

--- a/frontend/www/js/omegaup/arena/arena.js
+++ b/frontend/www/js/omegaup/arena/arena.js
@@ -704,7 +704,8 @@ export class Arena {
     let self = this;
     if (self.socket != null) return;
     setTimeout(function() {
-      API.Run.status({ run_alias: guid })
+      api.Run.status({ run_alias: guid })
+        .then(time.remoteTimeAdapter)
         .then(self.updateRun.bind(self))
         .catch(ui.ignoreError);
     }, 5000);

--- a/frontend/www/js/omegaup/arena/arena_transitional.ts
+++ b/frontend/www/js/omegaup/arena/arena_transitional.ts
@@ -4,6 +4,7 @@ import Vuex, { StoreOptions } from 'vuex';
 import { types } from '../api_types';
 import T from '../lang';
 import { OmegaUp } from '../omegaup';
+import * as time from '../time';
 
 Vue.use(Vuex);
 
@@ -202,11 +203,11 @@ export class EventsSocket {
     const data = JSON.parse(message.data);
 
     if (data.message == '/run/update/') {
-      data.run.time = OmegaUp.remoteTime(data.run.time * 1000);
+      data.run.time = time.remoteTime(data.run.time * 1000);
       this.arena.updateRun(data.run);
     } else if (data.message == '/clarification/update/') {
       if (!this.arena.options.disableClarifications) {
-        data.clarification.time = OmegaUp.remoteTime(
+        data.clarification.time = time.remoteTime(
           data.clarification.time * 1000,
         );
         this.arena.updateClarification(data.clarification);

--- a/frontend/www/js/omegaup/arena/contest_list.ts
+++ b/frontend/www/js/omegaup/arena/contest_list.ts
@@ -16,9 +16,9 @@ OmegaUp.on('ready', () => {
       continue;
     }
     contestList.forEach((contest: types.ContestListItem) => {
-      contest.finish_time = OmegaUp.remoteTime(contest.finish_time);
-      contest.last_updated = OmegaUp.remoteTime(contest.last_updated);
-      contest.start_time = OmegaUp.remoteTime(contest.start_time);
+      contest.finish_time = time.remoteDate(contest.finish_time);
+      contest.last_updated = time.remoteDate(contest.last_updated);
+      contest.start_time = time.remoteDate(contest.start_time);
     });
   }
   const contestList = new Vue({

--- a/frontend/www/js/omegaup/components/course/CourseDetails.vue
+++ b/frontend/www/js/omegaup/components/course/CourseDetails.vue
@@ -192,7 +192,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { OmegaUp, omegaup } from '../../omegaup';
+import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
 import * as time from '../../time';
@@ -205,7 +205,6 @@ export default class CourseDetails extends Vue {
 
   T = T;
   ui = ui;
-  OmegaUp = OmegaUp;
 
   get filteredHomeworks(): omegaup.Assignment[] {
     return this.course.assignments.filter(
@@ -226,7 +225,7 @@ export default class CourseDetails extends Vue {
   }
 
   getFormattedTime(timestamp: number): string {
-    return time.formatDateTime(OmegaUp.remoteTime(timestamp * 1000));
+    return time.formatDateTime(time.remoteTime(timestamp * 1000));
   }
 }
 </script>

--- a/frontend/www/js/omegaup/time.test.js
+++ b/frontend/www/js/omegaup/time.test.js
@@ -101,4 +101,56 @@ describe('omegaup.Time', function() {
       expect(omegaup.Time.toDDHHMM(2500000)).toEqual('28d 22h 26m');
     });
   });
+
+  describe('remoteTimeAdapter', function() {
+    beforeAll(function() {
+      omegaup.Time._setRemoteDeltaTime(1);
+    });
+
+    it('Should handle Dates', function() {
+      expect(omegaup.Time.remoteTimeAdapter(new Date(0))).toEqual(new Date(1));
+    });
+
+    it('Should handle arrays', function() {
+      expect(omegaup.Time.remoteTimeAdapter([new Date(0)])).toEqual([
+        new Date(1),
+      ]);
+    });
+
+    it('Should handle primitives', function() {
+      expect(omegaup.Time.remoteTimeAdapter(1)).toEqual(1);
+    });
+
+    it('Should handle objects', function() {
+      expect(
+        omegaup.Time.remoteTimeAdapter({
+          time: new Date(0),
+          status: 'ok',
+        }),
+      ).toEqual({
+        time: new Date(1),
+        status: 'ok',
+      });
+    });
+
+    it('Should handle complex objects', function() {
+      expect(
+        omegaup.Time.remoteTimeAdapter({
+          contests: [
+            {
+              time: new Date(0),
+            },
+          ],
+          status: 'ok',
+        }),
+      ).toEqual({
+        contests: [
+          {
+            time: new Date(1),
+          },
+        ],
+        status: 'ok',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Este cambio mueve la decisión de la conversión de las fechas del wrapper
de los APIs al lugar donde se mandan llamar. Esto permite que la misma
API se pueda invocar en dos contextos distintos, uno donde se require la
conversión (e.g. la arena) y otra donde no (e.g. el panel de
administración).