### PR TITLE
Haciendo significativamente más rápida la compilación de JavaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "webpack": "^4.29.0",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5",
-    "webpack-node-externals": "^1.7.2",
     "wrapper-webpack-plugin": "^2.0.0"
   },
   "scripts": {

--- a/webpack.config-frontend.js
+++ b/webpack.config-frontend.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
 
@@ -9,6 +10,7 @@ const defaultBadgeIcon = fs.readFileSync('./frontend/badges/default_icon.svg');
 
 module.exports = {
   name: 'frontend',
+
   entry: {
     omegaup: [
       '@babel/polyfill',
@@ -97,13 +99,19 @@ module.exports = {
     user_privacy_policy: './frontend/www/js/omegaup/user/privacy_policy.js',
     users_rank: './frontend/www/js/omegaup/user/rank.ts',
   },
+
   output: {
     path: path.resolve(__dirname, './frontend/www/'),
     publicPath: '/',
     filename: 'js/dist/[name].js',
     library: '[name]',
     libraryTarget: 'umd',
+
+    // use absolute paths in sourcemaps (important for debugging via IDE)
+    devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+    devtoolFallbackModuleFilenameTemplate: '[absolute-resource-path]?[hash]'
   },
+
   plugins: [
     new CopyWebpackPlugin([
       {
@@ -123,7 +131,13 @@ module.exports = {
       },
     ]),
     new VueLoaderPlugin(),
+    new ForkTsCheckerWebpackPlugin({
+      vue: true,
+      formatter: 'codeframe',
+      async: false,
+    }),
   ],
+
   optimization: {
     runtimeChunk: {
       name: 'commons',
@@ -175,11 +189,18 @@ module.exports = {
       },
     },
   },
+
   module: {
+    noParse: /^(vue|vue-router|vuex|vuex-router-sync)$/,
     rules: [
       {
         test: /\.vue$/,
         loader: 'vue-loader',
+        options: {
+          compilerOptions: {
+            whitespace: 'condense',
+          },
+        },
       },
       {
         test: /\.ts$/,
@@ -187,6 +208,8 @@ module.exports = {
         exclude: /node_modules/,
         options: {
           appendTsSuffixTo: [/\.vue$/],
+          transpileOnly: true,
+          happyPackMode: false,
         },
       },
       {
@@ -210,6 +233,7 @@ module.exports = {
       },
     ],
   },
+
   resolve: {
     extensions: ['.ts', '.js', '.vue', '.json'],
     alias: {

--- a/webpack.config-test.js
+++ b/webpack.config-test.js
@@ -1,89 +1,15 @@
-const fs = require('fs');
-const path = require('path');
-const webpack = require('webpack');
-const nodeExternals = require('webpack-node-externals');
-
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-const RemoveSourceWebpackPlugin = require('remove-source-webpack-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
 
-module.exports = {
-  mode: 'development',
-  target: 'node',
+const frontendConfig = require('./webpack.config-frontend.js');
 
-  output: {
-    path: path.resolve(__dirname, './frontend/www/'),
-    publicPath: '/',
-    filename: 'js/dist/[name].js',
-    library: '[name]',
-    libraryTarget: 'umd',
+frontendConfig.mode = 'development';
+frontendConfig.target = 'node';
+frontendConfig.devtool = 'inline-cheap-module-source-map';
+delete frontendConfig.entry;
+delete frontendConfig.optimization;
+frontendConfig.plugins = frontendConfig.plugins.filter(
+    plugin => (plugin instanceof ForkTsCheckerWebpackPlugin) ||
+        (plugin instanceof VueLoaderPlugin));
 
-    // use absolute paths in sourcemaps (important for debugging via IDE)
-    devtoolModuleFilenameTemplate: '[absolute-resource-path]',
-    devtoolFallbackModuleFilenameTemplate: '[absolute-resource-path]?[hash]'
-  },
-
-  plugins: [
-    new VueLoaderPlugin(),
-    new ForkTsCheckerWebpackPlugin({
-      vue: true,
-    }),
-  ],
-  module: {
-    noParse: /^(vue|vue-router|vuex|vuex-router-sync)$/,
-    rules: [
-      {
-        test: /\.vue$/,
-        loader: 'vue-loader',
-        options: {
-          compilerOptions: {
-            whitespace: 'condense',
-          },
-        },
-      },
-      {
-        test: /\.ts$/,
-        exclude: /node_modules/,
-        loader: 'ts-loader',
-        options: {
-          appendTsSuffixTo: [/\.vue$/],
-          transpileOnly: true,
-          happyPackMode: false,
-        },
-      },
-      {
-        test: /\.js$/,
-        loader: 'babel-loader?cacheDirectory',
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.(png|jpg|gif|svg)$/,
-        loader: 'file-loader',
-        options: { name: '[name].[ext]?[hash]' },
-      },
-      {
-        test: /\.css$/,
-        loader: 'style-loader!css-loader',
-      },
-      // inline scss styles on vue components
-      {
-        test: /\.scss$/,
-        use: ['vue-style-loader', 'css-loader', 'sass-loader'],
-      },
-    ],
-  },
-  resolve: {
-    extensions: ['.ts', '.js', '.vue', '.json'],
-    alias: {
-      vue$: 'vue/dist/vue.common.js',
-      '@': path.resolve(__dirname, './frontend/www/'),
-    },
-  },
-
-  externals: [nodeExternals()],
-  devtool: 'inline-cheap-module-source-map'
-};
+module.exports = frontendConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8285,11 +8285,6 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-node-externals@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
-  integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
-
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"


### PR DESCRIPTION
Este cambio usa el módulo `fork-ts-checker-webpack-plugin`, que hace que
el análisis semántico de TypeScript se haga en paralelo al resto de la
compilación.