### PR TITLE
Haciendo más robustas las pruebas para eliminar tareas de cursos

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -1424,31 +1424,21 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\DAO::transBegin();
 
         try {
-            \OmegaUp\DAO\ProblemsetProblems::removeProblemsFromProblemset(
-                $problemset->problemset_id
-            );
-
             \OmegaUp\DAO\Assignments::unlinkProblemset(
                 $assignment,
                 $problemset
             );
 
-            \OmegaUp\DAO\ProblemsetAccessLog::deleteByProblemset(
-                new \OmegaUp\DAO\VO\ProblemsetAccessLog([
-                    'problemset_id' => $problemset->problemset_id,
-                ])
+            \OmegaUp\DAO\ProblemsetAccessLog::removeAccessLogFromProblemset(
+                $problemset->problemset_id
             );
 
-            \OmegaUp\DAO\ProblemsetIdentities::deleteByProblemset(
-                new \OmegaUp\DAO\VO\ProblemsetIdentities([
-                    'problemset_id' => $problemset->problemset_id,
-                ])
+            \OmegaUp\DAO\ProblemsetIdentities::removeIdentitiesFromProblemset(
+                $problemset->problemset_id
             );
 
-            \OmegaUp\DAO\ProblemsetProblemOpened::deleteByProblemset(
-                new \OmegaUp\DAO\VO\ProblemsetProblemOpened([
-                    'problemset_id' => $problemset->problemset_id,
-                ])
+            \OmegaUp\DAO\ProblemsetProblemOpened::removeProblemOpenedFromProblemset(
+                $problemset->problemset_id
             );
 
             \OmegaUp\DAO\ProblemsetProblems::removeProblemsFromProblemset(

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -188,10 +188,9 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
 
     /**
      * Since Problemsets and Assignments tables are related to each other, it
-     * is necessary to unlink the assignment in Problemsets table, and then
-     * delete the row in both tables
+     * is necessary to unlink the assignment in Problemsets table.
      */
-    public static function deleteWithProblemset(
+    public static function unlinkProblemset(
         \OmegaUp\DAO\VO\Assignments $assignment,
         \OmegaUp\DAO\VO\Problemsets $problemset
     ): void {
@@ -207,9 +206,5 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
             $sql,
             [$problemset->problemset_id]
         );
-
-        \OmegaUp\DAO\Assignments::delete($assignment);
-
-        \OmegaUp\DAO\Problemsets::delete($problemset);
     }
 }

--- a/frontend/server/src/DAO/ProblemsetAccessLog.php
+++ b/frontend/server/src/DAO/ProblemsetAccessLog.php
@@ -114,4 +114,18 @@ class ProblemsetAccessLog extends \OmegaUp\DAO\Base\ProblemsetAccessLog {
         }
         return $problemsetAccessLog;
     }
+
+    final public static function removeAccessLogFromProblemset(
+        int $problemsetId
+    ): int {
+        $sql = '
+            DELETE FROM
+                `Problemset_Access_Log`
+            WHERE
+                `problemset_id` = ?;';
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [$problemsetId]);
+
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
 }

--- a/frontend/server/src/DAO/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/ProblemsetIdentities.php
@@ -278,8 +278,8 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
     }
 
-    final public static function deleteByProblemset(
-        \OmegaUp\DAO\VO\ProblemsetIdentities $problemsetIdentities
+    final public static function removeIdentitiesFromProblemset(
+        int $problemsetId
     ): int {
         $sql = '
             DELETE FROM
@@ -287,10 +287,8 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
             WHERE
                 `problemset_id` = ?;';
 
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            $sql,
-            [$problemsetIdentities->problemset_id]
-        );
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [$problemsetId]);
+
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
     }
 }

--- a/frontend/server/src/DAO/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/ProblemsetIdentities.php
@@ -277,4 +277,20 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
     }
+
+    final public static function deleteByProblemset(
+        \OmegaUp\DAO\VO\ProblemsetIdentities $problemsetIdentities
+    ): int {
+        $sql = '
+            DELETE FROM
+                `Problemset_Identities`
+            WHERE
+                `problemset_id` = ?;';
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            $sql,
+            [$problemsetIdentities->problemset_id]
+        );
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
 }

--- a/frontend/server/src/DAO/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/ProblemsetProblemOpened.php
@@ -12,4 +12,19 @@ namespace OmegaUp\DAO;
  * @access public
  */
 class ProblemsetProblemOpened extends \OmegaUp\DAO\Base\ProblemsetProblemOpened {
+    final public static function deleteByProblemset(
+        \OmegaUp\DAO\VO\ProblemsetProblemOpened $problemsetProblemOpened
+    ): int {
+        $sql = '
+            DELETE FROM
+                `Problemset_Problem_Opened`
+            WHERE
+                `problemset_id` = ?;';
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            $sql,
+            [$problemsetProblemOpened->problemset_id]
+        );
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
 }

