### PR TITLE
Eliminando un `print()` en las pruebas

### DIFF
--- a/frontend/tests/badges/legacyUserTest.php
+++ b/frontend/tests/badges/legacyUserTest.php
@@ -77,7 +77,6 @@ class LegacyUser extends \OmegaUp\Test\BadgesTestCase {
             )
         );
         $date = date_format($date, 'Y-m-d');
-        print($date);
         \OmegaUp\Time::setTimeForTesting(strtotime($date));
 
         $problemData = \OmegaUp\Test\Factories\Problem::getRequest(new \OmegaUp\Test\Factories\ProblemParams([


### PR DESCRIPTION
Este cambio elimina un `print()` que está de más en las pruebas y hace
ruido al momento de correrlas.