### PR TITLE
Actualizando hook_tools

### DIFF
--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -3,6 +3,7 @@
 GIT_PUSH=0
 EMPTY_HASH=0000000000000000000000000000000000000000
 REMOTE_HASH=
+PRE_UPLOAD_ARGS=""
 
 if [ $# = 0 ]; then
 	ARGS="HEAD"
@@ -11,6 +12,7 @@ elif [ $# = 1 ]; then
 else
 	read LOCAL_REF LOCAL_HASH REMOTE_REF REMOTE_HASH
 	ARGS="$REMOTE_HASH $LOCAL_HASH"
+	PRE_UPLOAD_ARGS="--pre-upload"
 	GIT_PUSH=1
 fi
 
@@ -56,4 +58,4 @@ fi
 
 /usr/bin/python3 "${OMEGAUP_ROOT}/stuff/database_schema.py" validate $ARGS
 /usr/bin/python3 "${OMEGAUP_ROOT}/stuff/policy-tool.py" validate
-exec "${OMEGAUP_ROOT}/stuff/lint.sh" validate $ARGS
+exec "${OMEGAUP_ROOT}/stuff/lint.sh" $PRE_UPLOAD_ARGS validate $ARGS

--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -13,7 +13,8 @@ else
 	fi
 	REMOTE_HASH="$(/usr/bin/git rev-parse "${REMOTE}/master")"
 	MERGE_BASE="$(/usr/bin/git merge-base "${REMOTE_HASH}" HEAD)"
-	ARGS="fix ${MERGE_BASE}"
+	HEAD="$(/usr/bin/git rev-parse HEAD)"
+	ARGS="fix ${MERGE_BASE} ${HEAD}"
 fi
 
 if [[ -t 0 ]]; then
@@ -33,4 +34,4 @@ exec /usr/bin/docker run $TTY_ARGS --rm \
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \
 	--env "MYPYPATH=${OMEGAUP_ROOT}/stuff" \
-	omegaup/hook_tools:20200702 $ARGS
+	omegaup/hook_tools:20200713 $ARGS


### PR DESCRIPTION
Este cambio hace que el pre-push hook ayude un poco más mencionando que
hay que volver a correr `git push` cuando hace cambios.