### PR TITLE
Empequeñeciendo mysql_types.log

### DIFF
--- a/stuff/mysql_types.sh
+++ b/stuff/mysql_types.sh
@@ -22,7 +22,8 @@ mv "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
 mv "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
 	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.2"
 
-cat "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.1" \
+sort --unique \
+	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.1" \
 	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.2" > \
 	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log"
 


### PR DESCRIPTION
Este cambio hace que mysql_types.log contenga las entradas de-duplicadas
para evitar que sean varios Megabytes de logs. Además de hacer que
GitHub nos odie menos por andar guardando toneladas de logs sin sentido,
esto ayuda al diagnóstico de errores porque ahora hay mucho menos
información que leer en caso de que algo falle.