### PR TITLE
Permitiendo enviar fechas como parámetros al API

### DIFF
--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -702,12 +702,16 @@ export function apiCall<
                   key =>
                     params[key] !== null && typeof params[key] !== 'undefined',
                 )
-                .map(
-                  key =>
-                    `${encodeURIComponent(key)}=${encodeURIComponent(
-                      params[key],
-                    )}`,
-                )
+                .map(key => {
+                  if (params[key] instanceof Date) {
+                    return `${encodeURIComponent(key)}=${encodeURIComponent(
+                      Math.round(params[key].getTime() / 1000),
+                    )}`;
+                  }
+                  return `${encodeURIComponent(key)}=${encodeURIComponent(
+                    params[key],
+                  )}`;
+                })
                 .join('&'),
               headers: {
                 'Content-Type':

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -23,12 +23,16 @@ export function apiCall<
                   key =>
                     params[key] !== null && typeof params[key] !== 'undefined',
                 )
-                .map(
-                  key =>
-                    `${encodeURIComponent(key)}=${encodeURIComponent(
-                      params[key],
-                    )}`,
-                )
+                .map(key => {
+                  if (params[key] instanceof Date) {
+                    return `${encodeURIComponent(key)}=${encodeURIComponent(
+                      Math.round(params[key].getTime() / 1000),
+                    )}`;
+                  }
+                  return `${encodeURIComponent(key)}=${encodeURIComponent(
+                    params[key],
+                  )}`;
+                })
                 .join('&'),
               headers: {
                 'Content-Type':


### PR DESCRIPTION
Este cambio hace que si se intenta enviar una fecha al API, en vez de
cadenificarla, se envíe como timestamp UNIX.