### PR TITLE
Haciendo menos flaky la instalación de MySQL 8

### DIFF
--- a/stuff/travis/common.sh
+++ b/stuff/travis/common.sh
@@ -15,7 +15,11 @@ init_submodules() {
 }
 
 install_mysql8() {
-	sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8C718D3B5072E1F5
+	for _ in `seq 30`; do
+		sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8C718D3B5072E1F5 && \
+			break || \
+			sleep 1
+	done
 	wget https://repo.mysql.com/mysql-apt-config_0.8.13-1_all.deb
 	sudo dpkg -i mysql-apt-config_0.8.13-1_all.deb
 	sudo apt-get update -q


### PR DESCRIPTION
Este cambio reintenta obtener la llave con la que se firmaron los
paquetes de MySQL, que es el punto más frágil de todo el proceso.