### PR TITLE
Arreglando el recorrido de resolución de parámetros

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -4023,6 +4023,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a detailed report of the contest
      *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $filterBy
+     *
      * @return array{finish_time: int|null, problems: list<array{alias: string, order: int}>, ranking: list<array{country: null|string, is_invited: bool, name: null|string, place?: int, problems: list<array{alias: string, penalty: float, percent: float, place?: int, points: float, run_details?: array{cases?: list<array{contest_score: float, max_score: float, meta: array{status: string}, name: null|string, out_diff: string, score: float, verdict: string}>, details: array{groups: list<array{cases: list<array{meta: array{memory: float, time: float, wall_time: float}}>}>}}, runs: int}>, total: array{penalty: float, points: float}, username: string}>, start_time: int, time: \OmegaUp\Timestamp, title: string}
      */
     public static function apiReport(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2181,6 +2181,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Show course intro only on public courses when user is not yet registered
      *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     *
      * @throws \OmegaUp\Exceptions\NotFoundException Course not found or trying to directly access a private course.
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -2195,6 +2198,9 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     *
      * @return array{inContest: bool, smartyProperties: array{coursePayload?: array{alias: string, currentUsername: string, description: string, isFirstTimeAccess: bool, name: string, needsBasicInformation: bool, requestsUserInformation: string, shouldShowAcceptTeacher: bool, shouldShowResults: bool, statements: array{acceptTeacher: array{gitObjectId: null|string, markdown: string, statementType: string}, privacy: array{gitObjectId: null|string, markdown: null|string, statementType: null|string}}, userRegistrationAccepted?: bool|null, userRegistrationAnswered?: bool, userRegistrationRequested?: bool}, payload?: array{details?: array{alias: string, assignments?: list<array{alias: string, assignment_type: string, description: string, finish_time: int|null, max_points: float, name: string, order: int, publish_time_delay: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: int}>, basic_information_required: bool, description: string, finish_time?: int|null, is_admin?: bool, name: string, public?: bool, requests_user_information: string, school_id?: int|null, school_name?: null|string, show_scoreboard?: bool, start_time?: int, student_count?: int}, progress?: AssignmentProgress, shouldShowFirstAssociatedIdentityRunWarning?: bool}, showRanking?: bool}, template: string}
      */
     public static function getCourseDetailsForSmarty(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1047,6 +1047,14 @@ _Nothing_
 
 Returns a detailed report of the contest
 
+### Parameters
+
+| Name            | Type    | Description |
+| --------------- | ------- | ----------- |
+| `auth_token`    | `mixed` |             |
+| `contest_alias` | `mixed` |             |
+| `filterBy`      | `mixed` |             |
+
 ### Returns
 
 | Name          | Type                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
@@ -1658,6 +1666,13 @@ types.CourseDetails;
 ### Description
 
 Show course intro only on public courses when user is not yet registered
+
+### Parameters
+
+| Name               | Type    | Description |
+| ------------------ | ------- | ----------- |
+| `assignment_alias` | `mixed` |             |
+| `course_alias`     | `mixed` |             |
 
 ### Returns
 
@@ -3758,6 +3773,12 @@ server roundtrip (about ~100msec on each pageload), it also returns the
 current time to be able to calculate the time delta between the
 contestant's machine and the server.
 
+### Parameters
+
+| Name         | Type          | Description |
+| ------------ | ------------- | ----------- |
+| `auth_token` | `null|string` |             |
+
 ### Returns
 
 | Name      | Type                                                                                                                   |
@@ -4120,6 +4141,12 @@ Get the results for this user in a given interview
 
 Gets the last privacy policy accepted by user
 
+### Parameters
+
+| Name       | Type    | Description |
+| ---------- | ------- | ----------- |
+| `username` | `mixed` |             |
+
 ### Returns
 
 | Name          | Type      |
@@ -4164,6 +4191,12 @@ Get the identities that have been associated to the logged user
 
 Get Problems unsolved by user
 
+### Parameters
+
+| Name       | Type    | Description |
+| ---------- | ------- | ----------- |
+| `username` | `mixed` |             |
+
 ### Returns
 
 | Name       | Type              |
@@ -4178,6 +4211,13 @@ Exposes API /user/login
 Expects in request:
 user
 password
+
+### Parameters
+
+| Name              | Type     | Description |
+| ----------------- | -------- | ----------- |
+| `password`        | `string` |             |
+| `usernameOrEmail` | `string` |             |
 
 ### Returns
 
@@ -4203,6 +4243,12 @@ Registers to the mailing list all users that have not been added before. Admin o
 
 Get Problems created by user
 
+### Parameters
+
+| Name       | Type    | Description |
+| ---------- | ------- | ----------- |
+| `username` | `mixed` |             |
+
 ### Returns
 
 | Name       | Type              |
@@ -4214,6 +4260,12 @@ Get Problems created by user
 ### Description
 
 Get Problems solved by user
+
+### Parameters
+
+| Name       | Type    | Description |
+| ---------- | ------- | ----------- |
+| `username` | `mixed` |             |
 
 ### Returns
 
@@ -4331,6 +4383,12 @@ _Nothing_
 ### Description
 
 Get stats
+
+### Parameters
+
+| Name       | Type    | Description |
+| ---------- | ------- | ----------- |
+| `username` | `mixed` |             |
 
 ### Returns
 

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -61,6 +61,8 @@ class Session extends \OmegaUp\Controllers\Controller {
      * current time to be able to calculate the time delta between the
      * contestant's machine and the server.
      *
+     * @omegaup-request-param null|string $auth_token
+     *
      * @return array{session: null|array{valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, auth_token: string|null, is_admin: bool}, time: int}
      */
     public static function apiCurrentSession(?\OmegaUp\Request $r = null): array {

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -380,6 +380,9 @@ class User extends \OmegaUp\Controllers\Controller {
      * user
      * password
      *
+     * @omegaup-request-param string $password
+     * @omegaup-request-param string $usernameOrEmail
+     *
      * @param \OmegaUp\Request $r
      *
      * @return array{auth_token: string}
@@ -1868,6 +1871,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Get Problems solved by user
      *
+     * @omegaup-request-param mixed $username
+     *
      * @return array{problems: list<Problem>}
      */
     public static function apiProblemsSolved(\OmegaUp\Request $r): array {
@@ -1899,6 +1904,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get Problems unsolved by user
+     *
+     * @omegaup-request-param mixed $username
      *
      * @return array{problems: list<Problem>}
      */
@@ -1933,6 +1940,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get Problems created by user
+     *
+     * @omegaup-request-param mixed $username
      *
      * @return array{problems: list<Problem>}
      */
@@ -2000,6 +2009,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Get stats
+     *
+     * @omegaup-request-param mixed $username
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
@@ -2998,6 +3009,8 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the last privacy policy saved in the data base
      *
+     * @omegaup-request-param mixed $username
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{policy_markdown: string, has_accepted: bool, git_object_id: string, statement_type: string}
@@ -3082,6 +3095,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
     /**
      * Gets the last privacy policy accepted by user
+     *
+     * @omegaup-request-param mixed $username
      *
      * @param \OmegaUp\Request $r
      *
@@ -3514,6 +3529,8 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $username
+     *
      * @return array{smartyProperties: array{STATUS_ERROR: string}|array{profile: array{birth_date?: int|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: false|null|string, gravatar_92?: null|string, hide_problem_tags?: bool|null, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{name?: null|string, problems_solved?: int|null, rank?: int|null}, scholar_degree?: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified?: bool|null}}, template: string}
      */
     public static function getProfileDetailsForSmarty(\OmegaUp\Request $r) {
@@ -3542,6 +3559,8 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $username
+     *
      * @return array{smartyProperties: array{STATUS_ERROR: string}|array{COUNTRIES: list<\OmegaUp\DAO\VO\Countries>, PROGRAMMING_LANGUAGES: array<string, string>, profile: array{birth_date?: int|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: false|null|string, gravatar_92?: null|string, hide_problem_tags?: bool|null, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{name?: null|string, problems_solved?: int|null, rank?: int|null}, scholar_degree?: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified?: bool|null}}, template: string}
      */
     public static function getProfileEditDetailsForSmarty(\OmegaUp\Request $r) {
@@ -3580,6 +3599,9 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param null|string $auth_token
+     * @omegaup-request-param mixed $username
+     *
      * @return array{smartyProperties: array{STATUS_ERROR?: string, payload?: array{email: null|string}, profile?: array{birth_date?: int|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: false|null|string, gravatar_92?: null|string, hide_problem_tags?: bool|null, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{name?: null|string, problems_solved?: int|null, rank?: int|null}, scholar_degree?: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified?: bool|null}}, template: string}
      */
     public static function getEmailEditDetailsForSmarty(\OmegaUp\Request $r) {
@@ -3616,6 +3638,8 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param mixed $username
+     *
      * @return array{smartyProperties: array{STATUS_ERROR?: string, admin?: true, practice?: false, profile?: array{birth_date?: int|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: false|null|string, gravatar_92?: null|string, hide_problem_tags?: bool|null, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{name?: null|string, problems_solved?: int|null, rank?: int|null}, scholar_degree?: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified?: bool|null}}, template: string}
      */
     public static function getInterviewResultsDetailsForSmarty(\OmegaUp\Request $r) {

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -240,7 +240,7 @@ class RequestParamChecker implements
         \Psalm\Type\Union &$returnTypeCandidate = null
     ) {
         if (is_null($context->calling_function_id)) {
-            // Not being called form within a function-like.
+            // Not being called from within a function-like.
             return;
         }
         $functionId = strtolower($context->calling_function_id);
@@ -250,22 +250,6 @@ class RequestParamChecker implements
         self::$methodCallGraph[$functionId][strtolower(
             $appearingMethodId
         )] = true;
-
-        if (
-            !array_key_exists(
-                strtolower($appearingMethodId),
-                self::$methodTypeMapping
-            )
-        ) {
-            return;
-        }
-        if (!array_key_exists($functionId, self::$methodTypeMapping)) {
-            self::$methodTypeMapping[$functionId] = [];
-        }
-        self::$methodTypeMapping[$functionId] = array_merge(
-            self::$methodTypeMapping[$functionId],
-            self::$methodTypeMapping[strtolower($appearingMethodId)]
-        );
     }
 
     /**
@@ -356,14 +340,17 @@ class RequestParamChecker implements
             }
 
             if (
-                !isset(self::$methodTypeMapping[$functionId]) ||
                 // Methods that do not have an \OmegaUp\Request argument don't
                 // need the annotations.
                 !$hasRequestArgument
             ) {
                 $expected = [];
             } else {
-                $expected = self::$methodTypeMapping[$functionId];
+                if (isset(self::$methodTypeMapping[$functionId])) {
+                    $expected = self::$methodTypeMapping[$functionId];
+                } else {
+                    $expected = [];
+                }
 
                 // Now go through the callgraph, parsing any unvisited methods if needed.
                 foreach (self::$methodCallGraph[$functionId] ?? [] as $calleeMethodId => $_) {


### PR DESCRIPTION
Este cambio hace que el recorrido de resolución transitiva de los
parámetros del API se haga _después_ de haber visitado cada archivo.
Esto hace que no importa el orden en el que los archivos se recorran,
siempre resulte en una cerradura transitiva consistente.