### PR TITLE
Poblando `show_penalty` en los APIs de concursos

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -903,7 +903,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * @omegaup-request-param mixed $contest_alias
      *
-     * @return array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null}
+     * @return array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null}
      */
     public static function apiPublicDetails(\OmegaUp\Request $r): array {
         try {
@@ -967,6 +967,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $result['user_registration_accepted'] = $registration->accepted;
             }
         }
+        $result['show_penalty'] = (
+            $result['penalty'] !== 0 ||
+            $result['penalty_type'] !== 'none'
+        );
 
         return $result;
     }
@@ -1099,7 +1103,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Returns details of a Contest. This is shared between apiDetails and
      * apiAdminDetails.
      *
-     * @return array{admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null}
+     * @return array{admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null}
      */
     private static function getCachedDetails(
         string $contestAlias,
@@ -1108,7 +1112,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::CONTEST_INFO,
             $contestAlias,
-            /** @return array{admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null} */
+            /** @return array{admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null} */
             function () use ($contest, &$result) {
                 // Initialize response to be the contest information
                 /** @var array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null} */
@@ -1206,6 +1210,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 );
                 $result['needs_basic_information'] = $needsBasicInformation;
                 $result['requests_user_information'] = $requestsUserInformation;
+                $result['show_penalty'] = (
+                    $result['penalty'] !== 0 ||
+                    $result['penalty_type'] !== 'none'
+                );
                 return $result;
             },
             APC_USER_CACHE_CONTEST_INFO_TIMEOUT
@@ -1220,7 +1228,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $token
      *
