### PR TITLE
Ocultando el checkbox de mostrar concursantes invitados en scoreboard de cursos

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -511,7 +511,7 @@ export class Arena {
               lastUpdated: this.lastUpdated,
               digitsAfterDecimalPoint: digitsAfterDecimalPoint,
               showPenalty: this.showPenalty,
-              shouldShowInvitedUsersFilter: self.options.contestAlias !== null,
+              showInvitedUsersFilter: self.options.contestAlias !== null,
             },
           });
         },

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -499,7 +499,6 @@ export class Arena {
     }
 
     if (this.elements.ranking.length) {
-      const self = this;
       this.scoreboard = new Vue({
         el: this.elements.ranking[0],
         render: function(createElement) {
@@ -511,7 +510,7 @@ export class Arena {
               lastUpdated: this.lastUpdated,
               digitsAfterDecimalPoint: digitsAfterDecimalPoint,
               showPenalty: this.showPenalty,
-              showInvitedUsersFilter: self.options.contestAlias !== null,
+              showInvitedUsersFilter: options.contestAlias !== null,
             },
           });
         },

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -314,7 +314,6 @@ export class Arena {
     | (Vue & {
         problems: omegaup.Problem[];
         ranking: types.ScoreboardRankingEntry[];
-        shouldShowInvitedUsersFilter: boolean;
         showPenalty: boolean;
         lastUpdated: Date;
       })
@@ -500,6 +499,7 @@ export class Arena {
     }
 
     if (this.elements.ranking.length) {
+      const self = this;
       this.scoreboard = new Vue({
         el: this.elements.ranking[0],
         render: function(createElement) {
@@ -511,7 +511,7 @@ export class Arena {
               lastUpdated: this.lastUpdated,
               digitsAfterDecimalPoint: digitsAfterDecimalPoint,
               showPenalty: this.showPenalty,
-              shouldShowInvitedUsersFilter: this.shouldShowInvitedUsersFilter,
+              shouldShowInvitedUsersFilter: self.options.contestAlias !== null,
             },
           });
         },
@@ -520,7 +520,6 @@ export class Arena {
           ranking: [],
           lastUpdated: new Date(0),
           showPenalty: true,
-          shouldShowInvitedUsersFilter: this.options.contestAlias !== null,
         },
         components: {
           'omegaup-arena-scoreboard': arena_Scoreboard,

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -314,6 +314,7 @@ export class Arena {
     | (Vue & {
         problems: omegaup.Problem[];
         ranking: types.ScoreboardRankingEntry[];
+        shouldShowInvitedUsersFilter: boolean;
         showPenalty: boolean;
         lastUpdated: Date;
       })
@@ -510,6 +511,7 @@ export class Arena {
               lastUpdated: this.lastUpdated,
               digitsAfterDecimalPoint: digitsAfterDecimalPoint,
               showPenalty: this.showPenalty,
+              shouldShowInvitedUsersFilter: this.shouldShowInvitedUsersFilter,
             },
           });
         },
@@ -518,6 +520,7 @@ export class Arena {
           ranking: [],
           lastUpdated: new Date(0),
           showPenalty: true,
+          shouldShowInvitedUsersFilter: this.options.contestAlias !== null,
         },
         components: {
           'omegaup-arena-scoreboard': arena_Scoreboard,

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
@@ -1,0 +1,191 @@
+import { shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+
+import T from '../../lang';
+import { omegaup } from '../../omegaup';
+import { types } from '../../api_types';
+import * as ui from '../../ui';
+
+import arena_Scoreboard from './Scoreboard.vue';
+
+describe('Scoreboard.vue', () => {
+  it('Should handle scoreboard in a contest', async () => {
+    const wrapper = shallowMount(arena_Scoreboard, {
+      propsData: {
+        digitsAfterDecimalPoint: 2,
+        lastUpdated: new Date(),
+        problems: [
+          {
+            accepted: 52,
+            alias: 'sumas',
+            commit: '587cb50672aa364c75e16b638ec7ca7289e24b08',
+            difficulty: 0,
+            languages:
+              'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,java,py2,py3,rb,cs,pas,hs,lua',
+            letter: 'A',
+            order: 1,
+            points: 100,
+            submissions: 193,
+            title: 'Sumas',
+            version: 'dba31432b084856b69bf4f661341561c08d0bbea',
+            visibility: 2,
+            visits: 0,
+          },
+        ] as omegaup.Problem[],
+        ranking: [
+          {
+            classname: 'user-rank-master',
+            country: 'xx',
+            is_invited: false,
+            name: 'test_user_0',
+            problems: [
+              { alias: 'sumas', penalty: 0, percent: 0, points: 0, runs: 2 },
+            ],
+            total: {
+              penalty: 0,
+              points: 0,
+            },
+            username: 'test_user_0',
+          },
+          {
+            classname: 'user-rank-master',
+            country: 'xx',
+            is_invited: true,
+            name: 'test_user_1',
+            problems: [
+              {
+                alias: 'sumas',
+                penalty: 0,
+                percent: 100,
+                points: 100,
+                runs: 1,
+              },
+            ],
+            total: {
+              penalty: 0,
+              points: 0,
+            },
+            username: 'test_user_1',
+          },
+        ],
+        scoreboardColors: [
+          '#FB3F51',
+          '#FF5D40',
+          '#FFA240',
+          '#FFC740',
+          '#59EA3A',
+          '#37DD6F',
+          '#34D0BA',
+          '#3AAACF',
+          '#8144D6',
+          '#CD35D3',
+        ],
+        shouldShowInvitedUsersFilter: true,
+        showPenalty: false,
+      },
+    });
+
+    expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(
+      'test_user_1',
+    );
+
+    await wrapper
+      .find('input[type="checkbox"].toggle-contestants')
+      .trigger('click');
+
+    expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(
+      'test_user_0',
+    );
+
+    expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(
+      'test_user_1',
+    );
+  });
+
+  it('Should handle scoreboard in a course', async () => {
+    const wrapper = shallowMount(arena_Scoreboard, {
+      propsData: {
+        digitsAfterDecimalPoint: 2,
+        lastUpdated: new Date(),
+        problems: [
+          {
+            accepted: 52,
+            alias: 'sumas',
+            commit: '587cb50672aa364c75e16b638ec7ca7289e24b08',
+            difficulty: 0,
+            languages:
+              'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,java,py2,py3,rb,cs,pas,hs,lua',
+            letter: 'A',
+            order: 1,
+            points: 100,
+            submissions: 23,
+            title: 'Sumas',
+            version: 'dba31432b084856b69bf4f661341561c08d0bbea',
+            visibility: 2,
+            visits: 0,
+          },
+        ] as omegaup.Problem[],
+        ranking: [
+          {
+            classname: 'user-rank-master',
+            country: 'xx',
+            is_invited: false,
+            name: 'test_user_0',
+            problems: [
+              { alias: 'sumas', penalty: 0, percent: 0, points: 0, runs: 2 },
+            ],
+            total: {
+              penalty: 0,
+              points: 0,
+            },
+            username: 'test_user_0',
+          },
+          {
+            classname: 'user-rank-master',
+            country: 'xx',
+            is_invited: true,
+            name: 'test_user_1',
+            problems: [
+              {
+                alias: 'sumas',
+                penalty: 0,
+                percent: 100,
+                points: 100,
+                runs: 1,
+              },
+            ],
+            total: { penalty: 0, points: 0 },
+            username: 'test_user_1',
+          },
+        ],
+        scoreboardColors: [
+          '#FB3F51',
+          '#FF5D40',
+          '#FFA240',
+          '#FFC740',
+          '#59EA3A',
+          '#37DD6F',
+          '#34D0BA',
+          '#3AAACF',
+          '#8144D6',
+          '#CD35D3',
+        ],
+        shouldShowInvitedUsersFilter: false,
+        showPenalty: false,
+      },
+    });
+    // All participants are visible and toggle contestants check is hidden
+    expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(
+      'test_user_0',
+    );
+
+    expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(
+      'test_user_1',
+    );
+
+    expect(
+      wrapper.find('input[type="checkbox"].toggle-contestants').exists(),
+    ).toBeFalsy();
+  });
+});

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
@@ -72,7 +72,6 @@ const baseScoreboardProps = {
     '#8144D6',
     '#CD35D3',
   ],
-  shouldShowInvitedUsersFilter: true,
   showPenalty: false,
 };
 

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
@@ -9,86 +9,91 @@ import * as ui from '../../ui';
 
 import arena_Scoreboard from './Scoreboard.vue';
 
+const baseScoreboardProps = {
+  digitsAfterDecimalPoint: 2,
+  lastUpdated: new Date(),
+  problems: [
+    {
+      accepted: 52,
+      alias: 'sumas',
+      commit: '587cb50672aa364c75e16b638ec7ca7289e24b08',
+      difficulty: 0,
+      languages:
+        'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,java,py2,py3,rb,cs,pas,hs,lua',
+      letter: 'A',
+      order: 1,
+      points: 100,
+      submissions: 193,
+      title: 'Sumas',
+      version: 'dba31432b084856b69bf4f661341561c08d0bbea',
+      visibility: 2,
+      visits: 0,
+    },
+  ] as omegaup.Problem[],
+  ranking: [
+    {
+      classname: 'user-rank-master',
+      country: 'xx',
+      is_invited: false,
+      name: 'test_user_0',
+      problems: [
+        { alias: 'sumas', penalty: 0, percent: 0, points: 0, runs: 2 },
+      ],
+      total: {
+        penalty: 0,
+        points: 0,
+      },
+      username: 'test_user_0',
+    },
+    {
+      classname: 'user-rank-master',
+      country: 'xx',
+      is_invited: true,
+      name: 'test_user_1',
+      problems: [
+        { alias: 'sumas', penalty: 0, percent: 100, points: 100, runs: 1 },
+      ],
+      total: {
+        penalty: 0,
+        points: 0,
+      },
+      username: 'test_user_1',
+    },
+  ],
+  scoreboardColors: [
+    '#FB3F51',
+    '#FF5D40',
+    '#FFA240',
+    '#FFC740',
+    '#59EA3A',
+    '#37DD6F',
+    '#34D0BA',
+    '#3AAACF',
+    '#8144D6',
+    '#CD35D3',
+  ],
+  shouldShowInvitedUsersFilter: true,
+  showPenalty: false,
+};
+
 describe('Scoreboard.vue', () => {
   it('Should handle scoreboard in a contest', async () => {
     const wrapper = shallowMount(arena_Scoreboard, {
-      propsData: {
-        digitsAfterDecimalPoint: 2,
-        lastUpdated: new Date(),
-        problems: [
-          {
-            accepted: 52,
-            alias: 'sumas',
-            commit: '587cb50672aa364c75e16b638ec7ca7289e24b08',
-            difficulty: 0,
-            languages:
-              'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,java,py2,py3,rb,cs,pas,hs,lua',
-            letter: 'A',
-            order: 1,
-            points: 100,
-            submissions: 193,
-            title: 'Sumas',
-            version: 'dba31432b084856b69bf4f661341561c08d0bbea',
-            visibility: 2,
-            visits: 0,
-          },
-        ] as omegaup.Problem[],
-        ranking: [
-          {
-            classname: 'user-rank-master',
-            country: 'xx',
-            is_invited: false,
-            name: 'test_user_0',
-            problems: [
-              { alias: 'sumas', penalty: 0, percent: 0, points: 0, runs: 2 },
-            ],
-            total: {
-              penalty: 0,
-              points: 0,
-            },
-            username: 'test_user_0',
-          },
-          {
-            classname: 'user-rank-master',
-            country: 'xx',
-            is_invited: true,
-            name: 'test_user_1',
-            problems: [
-              {
-                alias: 'sumas',
-                penalty: 0,
-                percent: 100,
-                points: 100,
-                runs: 1,
-              },
-            ],
-            total: {
-              penalty: 0,
-              points: 0,
-            },
-            username: 'test_user_1',
-          },
-        ],
-        scoreboardColors: [
-          '#FB3F51',
-          '#FF5D40',
-          '#FFA240',
-          '#FFC740',
-          '#59EA3A',
-          '#37DD6F',
-          '#34D0BA',
-          '#3AAACF',
-          '#8144D6',
-          '#CD35D3',
-        ],
-        shouldShowInvitedUsersFilter: true,
-        showPenalty: false,
-      },
+      propsData: Object.assign(
+        {
+          showInvitedUsersFilter: true,
+        },
+        baseScoreboardProps,
+      ),
     });
 
     expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(
       'test_user_1',
     );
+
+    expect(
+      wrapper.find('.omegaup-scoreboard table tbody').text(),
+    ).not.toContain('test_user_0');
 
     await wrapper
       .find('input[type="checkbox"].toggle-contestants')
@@ -103,77 +108,14 @@ describe('Scoreboard.vue', () => {
     );
   });
 
-  it('Should handle scoreboard in a course', async () => {
+  it('Should handle scoreboard in a course', () => {
     const wrapper = shallowMount(arena_Scoreboard, {
-      propsData: {
-        digitsAfterDecimalPoint: 2,
-        lastUpdated: new Date(),
-        problems: [
-          {
-            accepted: 52,
-            alias: 'sumas',
-            commit: '587cb50672aa364c75e16b638ec7ca7289e24b08',
-            difficulty: 0,
-            languages:
-              'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,java,py2,py3,rb,cs,pas,hs,lua',
-            letter: 'A',
-            order: 1,
-            points: 100,
-            submissions: 23,
-            title: 'Sumas',
-            version: 'dba31432b084856b69bf4f661341561c08d0bbea',
-            visibility: 2,
-            visits: 0,
-          },
-        ] as omegaup.Problem[],
-        ranking: [
-          {
-            classname: 'user-rank-master',
-            country: 'xx',
-            is_invited: false,
-            name: 'test_user_0',
-            problems: [
-              { alias: 'sumas', penalty: 0, percent: 0, points: 0, runs: 2 },
-            ],
-            total: {
-              penalty: 0,
-              points: 0,
-            },
-            username: 'test_user_0',
-          },
-          {
-            classname: 'user-rank-master',
-            country: 'xx',
-            is_invited: true,
-            name: 'test_user_1',
-            problems: [
-              {
-                alias: 'sumas',
-                penalty: 0,
-                percent: 100,
-                points: 100,
-                runs: 1,
-              },
-            ],
-            total: { penalty: 0, points: 0 },
-            username: 'test_user_1',
-          },
-        ],
-        scoreboardColors: [
-          '#FB3F51',
-          '#FF5D40',
-          '#FFA240',
-          '#FFC740',
-          '#59EA3A',
-          '#37DD6F',
-          '#34D0BA',
-          '#3AAACF',
-          '#8144D6',
-          '#CD35D3',
-        ],
-        shouldShowInvitedUsersFilter: false,
-        showPenalty: false,
-      },
+      propsData: Object.assign(
+        {
+          showInvitedUsersFilter: false,
+        },
+        baseScoreboardProps,
+      ),
     });
     // All participants are visible and toggle contestants check is hidden
     expect(wrapper.find('.omegaup-scoreboard table tbody').text()).toContain(

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -3,8 +3,8 @@
     <!-- id-lint off -->
     <div id="ranking-chart"></div>
     <!-- id-lint on -->
-    <label
-      ><input
+    <label v-if="this.shouldShowInvitedUsersFilter">
+      <input
         class="toggle-contestants"
         type="checkbox"
         v-model="onlyShowExplicitlyInvited"
@@ -165,6 +165,7 @@ export default class ArenaScoreboard extends Vue {
   @Prop() problems!: omegaup.Problem[];
   @Prop() ranking!: types.ScoreboardRankingEntry[];
   @Prop() lastUpdated!: Date;
+  @Prop() shouldShowInvitedUsersFilter!: boolean;
   @Prop({ default: true }) showPenalty!: boolean;
   @Prop({ default: 2 }) digitsAfterDecimalPoint!: number;
 
@@ -208,6 +209,9 @@ export default class ArenaScoreboard extends Vue {
   }
 
   showUser(userIsInvited: boolean): boolean {
+    // Invited users filter is only available in contests, in a course all users
+    // are visible in scoreboard.
+    if (!this.shouldShowInvitedUsersFilter) return true;
     return userIsInvited || !this.onlyShowExplicitlyInvited;
   }
 }

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -3,7 +3,7 @@
     <!-- id-lint off -->
     <div id="ranking-chart"></div>
     <!-- id-lint on -->
-    <label v-if="this.shouldShowInvitedUsersFilter">
+    <label v-if="this.showInvitedUsersFilter">
       <input
         class="toggle-contestants"
         type="checkbox"
@@ -165,7 +165,7 @@ export default class ArenaScoreboard extends Vue {
   @Prop() problems!: omegaup.Problem[];
   @Prop() ranking!: types.ScoreboardRankingEntry[];
   @Prop() lastUpdated!: Date;
-  @Prop() shouldShowInvitedUsersFilter!: boolean;
+  @Prop({ default: true }) showInvitedUsersFilter!: boolean;
   @Prop({ default: true }) showPenalty!: boolean;
   @Prop({ default: 2 }) digitsAfterDecimalPoint!: number;
 
@@ -211,7 +211,7 @@ export default class ArenaScoreboard extends Vue {
   showUser(userIsInvited: boolean): boolean {
     // Invited users filter is only available in contests, in a course all users
     // are visible in scoreboard.
-    if (!this.shouldShowInvitedUsersFilter) return true;
+    if (!this.showInvitedUsersFilter) return true;
     return userIsInvited || !this.onlyShowExplicitlyInvited;
   }
 }


### PR DESCRIPTION
# Descripción

Se deja de mostrar el checkbox de mostrar concursantes invitados a un curso en el scoreboard.

El motivo es por dos razones:

- En un curso no hay concursantes (cuyo caso debería decir participantes).
- Aún no hay casos en los que un curso público tenga participantes invitados, así que todos
deben ser visibles siempre.

![image](https://user-images.githubusercontent.com/3230352/85451765-d5b2b200-b55f-11ea-8ce0-60a4d2df55b5.png)


Fixes: #4230 


# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
