### PR TITLE
Escondiendo el scoreboard cutoff en cursos

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestSummary.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestSummary.vue
@@ -23,7 +23,13 @@
           }}
         </td>
       </tr>
-      <tr v-if="showRanking && duration != Infinity">
+      <tr
+        v-if="
+          showRanking &&
+            typeof contest.scoreboard === 'number' &&
+            duration != Infinity
+        "
+      >
         <td>
           <strong>{{ T.arenaPracticeScoreboardCutoff }}</strong>
         </td>


### PR DESCRIPTION
Este cambio hace que el scoreboard cutoff no se muestre si
`contest.scoreboard` no es un número válido.