### PR TITLE
Haciendo menos flaky la prueba de búsqueda de problemas

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -144,8 +144,12 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         if (!is_null($query)) {
             if (is_numeric($query)) {
                 $clauses[] = [
-                    'p.problem_id = ?',
-                    [intval($query)],
+                    "(
+                      p.title LIKE CONCAT('%', ?, '%') OR
+                      p.alias LIKE CONCAT('%', ?, '%') OR
+                      p.problem_id = ?
+                    )",
+                    [$query, $query, intval($query)],
                 ];
             } else {
                 $clauses[] = [

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -861,7 +861,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         // Expect public problem only
         $response = \OmegaUp\Controllers\Problem::apiList(new \OmegaUp\Request([
             'auth_token' => $userLogin->auth_token,
-            'query' => substr($problemDataPublic['request']['title'], 2, 5),
+            'query' => substr($problemDataPublic['request']['title'], 2, 8),
         ]));
         $this->assertArrayContainsInKey(
             $response['results'],
@@ -872,7 +872,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         // Expect 0 problems, matches are private for $user
         $response = \OmegaUp\Controllers\Problem::apiList(new \OmegaUp\Request([
             'auth_token' => $userLogin->auth_token,
-            'query' => substr($problemDataPrivate['request']['title'], 2, 5),
+            'query' => substr($problemDataPrivate['request']['title'], 2, 8),
         ]));
         $this->assertArrayNotContainsInKey(
             $response['results'],


### PR DESCRIPTION
Este cambio hace que la pruebas de búsqueda de problemas sea menos
flaky:

* Se le pasan más caracteres a la búsqueda para evitar falsos positivos.
* Se agrega la posibilidad de seguir buscando por subcadena en el título
  / alias, aún si el query es numérico.