### PR TITLE
Agregando Request::ensureOptionalBool()

### DIFF
--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -170,7 +170,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
 
         // Validate request
         $r->ensureInt('clarification_id');
-        $r->ensureBool('public', false /* not required */);
+        $r->ensureOptionalBool('public');
         \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['answer'],
             'answer'

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -497,7 +497,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     public static function getContestDetailsForSmarty(
         \OmegaUp\Request $r
     ): array {
-        $r->ensureBool('is_practice', false);
+        $r->ensureOptionalBool('is_practice');
 
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['contest_alias'],
@@ -1038,7 +1038,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $r->ensureBool('share_user_information', false);
+        $r->ensureOptionalBool('share_user_information');
         \OmegaUp\DAO\DAO::transBegin();
         try {
             \OmegaUp\DAO\ProblemsetIdentities::checkAndSaveFirstTimeAccess(
@@ -1699,7 +1699,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $r->ensureBool('basic_information', false);
+        $r->ensureOptionalBool('basic_information');
 
         $problemset = new \OmegaUp\DAO\VO\Problemsets([
             'needs_basic_information' => boolval($r['basic_information']),
@@ -1850,7 +1850,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         $r->ensureFloat('scoreboard', 0, 100, $isRequired);
         $r->ensureFloat('points_decay_factor', 0, 1, $isRequired);
-        $r->ensureBool('partial_score', false);
+        $r->ensureOptionalBool('partial_score');
         $r->ensureInt('submissions_gap', 0, null, $isRequired);
         // Validate the submission_gap in minutes so that the error message
         // matches what is displayed in the UI.
@@ -1926,7 +1926,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         // Show scoreboard is always optional
-        $r->ensureBool('show_scoreboard_after', false);
+        $r->ensureOptionalBool('show_scoreboard_after');
 
         // languages is always optional
         if (!empty($r['languages'])) {
@@ -3515,7 +3515,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'required',
             ]
         );
-        $r->ensureBool('basic_information', /*$required=*/ false);
+        $r->ensureOptionalBool('basic_information');
 
         self::forbiddenInVirtual($contest);
 
@@ -4354,10 +4354,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
-        // Validate value param
-        $r->ensureBool('value');
-
-        $contest->recommended = boolval($r['value']);
+        $contest->recommended = $r->ensureBool('value');
         \OmegaUp\DAO\Contests::update($contest);
 
         return ['status' => 'ok'];

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -106,13 +106,12 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
             $r['contest_alias']
         );
 
-        $r->ensureBool('only_ac');
         $r->ensureFloat('weight');
 
         \OmegaUp\DAO\GroupsScoreboardsProblemsets::create(new \OmegaUp\DAO\VO\GroupsScoreboardsProblemsets([
             'group_scoreboard_id' => $contestScoreboard['scoreboard']->group_scoreboard_id,
             'problemset_id' => $contestScoreboard['contest']->problemset_id,
-            'only_ac' => $r['only_ac'],
+            'only_ac' => $r->ensureBool('only_ac'),
             'weight' => $r['weight'],
         ]));
 

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -98,10 +98,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'problem_alias' => $r['problem_alias'],
         ];
         if (!is_null($r['email_clarifications'])) {
-            $r->ensureBool('email_clarifications', false);
-            $params['email_clarifications'] = boolval(
-                $r['email_clarifications']
-            );
+            $params['email_clarifications'] = $r->ensureOptionalBool(
+                'email_clarifications'
+            ) ?? false;
         }
         if (!is_null($r['extra_wall_time'])) {
             $params['extra_wall_time'] = intval($r['extra_wall_time']);
@@ -157,10 +156,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $params['show_diff'] = strval($r['show_diff']);
         }
         if (!is_null($r['allow_user_add_tags'])) {
-            $r->ensureBool('allow_user_add_tags', false);
-            $params['allow_user_add_tags'] = boolval(
-                $r['allow_user_add_tags']
-            );
+            $params['allow_user_add_tags'] = $r->ensureOptionalBool(
+                'allow_user_add_tags'
+            ) ?? false;
         }
         return new \OmegaUp\ProblemParams($params, $isRequired);
     }
@@ -2182,8 +2180,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $statement_type
      */
     public static function apiDetails(\OmegaUp\Request $r): array {
-        $r->ensureBool('show_solvers', /*required=*/false);
-        $r->ensureBool('prevent_problemset_open', /*required=*/false);
+        $showSolvers = $r->ensureOptionalBool('show_solvers') ?? false;
+        $preventProblemsetOptin = $r->ensureOptionalBool(
+            'prevent_problemset_open'
+        ) ?? false;
         \OmegaUp\Validators::validateOptionalStringNonEmpty($r['lang'], 'lang');
         \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['contest_alias'],
@@ -2220,7 +2220,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $problem,
             $problemset,
             strval($r['lang']),
-            boolval($r['show_solvers']),
+            $showSolvers,
             boolval($r['prevent_problemset_open']),
             $r['contest_alias']
         );
@@ -2554,8 +2554,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $problem
             )
         ) {
-            $r->ensureBool('forfeit_problem', false /*isRequired*/);
-            if ($r['forfeit_problem'] !== true) {
+            $forfeitProblem = $r->ensureOptionalBool('forfeit_problem');
+            if ($forfeitProblem !== true) {
                 throw new \OmegaUp\Exceptions\ForbiddenAccessException(
                     'problemSolutionNotVisible'
                 );
@@ -3930,7 +3930,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             // Do nothing. Not logged user can access here
             $r->identity = null;
         }
-        $r->ensureBool('prevent_problemset_open', /*required=*/false);
+        $preventProblemsetOpen = $r->ensureOptionalBool(
+            'prevent_problemset_open'
+        ) ?? false;
         \OmegaUp\Validators::validateOptionalStringNonEmpty($r['lang'], 'lang');
         \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['contest_alias'],
@@ -3962,7 +3964,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $problemset,
             strval($r['lang']),
             /*showSolvers=*/true,
-            boolval($r['prevent_problemset_open']),
+            $preventProblemsetOpen,
             $r['contest_alias']
         );
         if (is_null($details)) {

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -525,7 +525,6 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             $r['rationale'],
             'rationale'
         );
-        $r->ensureBool('all', false);
         // Validate request
         $r->ensureMainUserIdentity();
         self::validateMemberOfReviewerGroup($r);
@@ -602,7 +601,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
 
         $message = ($r['status'] === 'banned') ? 'banningProblemDueToReport' : 'banningDeclinedByReviewer';
 
-        if ($r['all']) {
+        if ($r->ensureOptionalBool('all') ?? false) {
             $nominations = \OmegaUp\DAO\QualityNominations::getAllDemotionsForProblem(
                 $qualitynomination->problem_id
             );

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1402,11 +1402,10 @@ class User extends \OmegaUp\Controllers\Controller {
                 'Identity'
             );
         }
-        $r->ensureBool('omit_rank', false);
         return self::getUserProfile(
             $r->identity,
             $identity,
-            boolval($r['omit_rank']),
+            $r->ensureOptionalBool('omit_rank') ?? false,
             $category
         );
     }
@@ -2301,8 +2300,8 @@ class User extends \OmegaUp\Controllers\Controller {
             $r->identity->language_id = $language->language_id;
         }
 
-        $r->ensureBool('is_private', false);
-        $r->ensureBool('hide_problem_tags', false);
+        $r->ensureOptionalBool('is_private');
+        $r->ensureOptionalBool('hide_problem_tags');
 
         if (!is_null($r['gender'])) {
             \OmegaUp\Validators::validateInEnum(

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -26,7 +26,8 @@ class RequestParamChecker implements
      * are enforcing the API parameter to be.
      */
     const ENSURE_TYPE_MAPPING = [
-        'OmegaUp\\Request::ensurebool' => 'bool|null',
+        'OmegaUp\\Request::ensurebool' => 'bool',
+        'OmegaUp\\Request::ensureoptionalbool' => 'bool|null',
         'OmegaUp\\Request::ensureint' => 'int',
         'OmegaUp\\Request::ensureoptionalint' => 'int|null',
         'OmegaUp\\Request::ensurefloat' => 'float|null',

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -94,9 +94,8 @@ class Request extends \ArrayObject {
      * Ensures that the value associated with the key is a bool.
      */
     public function ensureBool(
-        string $key,
-        bool $required = true
-    ): void {
+        string $key
+    ): bool {
         /** @var mixed */
         $val = $this->offsetGet($key);
         if (is_int($val)) {
@@ -104,17 +103,37 @@ class Request extends \ArrayObject {
         } elseif (is_bool($val)) {
             $this[$key] = $val;
         } else {
-            if (empty($val)) {
-                if (!$required) {
-                    return;
-                }
+            if ($val === '0' || $val === 'false') {
+                $this[$key] = false;
+            } elseif (empty($val)) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'parameterEmpty',
                     $key
                 );
+            } else {
+                $this[$key] = $val == '1' || $val == 'true';
             }
-            $this[$key] = $val == '1' || $val == 'true';
         }
+        return boolval($this[$key]);
+    }
+
+    /**
+     * Ensures that the value associated with the key is a bool or null.
+     */
+    public function ensureOptionalBool(
+        string $key,
+        bool $required = false
+    ): ?bool {
+        if (!self::offsetExists($key)) {
+            if (!$required) {
+                return null;
+            }
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                $key
+            );
+        }
+        return self::ensureBool($key);
     }
 
     /**


### PR DESCRIPTION
Este cambio permite separar los casos en los que un parámetro booleano
es requerido y cuando no.