### PR TITLE
Actualizando psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,11 @@
 {
+    "config": {
+      "platform": {
+        "php": "7.2.19"
+      }
+    },
     "require-dev": {
-        "vimeo/psalm": "^3.9",
+        "vimeo/psalm": "^3.11.2",
         "jetbrains/phpstorm-stubs": "^2019.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35d7790f3e9f68e816cededd1fe6aa13",
+    "content-hash": "041841eb41825a7c24d15b8828933e33",
     "packages": [],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.4.1",
+            "version": "v2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "2ac3b550c4997f2ec304faa63c8b2885079a2dc4"
+                "reference": "23ac95fc6d6973231763f5ed7d1309b39429b974"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/2ac3b550c4997f2ec304faa63c8b2885079a2dc4",
-                "reference": "2ac3b550c4997f2ec304faa63c8b2885079a2dc4",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/23ac95fc6d6973231763f5ed7d1309b39429b974",
+                "reference": "23ac95fc6d6973231763f5ed7d1309b39429b974",
                 "shasum": ""
             },
             "require": {
@@ -28,14 +28,15 @@
                 "amphp/php-cs-fixer-config": "dev-master",
                 "amphp/phpunit-util": "^1",
                 "ext-json": "*",
-                "phpstan/phpstan": "^0.8.5",
+                "jetbrains/phpstorm-stubs": "^2019.3",
                 "phpunit/phpunit": "^6.0.9 | ^7",
-                "react/promise": "^2"
+                "react/promise": "^2",
+                "vimeo/psalm": "^3.11@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -82,20 +83,20 @@
                 "non-blocking",
                 "promise"
             ],
-            "time": "2020-02-10T18:10:57+00:00"
+            "time": "2020-04-19T15:54:21+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.7.2",
+            "version": "v1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "1e52f1752b2e20e2a7e464476ef887a2388e3832"
+                "reference": "b867505edb79dda8f253ca3c3a2bbadae4b16592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/1e52f1752b2e20e2a7e464476ef887a2388e3832",
-                "reference": "1e52f1752b2e20e2a7e464476ef887a2388e3832",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/b867505edb79dda8f253ca3c3a2bbadae4b16592",
+                "reference": "b867505edb79dda8f253ca3c3a2bbadae4b16592",
                 "shasum": ""
             },
             "require": {
@@ -105,10 +106,16 @@
                 "amphp/php-cs-fixer-config": "dev-master",
                 "amphp/phpunit-util": "^1",
                 "friendsofphp/php-cs-fixer": "^2.3",
-                "infection/infection": "^0.9.3",
-                "phpunit/phpunit": "^6"
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "vimeo/psalm": "^3.9@dev"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Amp\\ByteStream\\": "lib"
@@ -141,7 +148,7 @@
                 "non-blocking",
                 "stream"
             ],
-            "time": "2020-01-29T18:22:23+00:00"
+            "time": "2020-04-04T16:56:54+00:00"
         },
         {
             "name": "composer/semver",
@@ -250,20 +257,20 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483"
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/a407a6cb0325cd489c6dff57afcba6baeccc0483",
-                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/0ed363f8de17d284d479ec813c9ad3f6834b5c40",
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40",
                 "shasum": ""
             },
             "require": {
-                "netresearch/jsonmapper": "^1.0",
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
                 "php": ">=7.0",
                 "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
             },
