### PR TITLE
Mejorando la manera en la que se reportan advertencias de Vue

### DIFF
--- a/frontend/www/js/omegaup/test.setup.js
+++ b/frontend/www/js/omegaup/test.setup.js
@@ -7,8 +7,11 @@ require('jsdom-global')(undefined, {
 global.jQuery = require('jquery');
 global.$ = global.jQuery;
 
+// Any write to console.error() will cause a test failure.
+const originalConsoleError = console.error;
 console.error = function() {
-  throw new Error(util.inspect(...arguments));
+  originalConsoleError(...arguments);
+  throw new Error('Unexpected call to console.error(). Failing test.');
 };
 
 // https://github.com/vuejs/vue-test-utils/issues/936


### PR DESCRIPTION
Este cambio hace que el manejador de errores global que se manda llamar
al momento de intenar escribir en la consola (mediante
`console.error()`) imprima lo que hubiera sido enviado a la consola
incondicionalmente antes de arrojar una excepción.

Esto es necesario porque el manejador de errores de Vue atrapa cualquier
error que es arrojado desde el manejador de errores, lo que ocasionaba
que el error original se perdiera.