### PR TITLE
Agregando una página de error para HTTP 400

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -301,6 +301,15 @@ class ApiCaller {
             );
         }
 
+        if ($apiException->getcode() == 400) {
+            self::$log->info("{$apiException}");
+            header('HTTP/1.1 400 Bad Request');
+            die(
+                file_get_contents(
+                    sprintf('%s/www/400.html', strval(OMEGAUP_ROOT))
+                )
+            );
+        }
         if ($apiException->getCode() == 401) {
             self::$log->info("{$apiException}");
             header(

--- a/frontend/www/400.html
+++ b/frontend/www/400.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+	<head>
+		<title>400 &ndash; omegaUp</title>
+		<style>
+			body { background: #eee; }
+			h1, h3 { font-family: "Trebuchet MS", sans-serif; text-align: center; }
+			h1 { margin-top: 2em; margin-bottom: 0; font-size: 10em; font-weight: bold; }
+			h3 { margin-top: 0; }
+			span { color: #679ce4; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: smaller; }
+		</style>
+	</head>
+	<body>
+			<h1><strong title="omega">&Omega;</strong><span title="Down">&#11015;</span></h1>
+			<h3>HTTP/1.1 400 - Bad Request</h3>
+			<h3><a href="https://omegaup.com">omegaup.com<a></h3>
+	</body>
+</html>


### PR DESCRIPTION
Este cambio hace que si un cliente hace una petición mal-formada, en vez
de decirle que hubo un error 500, le informa que hubo un error 400.