### PR TITLE
Mejorando cómo se imprime el comando para auto-arreglar cosas

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -46,4 +46,4 @@ exec "${DOCKER_PATH}" run $TTY_ARGS --rm \
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \
 	--env "MYPYPATH=${OMEGAUP_ROOT}/stuff" \
-	omegaup/hook_tools:20200713 $ARGS
+	omegaup/hook_tools:20200714 --command-name="./stuff/lint.sh" $ARGS


### PR DESCRIPTION
Este cambio hace que el comando que hook_tools imprime cuando puede
auto-arreglar algo use `./stuff/lint.sh` en vez de un comando docker
arbitrario.