### PR TITLE
Agregando más pruebas en componentes de editar curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/AdmissionMode.test.ts
+++ b/frontend/www/js/omegaup/components/course/AdmissionMode.test.ts
@@ -1,0 +1,45 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+import Clipboard from 'v-clipboard';
+
+import T from '../../lang';
+
+import course_AdmissionMode from './AdmissionMode.vue';
+
+describe('AdmissionMode.vue', () => {
+  const localVue = createLocalVue();
+  Vue.use(Clipboard);
+
+  it('Should handle admission mode as curator', () => {
+    const wrapper = shallowMount(course_AdmissionMode, {
+      localVue,
+      propsData: {
+        admissionModeDescription: T.contestNewFormAdmissionModeDescription,
+        courseAlias: 'DP',
+        initialAdmissionMode: 'private',
+        shouldShowPublicOption: true,
+      },
+    });
+
+    expect(wrapper.find('select[name="admission-mode"]').text()).toContain(
+      T.admissionModePublic,
+    );
+  });
+
+  it('Should handle admission mode as normal user', () => {
+    const wrapper = shallowMount(course_AdmissionMode, {
+      localVue,
+      propsData: {
+        admissionModeDescription: T.contestNewFormAdmissionModeDescription,
+        courseAlias: 'DP',
+        initialAdmissionMode: 'private',
+        shouldShowPublicOption: false,
+      },
+    });
+
+    expect(wrapper.find('select[name="admission-mode"]').text()).not.toContain(
+      T.admissionModePublic,
+    );
+  });
+});

--- a/frontend/www/js/omegaup/components/course/AssignmentList.test.ts
+++ b/frontend/www/js/omegaup/components/course/AssignmentList.test.ts
@@ -1,0 +1,59 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+import Sortable from 'sortablejs';
+
+import T from '../../lang';
+import { omegaup } from '../../omegaup';
+
+import course_AssignmentList from './AssignmentList.vue';
+
+describe('AssignmentList.vue', () => {
+  it('Should handle empty assignments list', () => {
+    const wrapper = shallowMount(course_AssignmentList, {
+      propsData: {
+        assignments: <omegaup.Assignment[]>[],
+        courseAlias: 'course_alias',
+      },
+    });
+
+    expect(wrapper.text()).toContain(T.courseAssignmentEmpty);
+  });
+
+  const localVue = createLocalVue();
+  localVue.directive('Sortable', {
+    inserted: (el: HTMLElement, binding) => {
+      new Sortable(el, binding.value || {});
+    },
+  });
+
+  it('Should handle assignments list', async () => {
+    const wrapper = shallowMount(course_AssignmentList, {
+      localVue,
+      propsData: {
+        assignments: <omegaup.Assignment[]>[
+          {
+            alias: 'CA',
+            assignment_type: 'test',
+            description: 'First test',
+            finish_time: new Date(),
+            has_runs: false,
+            max_points: 900,
+            name: 'Firste test',
+            order: 0,
+            publish_time_delay: 0,
+            scoreboard_url: 'cb01',
+            scoreboard_url_admin: 'sb02',
+            start_time: new Date(),
+          },
+        ],
+        courseAlias: 'course_alias',
+      },
+    });
+    await wrapper
+      .find('.omegaup-course-assignmentlist button[type="submit"]')
+      .trigger('click');
+
+    expect(wrapper.text()).not.toContain(T.courseAssignmentEmpty);
+  });
+});

--- a/frontend/www/js/omegaup/components/course/Clone.test.ts
+++ b/frontend/www/js/omegaup/components/course/Clone.test.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+
+import T from '../../lang';
+import { omegaup } from '../../omegaup';
+import { types } from '../../api_types';
+
+import course_Clone from './Clone.vue';
+
+describe('Clone.vue', () => {
+  it('Should handle clone course view', () => {
+    const wrapper = mount(course_Clone, {
+      propsData: {
+        initialAlias: 'CA',
+        initialName: 'initial name',
+      },
+    });
+
+    expect(
+      wrapper.find('.omegaup-course-clone input[type="date"]').text(),
+    ).toBe('');
+  });
+});

--- a/frontend/www/js/omegaup/components/course/ProblemList.test.ts
+++ b/frontend/www/js/omegaup/components/course/ProblemList.test.ts
@@ -1,0 +1,87 @@
+import { shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+
+import T from '../../lang';
+import { omegaup } from '../../omegaup';
+import { types } from '../../api_types';
+
+import course_ProblemLists from './ProblemList.vue';
+
+describe('ProblemLists.vue', () => {
+  it('Should handle empty assignments and problems', () => {
+    const wrapper = shallowMount(course_ProblemLists, {
+      propsData: {
+        assignmentProblems: <types.ProblemsetProblem[]>[],
+        assignments: <omegaup.Assignment[]>[],
+        selectedAssignment: <omegaup.Assignment>{},
+        taggedProblems: <omegaup.Problem[]>[],
+      },
+    });
+
+    expect(wrapper.find('select[name="assignments"]').text()).toBe('');
+    expect(
+      wrapper.find('.omegaup-course-problemlist button.form-control').text(),
+    ).toBe(T.courseEditAddProblems);
+  });
+
+  it('Should handle assignments and problems', () => {
+    const wrapper = shallowMount(course_ProblemLists, {
+      propsData: {
+        assignmentProblems: <types.ProblemsetProblem[]>[],
+        assignments: <omegaup.Assignment[]>[
+          {
+            alias: 'PE',
+            assignment_type: 'test',
+            description: 'Primer examen',
+            finish_time: new Date(),
+            has_runs: false,
+            max_points: 900,
+            name: 'Primer examen',
+            order: 0,
+            publish_time_delay: 0,
+            scoreboard_url: 'sb01',
+            scoreboard_url_admin: 'sb02',
+            start_time: new Date(),
+          },
+          {
+            alias: 'SE',
+            assignment_type: 'test',
+            description: 'Segundo examen',
+            finish_time: new Date(),
+            has_runs: false,
+            max_points: 900,
+            name: 'Segundo examen',
+            order: 0,
+            publish_time_delay: 0,
+            scoreboard_url: 'sb03',
+            scoreboard_url_admin: 'sb04',
+            start_time: new Date(),
+          },
+        ],
+        selectedAssignment: <omegaup.Assignment>{
+          alias: 'SE',
+          assignment_type: 'test',
+          description: 'Segundo examen',
+          finish_time: new Date(),
+          has_runs: false,
+          max_points: 900,
+          name: 'Segundo examen',
+          order: 0,
+          publish_time_delay: 0,
+          scoreboard_url: 'sb03',
+          scoreboard_url_admin: 'sb04',
+          start_time: new Date(),
+        },
+        taggedProblems: <omegaup.Problem[]>[],
+      },
+    });
+
+    expect(wrapper.find('select[name="assignments"]').text()).toContain(
+      'Primer examen',
+    );
+    expect(wrapper.find('select[name="assignments"]').text()).toContain(
+      'Segundo examen',
+    );
+  });
+});


### PR DESCRIPTION
# Descripción

Se agregan más pruebas de los componentes que aparecen en la vista de editar
curso. 

Part of: #4330 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
