### PR TITLE
Ordenando el scoreboard de cursos por ranking

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -3715,10 +3715,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             ])
         );
 
-        return $scoreboard->generate(
-            false /*withRunDetails*/,
-            true /*sortByName*/
-        );
+        return $scoreboard->generate();
     }
 
     /**

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -3715,7 +3715,10 @@ class Course extends \OmegaUp\Controllers\Controller {
             ])
         );
 
-        return $scoreboard->generate();
+        return $scoreboard->generate(
+            /*$withRunDetails=*/false,
+            /*$sortByName=*/false
+        );
     }
 
     /**

--- a/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
+++ b/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
@@ -54,19 +54,25 @@ class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             'assignment' => $courseData['assignment_alias']
         ]));
 
-        // Validation. Courses should be sorted by names instead of ranking.
+        $userScore = [];
+        foreach ($expectedScores as $index => $score) {
+            $key = array_keys($score);
+            $userScore[$index] = $score[$key[0]];
+        }
+
+        // Validation. Now, courses should be sorted by ranking.
         array_multisort(
+            array_values($userScore),
+            SORT_DESC,
             array_keys($expectedScores),
             SORT_ASC,
-            array_values($expectedScores),
-            SORT_DESC,
             $expectedScores
         );
         $expectedPlace = 0;
         $lastScore = 0;
         $i = 0;
         foreach ($expectedScores as $username => $score) {
-            if ($lastScore != $score) {
+            if ($lastScore !== $score) {
                 $expectedPlace = $i + 1;
                 $lastScore = $score;
             }
@@ -76,9 +82,10 @@ class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                 $response['ranking'][$i]['username'],
                 'Scoreboard is not properly sorted by username.'
             );
-            $this->assertFalse(
-                array_key_exists('place', $response['ranking'][$i]),
-                'Course scoreboard contains place information and should not.'
+            $this->assertEquals(
+                $expectedPlace,
+                $response['ranking'][$i]['place'],
+                'Course scoreboard place information is wrong.'
             );
             $i++;
         }


### PR DESCRIPTION
# Descripción

En este cambio se ordena por ranking el scoreboard de los cursos, ahora es
más parecido al scoreboard de concursos, ya que también incluye la posición
en la que se encuentra el estudiante dentro de una tarea/examen. 

![ScoreboardCourse](https://user-images.githubusercontent.com/3230352/85633168-4defa500-b63e-11ea-81ac-717bfdb645c5.gif)


Fixes: #3387 

# Comentarios

En este cambio no se consideró actualizar el scoreboard en tiempo real. Por lo
pronto ya no existe el checkbox de mostrar sólo usuarios invitados, lo cual 
hará más simple revisar el avance de los estudiantes.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.