### PR TITLE
Agregando scripts de release

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -1,0 +1,32 @@
+name: Daily Release
+
+# Run every day at 3:00 UTC. This translates to 20:00 PT.
+# TODO(#1624): Make this daily once we have better coverage of the frontend.
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Merge master into release
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+          if ! git diff --quiet release:frontend/database master:frontend/database; then
+            echo '::warning::Skipping release since there are database modifications'
+            exit 1
+          fi
+          if git cat-file -e master:.pause-release 2>/dev/null; then
+            echo '::warning::Skipping release since there is a `.pause-release` file.'
+            exit 1
+          fi
+
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/merges \
+            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --data "{\"base\":\"release\",\"head\":\"master\",\"commit_message\":\"Merge branch 'master' of github.com:omegaup/omegaup into release\"}"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,26 @@
+name: Weekly Release
+
+# Run every Monday at 3:00 UTC. This translates to Sunday 20:00 PT.
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Merge master into release
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          if git cat-file -e master:.pause-release 2>/dev/null; then
+            echo '::warning::Skipping release since there is a `.pause-release` file.'
+            exit 1
+          fi
+
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/merges \
+            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --data "{\"base\":\"release\",\"head\":\"master\",\"commit_message\":\"Merge branch 'master' of github.com:omegaup/omegaup into release\"}"


### PR DESCRIPTION
Este cambio agrega dos scripts de release:

* `weekly-release.yml`: Cada domingo a las 8P PT se hace merge de
  `master` a `release`. Esto no ocurre si existe un archivo llamado
  `.pause-release` en `master`.
* `daily-release.yml`: Cada sábado a las 8P PT se hace merge de
  `master` a `release`. Esto no ocurre si existe un archivo llamado
  `.pause-release` en `master` O si hay cambios al directorio
  `frontend/database/`.
  La idea es que conforme tengamos más cobertura de pruebas en el
  frontend, esto se pueda hacer cada día en vez de sólo una vez a la
  semana.

Fixes: #1624