### PR TITLE
Arreglando los nombres de los parámetros para la url de ordenar problemas

### DIFF
--- a/frontend/www/js/omegaup/problem/list.ts
+++ b/frontend/www/js/omegaup/problem/list.ts
@@ -67,7 +67,12 @@ OmegaUp.on('ready', () => {
             columnName: string,
             sortOrder: omegaup.SortOrder,
           ): void => {
-            const queryParameters = { language, query, columnName, sortOrder };
+            const queryParameters = {
+              language,
+              query,
+              order_by: columnName,
+              sort_order: sortOrder,
+            };
             window.location.replace(
               `/problem?${ui.buildURLQuery(queryParameters)}`,
             );


### PR DESCRIPTION
# Descripción

Un pequeño error que no revisé al subir el cambio de ordenar problemas.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
