### PR TITLE
Migrando a BS4 el formulario de nuevo problema

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4543,7 +4543,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param mixed $visibility
      *
-     * @return array{smartyProperties: array{problemNewPayload: ProblemFormPayload}, template: string}
+     * @return array{smartyProperties: array{payload: ProblemFormPayload}, entrypoint: string}
      */
     public static function getProblemNewForSmarty(
         \OmegaUp\Request $r
@@ -4583,7 +4583,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 }
                 return [
                     'smartyProperties' => [
-                        'problemNewPayload' => array_merge(
+                        'payload' => array_merge(
                             [
                                 'title' => strval($r['title']),
                                 'alias' => strval($r['problem_alias']),
@@ -4615,7 +4615,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                             self::getCommonPayloadForSmarty()
                         ),
                     ],
-                    'template' => 'problem.new.tpl',
+                    'entrypoint' => 'problem_new',
                 ];
             }
         }
@@ -4624,7 +4624,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         return [
             'smartyProperties' => [
-                'problemNewPayload' => array_merge(
+                'payload' => array_merge(
                     [
                         'title' => '',
                         'alias' => '',
@@ -4651,7 +4651,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     self::getCommonPayloadForSmarty()
                 ),
             ],
-            'template' => 'problem.new.tpl',
+            'entrypoint' => 'problem_new',
         ];
     }
 

--- a/frontend/templates/problem.new.tpl
+++ b/frontend/templates/problem.new.tpl
@@ -1,7 +1,0 @@
-{include file='redirect.tpl' inline}
-{include file='head.tpl' navbarSection='problems' headerPayload=$headerPayload htmlTitle="{#omegaupTitleProblemNew#}" inline}
-
-<div id="problem-new"></div>
-<script type="text/json" id="problem-new-payload">{$problemNewPayload|json_encode}</script>
-{js_include entrypoint="problem_new"}
-{include file='footer.tpl' inline}

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="panel panel-primary problem-form">
-    <div class="panel-heading" v-if="!isUpdate">
-      <h3 class="panel-title">
+  <div class="card problem-form">
+    <div class="card-header" v-if="!isUpdate">
+      <h3 class="card-title">
         {{ T.problemNew }}
       </h3>
     </div>
@@ -15,7 +15,7 @@
         </strong>
       </p>
     </div>
-    <div class="panel-body">
+    <div class="card-body">
       <form
         method="POST"
         class="form"

--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -16,15 +16,15 @@
         </div>
         <div class="form-group">
           <div class="tag-list pull-left">
-            <a
-              class="tag pull-left"
-              href="#tags"
+            <button
+              type="button"
+              class="btn btn-outline-primary m-1"
               v-bind:data-key="tag.name"
               v-for="tag in tags"
               v-on:click="onAddTag(tag.name, public)"
             >
               {{ T.hasOwnProperty(tag.name) ? T[tag.name] : tag.name }}
-            </a>
+            </button>
           </div>
         </div>
         <div class="form-group">

--- a/frontend/www/js/omegaup/problem/new.ts
+++ b/frontend/www/js/omegaup/problem/new.ts
@@ -7,14 +7,12 @@ import * as ui from '../ui';
 import * as api from '../api';
 
 OmegaUp.on('ready', () => {
-  const payload = types.payloadParsers.ProblemFormPayload(
-    'problem-new-payload',
-  );
+  const payload = types.payloadParsers.ProblemFormPayload();
   if (payload.statusError) {
     ui.error(payload.statusError);
   }
   const problemNew = new Vue({
-    el: '#problem-new',
+    el: '#main-container',
     render: function(createElement) {
       return createElement('omegaup-problem-new', {
         props: {


### PR DESCRIPTION
# Descripción

Este componente ya estaba migrado a TypeScript + Vue, sólo faltaba la migración
a BS4

![ProblemNew](https://user-images.githubusercontent.com/3230352/82980061-27423e00-9fae-11ea-9dbb-0ab12e9d59a9.gif)

Fixes: #3956 

# Comentarios

Hay algunos estilos que le afectarán a `problem.edit.tpl` y  a `Tags.vue` lo recomendable
será migrarlos también a BS4 lo antes posible. 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de  omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
