### PR TITLE
Soportando Request::ensureOptionalInt()

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -40,8 +40,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
         $contests = [];
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
         \OmegaUp\Validators::validateOptionalNumber($r['active'], 'active');
         \OmegaUp\Validators::validateOptionalNumber(
             $r['recommended'],
@@ -236,8 +236,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
 
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -281,8 +281,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $callbackUserFunction
     ): array {
         $r->ensureIdentity();
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -618,8 +618,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             // Do nothing.
             $r->identity = null;
         }
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -1528,7 +1528,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $originalContest->start_time->time
         );
 
-        $r->ensureInt('start_time', null, null, false);
+        $r->ensureOptionalInt('start_time');
         $startTime = (
             !is_null($r['start_time']) ?
             intval($r['start_time']) :
@@ -1826,11 +1826,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // Window_length is optional
         if (!empty($r['window_length'])) {
-            $r->ensureInt(
+            $r->ensureOptionalInt(
                 'window_length',
                 0,
-                is_null($contestLength) ? null : intval($contestLength / 60),
-                false
+                is_null($contestLength) ? null : intval($contestLength / 60)
             );
         }
 
@@ -1851,7 +1850,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $r->ensureFloat('scoreboard', 0, 100, $isRequired);
         $r->ensureFloat('points_decay_factor', 0, 1, $isRequired);
         $r->ensureOptionalBool('partial_score');
-        $r->ensureInt('submissions_gap', 0, null, $isRequired);
+        $r->ensureOptionalInt('submissions_gap', 0, null, $isRequired);
         // Validate the submission_gap in minutes so that the error message
         // matches what is displayed in the UI.
         \OmegaUp\Validators::validateNumberInRange(
@@ -2171,7 +2170,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             /*$required=*/ false
         );
         $r->ensureFloat('points', 0, INF);
-        $r->ensureInt('order_in_contest', 0, null, false);
+        $r->ensureOptionalInt('order_in_contest', 0, null);
 
         // Validate the request and get the problem and the contest in an array
         $params = self::validateAddToContestRequest(
@@ -2899,8 +2898,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
-        $r->ensureInt('offset', null, null, false /* optional */);
-        $r->ensureInt('rowcount', null, null, false /* optional */);
+        $r->ensureOptionalInt('offset' /* optional */);
+        $r->ensureOptionalInt('rowcount' /* optional */);
 
         return $contest;
     }
@@ -2916,8 +2915,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
      */
     public static function apiClarifications(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        $r->ensureInt('offset', null, null, false /* optional */);
-        $r->ensureInt('rowcount', null, null, false /* optional */);
+        $r->ensureOptionalInt('offset' /* optional */);
+        $r->ensureOptionalInt('rowcount' /* optional */);
         $contest = self::validateClarifications($r);
 
         $isContestDirector = \OmegaUp\Authorization::isContestAdmin(
@@ -3825,8 +3824,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $r->identity
         );
 
-        $r->ensureInt('offset', null, null, false);
-        $r->ensureInt('rowcount', null, null, false);
+        $r->ensureOptionalInt('offset');
+        $r->ensureOptionalInt('rowcount');
         \OmegaUp\Validators::validateOptionalInEnum(
             $r['status'],
             'status',

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -124,7 +124,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      */
     private static function validateClone(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
-        $r->ensureInt('start_time', null, null, true);
+        $r->ensureInt('start_time');
         \OmegaUp\Validators::validateValidAlias($r['alias'], 'alias', true);
     }
 
@@ -251,7 +251,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $isRequired
         );
 
-        $r->ensureInt('start_time', null, null, !$isUpdate);
+        $r->ensureOptionalInt('start_time', null, null, !$isUpdate);
         $r->ensureOptionalInt(
             'finish_time',
             null,
@@ -277,7 +277,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             ['no', 'optional', 'required']
         );
 
-        $r->ensureInt('school_id', null, null, false /*isRequired*/);
+        $r->ensureOptionalInt('school_id');
 
         if (is_null($r['school_id'])) {
             $school = null;
@@ -1336,8 +1336,8 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         $r->ensureIdentity();
 
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
@@ -3029,8 +3029,8 @@ class Course extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $r->ensureInt('offset', null, null, false);
-        $r->ensureInt('rowcount', null, null, false);
+        $r->ensureOptionalInt('offset');
+        $r->ensureOptionalInt('rowcount');
         \OmegaUp\Validators::validateOptionalInEnum(
             $r['status'],
             'status',

--- a/frontend/server/src/Controllers/Interview.php
+++ b/frontend/server/src/Controllers/Interview.php
@@ -38,7 +38,7 @@ class Interview extends \OmegaUp\Controllers\Controller {
             $r['description'],
             'description'
         );
-        $r->ensureInt('duration', 60, 60 * 5, false);
+        $r->ensureOptionalInt('duration', 60, 60 * 5);
 
         $acl = new \OmegaUp\DAO\VO\ACLs([
             'owner_id' => $r->user->user_id,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3526,8 +3526,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
 
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset(
@@ -3608,8 +3608,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $pageSize = intval($r['rowcount']);
         }
 
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = isset($r['page']) ? intval($r['page']) : 1;
 

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -771,8 +771,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         ?int $nominator,
         ?int $assignee
     ): array {
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('page_size', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page_size');
 
         $page = is_null($r['page']) ? 1 : intval($r['page']);
         $pageSize = is_null(
@@ -836,8 +836,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
 
         $r->ensureMainUserIdentity();
 
-        $r->ensureInt('offset', null, null, false);
-        $r->ensureInt('rowcount', null, null, false);
+        $r->ensureOptionalInt('offset');
+        $r->ensureOptionalInt('rowcount');
         \OmegaUp\Validators::validateOptionalInEnum(
             $r['status'],
             'status',
@@ -920,8 +920,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
 
         $r->ensureMainUserIdentity();
 
-        $r->ensureInt('offset', null, null, false);
-        $r->ensureInt('rowcount', null, null, false);
+        $r->ensureOptionalInt('offset');
+        $r->ensureOptionalInt('rowcount');
 
         $offset = is_null($r['offset']) ? 1 : intval($r['offset']);
         $rowCount = is_null(
@@ -1080,7 +1080,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         }
 
         $r->ensureMainUserIdentity();
-        $r->ensureInt('qualitynomination_id', null, null, true);
+        $r->ensureInt('qualitynomination_id');
 
         $qualityNominationId = intval($r['qualitynomination_id']);
 
@@ -1110,8 +1110,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         }
 
         $r->ensureMainUserIdentity();
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('length', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('length');
         self::validateMemberOfReviewerGroup($r);
 
         $page = is_null($r['page']) ? 1 : intval($r['page']);
@@ -1148,8 +1148,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         }
 
         $r->ensureMainUserIdentity();
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('length', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('length');
 
         $page = is_null($r['page']) ? 1 : intval($r['page']);
         $length = is_null(

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1321,11 +1321,11 @@ class Run extends \OmegaUp\Controllers\Controller {
         $r->ensureIdentity();
 
         // Defaults for offset and rowcount
-        $r->ensureInt('offset', null, null, false);
+        $r->ensureOptionalInt('offset');
         if (!isset($r['offset'])) {
             $r['offset'] = 0;
         }
-        $r->ensureInt('rowcount', null, null, false);
+        $r->ensureOptionalInt('rowcount');
         if (!isset($r['rowcount'])) {
             $r['rowcount'] = 100;
         }

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -281,8 +281,8 @@ class School extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page
      */
     public static function getRankForSmarty(\OmegaUp\Request $r): array {
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('length', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('length');
 
         $page = is_null($r['page']) ? 1 : intval($r['page']);
         $length = is_null($r['length']) ? 100 : intval($r['length']);

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -20,8 +20,8 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $username
      */
     public static function apiLatestSubmissions(\OmegaUp\Request $r) {
-        $r->ensureInt('offset', null, null, false);
-        $r->ensureInt('rowcount', null, null, false);
+        $r->ensureOptionalInt('offset');
+        $r->ensureOptionalInt('rowcount');
 
         $offset = is_null($r['offset']) ? 1 : intval($r['offset']);
         $rowCount = is_null($r['rowcount']) ? 100 : intval($r['rowcount']);
@@ -71,8 +71,8 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page
      */
     public static function getLatestSubmissionsForSmarty(\OmegaUp\Request $r): array {
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('length', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('length');
 
         $page = is_null($r['page']) ? 1 : intval($r['page']);
         $length = is_null($r['length']) ? 100 : intval($r['length']);
@@ -100,8 +100,8 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $username
      */
     public static function getLatestUserSubmissionsForSmarty(\OmegaUp\Request $r): array {
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('length', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('length');
 
         $identity = self::resolveTargetIdentity($r);
         if (is_null($identity)) {

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -3310,8 +3310,8 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page
      */
     public static function getRankForSmarty(\OmegaUp\Request $r) {
-        $r->ensureInt('page', null, null, false);
-        $r->ensureInt('length', null, null, false);
+        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('length');
         \OmegaUp\Validators::validateOptionalInEnum(
             $r['filter'],
             'filter',

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -142,13 +142,9 @@ class Request extends \ArrayObject {
     public function ensureInt(
         string $key,
         ?int $lowerBound = null,
-        ?int $upperBound = null,
-        bool $required = true
-    ): void {
+        ?int $upperBound = null
+    ): int {
         if (!self::offsetExists($key)) {
-            if (!$required) {
-                return;
-            }
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterEmpty',
                 $key
@@ -163,6 +159,7 @@ class Request extends \ArrayObject {
             $upperBound
         );
         $this[$key] = intval($val);
+        return intval($val);
     }
 
     /**
@@ -173,27 +170,17 @@ class Request extends \ArrayObject {
         ?int $lowerBound = null,
         ?int $upperBound = null,
         bool $required = false
-    ): void {
+    ): ?int {
         if (!self::offsetExists($key)) {
             if (!$required) {
-                return;
+                return null;
             }
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterEmpty',
                 $key
             );
         }
-        /** @var mixed */
-        $val = $this->offsetGet($key);
-        if (!is_null($val)) {
-            \OmegaUp\Validators::validateNumberInRange(
-                $val,
-                $key,
-                $lowerBound,
-                $upperBound
-            );
-            $this[$key] = intval($val);
-        }
+        return self::ensureInt($key, $lowerBound, $upperBound);
     }
 
     /**


### PR DESCRIPTION
Este cambio hace que sea más fácil identificar qué parámetros enteros
son requeridos y cuáles no son.