### PR TITLE
Mostrando el navbar común dentro de las tareas de cursos

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2612,7 +2612,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     ],
                 ],
                 'template' => 'arena.contest.course.tpl',
-                // It only considers hide navbar inside a test/exam
+                // Navbar is only hidden during exams.
                 'inContest' => $assignment->assignment_type === 'test',
             ];
         }

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2585,6 +2585,14 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         if ($showAssignment) {
+            \OmegaUp\Validators::validateStringNonEmpty(
+                $r['assignment_alias'],
+                'assignment_alias'
+            );
+            $assignment = self::validateCourseAssignmentAlias(
+                $course,
+                $r['assignment_alias']
+            );
             return [
                 'smartyProperties' => [
                     'showRanking' => \OmegaUp\Controllers\Course::shouldShowScoreboard(
@@ -2604,7 +2612,8 @@ class Course extends \OmegaUp\Controllers\Controller {
                     ],
                 ],
                 'template' => 'arena.contest.course.tpl',
-                'inContest' => true,
+                // It only considers hide navbar inside a test/exam
+                'inContest' => $assignment->assignment_type === 'test',
             ];
         }
 

--- a/frontend/www/js/omegaup/components/common/Navbar.test.ts
+++ b/frontend/www/js/omegaup/components/common/Navbar.test.ts
@@ -1,0 +1,90 @@
+import { shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+
+import T from '../../lang';
+import * as ui from '../../ui';
+
+import common_Navbar from './Navbar.vue';
+
+describe('Navbar.vue', () => {
+  it('Should handle empty navbar (in contest only)', async () => {
+    const wrapper = shallowMount(common_Navbar, {
+      propsData: {
+        currentUsername: 'user',
+        errorMessage: null,
+        graderInfo: null,
+        graderQueueLength: -1,
+        gravatarURL51:
+          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+        inContest: true,
+        initialClarifications: [],
+        isAdmin: false,
+        isLoggedIn: true,
+        isMainUserIdentity: true,
+        isReviewer: false,
+        lockDownImage: 'data:image/png;base64...',
+        navbarSection: '',
+        omegaUpLockDown: false,
+      },
+    });
+
+    expect(wrapper.find('.nav-contests').exists()).toBe(false);
+    expect(wrapper.find('.nav-courses').exists()).toBe(false);
+    expect(wrapper.find('.nav-problems').exists()).toBe(false);
+    expect(wrapper.find('.nav-rank').exists()).toBe(false);
+  });
+
+  it('Should handle common navbar to logged user', async () => {
+    const wrapper = shallowMount(common_Navbar, {
+      propsData: {
+        currentUsername: 'user',
+        errorMessage: null,
+        graderInfo: null,
+        graderQueueLength: -1,
+        gravatarURL51:
+          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+        inContest: false,
+        initialClarifications: [],
+        isAdmin: false,
+        isLoggedIn: true,
+        isMainUserIdentity: true,
+        isReviewer: false,
+        lockDownImage: 'data:image/png;base64...',
+        navbarSection: '',
+        omegaUpLockDown: false,
+      },
+    });
+
+    expect(wrapper.find('.nav-contests').exists()).toBe(true);
+    expect(wrapper.find('.nav-courses').exists()).toBe(true);
+    expect(wrapper.find('.nav-problems').exists()).toBe(true);
+    expect(wrapper.find('.nav-rank').exists()).toBe(true);
+  });
+
+  it('Should handle common navbar to not-logged user', async () => {
+    const wrapper = shallowMount(common_Navbar, {
+      propsData: {
+        currentUsername: 'user',
+        errorMessage: null,
+        graderInfo: null,
+        graderQueueLength: -1,
+        gravatarURL51:
+          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+        inContest: false,
+        initialClarifications: [],
+        isAdmin: false,
+        isLoggedIn: false,
+        isMainUserIdentity: true,
+        isReviewer: false,
+        lockDownImage: 'data:image/png;base64...',
+        navbarSection: '',
+        omegaUpLockDown: false,
+      },
+    });
+
+    expect(wrapper.find('.nav-problems').exists()).toBe(true);
+    expect(wrapper.find('.nav-rank').exists()).toBe(true);
+    expect(wrapper.find('.navbar-right').text()).toBe(T.navLogIn);
+  });
+});


### PR DESCRIPTION
# Descripción

Se muestran todos los tabs del navbar cuando se ingresa a una tarea de curso.
Por el momento se ocultan estos tabs en los exámenes para evitar distractores.

![NavbarInCourse](https://user-images.githubusercontent.com/3230352/84076716-e37f0980-a99b-11ea-8add-362c2f2b8269.gif)

Fixes: #3618 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
