### PR TITLE
Uprev de gitserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       dockerfile: ./Dockerfile.dev-php
       context: ./stuff/docker/
-    image: omegaup/dev-php:20200407
+    image: omegaup/dev-php:20200503
     restart: always
     volumes:
       - type: bind
@@ -27,7 +27,7 @@ services:
     build:
       dockerfile: ./Dockerfile.gitserver
       context: ./stuff/docker/
-    image: omegaup/dev-gitserver:20200407
+    image: omegaup/dev-gitserver:20200503
     restart: always
     depends_on:
       - mysql

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -27,7 +27,7 @@ RUN chmod +x /usr/bin/phpunit
 RUN curl -sL https://getcomposer.org/download/1.10.1/composer.phar -o /usr/bin/composer
 RUN chmod +x /usr/bin/composer
 
-RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.8/omegaup-gitserver.tar.xz | tar xJ -C /
+RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.9/omegaup-gitserver.tar.xz | tar xJ -C /
 
 RUN useradd --create-home --shell=/bin/bash ubuntu
 

--- a/stuff/docker/Dockerfile.gitserver
+++ b/stuff/docker/Dockerfile.gitserver
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.8/omegaup-gitserver.tar.xz | tar xJ -C /
+RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.9/omegaup-gitserver.tar.xz | tar xJ -C /
 RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar
 RUN mkdir -p /etc/omegaup/gitserver
 

--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -55,7 +55,7 @@ install_yarn() {
 }
 
 install_omegaup_gitserver() {
-	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.4.1/omegaup-gitserver.tar.xz'
+	DOWNLOAD_URL='https://github.com/omegaup/gitserver/releases/download/v1.4.9/omegaup-gitserver.tar.xz'
 	curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
 	# omegaup-gitserver depends on libinteractive.


### PR DESCRIPTION
Este cambio actualiza gitserver a v1.4.9, que permite obtener los
tamaños de los archivos de un directorio sin necesidad de obtener los
contenidos.

Part of: #990
Part of: #1998