### PR TITLE
Agregando un GitHub Action inicial de deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+      - release
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install yarn dependencies
+        run: yarn install
+
+      - name: Build webpack resources
+        run: yarn build
+
+      - name: Upload webpack artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: webpack-artifacts
+          path: frontend/www/*/dist


### PR DESCRIPTION
Este cambio agrega un GitHub Action para crear los artefactos necesarios
para hacer un deployment. Esto únicamente sube los artefactos, no crea
el deployment aún porque es necesario hacer más pruebas para asegurarnos
que esto va a funcionar.