### PR TITLE
Agregando un script para analizar las versiones de navegadores

### DIFF
--- a/stuff/browser_analytics.py
+++ b/stuff/browser_analytics.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python3
+"""Analyze browser usage from Google Analytics.
+
+In order to use this tool, export a .csv report of browsers (Audience >
+Technology > Browser & OS), with Secondary dimension of Browser Version.
+
+The mappings of some browser versions to their equivalent Chromium version may
+need to be maintained every now and then.
+"""
+
+import argparse
+import collections
+import csv
+import dataclasses
+
+from typing import Callable, DefaultDict, List, Sequence, TextIO, Tuple
+
+
+@dataclasses.dataclass
+class Browser:
+    """A Browser version"""
+    name: str = ''
+    version: str = ''
+    users: int = 0
+    users_share: float = 0
+
+
+def _parse_report(report: TextIO,
+                  column: str) -> Tuple[Browser, List[Browser]]:
+    # pylint: disable=too-many-branches,too-many-statements
+    csv_lines: List[str] = []
+    # Strip the header. It consists of a series of lines that start with #
+    # followed by an empty line.
+    for line in report:
+        if line.strip():
+            continue
+        break
+    # Parse the contents.
+    for line in report:
+        line = line.strip()
+        if not line:
+            break
+        csv_lines.append(line)
+
+    browser_mapping: DefaultDict[Tuple[str, str],
+                                 Browser] = collections.defaultdict(Browser)
+
+    reader = csv.DictReader(csv_lines)
+    totals = Browser(name='Total', users_share=1.)
+    for row in reader:
+        version = row['Browser Version'].split('.')[0]
+        if not version.isnumeric():
+            version = ''
+        name = row['Browser']
+        if name == 'Edge' and version >= '79':
+            # Edge started using Chromium since version 79.
+            name = 'Chrome'
+        elif name == 'Android Webview' and version >= '36':
+            # Android started using Chromium since Lollipop / version 36.
+            name = 'Chrome'
+        elif name == 'UC Browser':
+            chromium_version_mapping = {
+                '12': '57',
+            }
+            if version in chromium_version_mapping:
+                name = 'Chrome'
+                version = chromium_version_mapping[version]
+        elif name == 'Samsung Internet':
+            chromium_version_mapping = {
+                '4': '44',
+                '5': '51',
+                '6': '56',
+                '7': '59',
+                '8': '63',
+                '9': '67',
+                '10': '71',
+                '11': '75',
+                '12': '79',
+            }
+            if version in chromium_version_mapping:
+                name = 'Chrome'
+                version = chromium_version_mapping[version]
+        elif name == 'Opera':
+            chromium_version_mapping = {
+                '47': '48',
+                '50': '63',
+                '51': '64',
+                '52': '65',
+                '53': '66',
+                '54': '67',
+                '55': '68',
+                '56': '69',
+                '57': '70',
+                '58': '71',
+                '59': '72',
+                '60': '73',
+                '61': '74',
+                '62': '75',
+                '63': '76',
+                '64': '77',
+                '65': '78',
+                '66': '79',
+                '67': '80',
+                '68': '80',
+                '69': '83',
+            }
+            if version in chromium_version_mapping:
+                name = 'Chrome'
+                version = chromium_version_mapping[version]
+        elif name == 'YaBrowser':
+            chromium_version_mapping = {
+                '20': '83',
+            }
+            if version in chromium_version_mapping:
+                name = 'Chrome'
+                version = chromium_version_mapping[version]
+        elif name == 'Safari':
+            # Some versions of Safari report the WebKit version, not the Safari
+            # one.
+            if version == '602':
+                version = '10'
+            if version == '604':
+                version = '11'
+            if version == '605':
+                version = '11'
+        key = (name, version)
+        if key == ('', ''):
+            # This is the totals row
+            continue
+        value = int(row[column].replace(',', ''))
+        browser_mapping[key].users += value
+        totals.users += value
+
+    for (name, version), browser in browser_mapping.items():
+        browser.name = name
+        browser.version = version
+        browser.users_share = browser.users / totals.users
+
+    return totals, list(browser_mapping.values())
+
+
+def _is_filtered(browser: Browser, ignore: Sequence[str]) -> bool:
+    for descriptor in ignore:
+        op_mapping: Sequence[Tuple[str, Callable[[int, int], bool]]] = (
+            ('<=', lambda a, b: a <= b),
+            ('=', lambda a, b: a == b),
+            ('<', lambda a, b: a < b),
+        )
+        for op, fn in op_mapping:
+            if op not in descriptor:
+                continue
+            name, version = descriptor.split(op)
+            if browser.name == name and fn(int(browser.version), int(version)):
+                return True
+        if browser.name == descriptor:
+            return True
+    return False
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--ignore',
+                        default=[
+                            'Android Browser',
+                            'Android Runtime',
+                            'Android Webview<36',
+                            'Chrome<51',
+                            'Firefox<68',
+                            'Hexometer',
+                            'Internet Explorer',
+                            'Opera Mini',
+                            'Safari<12',
+                            'Samsung Internet<4',
+                            '[FBAN',
+                        ],
+                        type=str,
+                        nargs='*',
+                        help='Ignore browser')
+    parser.add_argument('--column', default='Users')
+    parser.add_argument('--sort-by-share', action='store_true')
+    parser.add_argument('report',
+                        type=argparse.FileType('r'),
+                        metavar='REPORT.CSV',
+                        help='An exported .csv from Google Analytics')
+    args = parser.parse_args()
+
+    totals, browsers = _parse_report(args.report, args.column)
+
+    if args.sort_by_share:
+        browsers.sort(key=lambda b: b.users, reverse=True)
+    else:
+        browsers.sort(key=lambda b: (b.name, b.version))
+
+    cumulative = 0.
+    print(f'{"Browser name":20} {"Version":7} '
+          f'{"Users":>6} {"Share%":>7} {"Cmltiv%":>7} ')
+    print('=' * 51)
+    for browser in browsers:
+        if _is_filtered(browser, args.ignore):
+            continue
+        cumulative += browser.users
+        print(f'{browser.name:20} {browser.version:>7} '
+              f'{browser.users:6} '
+              f'{browser.users_share*100:6.2f}% '
+              f'{cumulative/totals.users*100:6.2f}%')
+    print('=' * 51)
+    print(f'{totals.name:20} {totals.version:>7} '
+          f'{totals.users:6} '
+          f'{totals.users_share*100:6.2f}% '
+          f'{cumulative/totals.users*100:6.2f}%')
+
+
+if __name__ == '__main__':
+    _main()


