### PR TITLE
Agregando cambios necesarios para prueba de RunTestDownload

### DIFF
--- a/frontend/server/src/Grader.php
+++ b/frontend/server/src/Grader.php
@@ -181,13 +181,20 @@ class Grader {
         );
     }
 
+    /**
+     * @param list<string> $fileHeaders
+     */
     public function getGraderResourcePassthru(
         \OmegaUp\DAO\VO\Runs $run,
         string $filename,
-        bool $missingOk = false
+        bool $missingOk = false,
+        array $fileHeaders = []
     ): ?bool {
         if (self::$OMEGAUP_GRADER_FAKE) {
             return null;
+        }
+        foreach ($fileHeaders as $header) {
+            header($header);
         }
         /** @var null|bool */
         return $this->curlRequest(

--- a/frontend/tests/ControllerTestCase.php
+++ b/frontend/tests/ControllerTestCase.php
@@ -618,20 +618,6 @@ class NoOpGrader extends \OmegaUp\Grader {
         }
 
         $out = fopen('php://output', 'w');
-        if (!is_string($this->_resources[$path])) {
-            foreach (
-                range(
-                    0,
-                    $this->_resources[$path]->numFiles - 1
-                ) as $i => $file
-            ) {
-                $stat = $this->_resources[$path]->statIndex($i);
-                fputs($out, basename($stat['name']) . PHP_EOL);
-            }
-            fclose($out);
-            return true;
-        }
-
         fputs($out, $this->_resources[$path]);
         fclose($out);
         return true;

--- a/frontend/tests/Factories/Run.php
+++ b/frontend/tests/Factories/Run.php
@@ -217,12 +217,13 @@ class Run {
      * Given a run, set a score to a given run
      *
      * @param ?array{contestant: \OmegaUp\DAO\VO\Identities, request: \OmegaUp\Request, response: array{guid: string, submission_deadline: \OmegaUp\Timestamp, nextSubmissionTimestamp: \OmegaUp\Timestamp}}  $runData     The run.
-     * @param float   $points           The score of the run
-     * @param string  $verdict          The verdict of the run.
-     * @param ?int    $submitDelay      The number of minutes worth of penalty.
-     * @param ?string $runGuid          The GUID of the submission.
-     * @param ?int    $runID            The ID of the run.
-     * @param int     $problemsetPoints The max score of the run for the problemset.
+     * @param float                      $points             The score of the run
+     * @param string                     $verdict            The verdict of the run.
+     * @param ?int                       $submitDelay        The number of minutes worth of penalty.
+     * @param ?string                    $runGuid            The GUID of the submission.
+     * @param ?int                       $runID              The ID of the run.
+     * @param int                        $problemsetPoints   The max score of the run for the problemset.
+     * @param array<string, string>|null $outputFilesContent The content to compress in files.zip.
      */
     public static function gradeRun(
         ?array $runData,
@@ -231,7 +232,8 @@ class Run {
         ?int $submitDelay = null,
         ?string $runGuid = null,
         ?int $runId = null,
-        int $problemsetPoints = 100
+        int $problemsetPoints = 100,
+        ?array $outputFilesContent = null
     ): void {
         if (!is_null($runGuid)) {
             $guid = $runGuid;
@@ -246,7 +248,8 @@ class Run {
             $points,
             $verdict,
             $submitDelay,
-            $problemsetPoints
+            $problemsetPoints,
+            $outputFilesContent
         );
     }
 }

--- a/frontend/tests/Factories/Run.php
+++ b/frontend/tests/Factories/Run.php
@@ -217,13 +217,13 @@ class Run {
      * Given a run, set a score to a given run
      *
      * @param ?array{contestant: \OmegaUp\DAO\VO\Identities, request: \OmegaUp\Request, response: array{guid: string, submission_deadline: \OmegaUp\Timestamp, nextSubmissionTimestamp: \OmegaUp\Timestamp}}  $runData     The run.
-     * @param float                      $points             The score of the run
-     * @param string                     $verdict            The verdict of the run.
-     * @param ?int                       $submitDelay        The number of minutes worth of penalty.
-     * @param ?string                    $runGuid            The GUID of the submission.
-     * @param ?int                       $runID              The ID of the run.
-     * @param int                        $problemsetPoints   The max score of the run for the problemset.
-     * @param array<string, string>|null $outputFilesContent The content to compress in files.zip.
+     * @param float   $points             The score of the run
+     * @param string  $verdict            The verdict of the run.
+     * @param ?int    $submitDelay        The number of minutes worth of penalty.
+     * @param ?string $runGuid            The GUID of the submission.
+     * @param ?int    $runID              The ID of the run.
+     * @param int     $problemsetPoints   The max score of the run for the problemset.
+     * @param ?string $outputFilesContent The content to compress in files.zip.
      */
     public static function gradeRun(
         ?array $runData,
@@ -233,7 +233,7 @@ class Run {
         ?string $runGuid = null,
         ?int $runId = null,
         int $problemsetPoints = 100,
-        ?array $outputFilesContent = null
+        ?string $outputFilesContent = null
     ): void {
         if (!is_null($runGuid)) {
             $guid = $runGuid;

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -25,13 +25,13 @@ class Utils {
     /**
      * Given a run guid, set a score for its run
      *
-     * @param ?int                       $runID              The ID of the run.
-     * @param ?string                    $runGuid            The GUID of the submission.
-     * @param float                      $points             The score of the run
-     * @param string                     $verdict            The verdict of the run.
-     * @param ?int                       $submitDelay        The number of minutes worth of penalty.
-     * @param int                        $problemsetPoints   The max score of the run for the problemset.
-     * @param array<string, string>|null $outputFilesContent The content to compress in files.zip.
+     * @param ?int    $runID              The ID of the run.
+     * @param ?string $runGuid            The GUID of the submission.
+     * @param float   $points             The score of the run
+     * @param string  $verdict            The verdict of the run.
+     * @param ?int    $submitDelay        The number of minutes worth of penalty.
+     * @param int     $problemsetPoints   The max score of the run for the problemset.
+     * @param ?string $outputFileContents The content to compress in files.zip.
      */
     public static function gradeRun(
         ?int $runId = null,
@@ -40,7 +40,7 @@ class Utils {
         string $verdict = 'AC',
         ?int $submitDelay = null,
         int $problemsetPoints = 100,
-        ?array $outputFilesContent = null
+        ?string $outputFileContents = null
     ): void {
         if (!is_null($runId)) {
             $run = \OmegaUp\DAO\Runs::getByPK($runId);
@@ -100,25 +100,20 @@ class Utils {
             "\x6f\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         );
         // Creating the zip file.
-        $filesContentsAsString = self::createZipFileWithContent(
-            $outputFilesContent
-        );
-
         \OmegaUp\Grader::getInstance()->setGraderResourceForTesting(
             $run,
             'files.zip',
-            $filesContentsAsString
+            $outputFileContents ?? (
+                "\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00" .
+                "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            )
         );
     }
 
     /**
-     * @param array<string, string>|null $filesContents
+     * @param array<string, string> $filesContents
      */
-    private static function createZipFileWithContent($filesContents): string {
-        if (is_null($filesContents)) {
-            return "\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00" .
-                   "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-        }
+    public static function zipFileForContents($filesContents): string {
         $zipFile = tmpfile();
         $zipPath = stream_get_meta_data($zipFile)['uri'];
         $zip = new \ZipArchive();

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -97,12 +97,38 @@ class Utils {
             "\x1f\x8b\x08\x08\xaa\x31\x34\x5c\x00\x03\x66\x6f" .
             "\x6f\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         );
-        // An empty zip file.
+        // Creating the zip file.
+        $outputFilesContent = [
+            'easy.00.out' => '3',
+            'easy.01.out' => '5',
+            'medium.00.out' => '300',
+            'medium.01.out' => '6912',
+            'sample.out' => '3',
+        ];
+
+        $zipFile = tmpfile();
+        $zipPath = tempnam(sys_get_temp_dir(), 'files');
+        $zip = new \ZipArchive();
+        if (
+            $zip->open(
+                $zipPath,
+                \ZipArchive::CREATE | \ZipArchive::OVERWRITE
+            ) !== true
+        ) {
+            throw new \OmegaUp\Exceptions\NotFoundException();
+        }
+        foreach ($outputFilesContent as $fileName => $fileContent) {
+            if ($zip->addFromString($fileName, $fileContent) !== true) {
+                throw new \OmegaUp\Exceptions\NotFoundException();
+            }
+        }
+        if ($zip->close() !== true) {
+            throw new \OmegaUp\Exceptions\NotFoundException();
+        }
         \OmegaUp\Grader::getInstance()->setGraderResourceForTesting(
             $run,
             'files.zip',
-            "\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00" .
-            "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            file_get_contents($zipPath)
         );
     }
 

--- a/frontend/tests/controllers/RunDetailsTest.php
+++ b/frontend/tests/controllers/RunDetailsTest.php
@@ -161,7 +161,7 @@ class RunDetailsTest extends \OmegaUp\Test\ControllerTestCase {
             /*$runGuid=*/null,
             /*$runID*/null,
             /*$problemsetPoints*/100,
-            $outputFilesContent
+            \OmegaUp\Test\Utils::zipFileForContents($outputFilesContent)
         );
 
         ob_start();
@@ -184,25 +184,20 @@ class RunDetailsTest extends \OmegaUp\Test\ControllerTestCase {
             throw new \OmegaUp\Exceptions\NotFoundException();
         }
 
-        $index = 0;
         foreach ($outputFilesContent as $file => $fileContent) {
-            $this->assertEquals($zip->statIndex($index)['name'], $file);
+            $this->assertEquals($zip->statName($file)['name'], $file);
             $fp = $zip->getStream($file);
             if (!$fp) {
                 throw new \OmegaUp\Exceptions\NotFoundException();
             }
             $content = '';
             while (!feof($fp)) {
-                $content .= fread($fp, 2);
+                $content .= fread($fp, 1024);
             }
             fclose($fp);
 
             $this->assertEquals($content, $fileContent);
-
-            $index++;
         }
-
-        $this->assertEquals($zip->numFiles, 5);
     }
 
     /**


### PR DESCRIPTION
# Descripción

Se separa la prueba de `testDownload` para hacer más pequeño el cambio de `Run::apiDetails`

Part of: #3800 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
