### PR TITLE
Mejorando los tipos de los parámetros del API

### DIFF
--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -111,9 +111,9 @@ class Clarification extends \OmegaUp\Controllers\Controller {
     /**
      * API for getting a clarification
      *
-     * @omegaup-request-param mixed $clarification_id
-     *
      * @return array{message: string, answer: null|string, time: int, problem_id: int, problemset_id: int|null}
+     *
+     * @omegaup-request-param int $clarification_id
      */
     public static function apiDetails(\OmegaUp\Request $r) {
         // Authenticate the user
@@ -157,11 +157,12 @@ class Clarification extends \OmegaUp\Controllers\Controller {
     /**
      * Update a clarification
      *
-     * @omegaup-request-param mixed $answer
-     * @omegaup-request-param mixed $clarification_id
-     * @omegaup-request-param mixed $message
-     *
      * @return array{status: string}
+     *
+     * @omegaup-request-param mixed $answer
+     * @omegaup-request-param int $clarification_id
+     * @omegaup-request-param mixed $message
+     * @omegaup-request-param bool|null $public
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
         // Authenticate user

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -18,15 +18,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests
      *
+     * @return array{number_of_results: int, results: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}>}
+     *
      * @omegaup-request-param mixed $active
      * @omegaup-request-param mixed $admission_mode
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
      * @omegaup-request-param mixed $participating
      * @omegaup-request-param mixed $query
      * @omegaup-request-param mixed $recommended
-     *
-     * @return array{number_of_results: int, results: list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}>}
      */
     public static function apiList(\OmegaUp\Request $r): array {
         // Check who is visiting, but a not logged user can still view
@@ -228,10 +228,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Returns a list of contests where current user has admin rights (or is
      * the director).
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     *
      * @return array{contests: list<array{admission_mode: string, alias: string, finish_time: \OmegaUp\Timestamp, rerun_id: int, scoreboard_url: string, scoreboard_url_admin: string, start_time: \OmegaUp\Timestamp, title: string}>}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
      */
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -267,14 +267,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Callback to get contests list, depending on a given method
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     * @omegaup-request-param mixed $query
-     *
      * @param \OmegaUp\Request $r
      * @param Closure(int, int, int, null|string):list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: \OmegaUp\Timestamp, languages?: null|string, last_updated: \OmegaUp\Timestamp, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: \OmegaUp\Timestamp, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}> $callbackUserFunction
      *
      * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: \OmegaUp\Timestamp, languages?: null|string, last_updated: \OmegaUp\Timestamp, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: \OmegaUp\Timestamp, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param mixed $query
      */
     private static function getContestListInternal(
         \OmegaUp\Request $r,
@@ -308,11 +308,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests where current user is the director
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     * @omegaup-request-param mixed $query
-     *
      * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: \OmegaUp\Timestamp, languages?: null|string, last_updated: \OmegaUp\Timestamp, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: \OmegaUp\Timestamp, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param mixed $query
      */
     public static function apiMyList(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -337,11 +337,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests where current user is participating in
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     * @omegaup-request-param mixed $query
-     *
      * @return array{contests: list<array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: \OmegaUp\Timestamp, languages?: null|string, last_updated: \OmegaUp\Timestamp, original_finish_time?: \OmegaUp\Timestamp, partial_score?: int, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: \OmegaUp\Timestamp, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}>}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param mixed $query
      */
     public static function apiListParticipating(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -488,11 +488,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Get all the properties for smarty.
      *
+     * @return array{inContest?: bool, smartyProperties: array{needsBasicInformation?: bool, requestsUserInformation?: false, privacyStatement?: array{markdown: string, statementType: string, gitObjectId?: string}, payload?: array{shouldShowFirstAssociatedIdentityRunWarning: bool}}, template: string}
+     *
      * @omegaup-request-param null|string $auth_token
      * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $is_practice
-     *
-     * @return array{inContest?: bool, smartyProperties: array{needsBasicInformation?: bool, requestsUserInformation?: false, privacyStatement?: array{markdown: string, statementType: string, gitObjectId?: string}, payload?: array{shouldShowFirstAssociatedIdentityRunWarning: bool}}, template: string}
+     * @omegaup-request-param bool|null $is_practice
      */
     public static function getContestDetailsForSmarty(
         \OmegaUp\Request $r
@@ -603,11 +603,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     * @omegaup-request-param mixed $query
-     *
      * @return array{smartyProperties: array{contestListPayload: ContestListPayload}, template: string}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param mixed $query
      */
     public static function getContestListDetailsForSmarty(
         \OmegaUp\Request $r
@@ -705,11 +705,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     * @omegaup-request-param mixed $query
-     *
      * @return array{smartyProperties: array{payload: array{contests: list<array{contest_id: int, problemset_id: int, acl_id?: int, title: string, description: string, original_finish_time?: \OmegaUp\Timestamp, start_time: \OmegaUp\Timestamp|null, finish_time: \OmegaUp\Timestamp|null, last_updated: \OmegaUp\Timestamp|null, window_length: null|int, rerun_id: int, admission_mode: string, alias: string, scoreboard?: int, points_decay_factor?: float, partial_score?: int, submissions_gap?: int, feedback?: string, penalty?: int, penalty_type?: string, penalty_calc_policy?: string, show_scoreboard_after?: int, urgent?: int, languages?: null|string, recommended: bool, scoreboard_url: string, scoreboard_url_admin: string}>}, privateContestsAlert: bool}, template: string}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param mixed $query
      */
     public static function getContestListMineForSmarty(
         \OmegaUp\Request $r
@@ -1005,15 +1005,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Joins a contest - explicitly adds a identity to a contest.
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $privacy_git_object_id
-     * @omegaup-request-param mixed $share_user_information
-     * @omegaup-request-param mixed $statement_type
-     * @omegaup-request-param mixed $token
-     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{status: string}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $privacy_git_object_id
+     * @omegaup-request-param bool|null $share_user_information
+     * @omegaup-request-param mixed $statement_type
+     * @omegaup-request-param mixed $token
      */
     public static function apiOpen(\OmegaUp\Request $r): array {
         // Authenticate request
@@ -1496,10 +1496,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $alias
-     * @omegaup-request-param mixed $start_time
-     *
      * @return array{alias: string}
+     *
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param int $start_time
      */
     public static function apiCreateVirtual(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -1652,9 +1652,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Creates a new contest
      *
+     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
+     *
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
-     * @omegaup-request-param mixed $basic_information
+     * @omegaup-request-param bool|null $basic_information
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $feedback
      * @omegaup-request-param mixed $finish_time
@@ -1672,10 +1676,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $submissions_gap
      * @omegaup-request-param mixed $title
      * @omegaup-request-param mixed $window_length
-     *
-     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
-     *
-     * @return array{status: string}
      */
     public static function apiCreate(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -1740,21 +1740,25 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * In case of update, everything is optional except the contest_alias
      * In case of error, this function throws.
      *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $feedback
-     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param int $finish_time
      * @omegaup-request-param mixed $languages
+     * @omegaup-request-param bool|null $partial_score
      * @omegaup-request-param mixed $penalty_calc_policy
      * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param mixed $problems
-     * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param float|null $scoreboard
+     * @omegaup-request-param bool|null $show_scoreboard_after
+     * @omegaup-request-param int $start_time
+     * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param mixed $title
-     * @omegaup-request-param mixed $window_length
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     * @omegaup-request-param int $window_length
      */
     private static function validateCommonCreateOrUpdate(
         \OmegaUp\Request $r,
@@ -1945,21 +1949,25 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Validates that Request contains expected data to create a contest
      * In case of error, this function throws.
      *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $feedback
-     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param int $finish_time
      * @omegaup-request-param mixed $languages
+     * @omegaup-request-param bool|null $partial_score
      * @omegaup-request-param mixed $penalty_calc_policy
      * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param mixed $problems
-     * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param float|null $scoreboard
+     * @omegaup-request-param bool|null $show_scoreboard_after
+     * @omegaup-request-param int $start_time
+     * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param mixed $title
-     * @omegaup-request-param mixed $window_length
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     * @omegaup-request-param int $window_length
      */
     private static function validateCreate(
         \OmegaUp\Request $r,
@@ -1973,23 +1981,27 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * everything is optional except the contest_alias
      * In case of error, this function throws.
      *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     *
+     * @return \OmegaUp\DAO\VO\Contests
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $feedback
-     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param int $finish_time
      * @omegaup-request-param mixed $languages
+     * @omegaup-request-param bool|null $partial_score
      * @omegaup-request-param mixed $penalty_calc_policy
      * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param mixed $problems
+     * @omegaup-request-param float|null $scoreboard
+     * @omegaup-request-param bool|null $show_scoreboard_after
      * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param mixed $title
-     * @omegaup-request-param mixed $window_length
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
-     *
-     * @return \OmegaUp\DAO\VO\Contests
+     * @omegaup-request-param int $window_length
      */
     private static function validateUpdate(
         \OmegaUp\Request $r,
@@ -2121,13 +2133,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Adds a problem to a contest
      *
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $commit
      * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $order_in_contest
-     * @omegaup-request-param mixed $points
+     * @omegaup-request-param int $order_in_contest
+     * @omegaup-request-param float|null $points
      * @omegaup-request-param mixed $problem_alias
-     *
-     * @return array{status: string}
      */
     public static function apiAddProblem(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -2871,6 +2883,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Validate the Clarifications request
      *
      * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param int $rowcount
      */
     private static function validateClarifications(\OmegaUp\Request $r): \OmegaUp\DAO\VO\Contests {
         // Check contest_alias
@@ -2893,11 +2907,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Get clarifications of a contest
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $rowcount
-     *
      * @return array{clarifications: list<Clarification>}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param int $rowcount
      */
     public static function apiClarifications(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -3454,24 +3468,28 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Update a Contest
      *
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
-     * @omegaup-request-param mixed $basic_information
+     * @omegaup-request-param bool|null $basic_information
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $feedback
-     * @omegaup-request-param mixed $finish_time
+     * @omegaup-request-param int $finish_time
      * @omegaup-request-param mixed $languages
+     * @omegaup-request-param bool|null $partial_score
      * @omegaup-request-param mixed $penalty_calc_policy
      * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param mixed $problems
      * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param float|null $scoreboard
+     * @omegaup-request-param bool|null $show_scoreboard_after
      * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $submissions_gap
+     * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param mixed $title
-     * @omegaup-request-param mixed $window_length
-     *
-     * @return array{status: string}
+     * @omegaup-request-param int $window_length
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -3632,13 +3650,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Update Contest end time for an identity when window_length
      * option is turned on
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $end_time
-     * @omegaup-request-param mixed $username
-     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
      * @return array{status: string}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param int $end_time
+     * @omegaup-request-param mixed $username
      */
     public static function apiUpdateEndTimeForIdentity(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -3726,19 +3744,19 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Validates runs API
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $language
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $problem_alias
-     * @omegaup-request-param mixed $rowcount
-     * @omegaup-request-param mixed $status
-     * @omegaup-request-param mixed $username
-     * @omegaup-request-param mixed $verdict
-     *
      * @throws \OmegaUp\Exceptions\NotFoundException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{0: \OmegaUp\DAO\VO\Contests, 1: \OmegaUp\DAO\VO\Problems|null, 2: \OmegaUp\DAO\VO\Identities|null}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param int $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
      */
     private static function validateRuns(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -4312,10 +4330,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Given a contest_alias, sets the recommended flag on/off.
      * Only omegaUp admins can call this API.
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $value
-     *
      * @return array{status: string}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param bool|null $value
      */
     public static function apiSetRecommended(\OmegaUp\Request $r): array {
         $r->ensureIdentity();

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -47,13 +47,15 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates request for creating a new Assignment
      *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     *
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $assignment_type
      * @omegaup-request-param mixed $description
+     * @omegaup-request-param OmegaUp\Timestamp|null $finish_time
      * @omegaup-request-param mixed $name
-     * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     * @omegaup-request-param OmegaUp\Timestamp $start_time
+     * @omegaup-request-param bool|null $unlimited_duration
      */
     private static function validateCreateAssignment(
         \OmegaUp\Request $r,
@@ -117,6 +119,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $name
+     * @omegaup-request-param int $start_time
      */
     private static function validateClone(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
@@ -127,20 +130,22 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates create Courses
      *
+     * @param \OmegaUp\Request $r
+     *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     * @throws \OmegaUp\Exceptions\ForbiddenAccessException
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $finish_time
      * @omegaup-request-param mixed $name
+     * @omegaup-request-param bool|null $needs_basic_information
      * @omegaup-request-param mixed $requests_user_information
-     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param int $school_id
+     * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @param \OmegaUp\Request $r
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
-     * @throws \OmegaUp\Exceptions\ForbiddenAccessException
+     * @omegaup-request-param bool|null $unlimited_duration
      */
     private static function validateCreate(
         \OmegaUp\Request $r
@@ -160,18 +165,20 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates update Courses
      *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     * @throws \OmegaUp\Exceptions\ForbiddenAccessException
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $finish_time
      * @omegaup-request-param mixed $name
+     * @omegaup-request-param bool|null $needs_basic_information
      * @omegaup-request-param mixed $requests_user_information
-     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param int $school_id
+     * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param mixed $start_time
      * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
-     * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      */
     private static function validateUpdate(
         \OmegaUp\Request $r,
@@ -206,19 +213,23 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates basic information of a course
      *
-     * @omegaup-request-param mixed $admission_mode
-     * @omegaup-request-param mixed $alias
-     * @omegaup-request-param mixed $description
-     * @omegaup-request-param mixed $name
-     * @omegaup-request-param mixed $requests_user_information
-     * @omegaup-request-param mixed $school_id
-     * @omegaup-request-param mixed $unlimited_duration
-     *
      * @param \OmegaUp\Request $r
      * @param bool $isUpdate
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
+     *
+     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param mixed $alias
+     * @omegaup-request-param mixed $description
+     * @omegaup-request-param int|null $finish_time
+     * @omegaup-request-param mixed $name
+     * @omegaup-request-param bool|null $needs_basic_information
+     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param int $school_id
+     * @omegaup-request-param bool|null $show_scoreboard
+     * @omegaup-request-param int $start_time
+     * @omegaup-request-param bool|null $unlimited_duration
      */
     private static function validateBasicCreateOrUpdate(
         \OmegaUp\Request $r,
@@ -453,6 +464,11 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Create new course API
      *
+     * @return array{status: string}
+     *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
@@ -464,12 +480,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $school_id
      * @omegaup-request-param mixed $show_scoreboard
      * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @return array{status: string}
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
-     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
+     * @omegaup-request-param bool|null $unlimited_duration
      */
     public static function apiCreate(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -650,6 +661,8 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * API to Create an assignment
      *
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $assignment_type
      * @omegaup-request-param mixed $course_alias
@@ -659,9 +672,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $order
      * @omegaup-request-param mixed $publish_time_delay
      * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @return array{status: string}
+     * @omegaup-request-param bool|null $unlimited_duration
      */
     public static function apiCreateAssignment(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -705,13 +716,13 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Update an assignment
      *
+     * @return array{status: 'ok'}
+     *
      * @omegaup-request-param mixed $assignment
      * @omegaup-request-param mixed $course
-     * @omegaup-request-param mixed $finish_time
-     * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @return array{status: 'ok'}
+     * @omegaup-request-param OmegaUp\Timestamp $finish_time
+     * @omegaup-request-param OmegaUp\Timestamp $start_time
+     * @omegaup-request-param bool|null $unlimited_duration
      */
     public static function apiUpdateAssignment(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -1308,12 +1319,12 @@ class Course extends \OmegaUp\Controllers\Controller {
      * Returns courses for which the current user is an admin and
      * for in which the user is a student.
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     *
      * @return array{admin: list<array{alias: string, counts: array<string, int>, finish_time: int|null, name: string, start_time: int}>, public: list<array{alias: string, counts: array<string, int>, finish_time: int|null, name: string, start_time: int}>, student: list<array{alias: string, counts: array<string, int>, finish_time: int|null, name: string, start_time: int}>}
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
      */
     public static function apiListCourses(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -2964,20 +2975,20 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates runs API
      *
-     * @omegaup-request-param mixed $assignment_alias
-     * @omegaup-request-param mixed $course_alias
-     * @omegaup-request-param mixed $language
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $problem_alias
-     * @omegaup-request-param mixed $rowcount
-     * @omegaup-request-param mixed $status
-     * @omegaup-request-param mixed $username
-     * @omegaup-request-param mixed $verdict
-     *
      * @return array{assignment: \OmegaUp\DAO\VO\Assignments, problem: \OmegaUp\DAO\VO\Problems|null, identity: \OmegaUp\DAO\VO\Identities|null}
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
+     *
+     * @omegaup-request-param mixed $assignment_alias
+     * @omegaup-request-param mixed $course_alias
+     * @omegaup-request-param mixed $language
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param int $rowcount
+     * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $username
+     * @omegaup-request-param mixed $verdict
      */
     private static function validateRuns(
         \OmegaUp\Request $r
@@ -3110,18 +3121,20 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Edit Course contents
      *
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $course_alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $finish_time
      * @omegaup-request-param mixed $name
+     * @omegaup-request-param bool|null $needs_basic_information
      * @omegaup-request-param mixed $requests_user_information
-     * @omegaup-request-param mixed $school_id
+     * @omegaup-request-param int $school_id
+     * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param mixed $start_time
      * @omegaup-request-param mixed $unlimited_duration
-     *
-     * @return array{status: string}
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -75,15 +75,15 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
     /**
      * Add contest to a group scoreboard
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $group_alias
-     * @omegaup-request-param mixed $only_ac
-     * @omegaup-request-param mixed $scoreboard_alias
-     * @omegaup-request-param mixed $weight
-     *
      * @param \OmegaUp\Request $r
      *
      * @return array{status: string}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $group_alias
+     * @omegaup-request-param bool|null $only_ac
+     * @omegaup-request-param mixed $scoreboard_alias
+     * @omegaup-request-param float|null $weight
      */
     public static function apiAddContest(\OmegaUp\Request $r): array {
         $r->ensureIdentity();

--- a/frontend/server/src/Controllers/Interview.php
+++ b/frontend/server/src/Controllers/Interview.php
@@ -4,12 +4,12 @@
 
 class Interview extends \OmegaUp\Controllers\Controller {
     /**
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
-     * @omegaup-request-param mixed $duration
+     * @omegaup-request-param int $duration
      * @omegaup-request-param mixed $title
-     *
-     * @return array{status: string}
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -65,7 +65,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * Returns a ProblemParams instance from the Request values.
      *
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $languages
@@ -317,8 +317,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Create a new problem
      *
+     * @throws \OmegaUp\Exceptions\ApiException
+     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
+     *
+     * @return array{status: string}
+     *
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $languages
@@ -335,11 +340,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param mixed $visibility
-     *
-     * @throws \OmegaUp\Exceptions\ApiException
-     * @throws \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException
-     *
-     * @return array{status: string}
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -958,8 +958,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Update problem contents
      *
+     * @param \OmegaUp\Request $r
+     *
+     * @return array{rejudged: bool}
+     *
+     * @throws \OmegaUp\Exceptions\ApiException
+     *
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $languages
@@ -978,12 +984,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param mixed $visibility
-     *
-     * @param \OmegaUp\Request $r
-     *
-     * @return array{rejudged: bool}
-     *
-     * @throws \OmegaUp\Exceptions\ApiException
      */
     public static function apiUpdate(\OmegaUp\Request $r) {
         $r->ensureMainUserIdentity();
@@ -1509,8 +1509,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Updates problem statement only
      *
+     * @throws \OmegaUp\Exceptions\ApiException
+     *
+     * @return array{status: string}
+     *
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $lang
@@ -1530,10 +1534,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param mixed $visibility
-     *
-     * @throws \OmegaUp\Exceptions\ApiException
-     *
-     * @return array{status: string}
      */
     public static function apiUpdateStatement(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -1601,8 +1601,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Updates problem solution only
      *
+     * @throws \OmegaUp\Exceptions\ApiException
+     *
+     * @return array{status: string}
+     *
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $lang
@@ -1622,10 +1626,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param mixed $visibility
-     *
-     * @throws \OmegaUp\Exceptions\ApiException
-     *
-     * @return array{status: string}
      */
     public static function apiUpdateSolution(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -2168,17 +2168,17 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Entry point for Problem Details API
      *
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $lang
-     * @omegaup-request-param mixed $prevent_problemset_open
-     * @omegaup-request-param mixed $problem_alias
-     * @omegaup-request-param mixed $problemset_id
-     * @omegaup-request-param mixed $show_solvers
-     * @omegaup-request-param mixed $statement_type
-     *
      * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
      *
      * @return array{accepted?: int, admin?: bool, alias?: string, commit?: string, creation_date?: int, difficulty?: float|null, email_clarifications?: bool, exists: bool, input_limit?: int, languages?: list<string>, order?: string, points?: float, preferred_language?: string, problemsetter?: array{creation_date: int, name: string, username: string}, quality_seal?: bool, runs?: list<array{alias: string, contest_score: float|null, guid: string, language: string, memory: int, penalty: int, runtime: int, score: float, status: string, submit_delay: int, time: \OmegaUp\Timestamp, username: string, verdict: string}>, score?: float, settings?: array{cases: array<string, array{in: string, out: string, weight?: float}>, limits: array{MemoryLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator?: array{name: string, tolerance?: float}}, solvers?: list<array{language: string, memory: float, runtime: float, time: \OmegaUp\Timestamp, username: string}>, source?: string, statement?: array{images: array<string, string>, language: string, markdown: string}, submissions?: int, title?: string, version?: string, visibility?: int, visits?: int}
+     *
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param mixed $lang
+     * @omegaup-request-param bool|null $prevent_problemset_open
+     * @omegaup-request-param mixed $problem_alias
+     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param bool|null $show_solvers
+     * @omegaup-request-param mixed $statement_type
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
         $r->ensureBool('show_solvers', /*required=*/false);
@@ -2493,16 +2493,16 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the solution for a problem if conditions are satisfied.
      *
+     * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
+     *
+     * @return array{exists: bool, solution?: array{language: string, markdown: string, images: array<string, string>}}
+     *
      * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $forfeit_problem
+     * @omegaup-request-param bool|null $forfeit_problem
      * @omegaup-request-param mixed $lang
      * @omegaup-request-param mixed $problem_alias
      * @omegaup-request-param mixed $problemset_id
      * @omegaup-request-param mixed $statement_type
-     *
-     * @throws \OmegaUp\Exceptions\InvalidFilesystemOperationException
-     *
-     * @return array{exists: bool, solution?: array{language: string, markdown: string, images: array<string, string>}}
      */
     public static function apiSolution(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -3539,10 +3539,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * Returns a list of problems where current user has admin rights (or is
      * the owner).
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     *
      * @return array{pagerItems: list<PageItem>, problems: list<array{tags: list<array{name: string, source: string}>}>}
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
      */
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -3608,11 +3608,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of problems where current user is the owner
      *
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $rowcount
-     *
      * @return array{pagerItems: list<PageItem>, problems: list<array{tags: list<array{name: string, source: string}>}>}
+     *
+     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param mixed $rowcount
      */
     public static function apiMyList(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -3903,14 +3904,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @return array{smartyProperties: array{input_limit: string, karel_problem: bool, memory_limit: string, overall_wall_time_limit: string, payload: array{accepted: int, admin?: bool, alias: string, commit: string, creation_date: int, difficulty: float|null, email_clarifications: bool, histogram: array{difficulty: float, difficulty_histogram: null|string, quality: float, quality_histogram: null|string}, input_limit: int, languages: list<string>, order: string, points: float, preferred_language?: string, problemsetter?: array{creation_date: int, name: string, username: string}, quality_seal: bool, runs?: list<array{alias: string, contest_score: float|null, guid: string, language: string, memory: int, penalty: int, runtime: int, score: float, status: string, submit_delay: int, time: \OmegaUp\Timestamp, username: string, verdict: string}>, score: float, settings: array{cases: array<string, array{in: string, out: string, weight?: float}>, limits: array{ExtraWallTime?: int|string, MemoryLimit: int|string, OutputLimit?: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance?: float}}, shouldShowFirstAssociatedIdentityRunWarning?: bool, solution_status?: string, solvers?: list<array{language: string, memory: float, runtime: float, time: \OmegaUp\Timestamp, username: string}>, source?: string, statement: array{images: array<string, string>, language: string, markdown: string}, submissions: int, title: string, user: array{admin: bool, logged_in: bool, reviewer: bool}, version: string, visibility: int, visits: int}, points: float, problem_admin: bool, problem_alias: string, problemsetter: array{creation_date: int, name: string, username: string}|null, quality_payload: array{can_nominate_problem?: bool, dismissed: bool, dismissedBeforeAC?: bool, language?: string, nominated: bool, nominatedBeforeAC?: bool, problem_alias?: string, solved: bool, tried: bool}, nomination_payload: array{problem_alias: string, reviewer: bool, already_reviewed: bool}, solvers: list<array{language: string, memory: float, runtime: float, time: \OmegaUp\Timestamp, username: string}>, source: null|string, time_limit: string, title: string, quality_seal: bool, visibility: int}, template: string}
+     *
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $lang
-     * @omegaup-request-param mixed $prevent_problemset_open
+     * @omegaup-request-param bool|null $prevent_problemset_open
      * @omegaup-request-param mixed $problem_alias
      * @omegaup-request-param mixed $problemset_id
      * @omegaup-request-param mixed $statement_type
-     *
-     * @return array{smartyProperties: array{input_limit: string, karel_problem: bool, memory_limit: string, overall_wall_time_limit: string, payload: array{accepted: int, admin?: bool, alias: string, commit: string, creation_date: int, difficulty: float|null, email_clarifications: bool, histogram: array{difficulty: float, difficulty_histogram: null|string, quality: float, quality_histogram: null|string}, input_limit: int, languages: list<string>, order: string, points: float, preferred_language?: string, problemsetter?: array{creation_date: int, name: string, username: string}, quality_seal: bool, runs?: list<array{alias: string, contest_score: float|null, guid: string, language: string, memory: int, penalty: int, runtime: int, score: float, status: string, submit_delay: int, time: \OmegaUp\Timestamp, username: string, verdict: string}>, score: float, settings: array{cases: array<string, array{in: string, out: string, weight?: float}>, limits: array{ExtraWallTime?: int|string, MemoryLimit: int|string, OutputLimit?: int|string, OverallWallTimeLimit: string, TimeLimit: string}, validator: array{name: string, tolerance?: float}}, shouldShowFirstAssociatedIdentityRunWarning?: bool, solution_status?: string, solvers?: list<array{language: string, memory: float, runtime: float, time: \OmegaUp\Timestamp, username: string}>, source?: string, statement: array{images: array<string, string>, language: string, markdown: string}, submissions: int, title: string, user: array{admin: bool, logged_in: bool, reviewer: bool}, version: string, visibility: int, visits: int}, points: float, problem_admin: bool, problem_alias: string, problemsetter: array{creation_date: int, name: string, username: string}|null, quality_payload: array{can_nominate_problem?: bool, dismissed: bool, dismissedBeforeAC?: bool, language?: string, nominated: bool, nominatedBeforeAC?: bool, problem_alias?: string, solved: bool, tried: bool}, nomination_payload: array{problem_alias: string, reviewer: bool, already_reviewed: bool}, solvers: list<array{language: string, memory: float, runtime: float, time: \OmegaUp\Timestamp, username: string}>, source: null|string, time_limit: string, title: string, quality_seal: bool, visibility: int}, template: string}
      */
     public static function getProblemDetailsForSmarty(
         \OmegaUp\Request $r
@@ -4271,8 +4272,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @return array{smartyProperties: array{IS_UPDATE: true, LOAD_MATHJAX: true, STATUS_ERROR?: string, STATUS_SUCCESS: null|string, problemEditPayload?: ProblemEditPayload, problemTagsPayload: array{alias: string, selectedTags: list<array{public: bool, tagname: string}>, tags: list<array{name: null|string}>}}, template: string}
+     *
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $languages
@@ -4295,8 +4298,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param mixed $visibility
      * @omegaup-request-param mixed $wmd-input-statement
-     *
-     * @return array{smartyProperties: array{IS_UPDATE: true, LOAD_MATHJAX: true, STATUS_ERROR?: string, STATUS_SUCCESS: null|string, problemEditPayload?: ProblemEditPayload, problemTagsPayload: array{alias: string, selectedTags: list<array{public: bool, tagname: string}>, tags: list<array{name: null|string}>}}, template: string}
      */
     public static function getProblemEditDetailsForSmarty(
         \OmegaUp\Request $r

--- a/frontend/server/src/Controllers/Problemset.php
+++ b/frontend/server/src/Controllers/Problemset.php
@@ -95,17 +95,17 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @return array{admin?: bool, admission_mode?: string, alias?: string, assignment_type?: null|string, contest_alias?: null|string, courseAssignments?: list<array{name: string, description: string, alias: string, publish_time_delay: ?int, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, description?: null|string, director?: null|string, exists?: bool, feedback?: string, finish_time?: null|int, languages?: list<string>, name?: string, needs_basic_information?: bool, opened?: bool, original_contest_alias?: null|string, original_problemset_id?: int|null, partial_score?: bool, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problems?: list<ProblemsetProblem>, problemset_id?: int|null, requests_user_information?: string, scoreboard?: int, show_scoreboard_after?: bool, start_time?: int, submission_deadline?: int, submissions_gap?: int, title?: string, users?: list<array{access_time: \OmegaUp\Timestamp|null, country: null|string, email: null|string, opened_interview: bool, user_id: int|null, username: string}>, window_length?: int|null}
+     *
      * @omegaup-request-param mixed $assignment
      * @omegaup-request-param mixed $auth_token
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $course
      * @omegaup-request-param mixed $interview_alias
-     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param int $problemset_id
      * @omegaup-request-param mixed $token
      * @omegaup-request-param mixed $tokens
      * @omegaup-request-param mixed $username
-     *
-     * @return array{admin?: bool, admission_mode?: string, alias?: string, assignment_type?: null|string, contest_alias?: null|string, courseAssignments?: list<array{name: string, description: string, alias: string, publish_time_delay: ?int, assignment_type: string, start_time: int, finish_time: int|null, max_points: float, order: int, scoreboard_url: string, scoreboard_url_admin: string}>, description?: null|string, director?: null|string, exists?: bool, feedback?: string, finish_time?: null|int, languages?: list<string>, name?: string, needs_basic_information?: bool, opened?: bool, original_contest_alias?: null|string, original_problemset_id?: int|null, partial_score?: bool, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problems?: list<ProblemsetProblem>, problemset_id?: int|null, requests_user_information?: string, scoreboard?: int, show_scoreboard_after?: bool, start_time?: int, submission_deadline?: int, submissions_gap?: int, title?: string, users?: list<array{access_time: \OmegaUp\Timestamp|null, country: null|string, email: null|string, opened_interview: bool, user_id: int|null, username: string}>, window_length?: int|null}
      */
     public static function apiDetails(\OmegaUp\Request $r) {
         [
@@ -140,15 +140,15 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @return Scoreboard
+     *
      * @omegaup-request-param mixed $assignment
      * @omegaup-request-param mixed $auth_token
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $course
-     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param int $problemset_id
      * @omegaup-request-param mixed $token
      * @omegaup-request-param mixed $tokens
-     *
-     * @return Scoreboard
      */
     public static function apiScoreboard(\OmegaUp\Request $r): array {
         [
@@ -181,17 +181,17 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the Scoreboard events
      *
+     * @throws \OmegaUp\Exceptions\NotFoundException
+     *
+     * @return array{events: list<array{country: null|string, delta: float, is_invited: bool, total: array{points: float, penalty: float}, name: null|string, username: string, problem: array{alias: string, points: float, penalty: float}}>}
+     *
      * @omegaup-request-param mixed $assignment
      * @omegaup-request-param mixed $auth_token
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $course
-     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param int $problemset_id
      * @omegaup-request-param mixed $token
      * @omegaup-request-param mixed $tokens
-     *
-     * @throws \OmegaUp\Exceptions\NotFoundException
-     *
-     * @return array{events: list<array{country: null|string, delta: float, is_invited: bool, total: array{points: float, penalty: float}, name: null|string, username: string, problem: array{alias: string, points: float, penalty: float}}>}
      */
     public static function apiScoreboardEvents(\OmegaUp\Request $r): array {
         [
@@ -221,17 +221,17 @@ class Problemset extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $auth_token
-     * @omegaup-request-param mixed $contest_alias
-     * @omegaup-request-param mixed $problemset_id
-     * @omegaup-request-param mixed $token
-     * @omegaup-request-param mixed $tokens
-     *
      * @param \OmegaUp\Request $r $r['tokens'][0] = invalid filter $r['tokens'][1] = Type of filter (all-events, user, contest, problemset, problem) $r['tokens'][2] = Id of entity ($tokens[2]) $r['tokens'][3] = Token given by the filter
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      *
      * @return array{problemset: array{assignment: null|string, contest_alias: null|string, course: null|string, interview_alias: null|string, type: string}, request: \OmegaUp\Request}
+     *
+     * @omegaup-request-param mixed $auth_token
+     * @omegaup-request-param mixed $contest_alias
+     * @omegaup-request-param int $problemset_id
+     * @omegaup-request-param mixed $token
+     * @omegaup-request-param mixed $tokens
      */
     public static function wrapRequest(\OmegaUp\Request $r): array {
         $r->ensureInt('problemset_id');

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -740,14 +740,14 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * assigned to $assignee (if non-null) or all nominations (if both
      * $nominator and $assignee are null).
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     *
      * @param \OmegaUp\Request $r         The request.
      * @param int     $nominator The user id of the person that made the nomination.  May be null.
      * @param int     $assignee  The user id of the person assigned to review nominations.  May be null.
      *
      * @return array{nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: \OmegaUp\Timestamp, votes: list<array{time: \OmegaUp\Timestamp|null, user: array{name: null|string, username: string}, vote: int}>}|null>} The response.
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
      */
     private static function getListImpl(
         \OmegaUp\Request $r,
@@ -806,11 +806,11 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $status
-     * @omegaup-request-param mixed $rowcount
-     *
      * @return array{nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: \OmegaUp\Timestamp, votes: list<array{time: \OmegaUp\Timestamp|null, user: array{name: null|string, username: string}, vote: int}>}|null>, pager_items: list<array{class: string, label: string, page: int}>}
+     *
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param int $rowcount
+     * @omegaup-request-param mixed $status
      */
     public static function apiList(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -869,14 +869,14 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     /**
      * Displays the nominations that this user has been assigned.
      *
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $page_size
-     *
      * @param \OmegaUp\Request $r
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @return array{nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: \OmegaUp\Timestamp, votes: list<array{time: \OmegaUp\Timestamp|null, user: array{name: null|string, username: string}, vote: int}>}|null>} The response.
+     *
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
      */
     public static function apiMyAssignedList(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -891,10 +891,10 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $rowcount
-     *
      * @return array{nominations: list<array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nominator: array{name: null|string, username: string}, problem: array{alias: string, title: string}, qualitynomination_id: int, status: string, time: \OmegaUp\Timestamp, votes: list<array{time: \OmegaUp\Timestamp|null, user: array{name: null|string, username: string}, vote: int}>}|null>, pager_items: list<array{class: string, label: string, page: int}>}
+     *
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param int $rowcount
      */
     public static function apiMyList(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -945,13 +945,13 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * Displays the details of a nomination. The user needs to be either the
      * nominator or a member of the reviewer group.
      *
-     * @omegaup-request-param mixed $qualitynomination_id
-     *
      * @param \OmegaUp\Request $r
      *
      * @return array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nomination_status: string, nominator: array{name: null|string, username: string}, original_contents?: array{source: null|string, statements: array<string, array{language: string, markdown: string, images: array<string, string>}>|\stdClass, tags?: list<array{source: string, name: string}>}, problem: array{alias: string, title: string}, qualitynomination_id: int, reviewer: bool, time: \OmegaUp\Timestamp, votes: list<array{time: \OmegaUp\Timestamp|null, user: array{name: null|string, username: string}, vote: int}>}
      *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
+     *
+     * @omegaup-request-param int $qualitynomination_id
      */
     public static function apiDetails(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -1051,9 +1051,9 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $qualitynomination_id
-     *
      * @return array{smartyProperties: array{payload: array{author: array{name: null|string, username: string}, contents?: array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>}, nomination: string, nomination_status: string, nominator: array{name: null|string, username: string}, original_contents?: array{source: null|string, statements: mixed|\stdClass, tags?: list<array{source: string, name: string}>}, problem: array{alias: string, title: string}, qualitynomination_id: int, reviewer: bool, status: string, time: \OmegaUp\Timestamp, votes: list<array{time: \OmegaUp\Timestamp|null, user: array{name: null|string, username: string}, vote: int}>}}, template: string}
+     *
+     * @omegaup-request-param int $qualitynomination_id
      */
     public static function getDetailsForSmarty(
         \OmegaUp\Request $r
@@ -1082,10 +1082,10 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * Gets the details for the quality nomination's list
      * with pagination
      *
-     * @omegaup-request-param mixed $length
-     * @omegaup-request-param mixed $page
-     *
      * @return array{smartyProperties: array{payload: array{page: int, length: int, myView: bool}}, template: string}
+     *
+     * @omegaup-request-param int $length
+     * @omegaup-request-param int $page
      */
     public static function getListForSmarty(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {
@@ -1120,10 +1120,10 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * Gets the details for the quality nomination's list
      * with pagination for a certain user
      *
-     * @omegaup-request-param mixed $length
-     * @omegaup-request-param mixed $page
-     *
      * @return array{smartyProperties: array{payload: array{page: int, length: int, myView: bool}}, template: string}
+     *
+     * @omegaup-request-param int $length
+     * @omegaup-request-param int $page
      */
     public static function getMyListForSmarty(\OmegaUp\Request $r): array {
         if (OMEGAUP_LOCKDOWN) {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -389,9 +389,9 @@ API for getting a clarification
 
 ### Parameters
 
-| Name               | Type    | Description |
-| ------------------ | ------- | ----------- |
-| `clarification_id` | `mixed` |             |
+| Name               | Type  | Description |
+| ------------------ | ----- | ----------- |
+| `clarification_id` | `int` |             |
 
 ### Returns
 
@@ -411,11 +411,12 @@ Update a clarification
 
 ### Parameters
 
-| Name               | Type    | Description |
-| ------------------ | ------- | ----------- |
-| `answer`           | `mixed` |             |
-| `clarification_id` | `mixed` |             |
-| `message`          | `mixed` |             |
+| Name               | Type        | Description |
+| ------------------ | ----------- | ----------- |
+| `answer`           | `mixed`     |             |
+| `clarification_id` | `int`       |             |
+| `message`          | `mixed`     |             |
+| `public`           | `bool|null` |             |
 
 ### Returns
 
@@ -503,13 +504,13 @@ Adds a problem to a contest
 
 ### Parameters
 
-| Name               | Type    | Description |
-| ------------------ | ------- | ----------- |
-| `commit`           | `mixed` |             |
-| `contest_alias`    | `mixed` |             |
-| `order_in_contest` | `mixed` |             |
-| `points`           | `mixed` |             |
-| `problem_alias`    | `mixed` |             |
+| Name               | Type         | Description |
+| ------------------ | ------------ | ----------- |
+| `commit`           | `mixed`      |             |
+| `contest_alias`    | `mixed`      |             |
+| `order_in_contest` | `int`        |             |
+| `points`           | `float|null` |             |
+| `problem_alias`    | `mixed`      |             |
 
 ### Returns
 
@@ -593,10 +594,10 @@ the director).
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `page`      | `mixed` |             |
-| `page_size` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `page`      | `int` |             |
+| `page_size` | `int` |             |
 
 ### Returns
 
@@ -651,8 +652,8 @@ Get clarifications of a contest
 | Name            | Type    | Description |
 | --------------- | ------- | ----------- |
 | `contest_alias` | `mixed` |             |
-| `offset`        | `mixed` |             |
-| `rowcount`      | `mixed` |             |
+| `offset`        | `int`   |             |
+| `rowcount`      | `int`   |             |
 
 ### Returns
 
@@ -711,28 +712,28 @@ Creates a new contest
 
 ### Parameters
 
-| Name                        | Type    | Description |
-| --------------------------- | ------- | ----------- |
-| `admission_mode`            | `mixed` |             |
-| `alias`                     | `mixed` |             |
-| `basic_information`         | `mixed` |             |
-| `description`               | `mixed` |             |
-| `feedback`                  | `mixed` |             |
-| `finish_time`               | `mixed` |             |
-| `languages`                 | `mixed` |             |
-| `partial_score`             | `mixed` |             |
-| `penalty`                   | `mixed` |             |
-| `penalty_calc_policy`       | `mixed` |             |
-| `penalty_type`              | `mixed` |             |
-| `points_decay_factor`       | `mixed` |             |
-| `problems`                  | `mixed` |             |
-| `requests_user_information` | `mixed` |             |
-| `scoreboard`                | `mixed` |             |
-| `show_scoreboard_after`     | `mixed` |             |
-| `start_time`                | `mixed` |             |
-| `submissions_gap`           | `mixed` |             |
-| `title`                     | `mixed` |             |
-| `window_length`             | `mixed` |             |
+| Name                        | Type        | Description |
+| --------------------------- | ----------- | ----------- |
+| `admission_mode`            | `mixed`     |             |
+| `alias`                     | `mixed`     |             |
+| `basic_information`         | `bool|null` |             |
+| `description`               | `mixed`     |             |
+| `feedback`                  | `mixed`     |             |
+| `finish_time`               | `mixed`     |             |
+| `languages`                 | `mixed`     |             |
+| `partial_score`             | `mixed`     |             |
+| `penalty`                   | `mixed`     |             |
+| `penalty_calc_policy`       | `mixed`     |             |
+| `penalty_type`              | `mixed`     |             |
+| `points_decay_factor`       | `mixed`     |             |
+| `problems`                  | `mixed`     |             |
+| `requests_user_information` | `mixed`     |             |
+| `scoreboard`                | `mixed`     |             |
+| `show_scoreboard_after`     | `mixed`     |             |
+| `start_time`                | `mixed`     |             |
+| `submissions_gap`           | `mixed`     |             |
+| `title`                     | `mixed`     |             |
+| `window_length`             | `mixed`     |             |
 
 ### Returns
 
@@ -747,7 +748,7 @@ _Nothing_
 | Name         | Type    | Description |
 | ------------ | ------- | ----------- |
 | `alias`      | `mixed` |             |
-| `start_time` | `mixed` |             |
+| `start_time` | `int`   |             |
 
 ### Returns
 
@@ -814,8 +815,8 @@ Returns a list of contests
 | ---------------- | ------- | ----------- |
 | `active`         | `mixed` |             |
 | `admission_mode` | `mixed` |             |
-| `page`           | `mixed` |             |
-| `page_size`      | `mixed` |             |
+| `page`           | `int`   |             |
+| `page_size`      | `int`   |             |
 | `participating`  | `mixed` |             |
 | `query`          | `mixed` |             |
 | `recommended`    | `mixed` |             |
@@ -837,8 +838,8 @@ Returns a list of contests where current user is participating in
 
 | Name        | Type    | Description |
 | ----------- | ------- | ----------- |
-| `page`      | `mixed` |             |
-| `page_size` | `mixed` |             |
+| `page`      | `int`   |             |
+| `page_size` | `int`   |             |
 | `query`     | `mixed` |             |
 
 ### Returns
@@ -857,8 +858,8 @@ Returns a list of contests where current user is the director
 
 | Name        | Type    | Description |
 | ----------- | ------- | ----------- |
-| `page`      | `mixed` |             |
-| `page_size` | `mixed` |             |
+| `page`      | `int`   |             |
+| `page_size` | `int`   |             |
 | `query`     | `mixed` |             |
 
 ### Returns
@@ -875,13 +876,13 @@ Joins a contest - explicitly adds a identity to a contest.
 
 ### Parameters
 
-| Name                     | Type    | Description |
-| ------------------------ | ------- | ----------- |
-| `contest_alias`          | `mixed` |             |
-| `privacy_git_object_id`  | `mixed` |             |
-| `share_user_information` | `mixed` |             |
-| `statement_type`         | `mixed` |             |
-| `token`                  | `mixed` |             |
+| Name                     | Type        | Description |
+| ------------------------ | ----------- | ----------- |
+| `contest_alias`          | `mixed`     |             |
+| `privacy_git_object_id`  | `mixed`     |             |
+| `share_user_information` | `bool|null` |             |
+| `statement_type`         | `mixed`     |             |
+| `token`                  | `mixed`     |             |
 
 ### Returns
 
@@ -1220,10 +1221,10 @@ Only omegaUp admins can call this API.
 
 ### Parameters
 
-| Name            | Type    | Description |
-| --------------- | ------- | ----------- |
-| `contest_alias` | `mixed` |             |
-| `value`         | `mixed` |             |
+| Name            | Type        | Description |
+| --------------- | ----------- | ----------- |
+| `contest_alias` | `mixed`     |             |
+| `value`         | `bool|null` |             |
 
 ### Returns
 
@@ -1262,24 +1263,28 @@ Update a Contest
 
 ### Parameters
 
-| Name                        | Type    | Description |
-| --------------------------- | ------- | ----------- |
-| `admission_mode`            | `mixed` |             |
-| `alias`                     | `mixed` |             |
-| `basic_information`         | `mixed` |             |
-| `contest_alias`             | `mixed` |             |
-| `description`               | `mixed` |             |
-| `feedback`                  | `mixed` |             |
-| `finish_time`               | `mixed` |             |
-| `languages`                 | `mixed` |             |
-| `penalty_calc_policy`       | `mixed` |             |
-| `penalty_type`              | `mixed` |             |
-| `problems`                  | `mixed` |             |
-| `requests_user_information` | `mixed` |             |
-| `start_time`                | `mixed` |             |
-| `submissions_gap`           | `mixed` |             |
-| `title`                     | `mixed` |             |
-| `window_length`             | `mixed` |             |
+| Name                        | Type         | Description |
+| --------------------------- | ------------ | ----------- |
+| `admission_mode`            | `mixed`      |             |
+| `alias`                     | `mixed`      |             |
+| `basic_information`         | `bool|null`  |             |
+| `contest_alias`             | `mixed`      |             |
+| `description`               | `mixed`      |             |
+| `feedback`                  | `mixed`      |             |
+| `finish_time`               | `int`        |             |
+| `languages`                 | `mixed`      |             |
+| `partial_score`             | `bool|null`  |             |
+| `penalty_calc_policy`       | `mixed`      |             |
+| `penalty_type`              | `mixed`      |             |
+| `points_decay_factor`       | `float|null` |             |
+| `problems`                  | `mixed`      |             |
+| `requests_user_information` | `mixed`      |             |
+| `scoreboard`                | `float|null` |             |
+| `show_scoreboard_after`     | `bool|null`  |             |
+| `start_time`                | `mixed`      |             |
+| `submissions_gap`           | `int`        |             |
+| `title`                     | `mixed`      |             |
+| `window_length`             | `int`        |             |
 
 ### Returns
 
@@ -1297,7 +1302,7 @@ option is turned on
 | Name            | Type    | Description |
 | --------------- | ------- | ----------- |
 | `contest_alias` | `mixed` |             |
-| `end_time`      | `mixed` |             |
+| `end_time`      | `int`   |             |
 | `username`      | `mixed` |             |
 
 ### Returns
@@ -1582,20 +1587,20 @@ Create new course API
 
 ### Parameters
 
-| Name                        | Type    | Description |
-| --------------------------- | ------- | ----------- |
-| `admission_mode`            | `mixed` |             |
-| `alias`                     | `mixed` |             |
-| `description`               | `mixed` |             |
-| `finish_time`               | `mixed` |             |
-| `name`                      | `mixed` |             |
-| `needs_basic_information`   | `mixed` |             |
-| `public`                    | `mixed` |             |
-| `requests_user_information` | `mixed` |             |
-| `school_id`                 | `mixed` |             |
-| `show_scoreboard`           | `mixed` |             |
-| `start_time`                | `mixed` |             |
-| `unlimited_duration`        | `mixed` |             |
+| Name                        | Type        | Description |
+| --------------------------- | ----------- | ----------- |
+| `admission_mode`            | `mixed`     |             |
+| `alias`                     | `mixed`     |             |
+| `description`               | `mixed`     |             |
+| `finish_time`               | `mixed`     |             |
+| `name`                      | `mixed`     |             |
+| `needs_basic_information`   | `mixed`     |             |
+| `public`                    | `mixed`     |             |
+| `requests_user_information` | `mixed`     |             |
+| `school_id`                 | `mixed`     |             |
+| `show_scoreboard`           | `mixed`     |             |
+| `start_time`                | `mixed`     |             |
+| `unlimited_duration`        | `bool|null` |             |
 
 ### Returns
 
@@ -1609,18 +1614,18 @@ API to Create an assignment
 
 ### Parameters
 
-| Name                 | Type    | Description |
-| -------------------- | ------- | ----------- |
-| `alias`              | `mixed` |             |
-| `assignment_type`    | `mixed` |             |
-| `course_alias`       | `mixed` |             |
-| `description`        | `mixed` |             |
-| `finish_time`        | `mixed` |             |
-| `name`               | `mixed` |             |
-| `order`              | `mixed` |             |
-| `publish_time_delay` | `mixed` |             |
-| `start_time`         | `mixed` |             |
-| `unlimited_duration` | `mixed` |             |
+| Name                 | Type        | Description |
+| -------------------- | ----------- | ----------- |
+| `alias`              | `mixed`     |             |
+| `assignment_type`    | `mixed`     |             |
+| `course_alias`       | `mixed`     |             |
+| `description`        | `mixed`     |             |
+| `finish_time`        | `mixed`     |             |
+| `name`               | `mixed`     |             |
+| `order`              | `mixed`     |             |
+| `publish_time_delay` | `mixed`     |             |
+| `start_time`         | `mixed`     |             |
+| `unlimited_duration` | `bool|null` |             |
 
 ### Returns
 
@@ -1718,10 +1723,10 @@ for in which the user is a student.
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `page`      | `mixed` |             |
-| `page_size` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `page`      | `int` |             |
+| `page_size` | `int` |             |
 
 ### Returns
 
@@ -1957,18 +1962,20 @@ Edit Course contents
 
 ### Parameters
 
-| Name                        | Type    | Description |
-| --------------------------- | ------- | ----------- |
-| `admission_mode`            | `mixed` |             |
-| `alias`                     | `mixed` |             |
-| `course_alias`              | `mixed` |             |
-| `description`               | `mixed` |             |
-| `finish_time`               | `mixed` |             |
-| `name`                      | `mixed` |             |
-| `requests_user_information` | `mixed` |             |
-| `school_id`                 | `mixed` |             |
-| `start_time`                | `mixed` |             |
-| `unlimited_duration`        | `mixed` |             |
+| Name                        | Type        | Description |
+| --------------------------- | ----------- | ----------- |
+| `admission_mode`            | `mixed`     |             |
+| `alias`                     | `mixed`     |             |
+| `course_alias`              | `mixed`     |             |
+| `description`               | `mixed`     |             |
+| `finish_time`               | `mixed`     |             |
+| `name`                      | `mixed`     |             |
+| `needs_basic_information`   | `bool|null` |             |
+| `requests_user_information` | `mixed`     |             |
+| `school_id`                 | `int`       |             |
+| `show_scoreboard`           | `bool|null` |             |
+| `start_time`                | `mixed`     |             |
+| `unlimited_duration`        | `mixed`     |             |
 
 ### Returns
 
@@ -1982,13 +1989,13 @@ Update an assignment
 
 ### Parameters
 
-| Name                 | Type    | Description |
-| -------------------- | ------- | ----------- |
-| `assignment`         | `mixed` |             |
-| `course`             | `mixed` |             |
-| `finish_time`        | `mixed` |             |
-| `start_time`         | `mixed` |             |
-| `unlimited_duration` | `mixed` |             |
+| Name                 | Type                | Description |
+| -------------------- | ------------------- | ----------- |
+| `assignment`         | `mixed`             |             |
+| `course`             | `mixed`             |             |
+| `finish_time`        | `OmegaUp\Timestamp` |             |
+| `start_time`         | `OmegaUp\Timestamp` |             |
+| `unlimited_duration` | `bool|null`         |             |
 
 ### Returns
 
@@ -2202,13 +2209,13 @@ Add contest to a group scoreboard
 
 ### Parameters
 
-| Name               | Type    | Description |
-| ------------------ | ------- | ----------- |
-| `contest_alias`    | `mixed` |             |
-| `group_alias`      | `mixed` |             |
-| `only_ac`          | `mixed` |             |
-| `scoreboard_alias` | `mixed` |             |
-| `weight`           | `mixed` |             |
+| Name               | Type         | Description |
+| ------------------ | ------------ | ----------- |
+| `contest_alias`    | `mixed`      |             |
+| `group_alias`      | `mixed`      |             |
+| `only_ac`          | `bool|null`  |             |
+| `scoreboard_alias` | `mixed`      |             |
+| `weight`           | `float|null` |             |
 
 ### Returns
 
@@ -2392,7 +2399,7 @@ _Nothing_
 | ------------- | ------- | ----------- |
 | `alias`       | `mixed` |             |
 | `description` | `mixed` |             |
-| `duration`    | `mixed` |             |
+| `duration`    | `int`   |             |
 | `title`       | `mixed` |             |
 
 ### Returns
@@ -2528,10 +2535,10 @@ the owner).
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `page`      | `mixed` |             |
-| `page_size` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `page`      | `int` |             |
+| `page_size` | `int` |             |
 
 ### Returns
 
@@ -2610,26 +2617,26 @@ Create a new problem
 
 ### Parameters
 
-| Name                      | Type     | Description |
-| ------------------------- | -------- | ----------- |
-| `allow_user_add_tags`     | `bool`   |             |
-| `email_clarifications`    | `mixed`  |             |
-| `extra_wall_time`         | `mixed`  |             |
-| `input_limit`             | `mixed`  |             |
-| `languages`               | `mixed`  |             |
-| `memory_limit`            | `mixed`  |             |
-| `output_limit`            | `mixed`  |             |
-| `overall_wall_time_limit` | `mixed`  |             |
-| `problem_alias`           | `mixed`  |             |
-| `selected_tags`           | `mixed`  |             |
-| `show_diff`               | `string` |             |
-| `source`                  | `mixed`  |             |
-| `time_limit`              | `mixed`  |             |
-| `title`                   | `mixed`  |             |
-| `update_published`        | `mixed`  |             |
-| `validator`               | `mixed`  |             |
-| `validator_time_limit`    | `mixed`  |             |
-| `visibility`              | `mixed`  |             |
+| Name                      | Type        | Description |
+| ------------------------- | ----------- | ----------- |
+| `allow_user_add_tags`     | `bool`      |             |
+| `email_clarifications`    | `bool|null` |             |
+| `extra_wall_time`         | `mixed`     |             |
+| `input_limit`             | `mixed`     |             |
+| `languages`               | `mixed`     |             |
+| `memory_limit`            | `mixed`     |             |
+| `output_limit`            | `mixed`     |             |
+| `overall_wall_time_limit` | `mixed`     |             |
+| `problem_alias`           | `mixed`     |             |
+| `selected_tags`           | `mixed`     |             |
+| `show_diff`               | `string`    |             |
+| `source`                  | `mixed`     |             |
+| `time_limit`              | `mixed`     |             |
+| `title`                   | `mixed`     |             |
+| `update_published`        | `mixed`     |             |
+| `validator`               | `mixed`     |             |
+| `validator_time_limit`    | `mixed`     |             |
+| `visibility`              | `mixed`     |             |
 
 ### Returns
 
@@ -2659,15 +2666,15 @@ Entry point for Problem Details API
 
 ### Parameters
 
-| Name                      | Type    | Description |
-| ------------------------- | ------- | ----------- |
-| `contest_alias`           | `mixed` |             |
-| `lang`                    | `mixed` |             |
-| `prevent_problemset_open` | `mixed` |             |
-| `problem_alias`           | `mixed` |             |
-| `problemset_id`           | `mixed` |             |
-| `show_solvers`            | `mixed` |             |
-| `statement_type`          | `mixed` |             |
+| Name                      | Type        | Description |
+| ------------------------- | ----------- | ----------- |
+| `contest_alias`           | `mixed`     |             |
+| `lang`                    | `mixed`     |             |
+| `prevent_problemset_open` | `bool|null` |             |
+| `problem_alias`           | `mixed`     |             |
+| `problemset_id`           | `mixed`     |             |
+| `show_solvers`            | `bool|null` |             |
+| `statement_type`          | `mixed`     |             |
 
 ### Returns
 
@@ -2741,11 +2748,12 @@ Gets a list of problems where current user is the owner
 
 ### Parameters
 
-| Name       | Type    | Description |
-| ---------- | ------- | ----------- |
-| `offset`   | `mixed` |             |
-| `page`     | `mixed` |             |
-| `rowcount` | `mixed` |             |
+| Name        | Type    | Description |
+| ----------- | ------- | ----------- |
+| `offset`    | `mixed` |             |
+| `page`      | `int`   |             |
+| `page_size` | `int`   |             |
+| `rowcount`  | `mixed` |             |
 
 ### Returns
 
@@ -2891,14 +2899,14 @@ Returns the solution for a problem if conditions are satisfied.
 
 ### Parameters
 
-| Name              | Type    | Description |
-| ----------------- | ------- | ----------- |
-| `contest_alias`   | `mixed` |             |
-| `forfeit_problem` | `mixed` |             |
-| `lang`            | `mixed` |             |
-| `problem_alias`   | `mixed` |             |
-| `problemset_id`   | `mixed` |             |
-| `statement_type`  | `mixed` |             |
+| Name              | Type        | Description |
+| ----------------- | ----------- | ----------- |
+| `contest_alias`   | `mixed`     |             |
+| `forfeit_problem` | `bool|null` |             |
+| `lang`            | `mixed`     |             |
+| `problem_alias`   | `mixed`     |             |
+| `problemset_id`   | `mixed`     |             |
+| `statement_type`  | `mixed`     |             |
 
 ### Returns
 
@@ -2955,28 +2963,28 @@ Update problem contents
 
 ### Parameters
 
-| Name                      | Type     | Description |
-| ------------------------- | -------- | ----------- |
-| `allow_user_add_tags`     | `bool`   |             |
-| `email_clarifications`    | `mixed`  |             |
-| `extra_wall_time`         | `mixed`  |             |
-| `input_limit`             | `mixed`  |             |
-| `languages`               | `mixed`  |             |
-| `memory_limit`            | `mixed`  |             |
-| `message`                 | `mixed`  |             |
-| `output_limit`            | `mixed`  |             |
-| `overall_wall_time_limit` | `mixed`  |             |
-| `problem_alias`           | `mixed`  |             |
-| `redirect`                | `mixed`  |             |
-| `selected_tags`           | `mixed`  |             |
-| `show_diff`               | `string` |             |
-| `source`                  | `mixed`  |             |
-| `time_limit`              | `mixed`  |             |
-| `title`                   | `mixed`  |             |
-| `update_published`        | `mixed`  |             |
-| `validator`               | `mixed`  |             |
-| `validator_time_limit`    | `mixed`  |             |
-| `visibility`              | `mixed`  |             |
+| Name                      | Type        | Description |
+| ------------------------- | ----------- | ----------- |
+| `allow_user_add_tags`     | `bool`      |             |
+| `email_clarifications`    | `bool|null` |             |
+| `extra_wall_time`         | `mixed`     |             |
+| `input_limit`             | `mixed`     |             |
+| `languages`               | `mixed`     |             |
+| `memory_limit`            | `mixed`     |             |
+| `message`                 | `mixed`     |             |
+| `output_limit`            | `mixed`     |             |
+| `overall_wall_time_limit` | `mixed`     |             |
+| `problem_alias`           | `mixed`     |             |
+| `redirect`                | `mixed`     |             |
+| `selected_tags`           | `mixed`     |             |
+| `show_diff`               | `string`    |             |
+| `source`                  | `mixed`     |             |
+| `time_limit`              | `mixed`     |             |
+| `title`                   | `mixed`     |             |
+| `update_published`        | `mixed`     |             |
+| `validator`               | `mixed`     |             |
+| `validator_time_limit`    | `mixed`     |             |
+| `visibility`              | `mixed`     |             |
 
 ### Returns
 
@@ -2992,29 +3000,29 @@ Updates problem solution only
 
 ### Parameters
 
-| Name                      | Type     | Description |
-| ------------------------- | -------- | ----------- |
-| `allow_user_add_tags`     | `bool`   |             |
-| `email_clarifications`    | `mixed`  |             |
-| `extra_wall_time`         | `mixed`  |             |
-| `input_limit`             | `mixed`  |             |
-| `lang`                    | `mixed`  |             |
-| `languages`               | `mixed`  |             |
-| `memory_limit`            | `mixed`  |             |
-| `message`                 | `mixed`  |             |
-| `output_limit`            | `mixed`  |             |
-| `overall_wall_time_limit` | `mixed`  |             |
-| `problem_alias`           | `mixed`  |             |
-| `selected_tags`           | `mixed`  |             |
-| `show_diff`               | `string` |             |
-| `solution`                | `mixed`  |             |
-| `source`                  | `mixed`  |             |
-| `time_limit`              | `mixed`  |             |
-| `title`                   | `mixed`  |             |
-| `update_published`        | `mixed`  |             |
-| `validator`               | `mixed`  |             |
-| `validator_time_limit`    | `mixed`  |             |
-| `visibility`              | `mixed`  |             |
+| Name                      | Type        | Description |
+| ------------------------- | ----------- | ----------- |
+| `allow_user_add_tags`     | `bool`      |             |
+| `email_clarifications`    | `bool|null` |             |
+| `extra_wall_time`         | `mixed`     |             |
+| `input_limit`             | `mixed`     |             |
+| `lang`                    | `mixed`     |             |
+| `languages`               | `mixed`     |             |
+| `memory_limit`            | `mixed`     |             |
+| `message`                 | `mixed`     |             |
+| `output_limit`            | `mixed`     |             |
+| `overall_wall_time_limit` | `mixed`     |             |
+| `problem_alias`           | `mixed`     |             |
+| `selected_tags`           | `mixed`     |             |
+| `show_diff`               | `string`    |             |
+| `solution`                | `mixed`     |             |
+| `source`                  | `mixed`     |             |
+| `time_limit`              | `mixed`     |             |
+| `title`                   | `mixed`     |             |
+| `update_published`        | `mixed`     |             |
+| `validator`               | `mixed`     |             |
+| `validator_time_limit`    | `mixed`     |             |
+| `visibility`              | `mixed`     |             |
 
 ### Returns
 
@@ -3028,29 +3036,29 @@ Updates problem statement only
 
 ### Parameters
 
-| Name                      | Type     | Description |
-| ------------------------- | -------- | ----------- |
-| `allow_user_add_tags`     | `bool`   |             |
-| `email_clarifications`    | `mixed`  |             |
-| `extra_wall_time`         | `mixed`  |             |
-| `input_limit`             | `mixed`  |             |
-| `lang`                    | `mixed`  |             |
-| `languages`               | `mixed`  |             |
-| `memory_limit`            | `mixed`  |             |
-| `message`                 | `mixed`  |             |
-| `output_limit`            | `mixed`  |             |
-| `overall_wall_time_limit` | `mixed`  |             |
-| `problem_alias`           | `mixed`  |             |
-| `selected_tags`           | `mixed`  |             |
-| `show_diff`               | `string` |             |
-| `source`                  | `mixed`  |             |
-| `statement`               | `mixed`  |             |
-| `time_limit`              | `mixed`  |             |
-| `title`                   | `mixed`  |             |
-| `update_published`        | `mixed`  |             |
-| `validator`               | `mixed`  |             |
-| `validator_time_limit`    | `mixed`  |             |
-| `visibility`              | `mixed`  |             |
+| Name                      | Type        | Description |
+| ------------------------- | ----------- | ----------- |
+| `allow_user_add_tags`     | `bool`      |             |
+| `email_clarifications`    | `bool|null` |             |
+| `extra_wall_time`         | `mixed`     |             |
+| `input_limit`             | `mixed`     |             |
+| `lang`                    | `mixed`     |             |
+| `languages`               | `mixed`     |             |
+| `memory_limit`            | `mixed`     |             |
+| `message`                 | `mixed`     |             |
+| `output_limit`            | `mixed`     |             |
+| `overall_wall_time_limit` | `mixed`     |             |
+| `problem_alias`           | `mixed`     |             |
+| `selected_tags`           | `mixed`     |             |
+| `show_diff`               | `string`    |             |
+| `source`                  | `mixed`     |             |
+| `statement`               | `mixed`     |             |
+| `time_limit`              | `mixed`     |             |
+| `title`                   | `mixed`     |             |
+| `update_published`        | `mixed`     |             |
+| `validator`               | `mixed`     |             |
+| `validator_time_limit`    | `mixed`     |             |
+| `visibility`              | `mixed`     |             |
 
 ### Returns
 
@@ -3108,7 +3116,7 @@ and the number of solutions already seen
 | `contest_alias`   | `mixed` |             |
 | `course`          | `mixed` |             |
 | `interview_alias` | `mixed` |             |
-| `problemset_id`   | `mixed` |             |
+| `problemset_id`   | `int`   |             |
 | `token`           | `mixed` |             |
 | `tokens`          | `mixed` |             |
 | `username`        | `mixed` |             |
@@ -3163,7 +3171,7 @@ and the number of solutions already seen
 | `auth_token`    | `mixed` |             |
 | `contest_alias` | `mixed` |             |
 | `course`        | `mixed` |             |
-| `problemset_id` | `mixed` |             |
+| `problemset_id` | `int`   |             |
 | `token`         | `mixed` |             |
 | `tokens`        | `mixed` |             |
 
@@ -3187,7 +3195,7 @@ Returns the Scoreboard events
 | `auth_token`    | `mixed` |             |
 | `contest_alias` | `mixed` |             |
 | `course`        | `mixed` |             |
-| `problemset_id` | `mixed` |             |
+| `problemset_id` | `int`   |             |
 | `token`         | `mixed` |             |
 | `tokens`        | `mixed` |             |
 
@@ -3287,9 +3295,9 @@ nominator or a member of the reviewer group.
 
 ### Parameters
 
-| Name                   | Type    | Description |
-| ---------------------- | ------- | ----------- |
-| `qualitynomination_id` | `mixed` |             |
+| Name                   | Type  | Description |
+| ---------------------- | ----- | ----------- |
+| `qualitynomination_id` | `int` |             |
 
 ### Returns
 
@@ -3315,9 +3323,9 @@ nominator or a member of the reviewer group.
 
 | Name       | Type    | Description |
 | ---------- | ------- | ----------- |
-| `offset`   | `mixed` |             |
+| `offset`   | `int`   |             |
+| `rowcount` | `int`   |             |
 | `status`   | `mixed` |             |
-| `rowcount` | `mixed` |             |
 
 ### Returns
 
@@ -3334,10 +3342,10 @@ Displays the nominations that this user has been assigned.
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `page`      | `mixed` |             |
-| `page_size` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `page`      | `int` |             |
+| `page_size` | `int` |             |
 
 ### Returns
 
@@ -3351,10 +3359,10 @@ Displays the nominations that this user has been assigned.
 
 ### Parameters
 
-| Name       | Type    | Description |
-| ---------- | ------- | ----------- |
-| `offset`   | `mixed` |             |
-| `rowcount` | `mixed` |             |
+| Name       | Type  | Description |
+| ---------- | ----- | ----------- |
+| `offset`   | `int` |             |
+| `rowcount` | `int` |             |
 
 ### Returns
 
@@ -3542,9 +3550,9 @@ Gets a list of latest runs overall
 | Name            | Type    | Description |
 | --------------- | ------- | ----------- |
 | `language`      | `mixed` |             |
-| `offset`        | `mixed` |             |
+| `offset`        | `int`   |             |
 | `problem_alias` | `mixed` |             |
-| `rowcount`      | `mixed` |             |
+| `rowcount`      | `int`   |             |
 | `status`        | `mixed` |             |
 | `username`      | `mixed` |             |
 | `verdict`       | `mixed` |             |
@@ -3675,9 +3683,9 @@ months (including the current one)
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `school_id` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `school_id` | `int` |             |
 
 ### Returns
 
@@ -3693,9 +3701,9 @@ Returns rank of best schools in last month
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `school_id` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `school_id` | `int` |             |
 
 ### Returns
 
@@ -3711,9 +3719,9 @@ Selects a certain school as school of the month
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `school_id` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `school_id` | `int` |             |
 
 ### Returns
 
@@ -3728,9 +3736,9 @@ with the number of created problems, solved problems and organized contests.
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `school_id` | `mixed` |             |
+| Name        | Type  | Description |
+| ----------- | ----- | ----------- |
+| `school_id` | `int` |             |
 
 ### Returns
 
@@ -3816,8 +3824,8 @@ Returns the latest submissions
 
 | Name       | Type    | Description |
 | ---------- | ------- | ----------- |
-| `offset`   | `mixed` |             |
-| `rowcount` | `mixed` |             |
+| `offset`   | `int`   |             |
+| `rowcount` | `int`   |             |
 | `username` | `mixed` |             |
 
 ### Returns
@@ -4281,11 +4289,11 @@ Get general user info
 
 ### Parameters
 
-| Name        | Type    | Description |
-| ----------- | ------- | ----------- |
-| `category`  | `mixed` |             |
-| `omit_rank` | `mixed` |             |
-| `username`  | `mixed` |             |
+| Name        | Type        | Description |
+| ----------- | ----------- | ----------- |
+| `category`  | `mixed`     |             |
+| `omit_rank` | `bool|null` |             |
+| `username`  | `mixed`     |             |
 
 ### Returns
 
@@ -4423,20 +4431,22 @@ Update user profile
 
 ### Parameters
 
-| Name              | Type    | Description |
-| ----------------- | ------- | ----------- |
-| `auth_token`      | `mixed` |             |
-| `birth_date`      | `mixed` |             |
-| `country_id`      | `mixed` |             |
-| `gender`          | `mixed` |             |
-| `graduation_date` | `mixed` |             |
-| `locale`          | `mixed` |             |
-| `name`            | `mixed` |             |
-| `scholar_degree`  | `mixed` |             |
-| `school_id`       | `mixed` |             |
-| `school_name`     | `mixed` |             |
-| `state_id`        | `mixed` |             |
-| `username`        | `mixed` |             |
+| Name                | Type        | Description |
+| ------------------- | ----------- | ----------- |
+| `auth_token`        | `mixed`     |             |
+| `birth_date`        | `mixed`     |             |
+| `country_id`        | `mixed`     |             |
+| `gender`            | `mixed`     |             |
+| `graduation_date`   | `mixed`     |             |
+| `hide_problem_tags` | `bool|null` |             |
+| `is_private`        | `bool|null` |             |
+| `locale`            | `mixed`     |             |
+| `name`              | `mixed`     |             |
+| `scholar_degree`    | `mixed`     |             |
+| `school_id`         | `mixed`     |             |
+| `school_name`       | `mixed`     |             |
+| `state_id`          | `mixed`     |             |
+| `username`          | `mixed`     |             |
 
 ### Returns
 
@@ -4499,7 +4509,7 @@ contest updates with an access token.
 | `contest_admin` | `mixed` |             |
 | `contest_alias` | `mixed` |             |
 | `filter`        | `mixed` |             |
-| `problemset_id` | `mixed` |             |
+| `problemset_id` | `int`   |             |
 | `token`         | `mixed` |             |
 | `tokens`        | `mixed` |             |
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1304,15 +1304,15 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of latest runs overall
      *
+     * @return array{runs: list<array{alias: string, classname: string, contest_alias: null|string, contest_score: float|null, country_id: null|string, guid: string, judged_by: null|string, language: string, memory: int, penalty: int, run_id: int, runtime: int, score: float, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, username: string, verdict: string}>}
+     *
      * @omegaup-request-param mixed $language
-     * @omegaup-request-param mixed $offset
+     * @omegaup-request-param int $offset
      * @omegaup-request-param mixed $problem_alias
-     * @omegaup-request-param mixed $rowcount
+     * @omegaup-request-param int $rowcount
      * @omegaup-request-param mixed $status
      * @omegaup-request-param mixed $username
      * @omegaup-request-param mixed $verdict
-     *
-     * @return array{runs: list<array{alias: string, classname: string, contest_alias: null|string, contest_score: float|null, country_id: null|string, guid: string, judged_by: null|string, language: string, memory: int, penalty: int, run_id: int, runtime: int, score: float, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, username: string, verdict: string}>}
      */
     public static function apiList(\OmegaUp\Request $r): array {
         // Authenticate request

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -49,11 +49,11 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the basic details for school
      *
-     * @omegaup-request-param mixed $school_id
-     *
      * @param \OmegaUp\Request $r
      *
      * @return array{template: string, smartyProperties: array{details: array{school_id: int, school_name: string, ranking: int, country: array{id: string, name: string}|null, state_name: string|null}}}
+     *
+     * @omegaup-request-param int $school_id
      */
     public static function getSchoolProfileDetailsForSmarty(\OmegaUp\Request $r): array {
         $r->ensureInt('school_id');
@@ -172,11 +172,11 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Returns rank of best schools in last month
      *
-     * @omegaup-request-param mixed $school_id
-     *
      * @param \OmegaUp\Request $r
      *
      * @return array{coders: list<array{time: string, username: string, classname: string}>}
+     *
+     * @omegaup-request-param int $school_id
      */
     public static function apiSchoolCodersOfTheMonth(\OmegaUp\Request $r): array {
         $r->ensureInt('school_id');
@@ -196,11 +196,11 @@ class School extends \OmegaUp\Controllers\Controller {
      * Returns the number of solved problems on the last
      * months (including the current one)
      *
-     * @omegaup-request-param mixed $school_id
-     *
      * @param \OmegaUp\Request $r
      *
      * @return array{distinct_problems_solved: list<array{month: int, problems_solved: int, year: int}>}
+     *
+     * @omegaup-request-param int $school_id
      */
     public static function apiMonthlySolvedProblemsCount(\OmegaUp\Request $r): array {
         $r->ensureInt('school_id');
@@ -221,11 +221,11 @@ class School extends \OmegaUp\Controllers\Controller {
      * Returns the list of current students registered in a certain school
      * with the number of created problems, solved problems and organized contests.
      *
-     * @omegaup-request-param mixed $school_id
-     *
      * @param \OmegaUp\Request $r
      *
      * @return array{users: list<array{username: string, classname: string, created_problems: int, solved_problems: int, organized_contests: int}>}
+     *
+     * @omegaup-request-param int $school_id
      */
     public static function apiUsers(\OmegaUp\Request $r): array {
         $r->ensureInt('school_id');
@@ -270,10 +270,10 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details for historical rank of schools with pagination
      *
-     * @omegaup-request-param mixed $length
-     * @omegaup-request-param mixed $page
-     *
      * @return array{smartyProperties: array{payload: SchoolRankPayload}, template: string}
+     *
+     * @omegaup-request-param int $length
+     * @omegaup-request-param int $page
      */
     public static function getRankForSmarty(\OmegaUp\Request $r): array {
         $r->ensureInt('page', null, null, false);
@@ -437,9 +437,9 @@ class School extends \OmegaUp\Controllers\Controller {
     /**
      * Selects a certain school as school of the month
      *
-     * @omegaup-request-param mixed $school_id
-     *
      * @return array{status: string}
+     *
+     * @omegaup-request-param int $school_id
      */
     public static function apiSelectSchoolOfTheMonth(\OmegaUp\Request $r): array {
         $r->ensureIdentity();

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -13,11 +13,11 @@ class Submission extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the latest submissions
      *
-     * @omegaup-request-param mixed $offset
-     * @omegaup-request-param mixed $rowcount
-     * @omegaup-request-param mixed $username
-     *
      * @return array{submissions: list<array{time: \OmegaUp\Timestamp, username: string, school_id: int|null, school_name: string|null, alias: string, title: string, language: string, verdict: string, runtime: int, memory: int}>, totalRows: int}
+     *
+     * @omegaup-request-param int $offset
+     * @omegaup-request-param int $rowcount
+     * @omegaup-request-param mixed $username
      */
     public static function apiLatestSubmissions(\OmegaUp\Request $r) {
         $r->ensureInt('offset', null, null, false);
@@ -65,10 +65,10 @@ class Submission extends \OmegaUp\Controllers\Controller {
     /**
      * Gets the details for the latest submissions with pagination
      *
-     * @omegaup-request-param mixed $length
-     * @omegaup-request-param mixed $page
-     *
      * @return array{smartyProperties: array{submissionsPayload: array{page: int, length: int, includeUser: bool}}, template: string}
+     *
+     * @omegaup-request-param int $length
+     * @omegaup-request-param int $page
      */
     public static function getLatestSubmissionsForSmarty(\OmegaUp\Request $r): array {
         $r->ensureInt('page', null, null, false);
@@ -93,11 +93,11 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * Gets the details for the latest submissions of
      * a certain user with pagination
      *
-     * @omegaup-request-param mixed $length
-     * @omegaup-request-param mixed $page
-     * @omegaup-request-param mixed $username
-     *
      * @return array{smartyProperties: array{submissionsPayload: array{page: int, length: int, includeUser: bool}}, template: string}
+     *
+     * @omegaup-request-param int $length
+     * @omegaup-request-param int $page
+     * @omegaup-request-param mixed $username
      */
     public static function getLatestUserSubmissionsForSmarty(\OmegaUp\Request $r): array {
         $r->ensureInt('page', null, null, false);

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1377,11 +1377,11 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Get general user info
      *
-     * @omegaup-request-param mixed $category
-     * @omegaup-request-param mixed $omit_rank
-     * @omegaup-request-param mixed $username
-     *
      * @return array{birth_date?: int|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date?: int|null, gravatar_92?: null|string, hide_problem_tags?: bool|null, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{name?: null|string, problems_solved?: int|null, rank?: int|null}, scholar_degree?: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified?: bool|null}
+     *
+     * @omegaup-request-param mixed $category
+     * @omegaup-request-param bool|null $omit_rank
+     * @omegaup-request-param mixed $username
      */
     public static function apiProfile(\OmegaUp\Request $r): array {
         self::authenticateOrAllowUnauthenticatedRequest($r);
@@ -2112,11 +2112,17 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Update user profile
      *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
+     *
+     * @return array{status: string}
+     *
      * @omegaup-request-param mixed $auth_token
      * @omegaup-request-param mixed $birth_date
      * @omegaup-request-param mixed $country_id
      * @omegaup-request-param mixed $gender
      * @omegaup-request-param mixed $graduation_date
+     * @omegaup-request-param bool|null $hide_problem_tags
+     * @omegaup-request-param bool|null $is_private
      * @omegaup-request-param mixed $locale
      * @omegaup-request-param mixed $name
      * @omegaup-request-param mixed $scholar_degree
@@ -2124,10 +2130,6 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $school_name
      * @omegaup-request-param mixed $state_id
      * @omegaup-request-param mixed $username
-     *
-     * @throws \OmegaUp\Exceptions\InvalidParameterException
-     *
-     * @return array{status: string}
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
@@ -2623,15 +2625,15 @@ class User extends \OmegaUp\Controllers\Controller {
      * This API does not need authentication to be used. This allows to track
      * contest updates with an access token.
      *
+     * @return array{user: null|string, admin: bool, problem_admin: list<string>, contest_admin: list<string>, problemset_admin: list<int>}
+     *
      * @omegaup-request-param mixed $auth_token
      * @omegaup-request-param mixed $contest_admin
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $filter
-     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param int $problemset_id
      * @omegaup-request-param mixed $token
      * @omegaup-request-param mixed $tokens
-     *
-     * @return array{user: null|string, admin: bool, problem_admin: list<string>, contest_admin: list<string>, problemset_admin: list<int>}
      */
     public static function apiValidateFilter(\OmegaUp\Request $r): array {
         \OmegaUp\Validators::validateStringNonEmpty($r['filter'], 'filter');
@@ -3297,11 +3299,11 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Prepare all the properties to be sent to the rank table view via smarty
      *
-     * @omegaup-request-param mixed $filter
-     * @omegaup-request-param mixed $length
-     * @omegaup-request-param mixed $page
-     *
      * @return array{smartyProperties: array{payload: UserRankTablePayload}, template: string}
+     *
+     * @omegaup-request-param mixed $filter
+     * @omegaup-request-param int $length
+     * @omegaup-request-param int $page
      */
     public static function getRankForSmarty(\OmegaUp\Request $r) {
         $r->ensureInt('page', null, null, false);


### PR DESCRIPTION
Este cambio hace que los parámetros del API tengan el tipo correcto
cuando se invoca el método \OmegaUp\Request::ensureXxx().