### PR TITLE
Advirtiendo sobre correr ./stuff/lint.sh en un contenedor

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -24,7 +24,19 @@ else
 	TTY_ARGS=""
 fi
 
-exec /usr/bin/docker run $TTY_ARGS --rm \
+if grep -q pids:/docker /proc/1/cgroup; then
+	echo "Running ./stuff/lint.sh inside a container is not supported." 1>&2
+	echo "Please run this command outside the container" 1>&2
+	exit 1
+fi
+DOCKER_PATH="$(which docker)"
+if [[ -z "${DOCKER_PATH}" ]]; then
+	echo "Docker binary not found." 1>&2
+	echo "Please install docker or run this command outside the container." 1>&2
+	exit 1
+fi
+
+exec "${DOCKER_PATH}" run $TTY_ARGS --rm \
 	--user "$(id -u):$(id -g)" \
 	--env "GIT_AUTHOR_NAME=$(git config user.name)" \
 	--env "GIT_AUTHOR_EMAIL=$(git config user.email)" \


### PR DESCRIPTION
Este cambio advierte al usuario que correr ./stuff/lint.sh dentro de un
contenedor no está soportado.