### PR TITLE
Migrando arena a TypeScript

### DIFF
--- a/frontend/www/js/omegaup/arena/admin_arena.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import Vue from 'vue';
 
 import * as api from '../api';

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import Vue from 'vue';
 
 import * as api from '../api';
@@ -19,7 +21,7 @@ import * as time from '../time';
 import * as typeahead from '../typeahead';
 import * as ui from '../ui';
 
-import ArenaAdmin from './admin_arena.js';
+import ArenaAdmin from './admin_arena';
 import {
   EphemeralGrader,
   EventsSocket,

--- a/frontend/www/js/omegaup/course/scoreboard.js
+++ b/frontend/www/js/omegaup/course/scoreboard.js
@@ -1,4 +1,4 @@
-import { Arena } from '../arena/arena.js';
+import { Arena } from '../arena/arena';
 import { OmegaUp } from '../omegaup';
 import * as api from '../api';
 import * as UI from '../ui';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "sortablejs": "^1.7.0",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.0.2",
-    "typescript": "^3.5.1",
+    "typescript": "^3.8.3",
     "unfetch": "^4.1.0",
     "vue-codemirror-lite": "^1.0.4",
     "vue-form-wizard": "^0.8.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ let config = [
         './frontend/www/js/omegaup/polyfills.js',
         './frontend/www/js/omegaup/omegaup.js',
       ],
-      arena: './frontend/www/js/omegaup/arena/arena.js',
+      arena: './frontend/www/js/omegaup/arena/arena.ts',
       activity_feed: './frontend/www/js/omegaup/activity/feed.js',
       admin_support: './frontend/www/js/omegaup/admin/support.js',
       admin_user: './frontend/www/js/omegaup/admin/user.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6397,10 +6397,10 @@ typescript-optional@^2.0.1:
   resolved "https://registry.yarnpkg.com/typescript-optional/-/typescript-optional-2.0.1.tgz#1dd4826bd751f78756e7eb3f96a16fbbeb3f7ee6"
   integrity sha512-xuwmqsCjE4OeeMKxbNX3jjNcISGzYh5Q9R1rM5OyxEVNIr94CB5llCkfKW+1nZTKbbUV0axN3QAUuX2fus/DhQ==
 
-typescript@^3.5.1:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 unfetch@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Esto sólo migra Arena a TypeScript en nombre, porque los archivos tienen
un comentario `// @ts-nocheck`, que deshabilita cualquier error en esos
archivos. De cualquier manera, es progreso.