### PR TITLE
Agregando manera de cambiar los timeouts para AWS

### DIFF
--- a/stuff/bootstrap-environment.py
+++ b/stuff/bootstrap-environment.py
@@ -255,7 +255,7 @@ def main():
 
         db_migrate_args = [
             os.path.join(OMEGAUP_ROOT, 'stuff/db-migrate.py'),
-            '--kill-other-connections'
+            '--kill-other-connections',
         ]
         for name, value in [('--username', args.username),
                             ('--password', args.password),

--- a/stuff/database_utils.py
+++ b/stuff/database_utils.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-# type: ignore
 
 '''Library of utilities to work with MySQL.'''
 
@@ -9,14 +8,14 @@ import os
 import shlex
 import subprocess
 import tempfile
-from typing import Optional
+from typing import Optional, Sequence
 
 
 _MYSQL_BINARY = '/usr/bin/mysql'
 _MYSQLDUMP_BINARY = '/usr/bin/mysqldump'
 
 
-def quote(s):
+def quote(s: str) -> str:
     '''Escapes the string |s| so it can be safely used in a shell command.'''
     if 'quote' in dir(shlex):
         # This is unavailable in Python <3.3
@@ -43,8 +42,10 @@ def default_config_file() -> Optional[str]:
     return None
 
 
-def authentication(*, config_file=default_config_file(), username=None,
-                   password=None):
+def authentication(*,
+                   config_file: Optional[str] = default_config_file(),
+                   username: Optional[str] = None,
+                   password: Optional[str] = None) -> Sequence[str]:
     '''Computes the authentication arguments for mysql binaries.'''
     if config_file and os.path.isfile(config_file):
         return ['--defaults-file=%s' % quote(config_file)]
@@ -55,9 +56,12 @@ def authentication(*, config_file=default_config_file(), username=None,
     return args
 
 
-def mysql(query, *, dbname=None, auth=None):
+def mysql(query: str,
+          *,
+          dbname: Optional[str] = None,
+          auth: Sequence[str] = ()) -> str:
     '''Runs the MySQL commandline client with |query| as query.'''
-    args = [_MYSQL_BINARY] + auth
+    args = [_MYSQL_BINARY] + list(auth)
     if dbname:
         args.append(dbname)
     args.append('-NBe')
@@ -65,15 +69,24 @@ def mysql(query, *, dbname=None, auth=None):
     return subprocess.check_output(args, universal_newlines=True)
 
 
-def mysqldump(*, dbname=None, auth=None):
+def mysqldump(*,
+              dbname: Optional[str] = None,
+              auth: Sequence[str] = ()) -> bytes:
     '''Runs the mysqldump commandline tool.'''
-    args = [_MYSQLDUMP_BINARY] + auth
+    args = [_MYSQLDUMP_BINARY] + list(auth)
     if dbname:
         args.append(dbname)
-    with tempfile.NamedTemporaryFile() as outfile:
-        args.extend(['--no-data', '--skip-comments', '--skip-opt',
-                     '--create-options', '--single-transaction', '--routines',
-                     '--default-character-set=utf8',
-                     '--result-file', outfile.name])
+    with tempfile.NamedTemporaryFile(mode='rb') as outfile:
+        args.extend([
+            '--no-data',
+            '--skip-comments',
+            '--skip-opt',
+            '--create-options',
+            '--single-transaction',
+            '--routines',
+            '--default-character-set=utf8',
+            '--result-file',
+            outfile.name,
+        ])
         subprocess.check_call(args)
         return outfile.read()

--- a/stuff/db-migrate.py
+++ b/stuff/db-migrate.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# type: ignore
 # pylint: disable=invalid-name
 # This program is intended to be invoked from the console, not to be used as a
 # module.
@@ -28,13 +27,16 @@ import contextlib
 import logging
 import os.path
 import sys
+import time
+from typing import Iterator, List, Optional, Sequence, Tuple
 
 import database_utils
+from lib import aws
 
 OMEGAUP_ROOT = os.path.abspath(os.path.join(__file__, '..', '..'))
 
 
-def _revision(args, auth):
+def _revision(args: argparse.Namespace, auth: Sequence[str]) -> int:
     '''Returns the latest revision that has been applied to the database.
 
     Returns 0 if no revision has been applied.
@@ -47,12 +49,12 @@ def _revision(args, auth):
             auth=auth).strip())
 
 
-def _scripts():
+def _scripts() -> Sequence[Tuple[int, str, str]]:
     '''
     Returns the list of scripts in the frontend/database/ directory in the
     omegaUp checkout, ordered by revision.
     '''
-    scripts = []
+    scripts: List[Tuple[int, str, str]] = []
     scripts_dir = os.path.join(OMEGAUP_ROOT, 'frontend', 'database')
     for filename in os.listdir(scripts_dir):
         if not filename.endswith('.sql'):
@@ -66,53 +68,115 @@ def _scripts():
     return scripts
 
 
+def _set_aws_rds_timeout(args: argparse.Namespace,
+                         auth: Sequence[str],
+                         timeout: Optional[int] = None) -> None:
+    '''Set the MySQL through AWS RDS timeouts.'''
+    del auth  # unused
+    access_key, secret_key = aws.get_credentials(args.aws_username)
+    if timeout is None:
+        aws.request(access_key,
+                    secret_key,
+                    region=args.aws_rds_region,
+                    service='rds',
+                    request_parameters={
+                        'Action': 'ResetDBParameterGroup',
+                        'DBParameterGroupName':
+                        args.aws_rds_parameter_group_name,
+                        'Parameters.member.1.ApplyMethod': 'immediate',
+                        'Parameters.member.1.ParameterName': 'wait_timeout',
+                        'Version': '2014-09-01',
+                    })
+    else:
+        aws.request(access_key,
+                    secret_key,
+                    region=args.aws_rds_region,
+                    service='rds',
+                    request_parameters={
+                        'Action': 'ModifyDBParameterGroup',
+                        'DBParameterGroupName':
+                        args.aws_rds_parameter_group_name,
+                        'Parameters.member.1.ApplyMethod': 'immediate',
+                        'Parameters.member.1.ParameterName': 'wait_timeout',
+                        'Parameters.member.1.ParameterValue': '10',
+                        'Version': '2014-09-01',
+                    })
+
+
+def _set_mysql_timeout(args: argparse.Namespace,
+                       auth: Sequence[str],
+                       timeout: Optional[int] = None) -> None:
+    '''Set the MySQL timeouts.'''
+    del args  # unused
+    if timeout is None:
+        timeout_str = 'DEFAULT'
+    else:
+        timeout_str = str(timeout)
+    database_utils.mysql('SET GLOBAL interactive_timeout = %s;' % timeout_str,
+                         dbname='mysql',
+                         auth=auth)
+    database_utils.mysql('SET GLOBAL wait_timeout = %s;' % timeout_str,
+                         dbname='mysql',
+                         auth=auth)
+
+
 @contextlib.contextmanager
-def _kill_other_connections_wrapper(args, auth):
+def _connection_timeout_wrapper(
+        args: argparse.Namespace,
+        auth: Sequence[str],
+        lower_timeout: str = 'no',
+        kill_other_connections: bool = False) -> Iterator[None]:
     '''A context manager that temporarily lowers the wait timeout.
 
-    This also kills any existing connections to the database. By doing so, the
-    next time they connect, they will use the lowered wait timeout, which in
-    turn should make this script be able to grab any locks within ~10s.
+    This can also also optionally kill any existing connections to the
+    database. By doing so, the next time they connect, they will use the
+    lowered wait timeout, which in turn should make this script be able to grab
+    any locks within ~10s.
     '''
-    if not args.kill_other_connections:
-        yield
-        return
-
     try:
-        logging.info('Lowering MySQL timeout...')
-        database_utils.mysql(
-            'SET GLOBAL interactive_timeout = 10;', dbname='mysql', auth=auth)
-        database_utils.mysql(
-            'SET GLOBAL wait_timeout = 10;', dbname='mysql', auth=auth)
-        logging.info('Killing all other MySQL connections...')
-        for line in database_utils.mysql(
-                'SHOW FULL PROCESSLIST;', dbname='mysql',
-                auth=auth).strip().split('\n'):
-            try:
-                database_utils.mysql(
-                    'KILL %s;' % line.split()[0], dbname='mysql', auth=auth)
-            except:  # noqa: bare-except
-                # The command already logged the error. There is one unkillable
-                # system thread and one dead thread (the one that issued the
-                # `SHOW FULL PROCESSLIST;` query.
-                pass
+        if lower_timeout == 'mysql':
+            logging.info('Lowering MySQL timeout...')
+            _set_mysql_timeout(args, auth, 10)
+        elif lower_timeout == 'aws':
+            logging.info('Lowering MySQL timeout...')
+            _set_aws_rds_timeout(args, auth, 10)
+
+        if kill_other_connections:
+            logging.info('Killing all other MySQL connections...')
+            for line in database_utils.mysql(
+                    'SHOW FULL PROCESSLIST;', dbname='mysql',
+                    auth=auth).strip().split('\n'):
+                try:
+                    database_utils.mysql(
+                        'KILL %s;' % line.split()[0],
+                        dbname='mysql',
+                        auth=auth)
+                except:  # noqa: bare-except
+                    # The command already logged the error. There is one
+                    # unkillable system thread and one dead thread (the one
+                    # that issued the `SHOW FULL PROCESSLIST;` query.
+                    pass
+        else:
+            # If we are not killing connections, at least sleep on it.
+            time.sleep(10)
+
         yield
     finally:
-        logging.info('Restoring MySQL timeout...')
-        database_utils.mysql(
-            'SET GLOBAL wait_timeout = DEFAULT;', dbname='mysql', auth=auth)
-        database_utils.mysql(
-            'SET GLOBAL interactive_timeout = DEFAULT;',
-            dbname='mysql',
-            auth=auth)
+        if lower_timeout == 'mysql':
+            logging.info('Restoring MySQL timeout...')
+            _set_mysql_timeout(args, auth, None)
+        elif lower_timeout == 'aws':
+            logging.info('Restoring MySQL timeout...')
+            _set_aws_rds_timeout(args, auth, None)
 
 
-def exists(args, auth):  # pylint: disable=unused-argument
+def exists(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Determines whether the metadata database is present.
 
     Exits with 1 (error) if the metadata database has not been installed.
     This is a helper command for Puppet.
     '''
+    del args  # unused
     if not database_utils.mysql(
             'SHOW DATABASES LIKE "_omegaup_metadata";', auth=auth):
         sys.exit(1)
@@ -122,7 +186,7 @@ def exists(args, auth):  # pylint: disable=unused-argument
         sys.exit(1)
 
 
-def latest(args, auth):
+def latest(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Determines whether the latest revision is deployed.
 
     Exits with 1 (error) if the latest script in the checkout has not been
@@ -132,7 +196,9 @@ def latest(args, auth):
         sys.exit(1)
 
 
-def migrate(args, auth, update_metadata=True):
+def migrate(args: argparse.Namespace,
+            auth: Sequence[str],
+            update_metadata: bool = True) -> None:
     '''Performs the database schema migration.
 
     This command applies all scripts that have not yet been applied in order,
@@ -142,7 +208,11 @@ def migrate(args, auth, update_metadata=True):
     latest_revision = 0
     if update_metadata:
         latest_revision = _revision(args, auth)
-    with _kill_other_connections_wrapper(args, auth):
+    with _connection_timeout_wrapper(
+            args,
+            auth,
+            lower_timeout=args.lower_timeout,
+            kill_other_connections=args.kill_other_connections):
         for revision, name, path in _scripts():
             if latest_revision >= revision:
                 continue
@@ -171,8 +241,9 @@ def migrate(args, auth, update_metadata=True):
             logging.info('Done running script for revision %d', revision)
 
 
-def validate(args, auth):  # pylint: disable=unused-argument
+def validate(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Validates that the versioning is has no repeated or missing entries.'''
+    del args, auth  # unused
 
     expected_revision = 0
     valid = True
@@ -186,9 +257,11 @@ def validate(args, auth):  # pylint: disable=unused-argument
         sys.exit(1)
 
 
-def ensure(args, auth):  # pylint: disable=unused-argument
+def ensure(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Creates both the metadata database and table, if they don't exist yet.
     '''
+    del args  # unused
+
     database_utils.mysql(
         'CREATE DATABASE IF NOT EXISTS `_omegaup_metadata`;', auth=auth)
     # This is the table that tracks the migrations. |id| is the revision,
@@ -206,7 +279,7 @@ def ensure(args, auth):  # pylint: disable=unused-argument
         auth=auth)
 
 
-def reset(args, auth):
+def reset(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Forces the metadata table to be in a particular revision.
 
     Note that this does not apply or unapply any changes to the actual
@@ -225,18 +298,22 @@ def reset(args, auth):
             auth=auth)
 
 
-def print_revision(args, auth):
+def print_revision(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Prints the current revision.'''
     print(_revision(args, auth))
 
 
-def purge(args, auth):
+def purge(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Use purge to start from scratch.
 
     Drops & re-creates databases including the metadata. Note that purge will
     not re-apply the schema.
     '''
-    with _kill_other_connections_wrapper(args, auth):
+    with _connection_timeout_wrapper(
+            args,
+            auth,
+            lower_timeout=args.lower_timeout,
+            kill_other_connections=args.kill_other_connections):
         for dbname in args.databases.split(','):
             logging.info('Dropping database %s', dbname)
             database_utils.mysql(
@@ -249,7 +326,7 @@ def purge(args, auth):
             logging.info('Done creating database %s', dbname)
 
 
-def schema(args, auth):
+def schema(args: argparse.Namespace, auth: Sequence[str]) -> None:
     '''Prints the schema without modifying the usual database tables.
 
     This does touch the database, but is restricted to a dummy database
@@ -268,7 +345,7 @@ def schema(args, auth):
     database_utils.mysql('DROP DATABASE `%s`;' % _SCHEMA_DB, auth=auth)
 
 
-def main():
+def main() -> None:
     '''Main entrypoint.'''
 
     parser = argparse.ArgumentParser()
@@ -281,10 +358,26 @@ def main():
     parser.add_argument('--password', default='omegaup', help='MySQL password')
     parser.add_argument('--verbose', action='store_true')
     parser.add_argument(
+        '--aws-username',
+        default='omegaup-rds-deploy',
+        help='The name of the AWS user to change the RDS timeout')
+    parser.add_argument(
+        '--aws-rds-region',
+        default='us-east-1',
+        help='The region of the RDS database')
+    parser.add_argument(
+        '--aws-rds-parameter-group-name',
+        default='omegaup-frontend',
+        help='The name of the Parameter Group name')
+    parser.add_argument(
+        '--lower-timeout',
+        default='mysql',
+        choices=('no', 'mysql', 'aws'),
+        help='Temporarily lower the wait timeout.')
+    parser.add_argument(
         '--kill-other-connections',
         action='store_true',
-        help=('Kill all connections to MySQL and '
-              'temporarily lower the wait timeout.'))
+        help='Kill all connections to MySQL.')
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
 

--- a/stuff/lib/aws.py
+++ b/stuff/lib/aws.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+"""Library to perform calls to AWS."""
+
+import configparser
+import datetime
+import hashlib
+import hmac
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Dict, Optional, Tuple
+
+_ALGORITHM = 'AWS4-HMAC-SHA256'
+
+
+def _sign(key: bytes, msg: str) -> bytes:
+    """Perform one round of AWS HMAC signature."""
+    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+
+def _get_signature_key(key: str, date: str, region_name: str,
+                       service_name: str) -> bytes:
+    """Create the AWS signature key."""
+    key_date = _sign((f'AWS4{key}').encode('utf-8'), date)
+    key_region = _sign(key_date, region_name)
+    key_service = _sign(key_region, service_name)
+    return _sign(key_service, 'aws4_request')
+
+
+def get_credentials(aws_username: str,
+                    filename: Optional[str] = None) -> Tuple[str, str]:
+    """Get the AWS credentials from ~/.aws/credentials."""
+    if filename is None:
+        filename = os.path.join(os.environ['HOME'], '.aws/credentials')
+
+    parser = configparser.ConfigParser()
+    parser.read(filename)
+    return (parser.get(aws_username, 'aws_access_key_id'),
+            parser.get(aws_username, 'aws_secret_access_key'))
+
+
+def request(access_key: str, secret_key: str, region: str, service: str,
+            request_parameters: Dict[str, str]) -> None:
+    """Performs an AWS request.
+
+    From
+    https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
+    """
+    # pylint: disable=too-many-locals
+    now = datetime.datetime.utcnow()
+    amz_date = now.strftime('%Y%m%dT%H%M%SZ')
+    date = now.strftime('%Y%m%d')
+    host = f'{service}.{region}.amazonaws.com'
+
+    # Create the canonical request.
+    canonical_uri = '/'
+    canonical_querystring = urllib.parse.urlencode(
+        sorted(request_parameters.items()))
+    canonical_headers = f'host:{host}\nx-amz-date:{amz_date}\n'
+    signed_headers = 'host;x-amz-date'
+    payload_hash = hashlib.sha256(b'').hexdigest()
+    canonical_request = '\n'.join([
+        'GET', canonical_uri, canonical_querystring, canonical_headers,
+        signed_headers, payload_hash
+    ])
+
+    # Create the string to sign.
+    credential_scope = f'{date}/{region}/{service}/aws4_request'
+    string_to_sign = '\n'.join([
+        _ALGORITHM, amz_date, credential_scope,
+        hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()
+    ])
+
+    # Calculate the signature.
+    signing_key = _get_signature_key(secret_key, date, region, service)
+    signature = hmac.new(signing_key, string_to_sign.encode('utf-8'),
+                         hashlib.sha256).hexdigest()
+
+    # Perform the request.
+    authorization_header = (
+        f'{_ALGORITHM} Credential={access_key}/{credential_scope}, '
+        f'SignedHeaders={signed_headers}, Signature={signature}')
+    with urllib.request.urlopen(
+            urllib.request.Request(f'https://{host}/?{canonical_querystring}',
+                                   headers={
+                                       'x-amz-date': amz_date,
+                                       'Authorization': authorization_header,
+                                   })) as response:
+        response.read()


### PR DESCRIPTION
Este cambio hace que al momento de hacer deploy en producción, se pueda
cambiar los timeouts para automatizar el proceso lo más posible.