### PR TITLE
Agregando una cadenificación de \OmegaUp\Timestamp

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -877,7 +877,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 );
                 $exception->addCustomMessageToArray(
                     'start_time',
-                    $contest->start_time
+                    date('r', $contest->start_time->time)
                 );
 
                 throw $exception;


### PR DESCRIPTION
Aún no es momento de permitir que \OmegaUp\Timestamp se pueda
autocadenificar para evitar errores potenciales. Mientras tanto, este
cambio hace que se evite una excepción al intentar darle formato a una
excepción que tiene un \OmegaUp\Timestamp como parámetro adicional.