### PR TITLE
De-duplicando las pruebas de Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,6 @@ jobs:
     - env: TEST_SUITE=phpunit
       services:
         - mysql
-    - env: TEST_SUITE=phpunit UBUNTU=focal
-      php: 7.4.3
-      services:
-        - mysql
     - env: TEST_SUITE=lint
       addons:
         apt:

--- a/stuff/travis/phpunit.sh
+++ b/stuff/travis/phpunit.sh
@@ -4,8 +4,6 @@
 
 stage_before_install() {
 	init_submodules
-
-	# In addition to the newer PHP version, this needs MySQL 8.
 	install_mysql8
 }
 
@@ -34,26 +32,9 @@ stage_before_script() {
 stage_script() {
 	./stuff/mysql_types.sh
 
-	python3 stuff/policy-tool.py --database=omegaup-test validate
-	if [[ "${UBUNTU}" == "focal" ]]; then
-		python3 stuff/database_schema.py --database=omegaup-test validate --all < /dev/null
-	fi
-
 	# Create optional directories to simplify psalm config.
 	mkdir -p frontend/www/{phpminiadmin,preguntas}
 	touch 'frontend/server/config.php'
 	touch 'frontend/tests/test_config.php'
 	./vendor/bin/psalm
-}
-
-stage_after_success() {
-	if [[ "${UBUNTU}" != "focal" ]]; then
-		bash <(curl -s https://codecov.io/bash)
-	fi
-}
-
-stage_after_failure() {
-	if [[ "${UBUNTU}" != "focal" ]]; then
-		cat frontend/tests/controllers/gitserver.log
-	fi
 }


### PR DESCRIPTION
Dado que GitHub Actions ahora se encarga de las pruebas de PHP 7.4, no
tiene sentido hacer que Travis también corra esas pruebas. Esto debería
quitarle un poco de carga a Travis.

Part of: #4041