### PR DESCRIPTION
Este cambio agrega `stuff/browser_analytics.py`, que permite ayudar a
analizar qué versiones de navegadores deberíamos soportar y qué
polyfills son necesarios para hacerlo.

Si se convierten todos los navegadores basados en Blink / Chromium a sus
versiones equivalentes de Chrome, y se eliminan los navegadores que se
usan (en total) menos de 1% del tiempo / de los usuarios, terminamos con
la siguiente lista de navegadores:

* Chrome >= 51 (2016)
* Edge >= 12 (2016)
* Firefox >= 68 (2019, la versión ESR anterior)
* Safari >= 12 (2018)

```
Browser name         Version  Users  Share% Cmltiv% 
===================================================
Chrome                    51     30   0.28%   0.28%
Chrome                    52      1   0.01%   0.29%
Chrome                    54      1   0.01%   0.30%
Chrome                    55     18   0.17%   0.47%
Chrome                    56      3   0.03%   0.50%
Chrome                    57      3   0.03%   0.53%
Chrome                    58      7   0.07%   0.60%
Chrome                    59      7   0.07%   0.66%
Chrome                    60      1   0.01%   0.67%
Chrome                    61      3   0.03%   0.70%
Chrome                    62      1   0.01%   0.71%
Chrome                    63      4   0.04%   0.75%
Chrome                    64     10   0.09%   0.84%
Chrome                    65      1   0.01%   0.85%
Chrome                    66      6   0.06%   0.91%
Chrome                    67     17   0.16%   1.07%
Chrome                    68      9   0.09%   1.16%
Chrome                    69     12   0.11%   1.27%
Chrome                    70     23   0.22%   1.49%
Chrome                    71     51   0.48%   1.97%
Chrome                    72     10   0.09%   2.07%
Chrome                    73      9   0.09%   2.15%
Chrome                    74     31   0.29%   2.45%
Chrome                    75     76   0.72%   3.17%
Chrome                    76    356   3.38%   6.55%
Chrome                    77     33   0.31%   6.86%
Chrome                    78     45   0.43%   7.29%
Chrome                    79     85   0.81%   8.09%
Chrome                    80    453   4.30%  12.39%
Chrome                    81    380   3.61%  16.00%
Chrome                    83   7373  69.96%  85.96%
Chrome                    84      5   0.05%  86.00%
Chrome                    85     13   0.12%  86.13%
Edge                      12      2   0.02%  86.15%
Edge                      13      1   0.01%  86.16%
Edge                      14     45   0.43%  86.58%
Edge                      17      1   0.01%  86.59%
Edge                      18     81   0.77%  87.36%
Firefox                   68     40   0.38%  87.74%
Firefox                   70      3   0.03%  87.77%
Firefox                   72      4   0.04%  87.81%
Firefox                   74      2   0.02%  87.83%
Firefox                   75      7   0.07%  87.89%
Firefox                   76     68   0.65%  88.54%
Firefox                   77    308   2.92%  91.46%
Firefox                   78     21   0.20%  91.66%
Firefox                   79      2   0.02%  91.68%
Safari                    12     95   0.90%  92.58%
Safari                    13    540   5.12%  97.70%
Safari                    14      2   0.02%  97.72%
Safari (in-app)                 135   1.28%  99.00%
===================================================
Total                         10539 100.00%  99.00%
```