### PR TITLE
Normalizando las pruebas de vacuidad

### DIFF
--- a/frontend/tests/controllers/ClarificationCreateTest.php
+++ b/frontend/tests/controllers/ClarificationCreateTest.php
@@ -166,7 +166,7 @@ class ClarificationCreateTest extends \OmegaUp\Test\ControllerTestCase {
                 'problem_alias' => $problemData['request']['problem_alias'],
             ])
         );
-        $this->assertCount(0, $response['clarifications']);
+        $this->assertEmpty($response['clarifications']);
     }
 
     /**

--- a/frontend/tests/controllers/CourseCloneTest.php
+++ b/frontend/tests/controllers/CourseCloneTest.php
@@ -85,7 +85,7 @@ class CourseCloneTest extends \OmegaUp\Test\ControllerTestCase {
             'auth_token' => $adminLogin->auth_token,
             'course_alias' => $courseAlias
         ]));
-        $this->assertCount(0, $students['students']);
+        $this->assertEmpty($students['students']);
     }
 
     /**

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -325,7 +325,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
             'difficulty_range' => '1,4',
             'order_by' => 'quality',
         ]));
-        $this->assertCount(0, $response['results']);
+        $this->assertEmpty($response['results']);
     }
 
     /**


### PR DESCRIPTION
Este cambio usa `assertEmpty($x)` en vez de `assertCount(0, $x)`.