### PR TITLE
Arreglando el despliegue de LaTeX en Markdown.vue

### DIFF
--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -3,6 +3,16 @@
     data-markdown-statement
     v-bind:formula="html"
     v-bind:safe="false"
+    v-bind:options="{
+      tex2jax: {
+        inlineMath: [
+          ['$', '$'],
+          ['\\(', '\\)'],
+        ],
+        processEscapes: true,
+      },
+      skipStartupTypeset: true,
+    }"
   ></vue-mathjax>
 </template>
 


### PR DESCRIPTION
Este cambio agrega las opciones de LaTeX a vue-mathjax. En concreto,
evita que las expresiones de la forma `(...)` se interpreten como LaTeX
y en vez requiere que sean `\(...\)`.

Fixes: #4311