### PR TITLE
Haciendo las pruebas de PHPUnit determinísticas

### DIFF
--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -617,8 +617,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             'problem_alias' => $r['problem_alias'],
         ], /*$isRequired=*/ false);
 
-        \OmegaUp\DAO\DAO::transBegin();
         try {
+            \OmegaUp\DAO\DAO::transBegin();
             \OmegaUp\Controllers\Problem::updateProblem(
                 $r->identity,
                 $r->user,
@@ -640,7 +640,6 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                     ])
                 );
             }
-            \OmegaUp\DAO\DAO::transEnd();
             if ($r['status'] == 'banned' || $r['status'] == 'warning') {
                 self::sendNotificationEmail(
                     $problem,
@@ -649,6 +648,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                     strval($r['status'])
                 );
             }
+            \OmegaUp\DAO\DAO::transEnd();
         } catch (\Exception $e) {
             \OmegaUp\DAO\DAO::transRollback();
             self::$log->error('Failed to resolve demotion request', $e);

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -8,6 +8,9 @@ namespace OmegaUp\Test;
  * @author joemmanuel
  */
 class Utils {
+    /** @var bool */
+    public static $committed = false;
+
     public static function cleanup(): void {
         /** @var string $p */
         foreach ($_REQUEST as $p) {
@@ -22,37 +25,6 @@ class Utils {
     private static function cleanPath(string $path): void {
         \OmegaUp\FileHandler::deleteDirRecursively($path);
         mkdir($path, 0755, true);
-    }
-
-    public static function deleteAllSuggestions(): void {
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            "DELETE FROM `QualityNominations` WHERE `nomination` = 'suggestion';"
-        );
-    }
-
-    public static function deleteAllRanks(): void {
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            'DELETE FROM `User_Rank`;'
-        );
-    }
-
-    public static function deleteAllPreviousRuns(): void {
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            'DELETE FROM `Submission_Log`;'
-        );
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            'UPDATE `Submissions` SET `current_run_id` = NULL;'
-        );
-        \OmegaUp\MySQLConnection::getInstance()->Execute('DELETE FROM `Runs`;');
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            'DELETE FROM `Submissions`;'
-        );
-    }
-
-    public static function deleteAllProblemsOfTheWeek(): void {
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            'DELETE FROM `Problem_Of_The_Week`;'
-        );
     }
 
     /**
@@ -137,7 +109,7 @@ class Utils {
         );
     }
 
-    public static function setUpDefaultDataConfig(): void {
+    private static function setUpDefaultDataConfig(): void {
         // Create a test default user for manual UI operations
         \OmegaUp\Controllers\User::$sendEmailOnVerify = false;
         ['user' => $admin, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser(
@@ -189,7 +161,7 @@ class Utils {
         self::CleanupDB();
     }
 
-    public static function cleanupDB(): void {
+    private static function cleanupDB(): void {
         // Tables to truncate
         $tables = [
             'ACLs',
@@ -214,6 +186,7 @@ class Utils {
             'Notifications',
             'PrivacyStatement_Consent_Log',
             'Problems',
+            'Problem_Of_The_Week',
             'Problems_Forfeited',
             'Problems_Languages',
             'Problems_Tags',
@@ -282,7 +255,19 @@ class Utils {
                 'SET foreign_key_checks = 1;'
             );
         }
-        self::commit();
+        try {
+            \OmegaUp\MySQLConnection::getInstance()->StartTrans();
+        } finally {
+            \OmegaUp\MySQLConnection::getInstance()->CompleteTrans();
+        }
+    }
+
+    public static function cleanupDBForTearDown(): void {
+        if (!self::$committed) {
+            return;
+        }
+        self::cleanupDB();
+        self::$committed = false;
     }
 
     private static function shellExec(string $command): void {
@@ -311,12 +296,10 @@ class Utils {
         }
     }
 
-    public static function commit(): void {
-        try {
-            \OmegaUp\MySQLConnection::getInstance()->StartTrans();
-        } finally {
-            \OmegaUp\MySQLConnection::getInstance()->CompleteTrans();
-        }
+    private static function commit(): void {
+        \OmegaUp\MySQLConnection::getInstance()->CompleteTrans();
+        \OmegaUp\MySQLConnection::getInstance()->StartTrans();
+        self::$committed = true;
     }
 
     public static function runUpdateRanks(
@@ -369,6 +352,21 @@ class Utils {
              escapeshellarg(strval(OMEGAUP_ROOT)) .
              '/../stuff/cron/assign_badges.py' .
              ' --verbose ' .
+             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
+             ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
+             ' --password ' . escapeshellarg(OMEGAUP_DB_PASS))
+        );
+    }
+
+    public static function runCanonicalizeTags(): void {
+        // Ensure everything is commited before invoking external script
+        self::commit();
+        self::shellExec(
+            ('python3 ' .
+             escapeshellarg(strval(OMEGAUP_ROOT)) .
+             '/../stuff/canonicalize_tags.py' .
+             ' --quiet ' .
              ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -36,8 +36,6 @@ namespace {
     \OmegaUp\Test\Utils::cleanupFilesAndDB();
     // Clean APC cache
     \OmegaUp\Cache::clearCacheForTesting();
-    \OmegaUp\Test\Factories\QualityNomination::initQualityReviewers();
-    \OmegaUp\Test\Factories\QualityNomination::initTags();
 
     \OmegaUp\Grader::setInstanceForTesting(new \OmegaUp\Test\NoOpGrader());
 }

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -163,7 +163,6 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             ->modify('first day of last month')
             ->format('Y-m-d');
 
-        \OmegaUp\Test\Utils::deleteAllPreviousRuns();
         $this->createRuns($identity, $runCreationDate, 1 /*numRuns*/);
         $this->createRuns($identity, $runCreationDate, 1 /*numRuns*/);
         $this->createRuns($extraIdentity, $runCreationDate, 1 /*numRuns*/);