@@ -287,7 +294,7 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2020-02-11T20:48:40+00:00"
+            "time": "2020-03-11T15:21:41+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -382,16 +389,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v1.6.0",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "0d4d1b48d682a93b6bfedf60b88c7750e9cb0b06"
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/0d4d1b48d682a93b6bfedf60b88c7750e9cb0b06",
-                "reference": "0d4d1b48d682a93b6bfedf60b88c7750e9cb0b06",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
                 "shasum": ""
             },
             "require": {
@@ -402,8 +409,8 @@
                 "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",
-                "squizlabs/php_codesniffer": "~1.5"
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
             },
             "type": "library",
             "autoload": {
@@ -418,26 +425,26 @@
             "authors": [
                 {
                     "name": "Christian Weiske",
-                    "role": "Developer",
                     "email": "cweiske@cweiske.de",
-                    "homepage": "http://github.com/cweiske/jsonmapper/"
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
                 }
             ],
             "description": "Map nested JSON structures onto PHP classes",
-            "time": "2019-08-15T19:41:25+00:00"
+            "time": "2020-04-16T18:48:43+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.3.0",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
                 "shasum": ""
             },
             "require": {
@@ -476,7 +483,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-11-08T13:50:10+00:00"
+            "time": "2020-04-10T16:34:50+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -579,23 +586,20 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
@@ -627,7 +631,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2020-04-27T09:25:28+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -779,16 +783,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
                 "shasum": ""
             },
             "require": {
@@ -822,7 +826,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01T11:05:21+00:00"
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -882,16 +886,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.0.5",
+            "version": "v5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d29e2d36941de13600c399e393a60b8cfe59ac49"
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d29e2d36941de13600c399e393a60b8cfe59ac49",
-                "reference": "d29e2d36941de13600c399e393a60b8cfe59ac49",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
                 "shasum": ""
             },
             "require": {
@@ -954,20 +958,34 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-02-24T15:05:31+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-30T11:42:42+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
-                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
                 "shasum": ""
             },
             "require": {
@@ -979,7 +997,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -1012,20 +1030,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-01-13T11:15:53+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2"
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/34094cfa9abe1f0f14f48f490772db7a775559f2",
-                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
                 "shasum": ""
             },
             "require": {
@@ -1037,7 +1069,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -1071,20 +1103,34 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-01-13T11:15:53+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675"
+                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/5e66a0fa1070bf46bec4bea7962d285108edd675",
-                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
+                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
                 "shasum": ""
             },
             "require": {
@@ -1093,7 +1139,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.14-dev"
+                    "dev-master": "1.15-dev"
                 }
             },
             "autoload": {
@@ -1129,7 +1175,21 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-01-13T11:15:53+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1191,16 +1251,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.9.4",
+            "version": "3.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "352bd3f5c5789db04e4010856c2f4e01ed354f4e"
+                "reference": "d470903722cfcbc1cd04744c5491d3e6d13ec3d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/352bd3f5c5789db04e4010856c2f4e01ed354f4e",
-                "reference": "352bd3f5c5789db04e4010856c2f4e01ed354f4e",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d470903722cfcbc1cd04744c5491d3e6d13ec3d9",
+                "reference": "d470903722cfcbc1cd04744c5491d3e6d13ec3d9",
                 "shasum": ""
             },
             "require": {
@@ -1215,7 +1275,7 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.4",
-                "netresearch/jsonmapper": "^1.0",
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
                 "nikic/php-parser": "^4.3",
                 "ocramius/package-versions": "^1.2",
                 "openlss/lib-array2xml": "^1.0",
@@ -1229,13 +1289,15 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/amp": "^2.4.2",
                 "bamarni/composer-bin-plugin": "^1.2",
                 "brianium/paratest": "^4.0.0",
                 "ext-curl": "*",
+                "php-coveralls/php-coveralls": "^2.2",
                 "phpmyadmin/sql-parser": "5.1.0",
                 "phpspec/prophecy": ">=1.9.0",
-                "phpunit/phpunit": "^7.5.16 || ^8.5",
-                "psalm/plugin-phpunit": "^0.9",
+                "phpunit/phpunit": "^7.5.16 || ^8.5 || ^9.0",
+                "psalm/plugin-phpunit": "^0.10",
                 "slevomat/coding-standard": "^5.0",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3"
@@ -1283,20 +1345,20 @@
                 "inspection",
                 "php"
             ],
