### PR TITLE
Arreglando barra de navegación cuando un administrador ingresa a un curso

### DIFF
--- a/frontend/templates/arena.contest.admin.tpl
+++ b/frontend/templates/arena.contest.admin.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile=null admin=true showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true inline payload=$payload}
+{include file='arena.contest.tpl' jsfile=null admin=true showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true inline }
 {js_include entrypoint="arena_admin"}

--- a/frontend/templates/arena.contest.contestant.tpl
+++ b/frontend/templates/arena.contest.contestant.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile=null admin=false showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true payload=$payload inline}
+{include file='arena.contest.tpl' jsfile=null admin=false showClarifications=true showDeadlines=true showNavigation=true showPoints=true showRanking=true inline}
 {js_include entrypoint="arena_contest"}

--- a/frontend/templates/arena.contest.course.tpl
+++ b/frontend/templates/arena.contest.course.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile=null admin=false showClarifications=false showDeadlines=true showNavigation=true showPoints=true showRanking=$showRanking payload=$payload inArena=true inline}
+{include file='arena.contest.tpl' jsfile=null admin=false showClarifications=false showDeadlines=true showNavigation=true showPoints=true inArena=true inline}
 {js_include entrypoint="arena_assignment"}

--- a/frontend/templates/arena.contest.interview.tpl
+++ b/frontend/templates/arena.contest.interview.tpl
@@ -1,1 +1,1 @@
-{include file='arena.contest.tpl' jsfile={version_hash src='js/interviews.arena.contest.js'} admin=false showClarifications=true showDeadlines=false showNavigation=false showPoints=true showRanking=false inArena=true inline payload=[]}
+{include file='arena.contest.tpl' jsfile={version_hash src='js/interviews.arena.contest.js'} admin=false showClarifications=true showDeadlines=false showNavigation=false showPoints=true showRanking=false inArena=true inline }

--- a/frontend/templates/arena.contest.practice.tpl
+++ b/frontend/templates/arena.contest.practice.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile=null admin=false showClarifications=true showDeadlines=true showNavigation=false showPoints=false showRanking=false bodyid='practice' inline payload=$payload}
+{include file='arena.contest.tpl' jsfile=null admin=false showClarifications=true showDeadlines=true showNavigation=false showPoints=false showRanking=false bodyid='practice' inline }
 {js_include entrypoint="arena_contest"}

--- a/frontend/templates/arena.course.admin.tpl
+++ b/frontend/templates/arena.course.admin.tpl
@@ -1,2 +1,2 @@
-{include file='arena.contest.tpl' jsfile=null admin=true showClarifications=false showDeadlines=false showNavigation=true showPoints=true showRanking=true inline payload=[]}
+{include file='arena.contest.tpl' jsfile=null admin=true showClarifications=false showDeadlines=false showNavigation=true showPoints=true showRanking=true inline }
 {js_include entrypoint="arena_assignment_admin"}


### PR DESCRIPTION
# Descripción

Se arregla la barra de navegación cuando un administrador ingresa a un curso.

El problema que ocurría es que desde el archivo `.tpl` se asignaba `[]` a `payload`,
cuando anteriormente ese `payload` ya había sido poblado desde `UITools::render()`,
y como en arena se pregunta si `payload` existe para llenar el Nabvar, este llegaba
vacío y mostraba el Navbar como si no estuviera logueado el usuario.

Fixes: #4175 

# Comentarios

Otra cosa que noté de `Smarty` es que no es necesario pasar atributos de un 
template a otro con esta convención: `var=$var`, ya que pasan sin necesidad de 
agregarlos. Si creen que ese cambio no lo deba incluir en este PR, me avisan y 
lo dejamos para otra ocasión.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