@@ -228,8 +227,8 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             'category' => $category,
         ]));
 
-        // Just one Coder of The Month, the one calculated on the previous test.
-        $this->assertNotEmpty($response['coders']);
+        // There are no previous Coders of The Month.
+        $this->assertEmpty($response['coders']);
 
         // Adding parameter date should return the same value, it helps
         // to test getMonthlyList function.
@@ -239,7 +238,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             'date' => date('Y-m-d', \OmegaUp\Time::get()),
             'category' => $category,
         ]));
-        $this->assertNotEmpty($response['coders']);
+        $this->assertEmpty($response['coders']);
     }
 
     /**
@@ -291,7 +290,6 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 '-4 month'
             )
         );
-        \OmegaUp\Test\Utils::deleteAllPreviousRuns();
         $runCreationDate = date_format($runCreationDate, 'Y-m-d');
         $this->createRuns($identity1, $runCreationDate, 1 /*numRuns*/);
         \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
@@ -403,10 +401,6 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testCoderOfTheMonthAfterYear(string $category) {
         $gender = $category == 'all' ? 'male' : 'female';
-        // Cleaning Rank and Runs tables in order to avoid this test fails in
-        // the moment of calculate the coder of the month
-        \OmegaUp\Test\Utils::deleteAllRanks();
-        \OmegaUp\Test\Utils::deleteAllPreviousRuns();
         [
             'user' => $userLastYear,
             'identity' => $identity,
@@ -565,7 +559,6 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         self::updateIdentity($identity2, $gender);
         ['identity' => $identity3] = \OmegaUp\Test\Factories\User::createUser();
         self::updateIdentity($identity3, $gender);
-        \OmegaUp\Test\Utils::deleteAllPreviousRuns();
         $this->createRuns($identity1, $runCreationDate->format('Y-m-d'), 2);
         $this->createRuns($identity1, $runCreationDate->format('Y-m-d'), 4);
         $this->createRuns($identity2, $runCreationDate->format('Y-m-d'), 4);

--- a/frontend/tests/controllers/SchoolOfTheMonthTest.php
+++ b/frontend/tests/controllers/SchoolOfTheMonthTest.php
@@ -273,8 +273,6 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     public function testGetSchoolOfTheMonth() {
-        \OmegaUp\Test\Utils::cleanUpDB();
-
         $schoolsData = [
             \OmegaUp\Test\Factories\Schools::createSchool(),
             \OmegaUp\Test\Factories\Schools::createSchool(),
@@ -403,7 +401,7 @@ class SchoolOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\Time::setTimeForTesting(strtotime($nextMonthDate));
 
         $results = \OmegaUp\DAO\SchoolOfTheMonth::getSchoolsOfTheMonth();
-        $this->assertCount(3, $results);
+        $this->assertCount(1, $results);
         $this->assertEquals(
             $schoolsData[2]['school']->name,
             $results[0]['name']

--- a/frontend/tests/controllers/SubmissionsFeedTest.php
+++ b/frontend/tests/controllers/SubmissionsFeedTest.php
@@ -7,7 +7,6 @@
 
 class SubmissionsFeedTest extends \OmegaUp\Test\ControllerTestCase {
     public function testSubmissionsFeed() {
-        \OmegaUp\Test\Utils::cleanupDB();
         /**
          * Create 3 users, 3 problems and 1 contest.
          *


### PR DESCRIPTION
Este cambio hace que todas las pruebas de PHPUnit sean determinísticas.
En otras palabras, ahora no importa en qué orden se ejecuten las pruebas
(onda `phpunit --order=random`), el estado de la base de datos ahora
debería empezar desde cero para cada caso de prueba.

Esto se logra mediante el uso de transacciones que se deshacen cuando
cada caso de prueba termina. En las pruebas donde se _requiere_
persistir el estado de la base de datos (por ejemplo, si se va a correr
un script externo), la base de datos se limpia al terminar de ejecutarse
ese caso.

Este es el primer cambio para permitir la paralelización de la ejecución
de los casos de prueba, para que las pruebas corran más rápido!

Part of: #4041