--- a/frontend/server/src/DAO/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/ProblemsetProblemOpened.php
@@ -12,8 +12,8 @@ namespace OmegaUp\DAO;
  * @access public
  */
 class ProblemsetProblemOpened extends \OmegaUp\DAO\Base\ProblemsetProblemOpened {
-    final public static function deleteByProblemset(
-        \OmegaUp\DAO\VO\ProblemsetProblemOpened $problemsetProblemOpened
+    final public static function removeProblemOpenedFromProblemset(
+        int $problemsetId
     ): int {
         $sql = '
             DELETE FROM
@@ -21,10 +21,8 @@ class ProblemsetProblemOpened extends \OmegaUp\DAO\Base\ProblemsetProblemOpened 
             WHERE
                 `problemset_id` = ?;';
 
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            $sql,
-            [$problemsetProblemOpened->problemset_id]
-        );
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [$problemsetId]);
+
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
     }
 }

--- a/frontend/tests/controllers/AssignmentRemoveTest.php
+++ b/frontend/tests/controllers/AssignmentRemoveTest.php
@@ -4,6 +4,45 @@
  * @author juan.pablo
  */
 class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
+    private static $admin = null;
+    private static $participant = null;
+    private static $login = null;
+    private static $loginParticipant = null;
+    private static $courseData = null;
+    private static $problemData = null;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        ['identity' => self::$admin] = \OmegaUp\Test\Factories\User::createUser();
+        self::$login = self::login(self::$admin);
+
+        self::$courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
+            self::$admin,
+            self::$login
+        );
+
+        self::$problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+
+        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+            self::$login,
+            self::$courseData['course_alias'],
+            self::$courseData['assignment_alias'],
+            [self::$problemData]
+        );
+
+        [
+            'identity' => self::$participant,
+        ] = \OmegaUp\Test\Factories\User::createUser();
+
+        \OmegaUp\Test\Factories\Course::addStudentToCourse(
+            self::$courseData,
+            self::$participant
+        );
+
+        self::$loginParticipant = self::login(self::$participant);
+    }
+
     public function testAssignmentRemove() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithAssignments(
             /*$numberOfAssignments=*/5
@@ -36,53 +75,99 @@ class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertCount(4, $response['assignments']);
     }
 
+    /**
+     * A participant joins the assignment, and then, this assignment is removed
+     * by admin
+     */
+    public function testAssignmentRemoveWithAccessLog() {
+        $courseAlias = self::$courseData['course_alias'];
+        $assignmentAlias = self::$courseData['assignment_alias'];
+
+        $getAssignmentResponse = \OmegaUp\Controllers\Course::apiAssignmentDetails(
+            new \OmegaUp\Request([
+                'auth_token' => self::$loginParticipant->auth_token,
+                'course' => $courseAlias,
+                'assignment' => $assignmentAlias,
+            ])
+        );
+
+        self::$login = self::login(self::$admin);
+
+        \OmegaUp\Controllers\Course::apiRemoveAssignment(
+            new \OmegaUp\Request([
+                'auth_token' => self::$login->auth_token,
+                'assignment_alias' => $assignmentAlias,
+                'course_alias' => $courseAlias,
+            ])
+        );
+
+        $response = \OmegaUp\Controllers\Course::apiListAssignments(
+            new \OmegaUp\Request([
+                'auth_token' => self::$login->auth_token,
+                'course_alias' => $courseAlias
+            ])
+        );
+        $this->assertEmpty($response['assignments']);
+    }
+
+    /**
+     * A participant joins the assignment, open a problem, and then, the
+     * assignment is removed by admin
+     */
+    public function testAssignmentRemoveWithProblemOpened() {
+        $courseAlias = self::$courseData['course_alias'];
+        $assignmentAlias = self::$courseData['assignment_alias'];
+
+        $getAssignmentResponse = \OmegaUp\Controllers\Course::apiAssignmentDetails(
+            new \OmegaUp\Request([
+                'auth_token' => self::$loginParticipant->auth_token,
+                'course' => $courseAlias,
+                'assignment' => $assignmentAlias,
+            ])
+        );
+
+        \OmegaUp\Test\Factories\Course::openProblemInCourseAssignment(
+            self::$courseData,
+            self::$problemData,
+            self::$participant
+        );
+
+        self::$login = self::login(self::$admin);
+
+        \OmegaUp\Controllers\Course::apiRemoveAssignment(
+            new \OmegaUp\Request([
+                'auth_token' => self::$login->auth_token,
+                'assignment_alias' => $assignmentAlias,
+                'course_alias' => $courseAlias,
+            ])
+        );
+
+        $response = \OmegaUp\Controllers\Course::apiListAssignments(
+            new \OmegaUp\Request([
+                'auth_token' => self::$login->auth_token,
+                'course_alias' => $courseAlias
+            ])
+        );
+        $this->assertEmpty($response['assignments']);
+    }
+
     public function testAssignmentRemoveWithSubmittedRuns() {
-        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
-
-        ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
-
-        $login = self::login($admin);
-
-        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
-            $admin,
-            $login
-        );
-
-        $courseAlias = $courseData['course_alias'];
-        $assignmentAlias = $courseData['assignment_alias'];
-
-        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
-            $login,
-            $courseAlias,
-            $assignmentAlias,
-            [$problemData]
-        );
-
-        [
-            'identity' => $participant,
-        ] = \OmegaUp\Test\Factories\User::createUser();
-
-        \OmegaUp\Test\Factories\Course::addStudentToCourse(
-            $courseData,
-            $participant
-        );
-
         $runData = \OmegaUp\Test\Factories\Run::createCourseAssignmentRun(
-            $problemData,
-            $courseData,
-            $participant
+            self::$problemData,
+            self::$courseData,
+            self::$participant
         );
 
         \OmegaUp\Test\Factories\Run::gradeRun($runData);
 
