### PR TITLE
Evitando enviar parámetros como la cadena `"null"` al API

### DIFF
--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -698,7 +698,10 @@ export function apiCall<
           ? {
               method: 'POST',
               body: Object.keys(params)
-                .filter(key => typeof params[key] !== 'undefined')
+                .filter(
+                  key =>
+                    params[key] !== null && typeof params[key] !== 'undefined',
+                )
                 .map(
                   key =>
                     `${encodeURIComponent(key)}=${encodeURIComponent(

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -19,7 +19,10 @@ export function apiCall<
           ? {
               method: 'POST',
               body: Object.keys(params)
-                .filter(key => typeof params[key] !== 'undefined')
+                .filter(
+                  key =>
+                    params[key] !== null && typeof params[key] !== 'undefined',
+                )
                 .map(
                   key =>
                     `${encodeURIComponent(key)}=${encodeURIComponent(


### PR DESCRIPTION
Este cambio hace que si un parámetro del API es nulo, no se envíe al
controlador. Esto evita que el controlador lo reciba como la cadena
literal `"null"`.