### PR TITLE
Agregando una herramienta para facilitar la comunicación con gitserver

### DIFF
--- a/frontend/server/cmd/GitserverAuthorizationCmd.php
+++ b/frontend/server/cmd/GitserverAuthorizationCmd.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once(__DIR__ . '/../bootstrap.php');
+
+if (count($argv) < 3) {
+    echo "Usage: ${argv[0]} <problem> <username>\n";
+    die(1);
+}
+
+echo \OmegaUp\SecurityTools::getGitserverauthorizationHeader(
+    $argv[1],
+    $argv[2]
+) . "\n";


### PR DESCRIPTION
Este cambio agrega `GitserverAuthorizationCmd.php`, que genera la
cabecera de autenticación con gitserver. Esto ayuda al debugging.

Ejemplo para la máquina virtual:

```shell
curl -i \
    -H "$(php frontend/server/cmd/GitserverAuthorizationCmd.php sumas omegaup:system)" \
    http://localhost:33861/sumas/+/HEAD/
```