### PR TITLE
Arreglando el paginador de problemas

### DIFF
--- a/frontend/www/js/omegaup/components/common/Paginator.vue
+++ b/frontend/www/js/omegaup/components/common/Paginator.vue
@@ -5,7 +5,13 @@
         <ul class="pagination">
           <li v-for="page in pagerItems" v-bind:class="page.class">
             <a
+              v-if="page.url"
               v-bind:href="page.url"
+              v-bind:class="{ disabled: page.class !== 'active' }"
+              >{{ page.label }}</a
+            >
+            <a
+              v-else=""
               v-bind:class="{ disabled: page.class !== 'active' }"
               v-on:click.prevent="$emit('page-changed', page.page)"
               >{{ page.label }}</a


### PR DESCRIPTION
# Descripción

Se quita el `callback` del paginador cuando contiene una url válida para navegar
entre las páginas. El `callback` sólo se debe utilizar cuando las peticiones son vía
`API`

Fixes: #3803 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
