### PR TITLE
Agregando configuración de tamaños de fuentes para el nuevo homepage

### DIFF
--- a/frontend/www/js/omegaup/components/homepage/Section.vue
+++ b/frontend/www/js/omegaup/components/homepage/Section.vue
@@ -31,8 +31,9 @@ h3.display-4 {
   font-weight: normal;
 }
 
-p.section-description {
-  font-size: 1.15rem;
+p.section-description,
+a.section-link {
+  font-size: 1.3rem;
 }
 
 img.img-fluid {

--- a/frontend/www/js/omegaup/components/homepage/Section.vue
+++ b/frontend/www/js/omegaup/components/homepage/Section.vue
@@ -11,7 +11,7 @@
       class="col-md-6 mt-2 mt-md-0"
       v-bind:class="{ 'order-md-1': imageToRight }"
     >
-      <p>{{ description }}</p>
+      <p class="section-description">{{ description }}</p>
       <a
         v-if="button"
         class="btn btn-primary section-link mb-3"
@@ -29,6 +29,10 @@
 h3.display-4 {
   color: $omegaup-primary--darker;
   font-weight: normal;
+}
+
+p.section-description {
+  font-size: 1.15rem;
 }
 
 img.img-fluid {

--- a/frontend/www/js/omegaup/components/homepage/Slide.vue
+++ b/frontend/www/js/omegaup/components/homepage/Slide.vue
@@ -28,8 +28,12 @@
     height: 500px;
   }
 
+  h2 {
+    font-size: 2.4rem;
+  }
+
   p {
-    font-size: 1.1rem;
+    font-size: 1.2rem;
   }
 }
 </style>

--- a/frontend/www/js/omegaup/components/homepage/Slide.vue
+++ b/frontend/www/js/omegaup/components/homepage/Slide.vue
@@ -4,7 +4,7 @@
       class="slide d-flex align-items-center justify-content-around flex-wrap flex-lg-nowrap"
     >
       <div>
-        <h3>{{ title }}</h3>
+        <h2>{{ title }}</h2>
         <p>{{ description }}</p>
         <a
           class="btn btn-primary mb-3"
@@ -26,6 +26,10 @@
 .slide {
   @media only screen and (min-width: 767px) {
     height: 500px;
+  }
+
+  p {
+    font-size: 1.1rem;
   }
 }
 </style>

--- a/frontend/www/js/omegaup/components/homepage/Testimonials.vue
+++ b/frontend/www/js/omegaup/components/homepage/Testimonials.vue
@@ -65,7 +65,7 @@
 
   .carousel-item {
     blockquote.blockquote {
-      font-size: 1.1rem;
+      font-size: 1.15rem;
       line-height: 1.15;
 
       footer {

--- a/frontend/www/js/omegaup/components/user/Rank.vue
+++ b/frontend/www/js/omegaup/components/user/Rank.vue
@@ -69,7 +69,7 @@
       </thead>
       <tbody>
         <tr v-bind:key="index" v-for="(rank, index) in ranking">
-          <th scope="row">{{ rank.rank }}</th>
+          <th scope="row">{{ rank.ranking }}</th>
           <td>
             <omegaup-countryflag
               v-bind:country="rank.country"


### PR DESCRIPTION
# Descripción

Así se ven las fuentes ahora.

![image](https://user-images.githubusercontent.com/20785082/79510219-52328d00-8013-11ea-8a04-4b8c0ce29d79.png)


Fixes: #3748 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