-     * @return array{admin?: bool, admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, opened: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, scoreboard: int, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, submission_deadline?: \OmegaUp\Timestamp|null, title: string, window_length: int|null}
+     * @return array{admin?: bool, admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, opened: bool, partial_score: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, scoreboard: int, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, submission_deadline?: \OmegaUp\Timestamp|null, title: string, window_length: int|null}
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
         \OmegaUp\Validators::validateStringNonEmpty(
@@ -1288,7 +1296,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $contest_alias
      * @omegaup-request-param mixed $token
      *
-     * @return array{admin: bool, admission_mode: string, alias: string, available_languages: array<string, string>, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, partial_score: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null}
+     * @return array{admin: bool, admission_mode: string, alias: string, available_languages: array<string, string>, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, partial_score: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, problems: list<array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}>, points_decay_factor: float, problemset_id: int, requests_user_information: string, rerun_id: int, scoreboard: int, scoreboard_url: string, scoreboard_url_admin: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null}
      */
     public static function apiAdminDetails(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -579,6 +579,7 @@ remaining time from the contest, or register the opened time.
 | `scoreboard`                | `number`                                                                                                                                                                                                                                                    |
 | `scoreboard_url`            | `string`                                                                                                                                                                                                                                                    |
 | `scoreboard_url_admin`      | `string`                                                                                                                                                                                                                                                    |
+| `show_penalty`              | `boolean`                                                                                                                                                                                                                                                   |
 | `show_scoreboard_after`     | `boolean`                                                                                                                                                                                                                                                   |
 | `start_time`                | `Date`                                                                                                                                                                                                                                                      |
 | `submissions_gap`           | `number`                                                                                                                                                                                                                                                    |
@@ -796,6 +797,7 @@ in the contest, \OmegaUp\Controllers\Contest::apiOpen() must be used.
 | `problemset_id`             | `number`                                                                                                                                                                                                                                                    |
 | `requests_user_information` | `string`                                                                                                                                                                                                                                                    |
 | `scoreboard`                | `number`                                                                                                                                                                                                                                                    |
+| `show_penalty`              | `boolean`                                                                                                                                                                                                                                                   |
 | `show_scoreboard_after`     | `boolean`                                                                                                                                                                                                                                                   |
 | `start_time`                | `Date`                                                                                                                                                                                                                                                      |
 | `submissions_gap`           | `number`                                                                                                                                                                                                                                                    |
@@ -934,6 +936,7 @@ Gets the problems from a contest
 | `problemset_id`               | `number`  |
 | `rerun_id`                    | `number`  |
 | `scoreboard`                  | `number`  |
+| `show_penalty`                | `boolean` |
 | `show_scoreboard_after`       | `boolean` |
 | `start_time`                  | `Date`    |
 | `submissions_gap`             | `number`  |

--- a/frontend/www/js/omegaup/api.js
+++ b/frontend/www/js/omegaup/api.js
@@ -2,93 +2,12 @@ import * as types from './types.ts';
 import { OmegaUp } from './omegaup';
 import * as api from './api_transitional';
 
-function _normalizeContestFields(contest) {
-  OmegaUp.convertTimes(contest);
-  contest.submissions_gap = parseInt(contest.submissions_gap);
-  contest.show_penalty = contest.penalty != 0 || contest.penalty_type != 'none';
-  return contest;
-}
-
 export default {
   Badge: api.Badge,
 
   Clarification: api.Clarification,
 
-  Contest: {
-    activityReport: api.Contest.activityReport,
-
-    addAdmin: api.Contest.addAdmin,
-
-    addGroup: api.Contest.addGroup,
-
-    addGroupAdmin: api.Contest.addGroupAdmin,
-
-    addProblem: api.Contest.addProblem,
-
-    addUser: api.Contest.addUser,
-
-    adminDetails: api.apiCall('/api/contest/adminDetails/', function(contest) {
-      // We cannot use |_normalizeContestFields| because admins need to be
-      // able to get the unmodified times.
-      contest.start_time = new Date(contest.start_time * 1000);
-      contest.finish_time = new Date(contest.finish_time * 1000);
-      contest.submission_deadline = OmegaUp.remoteTime(
-        contest.submission_deadline * 1000,
-      );
-      contest.show_penalty =
-        contest.penalty != 0 || contest.penalty_type != 'none';
-      return contest;
-    }),
-
-    admins: api.Contest.admins,
-
-    arbitrateRequest: api.Contest.arbitrateRequest,
-
-    clone: api.Contest.clone,
-
-    contestants: api.Contest.contestants,
-
-    create: api.Contest.create,
-
-    createVirtual: api.Contest.createVirtual,
-
-    details: api.apiCall('/api/contest/details/', _normalizeContestFields),
-
-    list: api.Contest.list,
-
-    myList: api.Contest.myList,
-
-    open: api.Contest.open,
-
-    problems: api.Contest.problems,
-
-    publicDetails: api.apiCall(
-      '/api/contest/publicDetails/',
-      _normalizeContestFields,
-    ),
-
-    registerForContest: api.Contest.registerForContest,
-
-    removeAdmin: api.Contest.removeAdmin,
-
-    removeGroup: api.Contest.removeGroup,
-
-    removeGroupAdmin: api.Contest.removeGroupAdmin,
-
-    removeProblem: api.Contest.removeProblem,
-
-    removeUser: api.Contest.removeUser,
-
-    requests: api.Contest.requests,
-
-    runsDiff: api.Contest.runsDiff,
-
-    update: api.Contest.update,
-
-    updateEndTimeForIdentity: api.Contest.updateEndTimeForIdentity,
-
-    users: api.Contest.users,
-  },
+  Contest: api.Contest,
 
   Course: api.Course,
 

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1018,6 +1018,7 @@ export namespace messages {
     scoreboard: number;
     scoreboard_url: string;
     scoreboard_url_admin: string;
+    show_penalty: boolean;
     show_scoreboard_after: boolean;
     start_time: Date;
     submissions_gap: number;
@@ -1106,6 +1107,7 @@ export namespace messages {
     problemset_id: number;
     requests_user_information: string;
     scoreboard: number;
+    show_penalty: boolean;
     show_scoreboard_after: boolean;
     start_time: Date;
     submissions_gap: number;
@@ -1236,6 +1238,7 @@ export namespace messages {
     problemset_id: number;
     rerun_id: number;
     scoreboard: number;
+    show_penalty: boolean;
     show_scoreboard_after: boolean;
     start_time: Date;
     submissions_gap: number;


### PR DESCRIPTION
Este cambio pobla `show_penalty` desde los APIs de concursos para evitar
hacerlo desde el frontend.