-            "time": "2020-03-06T20:23:11+00:00"
+            "time": "2020-04-13T12:47:11+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -1304,7 +1366,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -1331,7 +1393,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         },
         {
             "name": "webmozart/glob",
@@ -1433,5 +1495,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2.19"
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -857,6 +857,23 @@ function listDir(string $path): Generator {
     closedir($dh);
 }
 
+// Psalm requires having a ProjectAnalyzer instance set up in order to resolve
+// some more complex types.
+//
+// It's a bit brittle to be fiddling with internal objects, but there is no
+// other way to get a valid instance.
+$rootDirectory = dirname(__DIR__, 3);
+define('PSALM_VERSION', \PackageVersions\Versions::getVersion('vimeo/psalm'));
+$projectAnalyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
+    \Psalm\Config::loadFromXMLFile(
+        "{$rootDirectory}/psalm.xml",
+        $rootDirectory
+    ),
+    new \Psalm\Internal\Provider\Providers(
+        new \Psalm\Internal\Provider\FileProvider()
+    )
+);
+
 $options = getopt('', ['file:']);
 if (!isset($options['file']) || !is_string($options['file'])) {
     throw new \Exception('Missing option for --file');

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2804,6 +2804,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             throw $e;
         }
 
+        /** @psalm-suppress RedundantCondition OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE may be defined as true in tests. */
         if (OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE) {
             self::$log->info(
                 'Calling \OmegaUp\Controllers\Problem::apiRejudge'

--- a/frontend/server/src/Controllers/Problemset.php
+++ b/frontend/server/src/Controllers/Problemset.php
@@ -253,11 +253,13 @@ class Problemset extends \OmegaUp\Controllers\Controller {
             if (isset($r['auth_token']) && is_string($r['auth_token'])) {
                 $request['auth_token'] = $r['auth_token'];
             }
+            /** @psalm-suppress MixedArgument $r['tokens'] is definitely an array here. */
             if (
                 isset($r['tokens']) &&
                 is_array($r['tokens']) &&
                 count($r['tokens']) >= 4
             ) {
+                /** @psalm-suppress MixedArrayAccess $r['tokens'] is definitely an array here. */
                 $request['token'] = strval($r['tokens'][3]);
             }
             $response = \OmegaUp\Controllers\Contest::validateDetails($request);

--- a/frontend/server/src/Controllers/Reset.php
+++ b/frontend/server/src/Controllers/Reset.php
@@ -35,6 +35,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
         $user->reset_sent_at = \OmegaUp\Time::get();
         \OmegaUp\DAO\Users::update($user);
 
+        /** @psalm-suppress TypeDoesNotContainType IS_TEST may be defined as true in tests. */
         if (IS_TEST) {
             return ['token' => $token];
         }
@@ -219,6 +220,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
 
         \OmegaUp\DAO\Identities::update($identity);
 
+        /** @psalm-suppress TypeDoesNotContainType IS_TEST may be defined as true in tests. */
         return [
             'message' => IS_TEST ?
                 'message' :

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -138,6 +138,7 @@ class User extends \OmegaUp\Controllers\Controller {
         if (!is_null($createUserParams->facebookUserId)) {
             $userData['facebook_user_id'] = $createUserParams->facebookUserId;
         }
+        /** @psalm-suppress TypeDoesNotContainType OMEGAUP_VALIDATE_CAPTCHA may be defined as true in tests. */
         if ($forceVerification) {
             $userData['verified'] = 1;
         } elseif (OMEGAUP_VALIDATE_CAPTCHA) {
@@ -153,16 +154,17 @@ class User extends \OmegaUp\Controllers\Controller {
             $data = [
                 'secret' => OMEGAUP_RECAPTCHA_SECRET,
                 'response' => $createUserParams->recaptcha,
-                'remoteip' => $_SERVER['REMOTE_ADDR']];
+                'remoteip' => $_SERVER['REMOTE_ADDR'],
+            ];
 
             // use key 'http' even if you send the request to https://...
             $options = [
-                    'http' => [
-                        'header'  => "Content-type: application/x-www-form-urlencoded\r\n",
-                        'method'  => 'POST',
-                        'content' => http_build_query($data),
-                        ],
-                    ];
+                'http' => [
+                    'header'  => "Content-type: application/x-www-form-urlencoded\r\n",
+                    'method'  => 'POST',
+                    'content' => http_build_query($data),
+                ],
+            ];
             $context  = stream_context_create($options);
             $result = file_get_contents($url, false, $context);
 

--- a/frontend/server/src/Grader.php
+++ b/frontend/server/src/Grader.php
@@ -13,6 +13,14 @@ class Grader {
     const REQUEST_MODE_RAW = 2;
     const REQUEST_MODE_PASSTHRU = 3;
 
+    /**
+     * This is needed to prevent Psalm from complaining every time this shows
+     * up, since this can be set to true in tests.
+     *
+     * @var bool
+     */
+    private static $OMEGAUP_GRADER_FAKE = OMEGAUP_GRADER_FAKE;
+
     public static function getInstance(): \OmegaUp\Grader {
         if (is_null(self::$_instance)) {
             self::$_instance = new \OmegaUp\Grader();
@@ -33,7 +41,7 @@ class Grader {
      * @throws \Exception
      */
     public function grade(\OmegaUp\DAO\VO\Runs $run, string $source): void {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             if (is_null($run->submission_id)) {
                 throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
             }
@@ -62,7 +70,7 @@ class Grader {
      * @throws \Exception
      */
     public function rejudge(array $runs, bool $debug): void {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             return;
         }
         $this->curlRequest(
@@ -86,7 +94,7 @@ class Grader {
      * @throws \Exception
      */
     public function getSource(string $guid): string {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             return file_get_contents("/tmp/{$guid}");
         }
         /** @var string */
@@ -102,7 +110,7 @@ class Grader {
      * @return GraderStatus
      */
     public function status(): array {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             return [
                 'status' => 'ok',
                 'broadcaster_sockets' => 0,
@@ -132,7 +140,7 @@ class Grader {
         int $userId = -1,
         bool $userOnly = false
     ): void {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             return;
         }
         $this->curlRequest(
@@ -158,7 +166,7 @@ class Grader {
         string $filename,
         bool $missingOk = false
     ): ?string {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             return null;
         }
         /** @var null|string */
@@ -178,7 +186,7 @@ class Grader {
         string $filename,
         bool $missingOk = false
     ): ?bool {
-        if (OMEGAUP_GRADER_FAKE) {
+        if (self::$OMEGAUP_GRADER_FAKE) {
             return null;
         }
         /** @var null|bool */

--- a/frontend/server/src/ProblemDeployer.php
+++ b/frontend/server/src/ProblemDeployer.php
@@ -48,7 +48,7 @@ class ProblemDeployer {
             && isset($_FILES['problem_contents']['tmp_name'])
             && is_string($_FILES['problem_contents']['tmp_name'])
             && \OmegaUp\FileHandler::getFileUploader()->isUploadedFile(
-                $_FILES['problem_contents']['tmp_name']
+                strval($_FILES['problem_contents']['tmp_name'])
             )
         ) {
             /** @psalm-suppress MixedArrayAccess */

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -68,10 +68,13 @@ class RequestParamChecker implements
             }
             return null;
         }
-        if (is_null($context->calling_function_id)) {
-            throw new \Exception('Should never happen');
+        if (!is_null($context->calling_function_id)) {
+            $functionId = strtolower($context->calling_function_id);
+        } elseif (!is_null($context->calling_method_id)) {
+            $functionId = $context->calling_method_id;
+        } else {
+            throw new \Exception('Empty calling method/function id');
         }
-        $functionId = strtolower($context->calling_function_id);
         if (!array_key_exists($functionId, self::$methodTypeMapping)) {
             self::$methodTypeMapping[$functionId] = [];
         }
@@ -239,11 +242,14 @@ class RequestParamChecker implements
         array &$fileReplacements = [],
         \Psalm\Type\Union &$returnTypeCandidate = null
     ) {
-        if (is_null($context->calling_function_id)) {
+        if (!is_null($context->calling_function_id)) {
+            $functionId = strtolower($context->calling_function_id);
+        } elseif (!is_null($context->calling_method_id)) {
+            $functionId = $context->calling_method_id;
+        } else {
             // Not being called from within a function-like.
             return;
         }
-        $functionId = strtolower($context->calling_function_id);
         if (!array_key_exists($functionId, self::$methodCallGraph)) {
             self::$methodCallGraph[$functionId] = [];
         }
@@ -310,7 +316,7 @@ class RequestParamChecker implements
             );
             $docblockStart = (
                 !is_null($docblock) ?
-                $docblock->getFilePos() :
+                $docblock->getStartFilePos() :
                 intval(
                     $methodStmt->getAttribute(
                         'startFilePos'

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -1,5 +1,9 @@
 <?php
+/** @psalm-suppress MixedOperand OMEGAUP_ROOT is definitely defined... */
 require_once OMEGAUP_ROOT . '/server/try_define.php';
+
+/** @var string */
+$_omegaUpRoot = OMEGAUP_ROOT;
 
 # ####################################
 # EXPERIMENTS
@@ -17,8 +21,8 @@ try_define('OMEGAUP_DB_HOST', '127.0.0.1');
 # ####################################
 # TEST CONFIG
 # ####################################
-try_define('OMEGAUP_TEST_ROOT', OMEGAUP_ROOT . '/tests/controllers/');
-try_define('OMEGAUP_TEST_RESOURCES_ROOT', OMEGAUP_ROOT . '/tests/resources/');
+try_define('OMEGAUP_TEST_ROOT', "{$_omegaUpRoot}/tests/controllers/");
+try_define('OMEGAUP_TEST_RESOURCES_ROOT', "{$_omegaUpRoot}/tests/resources/");
 try_define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', true);
 
 # ####################################
@@ -35,10 +39,10 @@ try_define('DUMP_MYSQL_QUERY_RESULT_TYPES', true);
 # ####################################
 # GRADER CONFIG
 # ####################################
-try_define('BIN_PATH', OMEGAUP_ROOT . '/../bin');
+try_define('BIN_PATH', "{$_omegaUpRoot}/../bin");
 try_define('IMAGES_PATH', OMEGAUP_TEST_ROOT . 'img/');
 try_define('IMAGES_URL_PATH', '/img/');
-try_define('OMEGAUP_CACERT_URL', OMEGAUP_ROOT . '/omegaup.pem');
+try_define('OMEGAUP_CACERT_URL', "{$_omegaUpRoot}/omegaup.pem");
 try_define('OMEGAUP_GITSERVER_PORT', '33863');
 try_define(
     'OMEGAUP_GITSERVER_URL',
@@ -48,7 +52,7 @@ try_define(
     'OMEGAUP_GITSERVER_SECRET_TOKEN',
     'cbaf89d3bb2ee6b0a90bc7a90d937f9ade16739ed9f573c76e1ac72064e397aac2b35075040781dd0df9a8f1d6fc4bd4a4941eb6b0b62541b0a35fb0f89cfc3f'
 );
-try_define('OMEGAUP_SSLCERT_URL', OMEGAUP_ROOT . '/omegaup.pem');
+try_define('OMEGAUP_SSLCERT_URL', "{$_omegaUpRoot}/omegaup.pem");
 try_define('TEMPLATES_PATH', OMEGAUP_TEST_ROOT . '/templates/');
 
 # #########################

--- a/frontend/www/login.php
+++ b/frontend/www/login.php
@@ -66,8 +66,8 @@ function shouldRedirect(string $url): bool {
     }
     // Just the path portion of the URL was given.
     if (
-        !isset($redirectParsedUrl['scheme']) &&
-        !isset($redirectParsedUrl['host'])
+        empty($redirectParsedUrl['scheme']) ||
+        empty($redirectParsedUrl['host'])
     ) {
         return true;
     }

--- a/stuff/travis/lint.sh
+++ b/stuff/travis/lint.sh
@@ -31,6 +31,11 @@ stage_script() {
 	yarn run build
 	yarn test
 
+	# Create optional directories to simplify psalm config.
+	mkdir -p frontend/www/{phpminiadmin,preguntas}
+	touch 'frontend/server/config.php'
+	touch 'frontend/tests/test_config.php'
+
 	python3 stuff/db-migrate.py validate
 	"${OMEGAUP_ROOT}/stuff/lint.sh" validate --all < /dev/null
 }


### PR DESCRIPTION
Este cambio actualiza psalm a 3.11.2, que entre otras cosas ya permite
expresar "intersecciones" de objetos. Esto significa que si se declara
un tipo `T1&T2`, donde tanto `T1` como `T2` son objetos arreglosos, el
tipo resultante contiene todas las propiedades de `T1` y `T2`.

También se actualiza `sodium_compat` porque uno de los docblocks
contenía una anotación que estaba haciendo no-feliz a psalm.