### PR TITLE
Dejando de llamar `exit` / `die()` en controladores

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -35,6 +35,9 @@ class ApiCaller {
                 200
             );
             return $response;
+        } catch (\OmegaUp\Exceptions\ExitException $e) {
+            // The controller has explicitly requested to exit.
+            exit;
         } catch (\OmegaUp\Exceptions\ApiException $e) {
             $apiException = $e;
         } catch (\Exception $e) {

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -4433,8 +4433,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
         fclose($out);
 
-        // X_X
-        die();
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
     }
 
     /**
@@ -4478,7 +4479,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         $zip->finish();
 
-        die();
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
     }
 
     /**

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2179,7 +2179,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
         $problemArtifacts->download();
 
-        die();
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
     }
 
     /**
@@ -4954,7 +4956,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $problemParams = self::convertRequestToProblemParams($r);
                 self::createProblem($r->user, $r->identity, $problemParams);
                 header("Location: /problem/{$r['problem_alias']}/edit/");
-                die();
+
+                // Since all the headers and response have been sent, make the API
+                // caller to exit quietly.
+                throw new \OmegaUp\Exceptions\ExitException();
+            } catch (\OmegaUp\Exceptions\ExitException $e) {
+                throw $e;
             } catch (\OmegaUp\Exceptions\ApiException $e) {
                 /** @var array{error?: string} */
                 $response = $e->asResponseArray();
@@ -5190,7 +5197,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'Location: ' . TEMPLATES_URL_PATH . "{$r['problem_alias']}/{$r['commit']}/{$r['filename']}?noredirect=1"
         );
         header('HTTP/1.1 303 See Other');
-        die();
+
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
     }
 
     public static function regenerateTemplates(
@@ -5253,7 +5263,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'Location: ' . IMAGES_URL_PATH . "{$r['problem_alias']}/{$r['object_id']}.{$r['extension']}?noredirect=1"
         );
         header('HTTP/1.1 303 See Other');
-        die();
+
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
     }
 
     public static function regenerateImage(
@@ -5417,7 +5430,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
             );
             readfile("{$dirname}/interactive.zip");
             \OmegaUp\FileHandler::deleteDirRecursively($dirname);
-            die();
+
+            // Since all the headers and response have been sent, make the API
+            // caller to exit quietly.
+            throw new \OmegaUp\Exceptions\ExitException();
+        } catch (\OmegaUp\Exceptions\ExitException $e) {
+            throw $e;
         } catch (\Exception $e) {
             return [
                 'smartyProperties' => [

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1065,7 +1065,10 @@ class Run extends \OmegaUp\Controllers\Controller {
         ) {
             http_response_code(404);
         }
-        exit;
+
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
     }
 
     /**

--- a/frontend/server/src/Exceptions/ExitException.php
+++ b/frontend/server/src/Exceptions/ExitException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OmegaUp\Exceptions;
+
+class ExitException extends \OmegaUp\Exceptions\ApiException {
+    public function __construct() {
+        parent::__construct('', 'HTTP/1.1 200 OK', 200);
+    }
+}

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -274,6 +274,9 @@ class UITools {
             $navbarSection = $response['navbarSection'] ?? '';
             /** @var array<string, mixed> */
             $payload = $smartyProperties['payload'] ?? [];
+        } catch (\OmegaUp\Exceptions\ExitException $e) {
+            // The callback explicitly requested to exit.
+            exit;
         } catch (\Exception $e) {
             \OmegaUp\ApiCaller::handleException($e);
         }


### PR DESCRIPTION
Este cambio introduce `ExitException`, para que los controladores dejen
de llamar cosas que matan súbitamente el proceso. Esto permite llamar
más cosas desde pruebas.