### PR TITLE
Obteniendo los logs del contenedor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,10 @@ jobs:
         with:
           name: test-logs
           path: frontend/tests/ui/results/
+
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-logs
+          path: frontend/tests/runfiles/*/*.log


### PR DESCRIPTION
Este cambio hace que se obtengan (y exporten) los logs de los
contenedores al momento de ejecutar las pruebas de Selenium.