### PR TITLE
Usando un PAT en vez de GITHUB_TOKEN

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -37,5 +37,5 @@ jobs:
         run: |
           curl --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/merges \
-            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header "Authorization: Bearer ${{ secrets.RELEASE_TOKEN }}" \
             --data "{\"base\":\"release\",\"head\":\"master\",\"commit_message\":\"Merge branch 'master' of github.com:omegaup/omegaup into release\"}"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -36,5 +36,5 @@ jobs:
         run: |
           curl --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/merges \
-            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            --header "Authorization: Bearer ${{ secrets.RELEASE_TOKEN }}" \
             --data "{\"base\":\"release\",\"head\":\"master\",\"commit_message\":\"Merge branch 'master' of github.com:omegaup/omegaup into release\"}"


### PR DESCRIPTION
Este cambio hace que el release se haga usando un PAT en vez de el token
default que está accesible a los GitHub Actions. Esto es porque ese
usuario no se puede agregar a la lista de usuarios que pueden hacer
merge a `release`.