### PR TITLE
Limpiando la interfaz de Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           python3 -m pip install --user setuptools
           python3 -m pip install --user wheel
-          python3 -m pip install --user mysqlclient
+          python3 -m pip install --user \
+            mysqlclient==1.4.6
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -219,8 +220,12 @@ jobs:
           python3 -m pip install --user setuptools
           python3 -m pip install --user wheel
           python3 -m pip install --user --upgrade urllib3
-          python3 -m pip install --user mysqlclient selenium pytest \
-            pytest-xdist flaky
+          python3 -m pip install --user \
+            mysqlclient==1.4.6 \
+            selenium \
+            pytest \
+            pytest-xdist \
+            flaky
 
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-progress

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -274,6 +274,8 @@ class Utils {
     }
 
     private static function shellExec(string $command): void {
+        $log = \Logger::getLogger('\\OmegaUp\\Test\\Utils::shellExec()');
+        $log->info("========== Starting {$command}");
         /** @psalm-suppress ForbiddenCode this only runs in tests. */
         $proc = proc_open(
             $command,
@@ -292,6 +294,7 @@ class Utils {
         $stderr = stream_get_contents($pipes[2]);
         fclose($pipes[2]);
         $processStatus = proc_close($proc);
+        $log->info("========== Finished {$command}: {$processStatus}");
         if ($processStatus != 0) {
             throw new \Exception(
                 "Failed to run `{$command}`: status={$processStatus}\nstdout={$stdout}\nstderr={$stderr}"
@@ -323,6 +326,7 @@ class Utils {
              escapeshellarg(strval(OMEGAUP_ROOT)) .
              '/../stuff/cron/update_ranks.py' .
              ' --verbose ' .
+             ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
              ' --update-coder-of-the-month ' .
              ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
@@ -341,6 +345,7 @@ class Utils {
              escapeshellarg(strval(OMEGAUP_ROOT)) .
              '/../stuff/cron/aggregate_feedback.py' .
              ' --verbose ' .
+             ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
              ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
@@ -356,6 +361,7 @@ class Utils {
              escapeshellarg(strval(OMEGAUP_ROOT)) .
              '/../stuff/cron/assign_badges.py' .
              ' --verbose ' .
+             ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
              ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .

--- a/frontend/www/js/omegaup/Markdown.Converter.d.ts
+++ b/frontend/www/js/omegaup/Markdown.Converter.d.ts
@@ -1,24 +1,11 @@
 declare module '@/third_party/js/pagedown/Markdown.Converter.js' {
-  export type ImageMapping = {
-    [url: string]: string;
-  };
-
-  type ProblemSettings = any;
-
   interface Hooks {
     chain: (eventName: string, callback: any) => void;
   }
 
   export class Converter {
     hooks: Hooks;
-    _settings?: ProblemSettings;
-    _imageMapping?: ImageMapping;
 
     makeHtml: (markdown: string) => string;
-    makeHtmlWithImages: (
-      markdown: string,
-      imageMapping: ImageMapping,
-      settings: ProblemSettings,
-    ) => string;
   }
 }

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -29,8 +29,6 @@ import ArenaAdmin from './admin_arena';
 
 export { ArenaAdmin };
 
-import * as MarkdownConverter from '@/third_party/js/pagedown/Markdown.Converter.js';
-
 Vue.use(Vuex);
 
 export interface ArenaOptions {
@@ -297,8 +295,8 @@ export class Arena {
 
   markdownView: Vue & {
     markdown: string;
-    imageMapping: MarkdownConverter.ImageMapping;
-    problemSettings: markdown.ProblemSettings;
+    imageMapping: markdown.ImageMapping;
+    problemSettings?: types.ProblemSettings;
   };
 
   runDetailsView:
@@ -625,8 +623,8 @@ export class Arena {
       },
       data: {
         markdown: '',
-        imageMapping: <MarkdownConverter.ImageMapping>{},
-        problemSettings: <markdown.ProblemSettings>{},
+        imageMapping: <markdown.ImageMapping>{},
+        problemSettings: <types.ProblemSettings | undefined>undefined,
       },
       components: {
         'omegaup-markdown': omegaup_Markdown,

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -131,7 +131,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import * as markdown from '../markdown';
-import * as MarkdownConverter from '@/third_party/js/pagedown/Markdown.Converter.js';
+import { types } from '../api_types';
 
 import { VueMathjax } from 'vue-mathjax';
 
@@ -142,18 +142,18 @@ import { VueMathjax } from 'vue-mathjax';
 })
 export default class Markdown extends Vue {
   @Prop() markdown!: string;
-  @Prop({ default: null }) imageMapping!: MarkdownConverter.ImageMapping | null;
-  @Prop({ default: null }) problemSettings!: markdown.ProblemSettings | null;
+  @Prop({ default: null }) imageMapping!: markdown.ImageMapping | null;
+  @Prop({ default: null }) problemSettings!: types.ProblemSettings | null;
   @Prop({ default: false }) preview!: boolean;
 
-  markdownConverter = markdown.markdownConverter({ preview: this.preview });
+  markdownConverter = new markdown.Converter({ preview: this.preview });
 
   get html(): string {
     if (this.problemSettings || this.imageMapping) {
       return this.markdownConverter.makeHtmlWithImages(
         this.markdown,
         this.imageMapping || {},
-        this.problemSettings || {},
+        this.problemSettings || undefined,
       );
     }
     return this.markdownConverter.makeHtml(this.markdown);

--- a/frontend/www/js/omegaup/components/problem/StatementEdit.vue
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.vue
@@ -116,9 +116,8 @@ import * as markdown from '../../markdown';
 import omegaup_Markdown from '../Markdown.vue';
 import user_Username from '../user/Username.vue';
 
-const markdownConverter = markdown.markdownConverter({
+const markdownConverter = new markdown.Converter({
   preview: true,
-  imageMapping: {},
 });
 
 @Component({
@@ -149,7 +148,7 @@ export default class ProblemStatementEdit extends Vue {
   markdownEditor: Markdown.Editor | null = null;
 
   mounted(): void {
-    this.markdownEditor = new Markdown.Editor(markdownConverter, '', {
+    this.markdownEditor = new Markdown.Editor(markdownConverter.converter, '', {
       panels: {
         buttonBar: this.markdownButtonBar,
         preview: null,

--- a/frontend/www/js/omegaup/markdown.test.ts
+++ b/frontend/www/js/omegaup/markdown.test.ts
@@ -3,8 +3,8 @@ import expect from 'expect';
 import * as markdown from './markdown';
 
 describe('markdown', () => {
-  describe('markdownConverter', () => {
-    let converter = markdown.markdownConverter();
+  describe('Converter', () => {
+    const converter = new markdown.Converter();
 
     it('Should handle trivial inputs', () => {
       expect(converter.makeHtml('Foo')).toEqual('<p>Foo</p>');

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -1,419 +1,438 @@
-import T from './lang';
-
 import * as Markdown from '@/third_party/js/pagedown/Markdown.Converter.js';
 import { getSanitizingConverter } from '@/third_party/js/pagedown/Markdown.Sanitizer.js';
 
-export type ProblemSettings = any;
+import T from './lang';
+import { types } from './api_types';
 
-export function markdownConverter(
-  options: {
-    preview?: boolean;
-    settings?: ProblemSettings;
-    imageMapping?: Markdown.ImageMapping;
-  } = {},
-) {
-  // Map of templates.
-  const templates: { [key: string]: string } = {};
-  if (options.preview) {
-    templates['libinteractive:download'] =
-      '<code class="libinteractive-download">' +
-      '<i class="glyphicon glyphicon-download-alt"></i></code>';
-  } else {
-    templates[
-      'libinteractive:download'
-    ] = `<div class="libinteractive-download panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
-          ${T.libinteractiveTitle}
-          <a class="libinteractive-help" target="_blank" href="/libinteractive/${T.locale}/contest/"><span class="glyphicon glyphicon-question-sign"></span></a>
-        </h3>
-      </div>
-      <div class="panel-body">
-        <form role="form">
-          <div class="form-horizontal">
-            <div class="form-group row">
-              <label class="col-xs-6 col-sm-2 control-label">${T.libinteractiveOs}</label>
-              <div class="col-xs-6 col-sm-10">
-                <select class="form-control download-os">
-                  <option value="unix">Linux/Mac OS X</option>
-                  <option value="windows">Windows</option>
-                </select>
+export type ImageMapping = {
+  [url: string]: string;
+};
+
+export interface ConverterOptions {
+  preview?: boolean;
+}
+
+export class Converter {
+  private _converter: Markdown.Converter;
+  private _settings?: types.ProblemSettings;
+  private _imageMapping?: ImageMapping;
+
+  constructor(options: ConverterOptions = {}) {
+    this._converter = getSanitizingConverter();
+
+    // Map of templates.
+    const templates: { [key: string]: string } = {};
+    if (options.preview) {
+      templates['libinteractive:download'] =
+        '<code class="libinteractive-download">' +
+        '<i class="glyphicon glyphicon-download-alt"></i></code>';
+    } else {
+      templates[
+        'libinteractive:download'
+      ] = `<div class="libinteractive-download panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            ${T.libinteractiveTitle}
+            <a class="libinteractive-help" target="_blank" href="/libinteractive/${T.locale}/contest/"><span class="glyphicon glyphicon-question-sign"></span></a>
+          </h3>
+        </div>
+        <div class="panel-body">
+          <form role="form">
+            <div class="form-horizontal">
+              <div class="form-group row">
+                <label class="col-xs-6 col-sm-2 control-label">${T.libinteractiveOs}</label>
+                <div class="col-xs-6 col-sm-10">
+                  <select class="form-control download-os">
+                    <option value="unix">Linux/Mac OS X</option>
+                    <option value="windows">Windows</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group row">
+                <label class="col-xs-6 col-sm-2 control-label">${T.libinteractiveLanguage}</label>
+                <div class="col-xs-6 col-sm-10">
+                  <select class="form-control download-lang">
+                    <option value="c" selected="selected">C</option>
+                    <option value="cpp">C++</option>
+                    <option value="java">Java</option>
+                    <option value="py">Python</option>
+                    <option value="pas">Pascal</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group row">
+                <strong class="col-xs-6 col-sm-2 control-label">${T.libinteractiveFilename}</strong>
+                <div class="col-xs-6 col-sm-10">
+                  <span class="libinteractive-interface-name"></span>.<span class="libinteractive-extension">c</span>
+                </div>
+              </div>
+              <div class="form-group row">
+                <div class="col-xs-12 col-sm-offset-2 offset-sm-2 col-sm-10">
+                  <button type="submit" class="btn btn-primary active">
+                    ${T.libinteractiveDownload}
+                  </button>
+                </div>
               </div>
             </div>
-            <div class="form-group row">
-              <label class="col-xs-6 col-sm-2 control-label">${T.libinteractiveLanguage}</label>
-              <div class="col-xs-6 col-sm-10">
-                <select class="form-control download-lang">
-                  <option value="c" selected="selected">C</option>
-                  <option value="cpp">C++</option>
-                  <option value="java">Java</option>
-                  <option value="py">Python</option>
-                  <option value="pas">Pascal</option>
-                </select>
-              </div>
-            </div>
-            <div class="form-group row">
-              <strong class="col-xs-6 col-sm-2 control-label">${T.libinteractiveFilename}</strong>
-              <div class="col-xs-6 col-sm-10">
-                <span class="libinteractive-interface-name"></span>.<span class="libinteractive-extension">c</span>
-              </div>
-            </div>
-            <div class="form-group row">
-              <div class="col-xs-12 col-sm-offset-2 offset-sm-2 col-sm-10">
-                <button type="submit" class="btn btn-primary active">
-                  ${T.libinteractiveDownload}
-                </button>
-              </div>
-            </div>
-          </div>
-        </form>
-      </div>
-    </div>`;
-  }
-
-  const converter = getSanitizingConverter();
-  const whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|figure|figcaption|code|i|table|tbody|thead|tr|th(?: align="\w+")?|td(?: align="\w+")?|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
-  const imageWhitelist = new RegExp(
-    '^<img\\ssrc="data:image/[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$',
-    'i',
-  );
-
-  converter.hooks.chain(
-    'isValidTag',
-    (tag: string): boolean =>
-      tag.match(whitelist) != null || tag.match(imageWhitelist) != null,
-  );
-
-  // These two functions are adapted from Markdown.Converter.js. They are
-  // needed to support images with some special characters in their name.
-  const escapeCharacters = (
-    text: string,
-    charsToEscape: string,
-    afterBackslash: boolean = false,
-    doNotEscapeTildeAndDollar: boolean = false,
-  ): string => {
-    // First we have to escape the escape characters so that
-    // we can build a character class out of them
-    let regexString = `([${charsToEscape.replace(/([\[\]\\])/g, '\\$1')}])`;
-
-    if (afterBackslash) {
-      regexString = `\\\\${regexString}`;
+          </form>
+        </div>
+      </div>`;
     }
 
-    const regex = new RegExp(regexString, 'g');
-    if (!doNotEscapeTildeAndDollar) {
-      text = text.replace(/~/g, '~T').replace(/\$/g, '~D');
-    }
-    return text.replace(regex, (wholeMatch, m1) => `~E${m1.charCodeAt(0)}E`);
-  };
-  const unescapeCharacters = (text: string): string => {
-    //
-    // Swap back in all the special characters we've hidden.
-    //
-    return text
-      .replace(/~E(\d+)E/g, (wholeMatch: string, m1: string): string => {
-        const charCodeToReplace = parseInt(m1);
-        return String.fromCharCode(charCodeToReplace);
-      })
-      .replace(/~D/g, '$')
-      .replace(/~T/g, '~');
-  };
+    const whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|figure|figcaption|code|i|table|tbody|thead|tr|th(?: align="\w+")?|td(?: align="\w+")?|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
+    const imageWhitelist = new RegExp(
+      '^<img\\ssrc="data:image/[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$',
+      'i',
+    );
 
-  converter.hooks.chain('postSpanGamut', (text: string): string => {
-    // Templates.
-    text = text.replace(
-      /^\s*\{\{([a-z0-9_:]+)\}\}\s*$/g,
-      (wholematch: string, m1: string): string => {
-        if (templates.hasOwnProperty(m1)) {
-          return templates[m1];
-        }
-        return (
-          '<strong style="color: red">Unrecognized template name: ' +
-          m1 +
-          '</strong>'
+    this._converter.hooks.chain(
+      'isValidTag',
+      (tag: string): boolean =>
+        tag.match(whitelist) != null || tag.match(imageWhitelist) != null,
+    );
+
+    // These two functions are adapted from Markdown.Converter.js. They are
+    // needed to support images with some special characters in their name.
+    const escapeCharacters = (
+      text: string,
+      charsToEscape: string,
+      afterBackslash: boolean = false,
+      doNotEscapeTildeAndDollar: boolean = false,
+    ): string => {
+      // First we have to escape the escape characters so that
+      // we can build a character class out of them
+      let regexString = `([${charsToEscape.replace(/([\[\]\\])/g, '\\$1')}])`;
+
+      if (afterBackslash) {
+        regexString = `\\\\${regexString}`;
+      }
+
+      const regex = new RegExp(regexString, 'g');
+      if (!doNotEscapeTildeAndDollar) {
+        text = text.replace(/~/g, '~T').replace(/\$/g, '~D');
+      }
+      return text.replace(regex, (wholeMatch, m1) => `~E${m1.charCodeAt(0)}E`);
+    };
+    const unescapeCharacters = (text: string): string => {
+      //
+      // Swap back in all the special characters we've hidden.
+      //
+      return text
+        .replace(/~E(\d+)E/g, (wholeMatch: string, m1: string): string => {
+          const charCodeToReplace = parseInt(m1);
+          return String.fromCharCode(charCodeToReplace);
+        })
+        .replace(/~D/g, '$')
+        .replace(/~T/g, '~');
+    };
+
+    this._converter.hooks.chain('postSpanGamut', (text: string): string => {
+      // Templates.
+      text = text.replace(
+        /^\s*\{\{([a-z0-9_:]+)\}\}\s*$/g,
+        (wholematch: string, m1: string): string => {
+          if (templates.hasOwnProperty(m1)) {
+            return templates[m1];
+          }
+          return (
+            '<strong style="color: red">Unrecognized template name: ' +
+            m1 +
+            '</strong>'
+          );
+        },
+      );
+      // Images.
+      const imageMapping: ImageMapping = this._imageMapping || {};
+      text = text.replace(
+        /<img src="([^"]+)"\s*([^>]+)>/g,
+        (wholeMatch: string, url: string, attributes: string): string => {
+          url = unescapeCharacters(url);
+          if (url.indexOf('/') != -1 || !imageMapping.hasOwnProperty(url)) {
+            return wholeMatch;
+          }
+          return `<img src="${escapeCharacters(
+            imageMapping[url],
+            '*_',
+          )}" ${attributes}>`;
+        },
+      );
+      // Figures.
+      text = text.replace(
+        /^\s*<img src="([^"]+)"\s*([^>]+)\s+title="([^"]+)"\s*\/>\s*$/g,
+        (wholeMatch: string, url: string, attributes: string, title: string) =>
+          `<figure><img src="${url}" ${attributes} />` +
+          `<figcaption>${title}</figcaption></figure>`,
+      );
+      return text;
+    });
+    this._converter.hooks.chain(
+      'postNormalization',
+      (text: string, blockGamut: (text: string) => string): string => {
+        // Sample I/O table.
+        const settings = this._settings;
+        return text.replace(
+          /^( {0,3}\|\| *(?:input|examplefile) *\n(?:.|\n)+?\n) {0,3}\|\| *end *\n/gm,
+          (whole: string, inner: string): string => {
+            var matches = inner.split(
+              / {0,3}\|\| *(examplefile|input|output|description) *\n/,
+            );
+            var result = '';
+            var description_column = false;
+            for (var i = 1; i < matches.length; i += 2) {
+              if (matches[i] == 'description') {
+                description_column = true;
+                break;
+              }
+            }
+            result += '<thead><tr>';
+            result += `<th>${T.wordsInput}</th>`;
+            result += `<th>${T.wordsOutput}</th>`;
+            if (description_column) {
+              result += `<th>${T.wordsDescription}</th>`;
+            }
+            result += '</tr></thead>';
+            var first_row = true;
+            var columns = 0;
+            result += '<tbody>';
+            for (var i = 1; i < matches.length; i += 2) {
+              if (matches[i] == 'description') {
+                result += '<td>' + blockGamut(matches[i + 1]) + '</td>';
+                columns++;
+              } else {
+                if (matches[i] == 'input' || matches[i] == 'examplefile') {
+                  if (!first_row) {
+                    while (columns < (description_column ? 3 : 2)) {
+                      result += '<td></td>';
+                      columns++;
+                    }
+                    result += '</tr>';
+                  }
+                  first_row = false;
+                  result += '<tr>';
+                  columns = 0;
+                }
+
+                if (matches[i] == 'examplefile') {
+                  let exampleFilename = matches[i + 1].trim();
+                  let exampleFile = {
+                    in: `{{examples/${exampleFilename}.in}}`,
+                    out: `{{examples/${exampleFilename}.out}}`,
+                  };
+                  if (settings?.cases.hasOwnProperty(exampleFilename)) {
+                    exampleFile = settings.cases[exampleFilename];
+                  }
+                  result += `<td><pre>${exampleFile['in'].replace(
+                    /\s+$/,
+                    '',
+                  )}</pre></td>`;
+                  result += `<td><pre>${exampleFile.out.replace(
+                    /\s+$/,
+                    '',
+                  )}</pre></td>`;
+                  columns += 2;
+                } else {
+                  result += `<td><pre>${escapeCharacters(
+                    matches[i + 1]
+                      .replace(/\s+$/, '')
+                      .replace(/&/g, '&amp;')
+                      .replace(/</g, '&lt;')
+                      .replace(/>/g, '&gt;'),
+                    ' \t*_{}[]()<>#+=.!|`-',
+                    /*afterBackslash=*/ false,
+                    /*doNotEscapeTildeAnDollar=*/ true,
+                  )}</pre></td>`;
+                  columns++;
+                }
+              }
+            }
+            while (columns < (description_column ? 3 : 2)) {
+              result += '<td></td>';
+              columns++;
+            }
+            result += '</tr></tbody>';
+
+            return '<table class="sample_io">\n' + result + '\n</table>\n';
+          },
         );
       },
     );
-    // Images.
-    const imageMapping: Markdown.ImageMapping =
-      converter._imageMapping || options.imageMapping || {};
-    text = text.replace(
-      /<img src="([^"]+)"\s*([^>]+)>/g,
-      (wholeMatch: string, url: string, attributes: string): string => {
-        url = unescapeCharacters(url);
-        if (url.indexOf('/') != -1 || !imageMapping.hasOwnProperty(url)) {
-          return wholeMatch;
-        }
-        return `<img src="${escapeCharacters(
-          imageMapping[url],
-          '*_',
-        )}" ${attributes}>`;
+    this._converter.hooks.chain(
+      'preBlockGamut',
+      (
+        text: string,
+        blockGamut: (text: string) => string,
+        spanGamut: (text: string) => string,
+      ): string => {
+        // GitHub-flavored fenced code blocks
+        const fencedCodeBlock = (
+          whole: string,
+          indentation: string,
+          fence: string,
+          infoString: string,
+          contents: string,
+        ) => {
+          contents = contents
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+          if (indentation != '') {
+            let lines = [];
+            let stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
+            for (let line of contents.split('\n')) {
+              lines.push(line.replace(stripPrefix, ''));
+            }
+            contents = escapeCharacters(
+              lines.join('\n'),
+              ' \t*_{}[]()<>#+=.!|`-',
+              /*afterBackslash=*/ false,
+              /*doNotEscapeTildeAnDollar=*/ true,
+            );
+          }
+          let className = '';
+          infoString = infoString.trim();
+          if (infoString != '') {
+            className = ` class="language-${infoString.split(/\s+/)[0]}"`;
+          }
+          return `<pre><code${className}>${contents}</code></pre>`;
+        };
+        text = text.replace(
+          new RegExp(
+            '^( {0,3})(`{3,})([^`\\n]*)\\n((?:.|\\n)*?\\n|) {0,3}\\2`* *$',
+            'gm',
+          ),
+          fencedCodeBlock,
+        );
+        return text.replace(
+          new RegExp(
+            '^( {0,3})((?:~T){3,})(?!~)([^\\n]*)\\n((.|\\n)*?\\n|) {0,3}\\2(?:~T)* *$',
+            'gm',
+          ),
+          fencedCodeBlock,
+        );
       },
     );
-    // Figures.
-    text = text.replace(
-      /^\s*<img src="([^"]+)"\s*([^>]+)\s+title="([^"]+)"\s*\/>\s*$/g,
-      (wholeMatch: string, url: string, attributes: string, title: string) =>
-        `<figure><img src="${url}" ${attributes} />` +
-        `<figcaption>${title}</figcaption></figure>`,
-    );
-    return text;
-  });
-  converter.hooks.chain(
-    'postNormalization',
-    (text: string, blockGamut: (text: string) => string): string => {
-      // Sample I/O table.
-      let settings = converter._settings || options.settings || { cases: {} };
-      return text.replace(
-        /^( {0,3}\|\| *(?:input|examplefile) *\n(?:.|\n)+?\n) {0,3}\|\| *end *\n/gm,
-        (whole: string, inner: string): string => {
-          var matches = inner.split(
-            / {0,3}\|\| *(examplefile|input|output|description) *\n/,
-          );
-          var result = '';
-          var description_column = false;
-          for (var i = 1; i < matches.length; i += 2) {
-            if (matches[i] == 'description') {
-              description_column = true;
-              break;
-            }
-          }
-          result += '<thead><tr>';
-          result += `<th>${T.wordsInput}</th>`;
-          result += `<th>${T.wordsOutput}</th>`;
-          if (description_column) {
-            result += `<th>${T.wordsDescription}</th>`;
-          }
-          result += '</tr></thead>';
-          var first_row = true;
-          var columns = 0;
-          result += '<tbody>';
-          for (var i = 1; i < matches.length; i += 2) {
-            if (matches[i] == 'description') {
-              result += '<td>' + blockGamut(matches[i + 1]) + '</td>';
-              columns++;
-            } else {
-              if (matches[i] == 'input' || matches[i] == 'examplefile') {
-                if (!first_row) {
-                  while (columns < (description_column ? 3 : 2)) {
-                    result += '<td></td>';
-                    columns++;
-                  }
-                  result += '</tr>';
-                }
-                first_row = false;
-                result += '<tr>';
-                columns = 0;
-              }
+    this._converter.hooks.chain(
+      'preBlockGamut',
+      (
+        text: string,
+        blockGamut: (text: string) => string,
+        spanGamut: (text: string) => string,
+      ): string => {
+        // GitHub-flavored Markdown table.
+        return text.replace(
+          /^ {0,3}\|[^\n]*\|[ \t]*(\n {0,3}\|[^\n]*\|[ \t]*)+$/gm,
+          (whole: string, inner: string): string => {
+            let cells = whole
+              .trim()
+              .split('\n')
+              .map((line: string) => {
+                const m = line.match(/(\\\||[^|])+/g);
+                if (!m) return '';
+                return m.map((value: string) =>
+                  value.trim().replace(/\\\|/g, '|'),
+                );
+              });
 
-              if (matches[i] == 'examplefile') {
-                let exampleFilename = matches[i + 1].trim();
-                let exampleFile = {
-                  in: `{{examples/${exampleFilename}.in}}`,
-                  out: `{{examples/${exampleFilename}.out}}`,
-                };
-                if (settings.cases.hasOwnProperty(exampleFilename)) {
-                  exampleFile = settings.cases[exampleFilename];
-                }
-                result += `<td><pre>${exampleFile['in'].replace(
-                  /\s+$/,
-                  '',
-                )}</pre></td>`;
-                result += `<td><pre>${exampleFile.out.replace(
-                  /\s+$/,
-                  '',
-                )}</pre></td>`;
-                columns += 2;
-              } else {
-                result += `<td><pre>${escapeCharacters(
-                  matches[i + 1]
-                    .replace(/\s+$/, '')
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;'),
-                  ' \t*_{}[]()<>#+=.!|`-',
-                  /*afterBackslash=*/ false,
-                  /*doNotEscapeTildeAnDollar=*/ true,
-                )}</pre></td>`;
-                columns++;
-              }
-            }
-          }
-          while (columns < (description_column ? 3 : 2)) {
-            result += '<td></td>';
-            columns++;
-          }
-          result += '</tr></tbody>';
-
-          return '<table class="sample_io">\n' + result + '\n</table>\n';
-        },
-      );
-    },
-  );
-  converter.hooks.chain(
-    'preBlockGamut',
-    (
-      text: string,
-      blockGamut: (text: string) => string,
-      spanGamut: (text: string) => string,
-    ): string => {
-      // GitHub-flavored fenced code blocks
-      const fencedCodeBlock = (
-        whole: string,
-        indentation: string,
-        fence: string,
-        infoString: string,
-        contents: string,
-      ) => {
-        contents = contents
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;');
-        if (indentation != '') {
-          let lines = [];
-          let stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
-          for (let line of contents.split('\n')) {
-            lines.push(line.replace(stripPrefix, ''));
-          }
-          contents = escapeCharacters(
-            lines.join('\n'),
-            ' \t*_{}[]()<>#+=.!|`-',
-            /*afterBackslash=*/ false,
-            /*doNotEscapeTildeAnDollar=*/ true,
-          );
-        }
-        let className = '';
-        infoString = infoString.trim();
-        if (infoString != '') {
-          className = ` class="language-${infoString.split(/\s+/)[0]}"`;
-        }
-        return `<pre><code${className}>${contents}</code></pre>`;
-      };
-      text = text.replace(
-        new RegExp(
-          '^( {0,3})(`{3,})([^`\\n]*)\\n((?:.|\\n)*?\\n|) {0,3}\\2`* *$',
-          'gm',
-        ),
-        fencedCodeBlock,
-      );
-      return text.replace(
-        new RegExp(
-          '^( {0,3})((?:~T){3,})(?!~)([^\\n]*)\\n((.|\\n)*?\\n|) {0,3}\\2(?:~T)* *$',
-          'gm',
-        ),
-        fencedCodeBlock,
-      );
-    },
-  );
-  converter.hooks.chain(
-    'preBlockGamut',
-    (
-      text: string,
-      blockGamut: (text: string) => string,
-      spanGamut: (text: string) => string,
-    ): string => {
-      // GitHub-flavored Markdown table.
-      return text.replace(
-        /^ {0,3}\|[^\n]*\|[ \t]*(\n {0,3}\|[^\n]*\|[ \t]*)+$/gm,
-        (whole: string, inner: string): string => {
-          let cells = whole
-            .trim()
-            .split('\n')
-            .map((line: string) => {
-              const m = line.match(/(\\\||[^|])+/g);
-              if (!m) return '';
-              return m.map((value: string) =>
-                value.trim().replace(/\\\|/g, '|'),
-              );
-            });
-
-          // The header row must match the delimiter row in the number of
-          // cells. If not, a table will not be recognized.
-          if (cells.length < 2) {
-            return whole;
-          }
-
-          const header = cells[0];
-          const delimiter = cells[1];
-          const alignment = [];
-          if (header.length != delimiter.length) {
-            return whole;
-          }
-          cells = cells.slice(2);
-
-          // The delimiter row consists of cells whose only content are
-          // hyphens (-), and optionally, a leading or trailing colon (:),
-          // or
-          // both, to indicate left, right, or center alignment
-          // respectively.
-          for (let i = 0; i < delimiter.length; i++) {
-            if (!delimiter[i].match(/^:?-+:?$/)) {
+            // The header row must match the delimiter row in the
+            // number of cells. If not, a table will not be
+            // recognized.
+            if (cells.length < 2) {
               return whole;
             }
-            if (
-              delimiter[i][0] == ':' &&
-              delimiter[i][delimiter[i].length - 1] == ':'
-            ) {
-              alignment.push('center');
-            } else if (delimiter[i][delimiter[i].length - 1] == ':') {
-              alignment.push('right');
-            } else {
-              alignment.push('');
+
+            const header = cells[0];
+            const delimiter = cells[1];
+            const alignment = [];
+            if (header.length != delimiter.length) {
+              return whole;
             }
-          }
+            cells = cells.slice(2);
 
-          const alignedTag = (tagName: string, align: string) =>
-            '<' + tagName + (align ? ` align="${align}"` : '') + '>';
-
-          let text = '<table>\n';
-          text += '<thead>\n';
-          text += '<tr>\n';
-          for (let i = 0; i < header.length; i++) {
-            text +=
-              alignedTag('th', alignment[i]) + spanGamut(header[i]) + '</th>\n';
-          }
-          text += '</tr>\n';
-          text += '</thead>\n';
-          if (cells.length) {
-            text += '<tbody>\n';
-            for (let i = 0; i < cells.length; i++) {
-              text += '<tr>\n';
-              const row = cells[i];
-              for (let j = 0; j < Math.min(alignment.length, row.length); j++) {
-                text +=
-                  alignedTag('td', alignment[j]) +
-                  spanGamut(row[j]) +
-                  '</td>\n';
+            // The delimiter row consists of cells whose only
+            // content are hyphens (-), and optionally, a leading or
+            // trailing colon (:), or both, to indicate left, right,
+            // or center alignment respectively.
+            for (let i = 0; i < delimiter.length; i++) {
+              if (!delimiter[i].match(/^:?-+:?$/)) {
+                return whole;
               }
-              for (let j = row.length; j < alignment.length; j++) {
-                text += alignedTag('td', alignment[j]) + '</td>\n';
+              if (
+                delimiter[i][0] == ':' &&
+                delimiter[i][delimiter[i].length - 1] == ':'
+              ) {
+                alignment.push('center');
+              } else if (delimiter[i][delimiter[i].length - 1] == ':') {
+                alignment.push('right');
+              } else {
+                alignment.push('');
               }
-              text += '</tr>\n';
             }
-            text += '</tbody>\n';
-          }
-          text += '</table>\n';
 
-          return text;
-        },
-      );
-    },
-  );
+            const alignedTag = (tagName: string, align: string) =>
+              '<' + tagName + (align ? ` align="${align}"` : '') + '>';
 
-  converter.makeHtmlWithImages = (
+            let text = '<table>\n';
+            text += '<thead>\n';
+            text += '<tr>\n';
+            for (let i = 0; i < header.length; i++) {
+              text +=
+                alignedTag('th', alignment[i]) +
+                spanGamut(header[i]) +
+                '</th>\n';
+            }
+            text += '</tr>\n';
+            text += '</thead>\n';
+            if (cells.length) {
+              text += '<tbody>\n';
+              for (let i = 0; i < cells.length; i++) {
+                text += '<tr>\n';
+                const row = cells[i];
+                for (
+                  let j = 0;
+                  j < Math.min(alignment.length, row.length);
+                  j++
+                ) {
+                  text +=
+                    alignedTag('td', alignment[j]) +
+                    spanGamut(row[j]) +
+                    '</td>\n';
+                }
+                for (let j = row.length; j < alignment.length; j++) {
+                  text += alignedTag('td', alignment[j]) + '</td>\n';
+                }
+                text += '</tr>\n';
+              }
+              text += '</tbody>\n';
+            }
+            text += '</table>\n';
+
+            return text;
+          },
+        );
+      },
+    );
+  }
+
+  public get converter(): Markdown.Converter {
+    return this._converter;
+  }
+
+  public makeHtml(markdown: string): string {
+    return this._converter.makeHtml(markdown);
+  }
+
+  public makeHtmlWithImages(
     markdown: string,
-    imageMapping: Markdown.ImageMapping,
-    settings: ProblemSettings,
-  ): string => {
+    imageMapping: ImageMapping,
+    settings?: types.ProblemSettings,
+  ): string {
     try {
-      converter._imageMapping = imageMapping;
-      converter._settings = settings;
-      return converter.makeHtml(markdown);
+      this._imageMapping = imageMapping;
+      this._settings = settings;
+      return this._converter.makeHtml(markdown);
     } finally {
-      delete converter._imageMapping;
-      delete converter._settings;
+      delete this._imageMapping;
+      delete this._settings;
     }
-  };
-
-  return converter;
+  }
 }


### PR DESCRIPTION
Este cambio hace que la interfaz pública del convertidor de Markdown
(markdown.ts) ya no necesite importar cosas de Markdown.Converter.js.