### PR TITLE
Moviendo el manejo de codemirror a CodeView.vue

### DIFF
--- a/frontend/www/js/omegaup/components/arena/CodeView.vue
+++ b/frontend/www/js/omegaup/components/arena/CodeView.vue
@@ -1,15 +1,15 @@
 <template>
-  <omegaup-arena-codemirror
+  <codemirror-editor
     ref="cm-wrapper"
     v-bind:options="editorOptions"
     v-bind:value="value"
     v-on:change="onChange"
     v-on:input="onInput"
-  ></omegaup-arena-codemirror>
+  ></codemirror-editor>
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop, Ref, Watch } from 'vue-property-decorator';
 import T from '../../lang';
 import * as UI from '../../ui';
 import { codemirror } from 'vue-codemirror-lite';
@@ -63,16 +63,25 @@ interface EditorOptions {
 
 @Component({
   components: {
-    'omegaup-arena-codemirror': codemirror,
+    'codemirror-editor': codemirror,
   },
 })
 export default class ArenaCodeView extends Vue {
   @Prop() language!: string;
   @Prop({ default: false }) readonly!: boolean;
   @Prop() value!: string;
+  @Ref('cm-wrapper') readonly cmWrapper!: codemirror;
 
   T = T;
   mode = languageModeMap[this.language] || languageModeMap['cpp17-gcc'];
+
+  refresh() {
+    // @ts-ignore vue-codemirror-lite does not declare `editor` as a legitimate
+    // property, so TypeScript cannot know about it.
+    // It's also possible for the actual editor to not have been set yet if
+    // this method is used before the mounted event handler is called.
+    this.cmWrapper.editor?.refresh();
+  }
 
   get editorOptions(): EditorOptions {
     return {


### PR DESCRIPTION
No tiene nada de sentido tener un componente y estar haciendo que el que
lo llame ande manipulando su estado interno. Sobre todo porque hay
manera de exponer la interfaz deseada sin andar rompiendo abstracciones.