### PR TITLE
Arreglando un error de jQuery

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1521,8 +1521,8 @@ export class Arena {
     const langElement = this.elements.submitForm.language;
 
     if (this.preferredLanguage) {
-      $('option', langElement).each(() => {
-        const option = $(this);
+      $('option', langElement).each((index, value) => {
+        const option = $(value);
         if (option.val() != this.preferredLanguage) return;
         option.prop('selected', true);
         return false;
@@ -1530,8 +1530,8 @@ export class Arena {
     }
     if (langElement.val()) return;
 
-    $('option', langElement).each(() => {
-      const option = $(this);
+    $('option', langElement).each((index, value) => {
+      const option = $(value);
 
       option.prop('selected', true);
       langElement.trigger('change');


### PR DESCRIPTION
Este cambio arregla un error de jQuery en el que no estaba pudiendo
actualizar los lenguajes de los problemas en la arena. Esto no estaba
haciendo reproducción en builds de desarrollador (por eso no se quejó
Travis, ni se podía hacer reproducción en local).

Esto es parte de la razón por la cual hay que Vueificar estas cosas u_u.

Fixes: #4038