### PR TITLE
Ocultando el mini-ranking de los cursos

### DIFF
--- a/frontend/www/js/omegaup/arena/admin_arena.test.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.test.ts
@@ -22,7 +22,6 @@ describe('arena', () => {
 
     it('can be instantiated', () => {
       const options = arena.GetDefaultOptions();
-      options.contestAlias = 'test';
 
       const arenaInstance = new arena.Arena(options);
       const adminInstance = new ArenaAdmin(arenaInstance);

--- a/frontend/www/js/omegaup/arena/arena.test.ts
+++ b/frontend/www/js/omegaup/arena/arena.test.ts
@@ -52,10 +52,8 @@ describe('arena', () => {
 
     it('can be instantiated', () => {
       const options = arena.GetDefaultOptions();
-      options.contestAlias = 'test';
 
       const arenaInstance = new arena.Arena(options);
-      expect(arenaInstance.options.contestAlias).toEqual('test');
       expect(arenaInstance.problemsetAdmin).toEqual(false);
     });
   });

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -474,7 +474,10 @@ export class Arena {
       navbarPayload = JSON.parse(navbar.innerText);
     }
 
-    if (document.getElementById('arena-navbar-miniranking') !== null) {
+    if (
+      document.getElementById('arena-navbar-miniranking') !== null &&
+      this.options.contestAlias !== null
+    ) {
       this.navbarMiniRanking = new Vue({
         el: '#arena-navbar-miniranking',
         render: function(createElement) {


### PR DESCRIPTION
# Descripción

Se oculta por completo el miniranking en los cursos.

![image](https://user-images.githubusercontent.com/3230352/84085847-14673a80-a9ac-11ea-9cd3-d31ab6ec8357.png)

Fixes: #4112 

# Comentarios

Si se decide no quitar por completo y que se pueda configurar para que el profesor elija, favor de hacérmelo saber.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
