### PR TITLE
Arreglando el contador de segundos entre envíos de un concurso

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -2018,9 +2018,7 @@ export class Arena {
     const problem = this.problems[this.currentProblem.alias];
     if (typeof problem !== 'undefined') {
       if (typeof problem.nextSubmissionTimestamp !== 'undefined') {
-        nextSubmissionTimestamp = new Date(
-          problem.nextSubmissionTimestamp.getTime(),
-        );
+        nextSubmissionTimestamp = problem.nextSubmissionTimestamp;
       } else if (
         typeof problem.runs !== 'undefined' &&
         typeof this.currentProblemset?.submissions_gap !== 'undefined' &&

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -2019,7 +2019,7 @@ export class Arena {
     if (typeof problem !== 'undefined') {
       if (typeof problem.nextSubmissionTimestamp !== 'undefined') {
         nextSubmissionTimestamp = new Date(
-          problem.nextSubmissionTimestamp.getTime() * 1000,
+          problem.nextSubmissionTimestamp.getTime(),
         );
       } else if (
         typeof problem.runs !== 'undefined' &&


### PR DESCRIPTION
# Descripción

Se arregla el contador de segundos entre envíos de un concurso. Al revisar los 
reportes anteriores de que desde el servidor si se está enviando bien la 
información, se revisa el archivo de `arena.ts` y se encuentra la posible falla.

![SubmissionGap](https://user-images.githubusercontent.com/3230352/82761992-f1416600-9dc3-11ea-89c3-6977df2aa824.gif)


Fixes: #4098 


# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) deomegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
