### PR TITLE
Pausando la actualización del Coder del Mes

### DIFF
--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -323,6 +323,7 @@ class Utils {
              escapeshellarg(strval(OMEGAUP_ROOT)) .
              '/../stuff/cron/update_ranks.py' .
              ' --verbose ' .
+             ' --update-coder-of-the-month ' .
              ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -520,16 +520,16 @@ def update_coder_of_the_month_candidates(
             1)
 
     # First make sure there are not already selected coder of the month
-        cur.execute('''
-                SELECT
-                    COUNT(*) AS `count`
-                FROM
-                    `Coder_Of_The_Month`
-                WHERE
-                    `time` = %s AND
-                    `selected_by` IS NOT NULL AND
-                    `category` = %s;
-                ''', (first_day_of_next_month, category))
+    cur.execute('''
+            SELECT
+                COUNT(*) AS `count`
+            FROM
+                `Coder_Of_The_Month`
+            WHERE
+                `time` = %s AND
+                `selected_by` IS NOT NULL AND
+                `category` = %s;
+            ''', (first_day_of_next_month, category))
     for row in cur:
         if row['count'] > 0:
             logging.info('Skipping because already exist selected coder')
@@ -667,7 +667,8 @@ def update_coder_of_the_month_candidates(
 def update_users_stats(
         cur: MySQLdb.cursors.BaseCursor,
         dbconn: MySQLdb.connections.Connection,
-        date: datetime.date) -> None:
+        date: datetime.date,
+        update_coder_of_the_month: bool) -> None:
     '''Updates all the information and ranks related to users'''
     logging.info('Updating users stats...')
     try:
@@ -686,21 +687,25 @@ def update_users_stats(
             logging.exception('Failed to update authors ranking')
             raise
 
-        try:
-            update_coder_of_the_month_candidates(cur, date, 'all')
-            dbconn.commit()
-        except:  # noqa: bare-except
-            logging.exception(
-                'Failed to update candidates to coder of the month')
-            raise
+        if update_coder_of_the_month:
+            try:
+                update_coder_of_the_month_candidates(cur, date, 'all')
+                dbconn.commit()
+            except:  # noqa: bare-except
+                logging.exception(
+                    'Failed to update candidates to coder of the month')
+                raise
 
-        try:
-            update_coder_of_the_month_candidates(cur, date, 'female')
-            dbconn.commit()
-        except:  # noqa: bare-except
-            logging.exception(
-                'Failed to update candidates to coder of the month female')
-            raise
+            try:
+                update_coder_of_the_month_candidates(cur, date, 'female')
+                dbconn.commit()
+            except:  # noqa: bare-except
+                logging.exception(
+                    'Failed to update candidates to coder of the month female')
+                raise
+        else:
+            logging.info('Skipping updating Coder of the Month')
+
         logging.info('Users stats updated')
     except:  # noqa: bare-except
         logging.exception('Failed to update all users stats')
@@ -750,6 +755,9 @@ def main() -> None:
                         type=_parse_date,
                         default=_default_date(),
                         help='The date the command should take as today')
+    parser.add_argument('--update-coder-of-the-month',
+                        action='store_true',
+                        help='Update the Coder of the Month')
     args = parser.parse_args()
     lib.logs.init(parser.prog, args)
 
@@ -758,7 +766,8 @@ def main() -> None:
     try:
         with dbconn.cursor(cursorclass=MySQLdb.cursors.DictCursor) as cur:
             update_problem_accepted_stats(cur)
-            update_users_stats(cur, dbconn, args.date)
+            update_users_stats(cur, dbconn, args.date,
+                               args.update_coder_of_the_month)
             update_schools_stats(cur, dbconn, args.date)
     finally:
         dbconn.close()


### PR DESCRIPTION
Este cambio hace que el cronjob del coder del mes deje de ejecutarse por
un tiempo. Esto hace que tengamos más tiempo para elegir al coder del
mes siguiente.