### PR TITLE
Usando artefactos de producción en las pruebas de Selenium

### DIFF
--- a/stuff/travis/selenium.sh
+++ b/stuff/travis/selenium.sh
@@ -58,7 +58,7 @@ stage_install() {
 	mysql -uroot -e "SET PASSWORD FOR 'root'@'localhost' = '';"
 
 	yarn install
-	yarn build-development
+	yarn build
 
 	stuff/travis/nginx/gitserver-start.sh
 


### PR DESCRIPTION
Este cambio hace que las pruebas de Selenium ya no usen `yarn
build-development`. Esto evita que se nos vayan errores causados por esa
diferencia a producción.

Fixes: #4041