### PR TITLE
Revert "Agregando campo commit para la tabla de envíos (#3891)"

### DIFF
--- a/frontend/database/150_remove_run_commit.sql
+++ b/frontend/database/150_remove_run_commit.sql
@@ -1,0 +1,6 @@
+-- Alter Runs table
+
+ALTER TABLE
+  `Runs`
+DROP COLUMN
+  `commit`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -800,7 +800,6 @@ CREATE TABLE `Runs` (
   `run_id` int NOT NULL AUTO_INCREMENT,
   `submission_id` int NOT NULL COMMENT 'El envío',
   `version` char(40) NOT NULL COMMENT 'El hash SHA1 del árbol de la rama private.',
-  `commit` char(40) NOT NULL COMMENT 'El hash SHA1 del commit en la rama master del problema con el que se realizó el envío.',
   `status` enum('new','waiting','compiling','running','ready') NOT NULL DEFAULT 'new',
   `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL,
   `runtime` int NOT NULL DEFAULT '0',

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -466,7 +466,6 @@ class Run extends \OmegaUp\Controllers\Controller {
 
         $run = new \OmegaUp\DAO\VO\Runs([
             'version' => $problem->current_version,
-            'commit' => $problem->commit,
             'status' => 'new',
             'runtime' => 0,
             'penalty' => $submitDelay,

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -34,7 +34,6 @@ abstract class Runs {
             SET
                 `submission_id` = ?,
                 `version` = ?,
-                `commit` = ?,
                 `status` = ?,
                 `verdict` = ?,
                 `runtime` = ?,
@@ -55,7 +54,6 @@ abstract class Runs {
                 intval($Runs->submission_id)
             ),
             $Runs->version,
-            $Runs->commit,
             $Runs->status,
             $Runs->verdict,
             intval($Runs->runtime),
@@ -95,7 +93,6 @@ abstract class Runs {
                 `Runs`.`run_id`,
                 `Runs`.`submission_id`,
                 `Runs`.`version`,
-                `Runs`.`commit`,
                 `Runs`.`status`,
                 `Runs`.`verdict`,
                 `Runs`.`runtime`,
@@ -189,7 +186,6 @@ abstract class Runs {
                 `Runs`.`run_id`,
                 `Runs`.`submission_id`,
                 `Runs`.`version`,
-                `Runs`.`commit`,
                 `Runs`.`status`,
                 `Runs`.`verdict`,
                 `Runs`.`runtime`,
@@ -251,7 +247,6 @@ abstract class Runs {
                 `Runs` (
                     `submission_id`,
                     `version`,
-                    `commit`,
                     `status`,
                     `verdict`,
                     `runtime`,
@@ -272,7 +267,6 @@ abstract class Runs {
                     ?,
                     ?,
                     ?,
-                    ?,
                     ?
                 );';
         $params = [
@@ -282,7 +276,6 @@ abstract class Runs {
                 intval($Runs->submission_id)
             ),
             $Runs->version,
-            $Runs->commit,
             $Runs->status,
             $Runs->verdict,
             intval($Runs->runtime),

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -481,10 +481,10 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         $sql = '
             INSERT IGNORE INTO
                 Runs (
-                    submission_id, version, commit, verdict
+                    submission_id, version, verdict
                 )
             SELECT
-                s.submission_id, ?, ?, "JE"
+                s.submission_id, ?, "JE"
             FROM
                 Submissions s
             WHERE
@@ -495,7 +495,6 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         ';
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [
             $problemsetProblem->version,
-            $problemsetProblem->commit,
             $problemsetProblem->problemset_id,
             $problemsetProblem->problem_id,
         ]);

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -726,35 +726,6 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     }
 
     /**
-     * @return \OmegaUp\DAO\VO\Runs|null
-     */
-    final public static function getByGUID(string $guid) {
-        $sql = '
-            SELECT
-                `r`.*
-            FROM
-                `Runs` `r`
-            INNER JOIN
-                `Submissions` `s`
-            ON
-                `r`.`submission_id` = `s`.`submission_id`
-            WHERE
-                `s`.`guid` = ?
-            LIMIT
-                1;
-        ';
-
-        /** @var array{commit: string, contest_score: float|null, judged_by: null|string, memory: int, penalty: int, run_id: int, runtime: int, score: float, status: string, submission_id: int, time: \OmegaUp\Timestamp, verdict: string, version: string}|null */
-        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$guid]);
-
-        if (is_null($row)) {
-            return null;
-        }
-
-        return new \OmegaUp\DAO\VO\Runs($row);
-    }
-
-    /**
      * @return list<\OmegaUp\DAO\VO\Runs>
      */
     final public static function getByProblem(
@@ -773,7 +744,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 s.problem_id = ?;
         ';
         $params = [$problemId];
-        /** @var list<array{commit: string, contest_score: float, judged_by: string, memory: int, penalty: int, run_id: int, runtime: int, score: float, submission_id: int, status: string, time: int, verdict: string, version: string}> $rs */
+        /** @var list<array{contest_score: float, judged_by: string, memory: int, penalty: int, run_id: int, runtime: int, score: float, submission_id: int, status: string, time: int, verdict: string, version: string}> $rs */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
         $runs = [];
         foreach ($rs as $row) {
@@ -879,7 +850,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         ';
 
         $result = [];
-        /** @var array{commit: string, contest_score: float|null, judged_by: null|string, memory: int, penalty: int, run_id: int, runtime: int, score: float, status: string, submission_id: int, time: \OmegaUp\Timestamp, verdict: string, version: string} $row */
+        /** @var array{contest_score: float|null, judged_by: null|string, memory: int, penalty: int, run_id: int, runtime: int, score: float, status: string, submission_id: int, time: \OmegaUp\Timestamp, verdict: string, version: string} $row */
         foreach (
             \OmegaUp\MySQLConnection::getInstance()->GetAll(
                 $sql,
@@ -1009,10 +980,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         $sql = '
             INSERT IGNORE INTO
                 Runs (
-                    submission_id, version, commit, verdict
+                    submission_id, version, verdict
                 )
             SELECT
-                s.submission_id, ?, ?, "JE"
+                s.submission_id, ?, "JE"
             FROM
                 Submissions s
             WHERE
@@ -1020,11 +991,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             ORDER BY
                 s.submission_id;
         ';
-        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [
-            $problem->current_version,
-            $problem->commit,
-            $problem->problem_id,
-        ]);
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            $sql,
+            [$problem->current_version, $problem->problem_id]
+        );
     }
 
     /**

--- a/frontend/server/src/DAO/VO/Runs.php
+++ b/frontend/server/src/DAO/VO/Runs.php
@@ -19,7 +19,6 @@ class Runs extends \OmegaUp\DAO\VO\VO {
         'run_id' => true,
         'submission_id' => true,
         'version' => true,
-        'commit' => true,
         'status' => true,
         'verdict' => true,
         'runtime' => true,
@@ -54,11 +53,6 @@ class Runs extends \OmegaUp\DAO\VO\VO {
         if (isset($data['version'])) {
             $this->version = strval(
                 $data['version']
-            );
-        }
-        if (isset($data['commit'])) {
-            $this->commit = strval(
-                $data['commit']
             );
         }
         if (isset($data['status'])) {
@@ -140,13 +134,6 @@ class Runs extends \OmegaUp\DAO\VO\VO {
      * @var string|null
      */
     public $version = null;
-
-    /**
-     * El hash SHA1 del commit en la rama master del problema con el que se realizó el envío.
-     *
-     * @var string|null
-     */
-    public $commit = null;
 
     /**
      * [Campo no documentado]

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -210,9 +210,6 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         // Check problem submissions (1)
         $problem = \OmegaUp\DAO\Problems::getByAlias($r['problem_alias']);
         $this->assertEquals(1, $problem->submissions);
-
-        $run = \OmegaUp\DAO\Runs::getByGUID($response['guid']);
-        $this->assertEquals($problem->commit, $run->commit);
     }
 
     /**


### PR DESCRIPTION
This reverts commit 92a3d4e0acdf03e74777a36aeef42d38ca60ddb6.

Resulta que a la base de datos en producción no le gustó este cambio
porque excede el tamaño máximo configurado de la tabla. Hay que hacer
ajustes de configuración antes de reintentar :/