### PR TITLE
Haciendo más robustas las pruebas de Selenium

### DIFF
--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -16,6 +16,7 @@ import pytest
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException, TimeoutException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
@@ -194,6 +195,27 @@ class Driver:  # pylint: disable=too-many-instance-attributes
                 (By.XPATH,
                  '//%s//div[@data-value = "%s"]' %
                  (parent_xpath, value)))).click()
+
+    def send_keys(self,  # pylint: disable=no-self-use
+                  element: WebElement,
+                  value: str,
+                  retries: int = 10) -> None:
+        '''Helper to _really_ send keys to an element.
+
+        For some yet unexplained reason when running in non-headless mode, the
+        interactions with text elements do not always register by the browser.
+        This causes input elements to remain empty even after sending the keys.
+
+        This method sends the keys and then ensures that the value of the
+        element is the expected string, retrying if necessary.
+        '''
+
+        for _ in range(retries):
+            element.clear()
+            element.send_keys(value)
+            if element.get_attribute('value') == value:
+                return
+        logging.error('Failed to send keys to the element')
 
     @contextlib.contextmanager
     def login_user(self):

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -9,7 +9,11 @@
           <div class="form-group col-md-4">
             <label
               >{{ T.wordsName }}
-              <input class="form-control name" type="text" v-model="name"
+              <input
+                class="form-control"
+                data-course-new-name
+                type="text"
+                v-model="name"
             /></label>
           </div>
           <div class="form-group col-md-4">
@@ -23,8 +27,9 @@
                 v-bind:title="T.courseNewFormShortTitle_alias_Desc"
               ></span>
               <input
-                class="form-control alias"
+                class="form-control"
                 type="text"
+                data-course-new-alias
                 v-bind:disabled="update"
                 v-model="alias"
             /></label>
@@ -232,7 +237,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
+import { types } from '../../api_types';
 import T from '../../lang';
 import * as typeahead from '../../typeahead';
 import DatePicker from '../DatePicker.vue';
@@ -243,21 +248,21 @@ import DatePicker from '../DatePicker.vue';
   },
 })
 export default class CourseDetails extends Vue {
-  @Prop() update!: boolean;
-  @Prop() course!: omegaup.Course;
+  @Prop({ default: false }) update!: boolean;
+  @Prop() course!: types.CourseDetails;
 
   T = T;
-  alias = this.course.alias || '';
-  description = this.course.description || '';
+  alias = this.course.alias;
+  description = this.course.description;
   finishTime = this.course.finish_time || new Date();
-  showScoreboard = !!this.course.show_scoreboard;
-  startTime = this.course.start_time || new Date();
-  name = this.course.name || '';
-  school_name = this.course.school_name || '';
+  showScoreboard = this.course.show_scoreboard;
+  startTime = this.course.start_time;
+  name = this.course.name;
+  school_name = this.course.school_name;
   school_id = this.course.school_id;
-  basic_information_required = !!this.course.basic_information_required;
-  requests_user_information = this.course.requests_user_information || 'no';
-  unlimitedDuration = !this.course.finish_time;
+  basic_information_required = this.course.basic_information_required;
+  requests_user_information = this.course.requests_user_information;
+  unlimitedDuration = this.course.finish_time === null;
 
   data(): { [name: string]: any } {
     return {
@@ -275,24 +280,18 @@ export default class CourseDetails extends Vue {
     );
   }
 
-  @Watch('course')
-  onCourseChange() {
-    this.reset();
-  }
-
   reset(): void {
-    this.alias = this.course.alias || '';
-    this.description = this.course.description || '';
+    this.alias = this.course.alias;
+    this.description = this.course.description;
     this.finishTime = this.course.finish_time || new Date();
-    this.showScoreboard = !!this.course.show_scoreboard;
-    this.startTime = this.course.start_time || new Date();
-    this.name = this.course.name || '';
-    this.school_id = this.course.school_id || undefined;
-    this.school_name = this.course.school_name || '';
-    this.basic_information_required = !!this.course.basic_information_required;
-    this.requests_user_information =
-      this.course.requests_user_information || 'no';
-    this.unlimitedDuration = !this.course.finish_time;
+    this.showScoreboard = this.course.show_scoreboard;
+    this.startTime = this.course.start_time;
+    this.name = this.course.name;
+    this.school_name = this.course.school_name;
+    this.school_id = this.course.school_id;
+    this.basic_information_required = this.course.basic_information_required;
+    this.requests_user_information = this.course.requests_user_information;
+    this.unlimitedDuration = this.course.finish_time === null;
   }
 
   onSubmit(): void {

--- a/frontend/www/js/omegaup/course/new.js
+++ b/frontend/www/js/omegaup/course/new.js
@@ -6,17 +6,28 @@ import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', function() {
-  var defaultDate = Date.create(Date.now());
-  defaultDate.set({ seconds: 0 });
-  var defaultStartTime = Date.create(defaultDate);
-  defaultDate.setDate(defaultDate.getDate() + 30);
-  var defaultFinishTime = Date.create(defaultDate);
+  var defaultStartTime = new Date();
+  defaultStartTime.setSeconds(0);
+  var defaultFinishTime = new Date(defaultStartTime);
+  defaultFinishTime.setDate(defaultFinishTime.getDate() + 30);
 
   var details = new Vue({
     el: '#course-details',
     render: function(createElement) {
-      return createElement('omegaup-course-details', {
-        props: { T: T, update: false, course: this.course },
+      return createElement('omegaup-course-form', {
+        props: {
+          course: {
+            alias: '',
+            description: '',
+            start_time: defaultStartTime,
+            finish_time: defaultFinishTime,
+            show_scoreboard: false,
+            name: '',
+            school_name: '',
+            basic_information_required: false,
+            requests_user_information: 'no',
+          },
+        },
         on: {
           submit: function(ev) {
             new Promise((accept, reject) => {
@@ -66,14 +77,8 @@ OmegaUp.on('ready', function() {
         },
       });
     },
-    data: {
-      course: {
-        start_time: defaultStartTime,
-        finish_time: defaultFinishTime,
-      },
-    },
     components: {
-      'omegaup-course-details': course_Form,
+      'omegaup-course-form': course_Form,
     },
   });
 });


### PR DESCRIPTION
Este cambio hace que las pruebas que tienen que ver con cursos sean un
poco más robustas. Concretamente:

* Al momento de hacer un envío en el curso, refresca la página para
  garantizar que el popup se muestre.

Pero también hace varios cambios para que esta prueba funcione
correctamente sin modo headless. El problema es que ahora el infobar que
se muestra cuando Chrome está siendo manipulado por chromedriver no se
muestra de manera constante, sino que aparece y desaparece cada que se
carga la página. Esto causa que la primera interacción que se tenga con
la página _a veces_ falle porque las coordenadas en las que Selenium
hace click ya no coinciden con las esperadas. Entonces para hacer que
esta prueba funcione sin el modo headless:

* Elimina el handler en la forma de crear un nuevo curso para cuando se
  cambia el `course`, que nunca debió haber sido necesario.
* Al momento de crear un curso nuevo, se asegura que el nombre sea
  escrito en el `input`. Esto falla a veces por razones misteriosas en
  modo no-headless.
* De igual manera, al momento de aceptar un maestro, se asegura que el
  `radio` tenga el estado deseado.