### PR TITLE
Arreglando los campos de autocomplete en las vistas de envíos

### DIFF
--- a/frontend/www/js/omegaup/arena/admin_arena.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.ts
@@ -36,7 +36,7 @@ export default class ArenaAdmin {
             showPager: true,
             showRejudge: true,
             showUser: true,
-            problemsetProblems: Object.values(self.arena.problems),
+            problemsetProblems: Object.values(arena.problems),
             globalRuns: globalRuns,
           },
           on: {

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -92,7 +92,13 @@
               <label
                 >{{ T.wordsProblem }}:
                 <omegaup-autocomplete
+                  v-if="problemsetProblems.length !== 0"
                   v-bind:init="initProblemAutocomplete"
+                  v-model="filterProblem"
+                ></omegaup-autocomplete>
+                <omegaup-autocomplete
+                  v-else=""
+                  v-bind:init="el => typeahead.problemTypeahead(el)"
                   v-model="filterProblem"
                 ></omegaup-autocomplete>
               </label>
@@ -110,9 +116,15 @@
               <label
                 >{{ T.wordsUser }}:
                 <omegaup-autocomplete
+                  v-if="problemsetProblems.length !== 0"
                   v-bind:init="
                     el => typeahead.userContestTypeahead(el, this.contestAlias)
                   "
+                  v-model="filterUsername"
+                ></omegaup-autocomplete>
+                <omegaup-autocomplete
+                  v-else=""
+                  v-bind:init="el => typeahead.userTypeahead(el)"
                   v-model="filterUsername"
                 ></omegaup-autocomplete>
               </label>
@@ -368,17 +380,13 @@ export default class Runs extends Vue {
   }
 
   initProblemAutocomplete(el: JQuery<HTMLElement>) {
-    if (this.problemsetProblems !== null) {
-      typeahead.problemContestTypeahead(
-        el,
-        () => this.problemsetProblems,
-        (event: Event, item: { alias: string; title: string }) => {
-          this.filterProblem = item.alias;
-        },
-      );
-    } else {
-      typeahead.problemTypeahead(el);
-    }
+    typeahead.problemsetProblemTypeahead(
+      el,
+      () => this.problemsetProblems,
+      (event: Event, item: { alias: string; title: string }) => {
+        this.filterProblem = item.alias;
+      },
+    );
   }
 
   memory(run: types.Run): string {

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -92,13 +92,7 @@
               <label
                 >{{ T.wordsProblem }}:
                 <omegaup-autocomplete
-                  v-if="problemsetProblems.length !== 0"
                   v-bind:init="initProblemAutocomplete"
-                  v-model="filterProblem"
-                ></omegaup-autocomplete>
-                <omegaup-autocomplete
-                  v-else=""
-                  v-bind:init="el => typeahead.problemTypeahead(el)"
                   v-model="filterProblem"
                 ></omegaup-autocomplete>
               </label>
@@ -116,15 +110,7 @@
               <label
                 >{{ T.wordsUser }}:
                 <omegaup-autocomplete
-                  v-if="problemsetProblems.length !== 0"
-                  v-bind:init="
-                    el => typeahead.userContestTypeahead(el, this.contestAlias)
-                  "
-                  v-model="filterUsername"
-                ></omegaup-autocomplete>
-                <omegaup-autocomplete
-                  v-else=""
-                  v-bind:init="el => typeahead.userTypeahead(el)"
+                  v-bind:init="initUserAutocomplete"
                   v-model="filterUsername"
                 ></omegaup-autocomplete>
               </label>
@@ -380,13 +366,25 @@ export default class Runs extends Vue {
   }
 
   initProblemAutocomplete(el: JQuery<HTMLElement>) {
-    typeahead.problemsetProblemTypeahead(
-      el,
-      () => this.problemsetProblems,
-      (event: Event, item: { alias: string; title: string }) => {
-        this.filterProblem = item.alias;
-      },
-    );
+    if (this.problemsetProblems.length !== 0) {
+      typeahead.problemsetProblemTypeahead(
+        el,
+        () => this.problemsetProblems,
+        (event: Event, item: { alias: string; title: string }) => {
+          this.filterProblem = item.alias;
+        },
+      );
+    } else {
+      typeahead.problemTypeahead(el);
+    }
+  }
+
+  initUserAutocomplete(el: JQuery<HTMLElement>) {
+    if (this.problemsetProblems.length !== 0 && this.contestAlias) {
+      typeahead.userContestTypeahead(el, this.contestAlias);
+    } else {
+      typeahead.userTypeahead(el);
+    }
   }
 
   memory(run: types.Run): string {

--- a/frontend/www/js/omegaup/typeahead.ts
+++ b/frontend/www/js/omegaup/typeahead.ts
@@ -140,7 +140,7 @@ export function problemTypeahead(
     .trigger('change');
 }
 
-export function problemContestTypeahead(
+export function problemsetProblemTypeahead(
   elem: JQuery<HTMLElement>,
   problemDataset: () => { alias: string; title: string }[],
   cb?: CallbackType<{ alias: string; title: string }>,


### PR DESCRIPTION
# Descripción

Se arregla el autocomplete de problemas y de usuarios en las vistas de envíos.

Contests:
![AutocompleteContestRuns](https://user-images.githubusercontent.com/3230352/85101868-01811100-b1c9-11ea-8d63-cd24efe47d73.gif)

Courses:
![AutocompleteCourseRuns](https://user-images.githubusercontent.com/3230352/85101885-0f369680-b1c9-11ea-9e6d-d7cbf1089f15.gif)

Global:
![AutocompleteGlobalRuns](https://user-images.githubusercontent.com/3230352/85101900-15c50e00-b1c9-11ea-87ba-f622597c21fe.gif)


Fixes: #4222 

# Comentarios

Se creó un Typeahead especial para que filtre de un listado de elementos,
en específico los problemas que pertenecen al Problemset. Esta función
debería funcionar tanto para cursos, como para concursos, pero por algún
motivo que aún no logro identificar, este listado de problemas no se 
obtiene correctamente en los concursos y por este motivo la búsqueda se
realiza en toda la tabla de problemas. 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
