### PR TITLE
Permitiendo usar una versión local del backend en Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ frontend/www/docs/pas
 # Ignore omegaup.db
 omegaup.db
 .my.cnf
+
+# Ignore backend stuff
+stuff/docker/go/*/

--- a/docker-compose.local-backend.yml
+++ b/docker-compose.local-backend.yml
@@ -1,0 +1,31 @@
+version: '3.3'
+
+services:
+
+  gitserver:
+    build:
+      dockerfile: ./Dockerfile.local-backend
+      context: ./stuff/docker/
+    image: omegaup/local-backend
+    entrypoint: ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-gitserver"]
+
+  grader:
+    build:
+      dockerfile: ./Dockerfile.local-backend
+      context: ./stuff/docker/
+    image: omegaup/local-backend
+    entrypoint: ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-grader"]
+
+  broadcaster:
+    build:
+      dockerfile: ./Dockerfile.local-backend
+      context: ./stuff/docker/
+    image: omegaup/local-backend
+    entrypoint: ["/usr/bin/omegaup-broadcaster"]
+
+  runner:
+    build:
+      dockerfile: ./Dockerfile.local-backend
+      context: ./stuff/docker/
+    image: omegaup/local-backend
+    entrypoint: ["wait-for-it", "grader:11302", "--", "/usr/bin/omegaup-runner", "-noop-sandbox"]

--- a/stuff/docker/Dockerfile.local-backend
+++ b/stuff/docker/Dockerfile.local-backend
@@ -1,0 +1,98 @@
+FROM ubuntu:bionic AS base-builder
+
+RUN apt update && \
+    apt install -y --no-install-recommends \
+        pkg-config cmake curl ca-certificates git gcc libc-dev zlib1g-dev && \
+    /usr/sbin/update-ca-certificates && \
+    curl --location https://dl.google.com/go/go1.13.11.linux-amd64.tar.gz | \
+        tar -xz -C /usr/local && \
+    apt autoremove -y && \
+    apt clean
+ENV PATH $PATH:/usr/local/go/bin
+RUN useradd --create-home --uid 1000 --shell /bin/bash --user-group ubuntu
+
+RUN mkdir -p /home/ubuntu/go/omegaup/bin
+WORKDIR /home/ubuntu/go/omegaup
+
+ADD go/go.mod /home/ubuntu/go/omegaup/
+RUN chown -R ubuntu:ubuntu /home/ubuntu/go/
+USER ubuntu
+
+# Get dependencies.
+RUN git clone --recurse-submodules https://github.com/lhchavez/git2go
+
+RUN go get -d -tags=static github.com/lhchavez/git2go/v29@v29.0.0
+
+RUN (cd git2go && \
+     git submodule update --init && \
+     ./script/build-libgit2-static.sh)
+
+
+FROM base-builder AS quark-builder
+
+COPY go/go-base go-base/
+COPY go/quark quark/
+
+RUN export QUARK_VERSION=$(cd /home/ubuntu/go/omegaup/quark && git describe --tags) && \
+    go build -o bin/omegaup-grader \
+      -ldflags "-X main.ProgramVersion=${QUARK_VERSION}" \
+      -tags=static \
+      github.com/omegaup/quark/cmd/omegaup-grader && \
+    go build -o bin/omegaup-runner \
+      -ldflags "-X main.ProgramVersion=${QUARK_VERSION}" \
+      -tags=static \
+      github.com/omegaup/quark/cmd/omegaup-runner && \
+    go build -o bin/omegaup-broadcaster \
+      -ldflags "-X main.ProgramVersion=${QUARK_VERSION}" \
+      -tags=static \
+      github.com/omegaup/quark/cmd/omegaup-broadcaster
+
+
+FROM base-builder AS gitserver-builder
+
+COPY go/go-base go-base/
+COPY go/quark quark/
+COPY go/githttp githttp/
+COPY go/gitserver gitserver/
+
+RUN export GITSERVER_VERSION=$(cd /home/ubuntu/go/omegaup/gitserver && git describe --tags) && \
+    go build -o bin/omegaup-gitserver \
+      -ldflags "-X main.ProgramVersion=${GITSERVER_VERSION}" \
+      -tags=static \
+      github.com/omegaup/gitserver/cmd/omegaup-gitserver
+
+
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+      curl ca-certificates openjdk-11-jre-headless wait-for-it && \
+    /usr/sbin/update-ca-certificates && \
+    apt-get autoremove -y && \
+    apt-get clean
+
+RUN curl -sL \
+      https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar \
+      -o /usr/share/java/libinteractive.jar
+RUN mkdir -p /etc/omegaup/{runner,grader,broadcaster,gitserver}
+
+RUN useradd --create-home --shell=/bin/bash ubuntu
+
+RUN mkdir -p /var/log/omegaup && chown -R ubuntu /var/log/omegaup
+RUN mkdir -p /var/lib/omegaup && chown -R ubuntu /var/lib/omegaup
+
+COPY ./etc/omegaup/runner/* /etc/omegaup/runner/
+COPY ./etc/omegaup/grader/* /etc/omegaup/grader/
+COPY ./etc/omegaup/broadcaster/* /etc/omegaup/broadcaster/
+COPY ./etc/omegaup/gitserver/* /etc/omegaup/gitserver/
+
+COPY --from=quark-builder /home/ubuntu/go/omegaup/bin/omegaup-runner /usr/bin/omegaup-runner
+COPY --from=quark-builder /home/ubuntu/go/omegaup/bin/omegaup-grader /usr/bin/omegaup-grader
+COPY --from=quark-builder /home/ubuntu/go/omegaup/bin/omegaup-broadcaster /usr/bin/omegaup-broadcaster
+COPY --from=gitserver-builder /home/ubuntu/go/omegaup/bin/omegaup-gitserver /usr/bin/omegaup-gitserver
+
+USER ubuntu
+WORKDIR /var/lib
+
+CMD ["echo", "plase choose a service to run"]

--- a/stuff/docker/Dockerfile.local-backend-test
+++ b/stuff/docker/Dockerfile.local-backend-test
@@ -1,0 +1,18 @@
+FROM omegaup/local-backend-base-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+USER root
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+        curl ca-certificates openjdk-11-jre-headless && \
+    /usr/sbin/update-ca-certificates && \
+    apt-get autoremove -y && \
+    apt-get clean
+
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar \
+        -o /usr/share/java/libinteractive.jar
+
+USER ubuntu
+ADD go/Makefile /home/ubuntu/go/omegaup/
+
+CMD ["/bin/bash"]

--- a/stuff/docker/go/Makefile
+++ b/stuff/docker/go/Makefile
@@ -1,0 +1,21 @@
+.PHONY: test
+test: test-quark test-gitserver
+
+.PHONY: test-quark
+test-quark: .get-stamp
+	go test -tags=static \
+		github.com/omegaup/quark/...
+
+.PHONY: test-gitserver
+test-gitserver: .get-stamp
+	go test -tags=static \
+		github.com/omegaup/gitserver/...
+
+.get-stamp:
+	go get -t -tags=static \
+		github.com/omegaup/go-base \
+		github.com/omegaup/quark \
+		github.com/omegaup/githttp \
+		github.com/omegaup/gitserver
+	touch $@
+

--- a/stuff/docker/go/go.mod
+++ b/stuff/docker/go/go.mod
@@ -1,0 +1,13 @@
+module github.com/omegaup
+
+go 1.13
+
+replace github.com/lhchavez/git2go/v29 => ./git2go
+
+replace github.com/omegaup/githttp => ./githttp
+
+replace github.com/omegaup/gitserver => ./gitserver
+
+replace github.com/omegaup/go-base => ./go-base
+
+replace github.com/omegaup/quark => ./quark

--- a/stuff/docker/go/test.sh
+++ b/stuff/docker/go/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+DIR="$(realpath "$(dirname "$(dirname "${0}")")")"
+
+if [[ ! -d "${DIR}/go/go-base" ]]; then
+	git clone https://github.com/omegaup/go-base.git "${DIR}/go/go-base"
+fi
+if [[ ! -d "${DIR}/go/quark" ]]; then
+	git clone https://github.com/omegaup/quark.git "${DIR}/go/quark"
+fi
+if [[ ! -d "${DIR}/go/githttp" ]]; then
+	git clone https://github.com/omegaup/githttp.git "${DIR}/go/githttp"
+fi
+if [[ ! -d "${DIR}/go/gitserver" ]]; then
+	git clone https://github.com/omegaup/gitserver.git "${DIR}/go/gitserver"
+fi
+
+docker build \
+	--target=base-builder \
+	--tag=omegaup/local-backend-base-builder \
+	--file="${DIR}/Dockerfile.local-backend" \
+	"${DIR}"
+docker build \
+	--tag=omegaup/local-backend-test \
+	--file="${DIR}/Dockerfile.local-backend-test" \
+	"${DIR}"
+docker run \
+	--rm \
+	--interactive \
+	--tty \
+	--name=dev-backend-test-local \
+	--mount "type=bind,source=${DIR}/go/go-base,target=/home/ubuntu/go/omegaup/go-base" \
+	--mount "type=bind,source=${DIR}/go/quark,target=/home/ubuntu/go/omegaup/quark" \
+	--mount "type=bind,source=${DIR}/go/githttp,target=/home/ubuntu/go/omegaup/githttp" \
+	--mount "type=bind,source=${DIR}/go/gitserver,target=/home/ubuntu/go/omegaup/gitserver" \
+	omegaup/local-backend-test


### PR DESCRIPTION
Este cambio hace que sea posible sobreescribir la versión de los varios
binarios involucrados en el backend para poder hacer pruebas (manuales)
de integración.

Para empezar, hay que correr las pruebas, que también clona los varios
repositorios de GitHub necesarios dentro de `stuff/docker/go/*`. Esto
deja abierta una consola para poder correr `make test`, `make
test-quark` o `make test-gitserver`.

```shell
$ ./stuff/docker/go/test.sh
```

Una vez que las pruebas pasen (y que los directorios estén en estado
esperado), se puede correr el frontend junto con los servicios
reemplazados:

```shell
$ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
      docker-compose --build \
      -f docker-compose.yml \
      -f docker-compose.local-backend.yml \
      up
```