### PR TITLE
Actualizando libinteractive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           curl --location "${DOWNLOAD_URL}" | sudo tar -xJv -C /
 
           # omegaup-gitserver depends on libinteractive.
-          DOWNLOAD_URL='https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar'
+          DOWNLOAD_URL='https://github.com/omegaup/libinteractive/releases/download/v2.0.26/libinteractive.jar'
           TARGET='/usr/share/java/libinteractive.jar'
           sudo curl --location "${DOWNLOAD_URL}" -o "${TARGET}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       dockerfile: ./Dockerfile.dev-php
       context: ./stuff/docker/
-    image: omegaup/dev-php:20200708
+    image: omegaup/dev-php:20200712
     restart: always
     volumes:
       - type: bind
@@ -29,7 +29,7 @@ services:
     build:
       dockerfile: ./Dockerfile.gitserver
       context: ./stuff/docker/
-    image: omegaup/dev-gitserver:20200702
+    image: omegaup/dev-gitserver:20200712
     restart: always
     depends_on:
       - mysql
@@ -57,7 +57,7 @@ services:
     build:
       dockerfile: ./Dockerfile.grader
       context: ./stuff/docker/
-    image: omegaup/dev-grader:20200530
+    image: omegaup/dev-grader:20200712
     restart: always
     depends_on:
       - mysql

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -24,7 +24,7 @@ RUN curl -sL https://getcomposer.org/download/1.10.1/composer.phar -o /usr/bin/c
 RUN chmod +x /usr/bin/composer
 
 RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.12/omegaup-gitserver.tar.xz | tar xJ -C /
-RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.26/libinteractive.jar -o /usr/share/java/libinteractive.jar
 
 RUN useradd --create-home --shell=/bin/bash ubuntu
 

--- a/stuff/docker/Dockerfile.gitserver
+++ b/stuff/docker/Dockerfile.gitserver
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
     apt-get clean
 
 RUN curl -sL https://github.com/omegaup/gitserver/releases/download/v1.4.12/omegaup-gitserver.tar.xz | tar xJ -C /
-RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.26/libinteractive.jar -o /usr/share/java/libinteractive.jar
 RUN mkdir -p /etc/omegaup/gitserver
 
 RUN useradd --create-home --shell=/bin/bash ubuntu

--- a/stuff/docker/Dockerfile.grader
+++ b/stuff/docker/Dockerfile.grader
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
     apt-get clean
 
 RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.1.34/omegaup-backend.tar.xz | tar xJ -C /
-RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar -o /usr/share/java/libinteractive.jar
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.26/libinteractive.jar -o /usr/share/java/libinteractive.jar
 RUN mkdir -p /etc/omegaup/grader
 
 RUN useradd --create-home --shell=/bin/bash ubuntu

--- a/stuff/docker/Dockerfile.local-backend
+++ b/stuff/docker/Dockerfile.local-backend
@@ -73,7 +73,7 @@ RUN apt-get update -y && \
     apt-get clean
 
 RUN curl -sL \
-      https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar \
+      https://github.com/omegaup/libinteractive/releases/download/v2.0.26/libinteractive.jar \
       -o /usr/share/java/libinteractive.jar
 RUN mkdir -p /etc/omegaup/{runner,grader,broadcaster,gitserver}
 

--- a/stuff/docker/Dockerfile.local-backend-test
+++ b/stuff/docker/Dockerfile.local-backend-test
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar \
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.26/libinteractive.jar \
         -o /usr/share/java/libinteractive.jar
 
 USER ubuntu


### PR DESCRIPTION
Este cambio actualiza libinteractive a v2.0.26, que arregla la
generación de plantillas para VSCode.