### PR TITLE
Ocultando los botones de agregar tarea/examen cuando no es admin

### DIFF
--- a/frontend/www/js/omegaup/components/course/Details.test.ts
+++ b/frontend/www/js/omegaup/components/course/Details.test.ts
@@ -9,7 +9,7 @@ import { types } from '../../api_types';
 import course_Details from './Details.vue';
 
 describe('Details.vue', () => {
-  it('Should handle empty assignments and progress', () => {
+  it('Should handle empty assignments and progress as admin', () => {
     const courseName = 'Test course';
     const wrapper = shallowMount(course_Details, {
       propsData: {
@@ -35,6 +35,39 @@ describe('Details.vue', () => {
     });
 
     expect(wrapper.text()).toContain(courseName);
+    expect(wrapper.find('a[data-button-homework]').text()).toBe(
+      T.wordsNewHomework,
+    );
+    expect(wrapper.find('a[data-button-exam]').text()).toBe(T.wordsNewExam);
+  });
+
+  it('Should handle empty assignments and progress as student', () => {
+    const courseName = 'Test course';
+    const wrapper = shallowMount(course_Details, {
+      propsData: {
+        course: <omegaup.Course>{
+          admission_mode: 'registration',
+          alias: 'test-course',
+          assignments: <omegaup.Assignment[]>[],
+          basic_information_required: false,
+          description: '# Test',
+          finish_time: null,
+          isCurator: false,
+          is_admin: false,
+          name: courseName,
+          public: true,
+          requests_user_information: 'no',
+          school_name: '',
+          show_scoreboard: false,
+          start_time: new Date(),
+          student_count: 1,
+        },
+        progress: <types.AssignmentProgress>{},
+      },
+    });
+
+    expect(wrapper.find('a[data-button-homework]').exists()).toBe(false);
+    expect(wrapper.find('a[data-button-exam]').exists()).toBe(false);
   });
 
   it('Should handle assignments without finish_time', () => {

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -112,7 +112,9 @@
       </div>
       <div class="card-footer">
         <a
+          data-button-homework
           class="btn btn-primary float-right"
+          v-if="course.is_admin"
           v-bind:href="
             `/course/${course.alias}/edit/#assignments/new/homework/`
           "
@@ -197,7 +199,9 @@
       </div>
       <div class="card-footer">
         <a
+          data-button-exam
           class="btn btn-primary float-right"
+          v-if="course.is_admin"
           v-bind:href="`/course/${course.alias}/edit/#assignments/new/test/`"
           >{{ T.wordsNewExam }}</a
         >


### PR DESCRIPTION
# Descripción

Se arregla el bug que dejaba ver el botón de crear nueva tarea o examen a 
todos los usuarios. También se agrega una prueba en `vue` para que esto no
vuelva a ocurrir.

![image](https://user-images.githubusercontent.com/3230352/84069658-7ca82300-a990-11ea-9664-352b0a107bcb.png)


Fixes: #4180 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.