### PR TITLE
Arreglando userContestTypeahead para que busque en el campo correcto

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -111,7 +111,7 @@
                 >{{ T.wordsUser }}:
                 <omegaup-autocomplete
                   v-bind:init="initUserAutocomplete"
-                  v-model="filterUsername"
+                  v-bind:value.sync="filterUsername"
                 ></omegaup-autocomplete>
               </label>
               <button

--- a/frontend/www/js/omegaup/typeahead.ts
+++ b/frontend/www/js/omegaup/typeahead.ts
@@ -243,7 +243,9 @@ export function userContestTypeahead(
   contestAlias: string,
 ): void {
   const cb = (event: Event, val: { label: string; value: string }) =>
-    $(<EventTarget>event.target).val(val.label);
+    $(<EventTarget>event.target)
+      .attr('data-value', val.value)
+      .val(val.label);
   elem
     .typeahead<{ label: string; value: string }>(
       {


### PR DESCRIPTION
# Descripción

Con este cambio se arregla la búsqueda de `userContestTypeahead`. 
![AutocompleteUserContest](https://user-images.githubusercontent.com/3230352/85175839-0207bf00-b23e-11ea-83f7-613099c518ba.gif)

Part of: #4222

# Comentarios

Resulta que el bug reportado en #4222 aún se puede reproducir. El problema
es que no era consistente, la falla, en ocasiones ocurría y en otras tantas, no.

Revisando el código, resulta que el componente de `arena/Runs.vue` tiene dos
instancias, y no logré identificar cual de las dos es la que se está mostrando. 

Así que para poder liberar este bug se aplica esta corrección más la de #4241 
en lo que se analiza a detalle lo del componente duplicado

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
