### PR TITLE
Haciendo que si se usa la consola se genere un error

### DIFF
--- a/frontend/www/js/omegaup/arena/admin_arena.test.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.test.ts
@@ -7,6 +7,16 @@ import { OmegaUp } from '../omegaup';
 describe('arena', () => {
   describe('ArenaAdmin', () => {
     before(() => {
+      // Create the mountpoint for the arena.Runs component.
+      const runsDiv = document.createElement('div');
+      runsDiv.id = 'runs';
+
+      const runsTable = document.createElement('table');
+      runsTable.className = 'runs';
+
+      runsDiv.appendChild(runsTable);
+      document.body.appendChild(runsDiv);
+
       OmegaUp.ready = true;
     });
 

--- a/frontend/www/js/omegaup/components/common/Stats.test.ts
+++ b/frontend/www/js/omegaup/components/common/Stats.test.ts
@@ -76,7 +76,7 @@ describe('Stats.vue', () => {
       time: { useUTC: true },
       title: { text: ui.formatString(T.wordsVerdictsOf, { alias: 'alias' }) },
     },
-    pendingChartsOptions: {
+    pendingChartOptions: {
       chart: {
         marginRight: 10,
         type: 'spline',

--- a/frontend/www/js/omegaup/test.setup.js
+++ b/frontend/www/js/omegaup/test.setup.js
@@ -1,9 +1,15 @@
+const util = require('util');
+
 require('jsdom-global')(undefined, {
   pretendToBeVisual: true,
   url: 'http://localhost',
 });
 global.jQuery = require('jquery');
 global.$ = global.jQuery;
+
+console.error = function() {
+  throw new Error(util.inspect(...arguments));
+};
 
 // https://github.com/vuejs/vue-test-utils/issues/936
 window.Date = Date;


### PR DESCRIPTION
Este cambio hace que si alguien usa `console.error`, se arroje un error.
Esto evita que se impriman cosas sin que nos demos cuenta.