### PR TITLE
Unificando las pruebas de PHPUnit

### DIFF
--- a/frontend/server/src/FileHandler.php
+++ b/frontend/server/src/FileHandler.php
@@ -39,12 +39,10 @@ class FileHandler {
     }
 
     public static function deleteDirRecursively(string $pathName): void {
-        self::$log->debug("Trying to delete dir recursively: {$pathName}");
         self::rrmdir($pathName);
     }
 
     public static function deleteFile(string $pathName): void {
-        self::$log->debug("Trying to delete file: {$pathName}");
         if (!@unlink($pathName)) {
             $errors = error_get_last();
             if (is_null($errors)) {

--- a/frontend/tests/BadgesTestCase.php
+++ b/frontend/tests/BadgesTestCase.php
@@ -26,7 +26,6 @@ class BadgesTestCase extends \OmegaUp\Test\ControllerTestCase {
     public function setUp(): void {
         parent::setUp();
         \OmegaUp\Time::setTimeForTesting(null);
-        \OmegaUp\Test\Utils::cleanupFilesAndDB();
         $this->originalFileUploader = \OmegaUp\FileHandler::getFileUploader();
         \OmegaUp\FileHandler::setFileUploaderForTesting(
             $this->createFileUploaderMock()

--- a/frontend/tests/ControllerTestCase.php
+++ b/frontend/tests/ControllerTestCase.php
@@ -43,6 +43,8 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
      */
     public function setUp(): void {
         parent::setUp();
+
+        self::log("===== Start {$this->toString()}");
         \OmegaUp\Controllers\User::$sendEmailOnVerify = false;
         \OmegaUp\Controllers\Session::setCookieOnRegisterSessionForTesting(
             false
@@ -60,6 +62,7 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
         //Clean $_REQUEST before each test
         unset($_REQUEST);
 
+        \OmegaUp\Test\Utils::cleanupProblemFiles();
         \OmegaUp\MySQLConnection::getInstance()->StartTrans();
     }
 
@@ -73,6 +76,8 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
         \OmegaUp\MySQLConnection::getInstance()->FailTrans();
         \OmegaUp\MySQLConnection::getInstance()->CompleteTrans();
         \OmegaUp\Test\Utils::cleanupDBForTearDown();
+
+        self::log("===== Stop {$this->toString()}");
     }
 
     public static function logout(): void {

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -139,28 +139,29 @@ class Utils {
         \OmegaUp\Controllers\Run::$defaultSubmissionGap = 0;
     }
 
-    public static function cleanupLogs(): void {
-        file_put_contents(OMEGAUP_LOG_FILE, '');
-        file_put_contents(OMEGAUP_MYSQL_TYPES_LOG_FILE, '');
-        file_put_contents(__DIR__ . '/controllers/gitserver.log', '');
+    public static function cleanupProblemFiles(): void {
+        $problemsGitPath = '/tmp/omegaup/problems.git';
+        self::cleanPath($problemsGitPath);
     }
 
     public static function cleanupFilesAndDB(): void {
+        // Clean log files
+        file_put_contents(OMEGAUP_LOG_FILE, '');
+        file_put_contents(OMEGAUP_MYSQL_TYPES_LOG_FILE, '');
+        file_put_contents(__DIR__ . '/controllers/gitserver.log', '');
         // Clean problems and runs path
         $runsPath = OMEGAUP_TEST_ROOT . 'submissions';
         // We need to have this directory be NOT within the /opt/omegaup directory
         // since we intend to share it through VirtualBox, and that does not support
         // mmapping files, which is needed for libgit2.
-        $problemsGitPath = '/tmp/omegaup/problems.git';
         self::cleanPath(IMAGES_PATH);
         self::cleanPath($runsPath);
         self::cleanPath(TEMPLATES_PATH);
-        self::cleanPath($problemsGitPath);
         for ($i = 0; $i < 256; $i++) {
             mkdir(sprintf('%s/%02x', $runsPath, $i), 0775, true);
         }
         // Clean DB
-        self::CleanupDB();
+        self::cleanupDB();
     }
 
     private static function cleanupDB(): void {

--- a/frontend/tests/bootstrap.php
+++ b/frontend/tests/bootstrap.php
@@ -32,10 +32,7 @@ namespace {
     require_once(OMEGAUP_ROOT . '/tests/Factories/Run.php');
     require_once(OMEGAUP_ROOT . '/tests/Factories/Schools.php');
     require_once(OMEGAUP_ROOT . '/tests/Factories/User.php');
-    \OmegaUp\Test\Utils::cleanupLogs();
     \OmegaUp\Test\Utils::cleanupFilesAndDB();
-    // Clean APC cache
-    \OmegaUp\Cache::clearCacheForTesting();
 
     \OmegaUp\Grader::setInstanceForTesting(new \OmegaUp\Test\NoOpGrader());
 }

--- a/frontend/tests/phpunit.xml
+++ b/frontend/tests/phpunit.xml
@@ -6,7 +6,18 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	stopOnFailure="false">
+	stopOnFailure="false"
+>
+	<testsuites>
+		<testsuite name="Controllers">
+			<directory>./controllers/</directory>
+		</testsuite>
+
+		<testsuite name="Badges">
+			<directory>./badges/</directory>
+		</testsuite>
+	</testsuites>
+
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">../server/</directory>

--- a/stuff/mysql_types.sh
+++ b/stuff/mysql_types.sh
@@ -11,20 +11,10 @@ OMEGAUP_ROOT=$(/usr/bin/git rev-parse --show-toplevel)
 	--bootstrap "${OMEGAUP_ROOT}/frontend/tests/bootstrap.php" \
 	--configuration="${OMEGAUP_ROOT}/frontend/tests/phpunit.xml" \
 	--coverage-clover="${OMEGAUP_ROOT}/coverage.xml" \
-	"${OMEGAUP_ROOT}/frontend/tests/controllers"
-mv "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
-	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.1"
-
-"${OMEGAUP_ROOT}/vendor/bin/phpunit" \
-	--bootstrap "${OMEGAUP_ROOT}/frontend/tests/bootstrap.php" \
-	--configuration="${OMEGAUP_ROOT}/frontend/tests/phpunit.xml" \
-	"${OMEGAUP_ROOT}/frontend/tests/badges"
-mv "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
-	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.2"
+	"${OMEGAUP_ROOT}/frontend/tests/"
 
 sort --unique \
-	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.1" \
-	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log.2" > \
+	--output "${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log" \
 	"${OMEGAUP_ROOT}/frontend/tests/controllers/mysql_types.log"
 
 python3 "${OMEGAUP_ROOT}/stuff/process_mysql_return_types.py" \


### PR DESCRIPTION
Este cambio hace que las pruebas de badges y controladores se puedan
correr en una sóla invocación. Esto debería hacer todo un poco más
rápido. Además es un paso hacia poder correr las pruebas en paralelo (en
teoría).