### PR TITLE
Renderizado condicional para usar grid paginator en perfil

### DIFF
--- a/frontend/www/js/omegaup/components/common/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card">
-    <h5 class="card-header">
+    <h5 class="card-header" v-if="title">
       {{ title }} <span class="badge badge-secondary">{{ items.length }}</span>
     </h5>
     <div class="card-body text-center" v-if="sortOptions.length > 0">


### PR DESCRIPTION
# Descripción

Se agrego renderizado condicional, para evitar redundancia al mostrar el titulo de la sección en las tabs en el nuevo diseño de perfil.
Antes: 
![image](https://user-images.githubusercontent.com/12377916/84216894-608bab00-aa90-11ea-9b29-ccf51af37e60.png)
Ahora:
![image](https://user-images.githubusercontent.com/12377916/84216985-9761c100-aa90-11ea-8895-9bb3216d512b.png)

Avance de: #3512 



# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
