### PR TITLE
Agregando una advertencia para correr `yarn run dev-all`

### DIFF
--- a/frontend/smarty_plugins/compiler.js_include.php
+++ b/frontend/smarty_plugins/compiler.js_include.php
@@ -5,11 +5,12 @@
  */
 function getJavaScriptDeps(string $entrypoint): array {
     $jsonPath = __DIR__ . "/../www/js/dist/{$entrypoint}.deps.json";
+    $textContents = @file_get_contents($jsonPath);
+    if ($textContents === false) {
+        die('Please run <tt style="background: #eee">yarn run dev-all</tt>.');
+    }
     /** @var array{css: list<string>, js: list<string>} */
-    $jsonContents = json_decode(
-        file_get_contents($jsonPath),
-        /*assoc=*/true
-    );
+    $jsonContents = json_decode($textContents, /*assoc=*/true);
     return $jsonContents['js'];
 }
 


### PR DESCRIPTION
Este cambio modifica el compilador para que emita una advertencia si se
intenta abrir un JSON de dependencias inexistente.