### PR TITLE
Reland "Agregando campo commit para la tabla de envíos (#3891)"

### DIFF
--- a/frontend/database/151_change_feedback_values.sql
+++ b/frontend/database/151_change_feedback_values.sql
@@ -1,0 +1,25 @@
+-- Alter Runs table
+
+ALTER TABLE
+  `Runs`
+ADD COLUMN
+  `commit` char(40) NOT NULL DEFAULT 'published'
+    AFTER `version`;
+
+-- Updating commit field
+UPDATE
+  `Runs`
+INNER JOIN
+  `Submissions` ON `Runs`.`submission_id` = `Submissions`.`submission_id`
+INNER JOIN
+  `Problems` ON `Submissions`.`problem_id` = `Problems`.`problem_id`
+SET
+  `Runs`.`commit` = `Problems`.`commit`;
+
+-- Alter table Runs, removing default value in commit column
+
+ALTER TABLE
+  `Runs`
+MODIFY COLUMN
+  `commit` char(40) NOT NULL
+    COMMENT 'El hash SHA1 del commit en la rama master del problema con el que se realizó el envío.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -800,6 +800,7 @@ CREATE TABLE `Runs` (
   `run_id` int NOT NULL AUTO_INCREMENT,
   `submission_id` int NOT NULL COMMENT 'El envío',
   `version` char(40) NOT NULL COMMENT 'El hash SHA1 del árbol de la rama private.',
+  `commit` char(40) NOT NULL COMMENT 'El hash SHA1 del commit en la rama master del problema con el que se realizó el envío.',
   `status` enum('new','waiting','compiling','running','ready') NOT NULL DEFAULT 'new',
   `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL,
   `runtime` int NOT NULL DEFAULT '0',

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -466,6 +466,7 @@ class Run extends \OmegaUp\Controllers\Controller {
 
         $run = new \OmegaUp\DAO\VO\Runs([
             'version' => $problem->current_version,
+            'commit' => $problem->commit,
             'status' => 'new',
             'runtime' => 0,
             'penalty' => $submitDelay,

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -34,6 +34,7 @@ abstract class Runs {
             SET
                 `submission_id` = ?,
                 `version` = ?,
+                `commit` = ?,
                 `status` = ?,
                 `verdict` = ?,
                 `runtime` = ?,
@@ -54,6 +55,7 @@ abstract class Runs {
                 intval($Runs->submission_id)
             ),
             $Runs->version,
+            $Runs->commit,
             $Runs->status,
             $Runs->verdict,
             intval($Runs->runtime),
@@ -93,6 +95,7 @@ abstract class Runs {
                 `Runs`.`run_id`,
                 `Runs`.`submission_id`,
                 `Runs`.`version`,
+                `Runs`.`commit`,
                 `Runs`.`status`,
                 `Runs`.`verdict`,
                 `Runs`.`runtime`,
@@ -186,6 +189,7 @@ abstract class Runs {
                 `Runs`.`run_id`,
                 `Runs`.`submission_id`,
                 `Runs`.`version`,
+                `Runs`.`commit`,
                 `Runs`.`status`,
                 `Runs`.`verdict`,
                 `Runs`.`runtime`,
@@ -247,6 +251,7 @@ abstract class Runs {
                 `Runs` (
                     `submission_id`,
                     `version`,
+                    `commit`,
                     `status`,
                     `verdict`,
                     `runtime`,
@@ -267,6 +272,7 @@ abstract class Runs {
                     ?,
                     ?,
                     ?,
+                    ?,
                     ?
                 );';
         $params = [
@@ -276,6 +282,7 @@ abstract class Runs {
                 intval($Runs->submission_id)
             ),
             $Runs->version,
+            $Runs->commit,
             $Runs->status,
             $Runs->verdict,
             intval($Runs->runtime),

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -481,10 +481,10 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         $sql = '
             INSERT IGNORE INTO
                 Runs (
-                    submission_id, version, verdict
+                    submission_id, version, commit, verdict
                 )
             SELECT
-                s.submission_id, ?, "JE"
+                s.submission_id, ?, ?, "JE"
             FROM
                 Submissions s
             WHERE
@@ -495,6 +495,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         ';
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [
             $problemsetProblem->version,
+            $problemsetProblem->commit,
             $problemsetProblem->problemset_id,
             $problemsetProblem->problem_id,
         ]);

--- a/frontend/server/src/DAO/VO/Runs.php
+++ b/frontend/server/src/DAO/VO/Runs.php
@@ -19,6 +19,7 @@ class Runs extends \OmegaUp\DAO\VO\VO {
         'run_id' => true,
         'submission_id' => true,
         'version' => true,
+        'commit' => true,
         'status' => true,
         'verdict' => true,
         'runtime' => true,
@@ -53,6 +54,11 @@ class Runs extends \OmegaUp\DAO\VO\VO {
         if (isset($data['version'])) {
             $this->version = strval(
                 $data['version']
+            );
+        }
+        if (isset($data['commit'])) {
+            $this->commit = strval(
+                $data['commit']
             );
         }
         if (isset($data['status'])) {
@@ -134,6 +140,13 @@ class Runs extends \OmegaUp\DAO\VO\VO {
      * @var string|null
      */
     public $version = null;
+
+    /**
+     * El hash SHA1 del commit en la rama master del problema con el que se realizó el envío.
+     *
+     * @var string|null
+     */
+    public $commit = null;
 
     /**
      * [Campo no documentado]

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -210,6 +210,9 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         // Check problem submissions (1)
         $problem = \OmegaUp\DAO\Problems::getByAlias($r['problem_alias']);
         $this->assertEquals(1, $problem->submissions);
+
+        $run = \OmegaUp\DAO\Runs::getByGUID($response['guid']);
+        $this->assertEquals($problem->commit, $run->commit);
     }
 
     /**


### PR DESCRIPTION
This reverts commit 33125fc70ddf2a6b20c68de925dd4e0b8e902e3d.

Este cambio re-introduce el campo commit para la tabla de envíos ahora
que ya se pudo realizar la actualización de la base de datos en producción.

Part of: #3800