### PR TITLE
Evitando advertencias cuando hay reconexiones de MySQL

### DIFF
--- a/frontend/server/src/MySQLConnection.php
+++ b/frontend/server/src/MySQLConnection.php
@@ -76,7 +76,7 @@ class MySQLConnection {
         $this->_connection->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true);
 
         if (
-            !$this->_connection->real_connect(
+            !@$this->_connection->real_connect(
                 'p:' . OMEGAUP_DB_HOST,
                 OMEGAUP_DB_USER,
                 OMEGAUP_DB_PASS,


### PR DESCRIPTION
Este cambio hace que mysql_real_connect() ya no emita advertencias
cuando la base de datos se va. Esto va a ocurrir cada vez que haya
deployment, así que no es un error de verdad.