### PR TITLE
Unificando los estilos de Markdown

### DIFF
--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -1,6 +1,113 @@
 <template>
-  <vue-mathjax v-bind:formula="html" v-bind:safe="false"></vue-mathjax>
+  <div class="statement">
+    <vue-mathjax v-bind:formula="html" v-bind:safe="false"></vue-mathjax>
+  </div>
 </template>
+
+<style lang="scss" scoped>
+.statement {
+  max-width: 50em;
+  margin: 0 auto;
+
+  h1 {
+    font-size: 1.3em;
+    margin: 1em 0 0.5em 0;
+    font-weight: bold;
+  }
+  h2 {
+    font-size: 1.1em;
+    margin: 1em 0 0.5em 0;
+    font-weight: bold;
+  }
+  h3 {
+    font-size: 1em;
+    margin: 1em 0 0.5em 0;
+    font-weight: bold;
+  }
+
+  p,
+  li {
+    hyphens: auto;
+    line-height: 150%;
+    text-align: justify;
+    orphans: 2;
+    widows: 2;
+    page-break-inside: avoid;
+  }
+  p {
+    margin-bottom: 1.5em;
+  }
+
+  ul {
+    list-style: disc;
+  }
+  ol {
+    list-style: decimal;
+  }
+  ul li,
+  ol li {
+    margin-left: 2em;
+  }
+
+  pre {
+    line-height: 125%;
+  }
+
+  figure {
+    text-align: center;
+    page-break-inside: avoid;
+  }
+
+  table td {
+    border: 1px solid #000;
+    padding: 10px;
+  }
+  table th {
+    text-align: center;
+  }
+  table.sample_io {
+    margin: 5px;
+    padding: 5px;
+    tbody {
+      background: #eee;
+      border: 1px solid #000;
+    }
+    th {
+      padding: 10px;
+      border-top: 0;
+    }
+    td {
+      vertical-align: top;
+      padding: 10px;
+      border: 1px solid #000;
+    }
+    pre {
+      white-space: pre;
+      word-break: keep-all;
+      word-wrap: normal;
+      background: transparent;
+      border: 0px;
+      padding: 0px;
+      margin: inherit;
+    }
+  }
+
+  iframe {
+    width: 100%;
+    height: 400px;
+  }
+
+  a.libinteractive-help {
+    display: inline-block;
+    float: right;
+  }
+
+  img {
+    max-width: 100%;
+    page-break-inside: avoid;
+  }
+}
+</style>
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';


### PR DESCRIPTION
Este cambio copia todos los estilos CSS relacionados con Markdown que
solían estar desperdigados entre los varios archivos `.css` a
`Markdown.vue`. Una vez que nos deshagamos del último conversor de
Markdown a mano, podemos eliminar todos los estilos duplicados!

Fixes: #4264