### PR TITLE
Subiendo el límite de memoria de las pruebas a 6G

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "test": "mochapack --webpack-config webpack.config-test.js --require frontend/www/js/omegaup/test.setup.js 'frontend/www/js/**/*.test.ts'",
     "test:watch": "mochapack --watch --webpack-config webpack.config-test.js --require frontend/www/js/omegaup/test.setup.js 'frontend/www/js/**/*.test.ts'",
-    "test:coverage": "cross-env NODE_ENV=coverage NODE_OPTIONS=--max-old-space-size=4096 nyc --reporter=json --reporter=text yarn run test",
+    "test:coverage": "cross-env NODE_ENV=coverage NODE_OPTIONS=--max-old-space-size=6144 nyc --reporter=json --reporter=text yarn run test",
     "dev": "cross-env webpack --config-name=frontend --watch --mode=development --display=minimal --display-chunk=false --color=true",
     "dev-all": "cross-env webpack --watch --mode=development --display=minimal --display-chunk=false --color=true",
     "build": "cross-env webpack --hide-modules --mode=production",


### PR DESCRIPTION
Este cambio usa 6 de los 7GB disponibles en GitHub Actions.