-        $login = self::login($admin);
+        self::$login = self::login(self::$admin);
 
         try {
             \OmegaUp\Controllers\Course::apiRemoveAssignment(
                 new \OmegaUp\Request([
-                    'auth_token' => $login->auth_token,
-                    'assignment_alias' => $assignmentAlias,
-                    'course_alias' => $courseAlias,
+                    'auth_token' => self::$login->auth_token,
+                    'assignment_alias' => self::$courseData['assignment_alias'],
+                    'course_alias' => self::$courseData['course_alias'],
                 ])
             );
             $this->fail('Should have thrown exception.');

--- a/frontend/tests/controllers/AssignmentRemoveTest.php
+++ b/frontend/tests/controllers/AssignmentRemoveTest.php
@@ -4,45 +4,6 @@
  * @author juan.pablo
  */
 class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
-    private static $admin = null;
-    private static $participant = null;
-    private static $login = null;
-    private static $loginParticipant = null;
-    private static $courseData = null;
-    private static $problemData = null;
-
-    public function setUp(): void {
-        parent::setUp();
-
-        ['identity' => self::$admin] = \OmegaUp\Test\Factories\User::createUser();
-        self::$login = self::login(self::$admin);
-
-        self::$courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
-            self::$admin,
-            self::$login
-        );
-
-        self::$problemData = \OmegaUp\Test\Factories\Problem::createProblem();
-
-        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
-            self::$login,
-            self::$courseData['course_alias'],
-            self::$courseData['assignment_alias'],
-            [self::$problemData]
-        );
-
-        [
-            'identity' => self::$participant,
-        ] = \OmegaUp\Test\Factories\User::createUser();
-
-        \OmegaUp\Test\Factories\Course::addStudentToCourse(
-            self::$courseData,
-            self::$participant
-        );
-
-        self::$loginParticipant = self::login(self::$participant);
-    }
-
     public function testAssignmentRemove() {
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithAssignments(
             /*$numberOfAssignments=*/5
@@ -80,22 +41,48 @@ class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
      * by admin
      */
     public function testAssignmentRemoveWithAccessLog() {
-        $courseAlias = self::$courseData['course_alias'];
-        $assignmentAlias = self::$courseData['assignment_alias'];
+        ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
+        $login = self::login($admin);
+
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
+            $admin,
+            $login
+        );
+
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+
+        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+            $login,
+            $courseData['course_alias'],
+            $courseData['assignment_alias'],
+            [$problemData]
+        );
+
+        ['identity' => $participant] = \OmegaUp\Test\Factories\User::createUser();
+
+        \OmegaUp\Test\Factories\Course::addStudentToCourse(
+            $courseData,
+            $participant
+        );
+
+        $loginParticipant = self::login($participant);
+
+        $courseAlias = $courseData['course_alias'];
+        $assignmentAlias = $courseData['assignment_alias'];
 
         $getAssignmentResponse = \OmegaUp\Controllers\Course::apiAssignmentDetails(
             new \OmegaUp\Request([
-                'auth_token' => self::$loginParticipant->auth_token,
+                'auth_token' => $loginParticipant->auth_token,
                 'course' => $courseAlias,
                 'assignment' => $assignmentAlias,
             ])
         );
 
-        self::$login = self::login(self::$admin);
+        $login = self::login($admin);
 
         \OmegaUp\Controllers\Course::apiRemoveAssignment(
             new \OmegaUp\Request([
-                'auth_token' => self::$login->auth_token,
+                'auth_token' => $login->auth_token,
                 'assignment_alias' => $assignmentAlias,
                 'course_alias' => $courseAlias,
             ])
@@ -103,7 +90,7 @@ class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
 
         $response = \OmegaUp\Controllers\Course::apiListAssignments(
             new \OmegaUp\Request([
-                'auth_token' => self::$login->auth_token,
+                'auth_token' => $login->auth_token,
                 'course_alias' => $courseAlias
             ])
         );
@@ -115,28 +102,54 @@ class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
      * assignment is removed by admin
      */
     public function testAssignmentRemoveWithProblemOpened() {
-        $courseAlias = self::$courseData['course_alias'];
-        $assignmentAlias = self::$courseData['assignment_alias'];
+        ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
+        $login = self::login($admin);
+
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
+            $admin,
+            $login
+        );
+
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+
+        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+            $login,
+            $courseData['course_alias'],
+            $courseData['assignment_alias'],
+            [$problemData]
+        );
+
+        ['identity' => $participant] = \OmegaUp\Test\Factories\User::createUser();
+
+        \OmegaUp\Test\Factories\Course::addStudentToCourse(
+            $courseData,
+            $participant
+        );
+
+        $loginParticipant = self::login($participant);
+
+        $courseAlias = $courseData['course_alias'];
+        $assignmentAlias = $courseData['assignment_alias'];
 
         $getAssignmentResponse = \OmegaUp\Controllers\Course::apiAssignmentDetails(
             new \OmegaUp\Request([
-                'auth_token' => self::$loginParticipant->auth_token,
+                'auth_token' => $loginParticipant->auth_token,
                 'course' => $courseAlias,
                 'assignment' => $assignmentAlias,
             ])
         );
 
         \OmegaUp\Test\Factories\Course::openProblemInCourseAssignment(
-            self::$courseData,
-            self::$problemData,
-            self::$participant
+            $courseData,
+            $problemData,
+            $participant
         );
 
-        self::$login = self::login(self::$admin);
+        $login = self::login($admin);
 
         \OmegaUp\Controllers\Course::apiRemoveAssignment(
             new \OmegaUp\Request([
-                'auth_token' => self::$login->auth_token,
+                'auth_token' => $login->auth_token,
                 'assignment_alias' => $assignmentAlias,
                 'course_alias' => $courseAlias,
             ])
@@ -144,7 +157,7 @@ class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
 
         $response = \OmegaUp\Controllers\Course::apiListAssignments(
             new \OmegaUp\Request([
-                'auth_token' => self::$login->auth_token,
+                'auth_token' => $login->auth_token,
                 'course_alias' => $courseAlias
             ])
         );
@@ -152,22 +165,46 @@ class AssignmentRemoveTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     public function testAssignmentRemoveWithSubmittedRuns() {
+        ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
+        $login = self::login($admin);
+
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
+            $admin,
+            $login
+        );
+
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+
+        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+            $login,
+            $courseData['course_alias'],
+            $courseData['assignment_alias'],
+            [$problemData]
+        );
+
+        ['identity' => $participant] = \OmegaUp\Test\Factories\User::createUser();
+
+        \OmegaUp\Test\Factories\Course::addStudentToCourse(
+            $courseData,
+            $participant
+        );
+
         $runData = \OmegaUp\Test\Factories\Run::createCourseAssignmentRun(
-            self::$problemData,
-            self::$courseData,
-            self::$participant
+            $problemData,
+            $courseData,
+            $participant
         );
 
         \OmegaUp\Test\Factories\Run::gradeRun($runData);
 
-        self::$login = self::login(self::$admin);
+        $login = self::login($admin);
 
         try {
             \OmegaUp\Controllers\Course::apiRemoveAssignment(
                 new \OmegaUp\Request([
-                    'auth_token' => self::$login->auth_token,
-                    'assignment_alias' => self::$courseData['assignment_alias'],
-                    'course_alias' => self::$courseData['course_alias'],
+                    'auth_token' => $login->auth_token,
+                    'assignment_alias' => $courseData['assignment_alias'],
+                    'course_alias' => $courseData['course_alias'],
                 ])
             );
             $this->fail('Should have thrown exception.');


### PR DESCRIPTION
# Descripción

Se hace más robusta la funcionalidad de eliminar tarea. Ahora se borran los 
registros del problemset en todas las tablas que están involucradas.

- `Assignments`
- `Problemset_Access_Log`
- `Problemset_Identities`
- `Problemset_Problem_Opened`
- `Problemset_Problems`

Fixes: #4235 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
