### PR TITLE
Arreglando el despliegue de perfiles cuando no se está logueado

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -3667,13 +3667,17 @@ class User extends \OmegaUp\Controllers\Controller {
                             $r
                         )['problems'],
                         'stats' => self::apiStats($r),
-                        'badges' => \OmegaUp\Controllers\Badge::apiList($r),
-                        'ownedBadges' => \OmegaUp\Controllers\Badge::apiMyList(
-                            $r
-                        )['badges'],
-                        'programmingLanguages' => \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                        'badges' => \OmegaUp\Controllers\Badge::getAllBadges(),
+                        'ownedBadges' => (
+                            is_null($r->user) ?
+                            [] :
+                            \OmegaUp\DAO\UsersBadges::getUserOwnedBadges(
+                                $r->user
+                            )
+                        ),
+                        'programmingLanguages' => \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES,
                     ],
-                    'title' => 'omegaupTitleProfile'
+                    'title' => 'omegaupTitleProfile',
                 ],
                 'template' => 'user.profile.tpl',
             ];

--- a/frontend/templates/user.profile.tpl
+++ b/frontend/templates/user.profile.tpl
@@ -1,6 +1,6 @@
 {include file='head.tpl' navbarSection='users' htmlTitle="{#omegaupTitleProfile#}" inline}
 
-{if !isset($STATUS_ERROR)}
+{if !isset($STATUS_ERROR) && !empty($payload['profile'])}
 <script type="text/json" id="payload">{['payload' => $payload['profile'], 'logged_in' => $LOGGED_IN == "1"]|json_encode}</script>
 <div id="user-profile"></div>
 {js_include entrypoint="user_profile"}


### PR DESCRIPTION
Llamar APIs desde controladores ataca de nuevo u_u. El error fue causado
por el hecho de que dentro de una llamada que permite que el usuario no
esté logueado se estaban llamando métodos que requieren que el usuario
lo esté (para obtener los badges).

Fixes: #4353