### PR TITLE
Deprecando más funciones del API viejo

### DIFF
--- a/frontend/www/js/omegaup/api.js
+++ b/frontend/www/js/omegaup/api.js
@@ -15,14 +15,7 @@ export default {
   Clarification: api.Clarification,
 
   Contest: {
-    activityReport: api.apiCall('/api/contest/activityReport/', function(
-      result,
-    ) {
-      for (let ev of result.events) {
-        ev.time = OmegaUp.remoteTime(ev.time * 1000);
-      }
-      return result;
-    }),
+    activityReport: api.Contest.activityReport,
 
     addAdmin: api.Contest.addAdmin,
 
@@ -61,21 +54,9 @@ export default {
 
     details: api.apiCall('/api/contest/details/', _normalizeContestFields),
 
-    list: api.apiCall('/api/contest/list/', function(result) {
-      for (var idx in result.results) {
-        var contest = result.results[idx];
-        OmegaUp.convertTimes(contest);
-      }
-      return result;
-    }),
+    list: api.Contest.list,
 
-    myList: api.apiCall('/api/contest/myList/', function(result) {
-      for (var idx in result.contests) {
-        var contest = result.contests[idx];
-        OmegaUp.convertTimes(contest);
-      }
-      return result;
-    }),
+    myList: api.Contest.myList,
 
     open: api.Contest.open,
 
@@ -106,110 +87,10 @@ export default {
 
     updateEndTimeForIdentity: api.Contest.updateEndTimeForIdentity,
 
-    users: api.apiCall('/api/contest/users/', function(result) {
-      for (const user of result.users) {
-        if (user.access_time !== null) {
-          user.access_time = OmegaUp.remoteTime(user.access_time * 1000);
-        }
-        if (user.end_time !== null) {
-          user.end_time = OmegaUp.remoteTime(user.end_time * 1000);
-        }
-      }
-      return result;
-    }),
+    users: api.Contest.users,
   },
 
-  Course: {
-    activityReport: api.Course.activityReport,
-
-    addAdmin: api.Course.addAdmin,
-
-    addGroupAdmin: api.Course.addGroupAdmin,
-
-    addProblem: api.Course.addProblem,
-
-    adminDetails: api.apiCall('/api/course/adminDetails/', function(result) {
-      if (result.finish_time) {
-        result.finish_time = new Date(result.finish_time * 1000);
-      }
-      result.start_time = new Date(result.start_time * 1000);
-      result.assignments.forEach(assignment => {
-        assignment.start_time = new Date(assignment.start_time * 1000);
-        if (assignment.finish_time) {
-          assignment.finish_time = new Date(assignment.finish_time * 1000);
-        }
-      });
-      return result;
-    }),
-
-    admins: api.Course.admins,
-
-    clone: api.Course.clone,
-
-    create: api.Course.create,
-
-    createAssignment: api.Course.createAssignment,
-
-    details: api.apiCall('/api/course/details/', function(data) {
-      if (data.finish_time) {
-        data.finish_time = new Date(data.finish_time * 1000);
-      }
-      data.start_time = new Date(data.start_time * 1000);
-      data.assignments.forEach(assignment => {
-        assignment.start_time = new Date(assignment.start_time * 1000);
-        if (assignment.finish_time) {
-          assignment.finish_time = new Date(assignment.finish_time * 1000);
-        }
-      });
-      return data;
-    }),
-
-    getAssignment: api.apiCall('/api/course/assignmentDetails', function(data) {
-      data.start_time = new Date(data.start_time * 1000);
-      if (data.finish_time) {
-        data.finish_time = new Date(data.finish_time * 1000);
-      }
-      return data;
-    }),
-
-    listAssignments: api.Course.listAssignments,
-
-    listCourses: api.apiCall('/api/course/listCourses/', function(result) {
-      result.admin.forEach(res => {
-        res.start_time = new Date(res.start_time * 1000);
-        if (res.finish_time) {
-          res.finish_time = new Date(res.finish_time * 1000);
-        }
-      });
-      result.student.forEach(res => {
-        res.start_time = new Date(res.start_time * 1000);
-        if (res.finish_time) {
-          res.finish_time = new Date(res.finish_time * 1000);
-        }
-      });
-      result.public.forEach(res => {
-        res.start_time = new Date(res.start_time * 1000);
-        if (res.finish_time) {
-          res.finish_time = new Date(res.finish_time * 1000);
-        }
-      });
-      return result;
-    }),
-
-    listSolvedProblems: api.Course.listSolvedProblems,
-
-    listUnsolvedProblems: api.Course.listUnsolvedProblems,
-
-    removeAssignment: api.Course.removeAssignment,
-
-    removeProblem: api.Course.removeProblem,
-
-    updateAssignment: api.Course.updateAssignment,
-
-    updateAssignmentsOrder: api.Course.updateAssignmentsOrder,
-
-    updateProblemsOrder: api.Course.updateProblemsOrder,
-  },
+  Course: api.Course,
 
   Group: api.Group,
 
@@ -332,17 +213,7 @@ export default {
       return data;
     }),
 
-    profile: api.apiCall('/api/user/profile/', function(data) {
-      if (data.birth_date !== null) {
-        data.birth_date = omegaup.OmegaUp.remoteTime(data.birth_date * 1000);
-      }
-      if (data.graduation_date !== null) {
-        data.graduation_date = omegaup.OmegaUp.remoteTime(
-          data.graduation_date * 1000,
-        );
-      }
-      return data;
-    }),
+    profile: api.User.profile,
 
     removeExperiment: api.User.removeExperiment,
 

--- a/frontend/www/js/omegaup/course/edit.js
+++ b/frontend/www/js/omegaup/course/edit.js
@@ -99,7 +99,7 @@ OmegaUp.on('ready', function() {
             ) {
               return;
             }
-            API.Course.removeAssignment({
+            api.Course.removeAssignment({
               course_alias: courseAlias,
               assignment_alias: assignment.alias,
             })
@@ -140,7 +140,7 @@ OmegaUp.on('ready', function() {
               .catch(UI.apiError);
           },
           'add-admin': function(useradmin) {
-            API.Course.addAdmin({
+            api.Course.addAdmin({
               course_alias: courseAlias,
               usernameOrEmail: useradmin,
             })
@@ -151,7 +151,7 @@ OmegaUp.on('ready', function() {
               .catch(UI.apiError);
           },
           'add-group-admin': function(groupadmin) {
-            API.Course.addGroupAdmin({
+            api.Course.addGroupAdmin({
               course_alias: courseAlias,
               group: groupadmin,
             })
@@ -205,7 +205,7 @@ OmegaUp.on('ready', function() {
             ) {
               return;
             }
-            API.Course.removeAssignment({
+            api.Course.removeAssignment({
               course_alias: courseAlias,
               assignment_alias: assignment.alias,
             })
@@ -221,7 +221,7 @@ OmegaUp.on('ready', function() {
             for (let homework of homeworks) {
               homework.order = index++;
             }
-            API.Course.updateAssignmentsOrder({
+            api.Course.updateAssignmentsOrder({
               course_alias: courseAlias,
               assignments: homeworks,
             }).catch(UI.apiError);
@@ -231,7 +231,7 @@ OmegaUp.on('ready', function() {
             for (let test of tests) {
               test.order = index++;
             }
-            API.Course.updateAssignmentsOrder({
+            api.Course.updateAssignmentsOrder({
               course_alias: courseAlias,
               assignments: tests,
             })
@@ -276,7 +276,7 @@ OmegaUp.on('ready', function() {
                 params.finish_time = ev.finishTime.getTime() / 1000;
               }
 
-              API.Course.updateAssignment(params)
+              api.Course.updateAssignment(params)
                 .then(function() {
                   UI.success(T.courseAssignmentUpdated);
                   refreshAssignmentsList();
@@ -301,7 +301,7 @@ OmegaUp.on('ready', function() {
                 params.finish_time = ev.finishTime.getTime() / 1000;
               }
 
-              API.Course.createAssignment(params)
+              api.Course.createAssignment(params)
                 .then(function() {
                   UI.success(T.courseAssignmentAdded);
                   updateNewAssignmentButtonVisibility(true);
@@ -417,7 +417,7 @@ OmegaUp.on('ready', function() {
         },
         on: {
           'add-problem': function(assignment, problemAlias) {
-            API.Course.addProblem({
+            api.Course.addProblem({
               course_alias: courseAlias,
               assignment_alias: assignment.alias,
               problem_alias: problemAlias,
@@ -442,7 +442,7 @@ OmegaUp.on('ready', function() {
             ) {
               return;
             }
-            API.Course.removeProblem({
+            api.Course.removeProblem({
               course_alias: courseAlias,
               problem_alias: problem.alias,
               assignment_alias: assignment.alias,
@@ -459,7 +459,7 @@ OmegaUp.on('ready', function() {
               problem.order = index;
               index++;
             }
-            API.Course.updateProblemsOrder({
+            api.Course.updateProblemsOrder({
               course_alias: courseAlias,
               assignment_alias: assignment.alias,
               problems: assignmentProblems,
@@ -468,7 +468,7 @@ OmegaUp.on('ready', function() {
               .catch(UI.apiError);
           },
           tags: function(tags) {
-            API.Problem.list({ tag: tags.join() })
+            api.Problem.list({ tag: tags.join() })
               .then(function(data) {
                 problemList.taggedProblems = data.results;
               })
@@ -614,7 +614,7 @@ OmegaUp.on('ready', function() {
         props: { initialAlias: courseAlias, initialName: this.initialName },
         on: {
           clone: function(ev) {
-            API.Course.clone({
+            api.Course.clone({
               course_alias: courseAlias,
               name: ev.name,
               alias: ev.alias,
@@ -661,7 +661,7 @@ OmegaUp.on('ready', function() {
     }
   }
 
-  API.Course.adminDetails({ alias: courseAlias })
+  api.Course.adminDetails({ alias: courseAlias })
     .then(function(course) {
       $('.course-header')
         .text(course.name)
@@ -687,7 +687,7 @@ OmegaUp.on('ready', function() {
   }
 
   function refreshAssignmentsList() {
-    API.Course.listAssignments({ course_alias: courseAlias })
+    api.Course.listAssignments({ course_alias: courseAlias })
       .then(function(data) {
         problemList.assignments = data.assignments;
         assignmentList.assignments = data.assignments;
@@ -696,7 +696,7 @@ OmegaUp.on('ready', function() {
   }
 
   function refreshProblemList(assignment) {
-    API.Course.getAssignment({
+    api.Course.assignmentDetails({
       assignment: assignment.alias,
       course: courseAlias,
     })
@@ -707,7 +707,7 @@ OmegaUp.on('ready', function() {
   }
 
   function refreshCourseAdmins() {
-    API.Course.admins({ course_alias: courseAlias })
+    api.Course.admins({ course_alias: courseAlias })
       .then(function(data) {
         administrators.admins = data.admins;
         administrators.groupadmins = data.group_admins;

--- a/frontend/www/js/omegaup/course/scoreboard.js
+++ b/frontend/www/js/omegaup/course/scoreboard.js
@@ -1,6 +1,6 @@
 import { Arena } from '../arena/arena.js';
 import { OmegaUp } from '../omegaup';
-import API from '../api.js';
+import * as api from '../api_transitional';
 import * as UI from '../ui';
 
 OmegaUp.on('ready', function() {
@@ -22,7 +22,7 @@ OmegaUp.on('ready', function() {
   let arena = new Arena(options);
   let getRankingByTokenRefresh = 5 * 60 * 1000; // 5 minutes
 
-  API.Course.getAssignment({
+  api.Course.assignmentDetails({
     course: arena.options.courseAlias,
     assignment: arena.options.assignmentAlias,
     token: arena.options.scoreboardToken,
@@ -33,7 +33,7 @@ OmegaUp.on('ready', function() {
       arena.initClock(course.start_time, course.finish_time);
       $('#title .course-title').text(course.name);
 
-      API.Problemset.scoreboard({
+      api.Problemset.scoreboard({
         problemset_id: arena.options.problemsetId,
         token: arena.options.scoreboardToken,
       })
@@ -41,7 +41,7 @@ OmegaUp.on('ready', function() {
         .catch(UI.ignoreError);
       if (new Date() < course.finish_time && !arena.socket) {
         setInterval(function() {
-          API.Problemset.scoreboard({
+          api.Problemset.scoreboard({
             problemset_id: arena.options.problemsetId,
             token: arena.options.scoreboardToken,
           })

--- a/frontend/www/ux/assignment.js
+++ b/frontend/www/ux/assignment.js
@@ -10,7 +10,7 @@ omegaup.OmegaUp.on('ready', function() {
 
   var arenaInstance = new arena.Arena(options);
   Highcharts.setOptions({ global: { useUTC: false } });
-  omegaup.API.Course.getAssignment({
+  omegaup.API.Course.assignmentDetails({
     course: arenaInstance.options.courseAlias,
     assignment: arenaInstance.options.assignmentAlias,
   })

--- a/frontend/www/ux/assignment_admin.js
+++ b/frontend/www/ux/assignment_admin.js
@@ -19,7 +19,7 @@ omegaup.OmegaUp.on('ready', function() {
   $('#root').fadeIn('slow');
 
   Highcharts.setOptions({ global: { useUTC: false } });
-  omegaup.API.Course.getAssignment({
+  omegaup.API.Course.assignmentDetails({
     course: arenaInstance.options.courseAlias,
     assignment: arenaInstance.options.assignmentAlias,
   })


### PR DESCRIPTION
Este cambio migra todos los APIs que sólo hacen conversiones de fechas,
que ya se manejan automágicamente por `api_transitional.ts`. Lo único
que falta es poblar `show_penalty` y hacer el mapping de tipos desde el
API para no tener que hacerlo en el frontend.