### PR TITLE
Guardando los resultados de Selenium en los artefactos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,4 +256,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test-logs
-          path: frontend/tests/runfiles/*/*.log
+          path: frontend/tests/ui/results/


### PR DESCRIPTION
Este cambio hace que si Selenium falla, se guarde el log y el screenshot
en los artefactos que se pueden descargar.