### PR TITLE
Soporte de controladores para buscar nominaciones

### DIFF
--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -831,6 +831,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $offset
      * @omegaup-request-param int $rowcount
      * @omegaup-request-param mixed $status
+     * @omegaup-request-param mixed $query
+     * @omegaup-request-param mixed $column
      */
     public static function apiList(\OmegaUp\Request $r) {
         if (OMEGAUP_LOCKDOWN) {
@@ -863,13 +865,33 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             ['promotion', 'demotion']
         );
 
+        if (!is_null($r['query'])) {
+            \OmegaUp\Validators::validateOptionalInEnum(
+                $r['column'],
+                'column',
+                ['alias','nominator_username','author_username']
+            );
+            $query = $r['query'];
+            $column = $r['column'];
+            $params = [
+                'query' => $query,
+                'column' => $column,
+            ];
+        } else {
+            $query = null;
+            $column = null;
+            $params = [];
+        }
+
         $response = \OmegaUp\DAO\QualityNominations::getNominations(
             /* nominator */ null,
             /* assignee */ null,
             $offset,
             $rowCount,
             $types,
-            $status
+            $status,
+            $query,
+            $column
         );
 
         $pagerItems = \OmegaUp\Pager::paginate(
@@ -877,7 +899,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             $rowCount,
             $offset,
             /*$adjacent=*/5,
-            /*$params=*/[]
+            /*$params=*/ $params
         );
 
         return [

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -865,7 +865,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             ['promotion', 'demotion']
         );
 
-        if (!is_null($r['query'])) {
+        if (!is_null($r['query']) && !is_null($r['column'])) {
             \OmegaUp\Validators::validateOptionalInEnum(
                 $r['column'],
                 'column',

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -871,8 +871,8 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 'column',
                 ['alias','nominator_username','author_username']
             );
-            $query = $r['query'];
-            $column = $r['column'];
+            $query = strval($r['query']);
+            $column = strval($r['column']);
             $params = [
                 'query' => $query,
                 'column' => $column,

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3283,6 +3283,8 @@ nominator or a member of the reviewer group.
 | `offset`   | `int`   |             |
 | `rowcount` | `int`   |             |
 | `status`   | `mixed` |             |
+| `query`    | `mixed` |             |
+| `column`   | `mixed` |             |
 
 ### Returns
 

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -338,7 +338,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             $params[] = $nominatorUserId;
         }
 
-        if (!is_null($query)) {
+        if (!is_null($query) && !is_null($column)) {
             // Some columns are renamed in the query.
             if ($column == 'author_username') {
                 $column = 'authorIdentity.username';

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -339,13 +339,16 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         }
 
         if (!is_null($query)) {
-            /*Because renamed columns in the query*/
+            // Some columns are renamed in the query.
             if ($column == 'author_username') {
                 $column = 'authorIdentity.username';
             } elseif ($column == 'nominator_username') {
                 $column = 'nominatorIdentity.username';
             }
-            $sqlSearch = " {$column} = '{$query}'";
+            $sqlSearch = \OmegaUp\MySQLConnection::getInstance()->escape(
+                $column
+            ) . " LIKE CONCAT('%', ?, '%')";
+            $params[] = $query;
         } else {
             $sqlSearch = '';
         }

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -262,7 +262,9 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         int $page,
         int $rowcount,
         array $types = ['demotion', 'promotion'],
-        string $status = 'all'
+        string $status = 'all',
+        ?string $query = null,
+        ?string $column = null
     ): array {
         $offset = ($page - 1) * $rowcount;
         $sqlFrom = '
@@ -336,8 +338,28 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             $params[] = $nominatorUserId;
         }
 
+        if (!is_null($query)) {
+            /*Because renamed columns in the query*/
+            if ($column == 'author_username') {
+                $column = 'authorIdentity.username';
+            } elseif ($column == 'nominator_username') {
+                $column = 'nominatorIdentity.username';
+            }
+            $sqlSearch = " {$column} = '{$query}'";
+        } else {
+            $sqlSearch = '';
+        }
+
         if (!empty($conditions)) {
-            $sqlFrom .= ' WHERE ' . implode(' AND ', $conditions);
+            $sqlFrom .= ' WHERE ' . implode(
+                ' AND ',
+                $conditions
+            );
+            if (!is_null($query)) {
+                $sqlFrom .= " AND {$sqlSearch} ";
+            }
+        } else {
+            $sqlFrom .= " WHERE {$sqlSearch} ";
         }
 
         if ($status != 'all') {


### PR DESCRIPTION
# Descripción

Soporte para poder buscar nominaciones de acuerdo algunas columnas

Part of: #4043 


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
