### PR TITLE
Cambiando el puerto default del servidor HTTP a 8001

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           mysql \
             -e 'CREATE USER "omegaup"@"localhost" IDENTIFIED BY "omegaup";'
           python3 stuff/bootstrap-environment.py \
-          --purge --verbose --root-url=http://localhost:8001
+          --purge --verbose
 
       - name: Install yarn dependencies
         run: yarn install
@@ -248,8 +248,7 @@ jobs:
         run: |
           python3 -m pytest ./frontend/tests/ui/ \
             --verbose --capture=no --log-cli-level=INFO --browser=chrome \
-            --force-flaky --max-runs=2 --min-passes=1 --numprocesses=4 \
-            --url=http://localhost:8001
+            --force-flaky --max-runs=2 --min-passes=1 --numprocesses=4
 
       - name: Collect container logs
         if: ${{ always() }}

--- a/frontend/tests/controllers/QualityNominationTest.php
+++ b/frontend/tests/controllers/QualityNominationTest.php
@@ -346,14 +346,14 @@ class QualityNominationTest extends \OmegaUp\Test\ControllerTestCase {
 
     public function testExtractAliasFromArgument() {
         $inputAndExpectedOutput =
-                ['http://localhost:8080/arena/prueba/#problems/sumas' => 'sumas',
-                 'http://localhost:8080/arena/prueba/practice/#problems/sumas' => 'sumas',
-                 'http://localhost:8080/arena/problem/sumas#problems' => 'sumas',
-                 'http://localhost:8080/course/prueba/assignment/prueba/#problems/sumas' => 'sumas',
-                 'http://localhost:8080/arena/prueba/#problems/sumas29187' => 'sumas29187',
-                 'http://localhost:8080/arena/prueba/practice/#problems/sumas_29187' => 'sumas_29187',
-                 'http://localhost:8080/arena/problem/_sumas29187-#problems' => '_sumas29187-',
-                 'http://localhost:8080/course/prueba/assignment/prueba/#problems/___asd_-_23-2-_' => '___asd_-_23-2-_'];
+                ['http://localhost:8001/arena/prueba/#problems/sumas' => 'sumas',
+                 'http://localhost:8001/arena/prueba/practice/#problems/sumas' => 'sumas',
+                 'http://localhost:8001/arena/problem/sumas#problems' => 'sumas',
+                 'http://localhost:8001/course/prueba/assignment/prueba/#problems/sumas' => 'sumas',
+                 'http://localhost:8001/arena/prueba/#problems/sumas29187' => 'sumas29187',
+                 'http://localhost:8001/arena/prueba/practice/#problems/sumas_29187' => 'sumas_29187',
+                 'http://localhost:8001/arena/problem/_sumas29187-#problems' => '_sumas29187-',
+                 'http://localhost:8001/course/prueba/assignment/prueba/#problems/___asd_-_23-2-_' => '___asd_-_23-2-_'];
 
         foreach ($inputAndExpectedOutput as $input => $expectedOutput) {
             $actualOutput = \OmegaUp\Controllers\QualityNomination::extractAliasFromArgument(

--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -535,7 +535,7 @@ def pytest_addoption(parser):
 
     parser.addoption('--browser', action='append', type=str, dest='browsers',
                      help='The browsers that the test will run against')
-    parser.addoption('--url', default=('http://localhost/'),
+    parser.addoption('--url', default='http://localhost:8001/',
                      help='The URL that the test will be run against')
     parser.addoption('--disable-headless', action='store_false',
                      dest='headless', help='Show the browser window')

--- a/frontend/www/js/omegaup/arena/arena.test.ts
+++ b/frontend/www/js/omegaup/arena/arena.test.ts
@@ -7,7 +7,7 @@ describe('arena', () => {
   describe('GetOptionsFromLocation', () => {
     it('Should detect normal contests', () => {
       const options = arena.GetOptionsFromLocation(
-        new window.URL('http://localhost/arena/test/'),
+        new window.URL('http://localhost:8001/arena/test/'),
       );
       expect(options.contestAlias).toEqual('test');
       expect(options.isPractice).toEqual(false);
@@ -22,7 +22,7 @@ describe('arena', () => {
 
     it('Should detect practice mode', () => {
       const options = arena.GetOptionsFromLocation(
-        new window.URL('http://localhost/arena/test/practice'),
+        new window.URL('http://localhost:8001/arena/test/practice'),
       );
       expect(options.contestAlias).toEqual('test');
       expect(options.isPractice).toEqual(true);
@@ -30,7 +30,7 @@ describe('arena', () => {
 
     it('Should detect only problems', () => {
       const options = arena.GetOptionsFromLocation(
-        new window.URL('http://localhost/arena/problem/test/'),
+        new window.URL('http://localhost:8001/arena/problem/test/'),
       );
       expect(options.contestAlias).toEqual(null);
       expect(options.onlyProblemAlias).toEqual('test');
@@ -39,7 +39,7 @@ describe('arena', () => {
 
     it('Should detect ws=off', () => {
       const options = arena.GetOptionsFromLocation(
-        new window.URL('http://localhost/arena/test/?ws=off'),
+        new window.URL('http://localhost:8001/arena/test/?ws=off'),
       );
       expect(options.disableSockets).toEqual(true);
     });

--- a/frontend/www/js/omegaup/components/arena/RunDetails.test.ts
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.test.ts
@@ -45,7 +45,7 @@ describe('RunDetails.vue', () => {
           source: 'print(3)',
           source_link: false,
           source_name: 'Main.py3',
-          source_url: 'blob:http://localhost:8080/url',
+          source_url: 'blob:http://localhost:8001/url',
         },
       },
     });

--- a/frontend/www/js/omegaup/test.setup.js
+++ b/frontend/www/js/omegaup/test.setup.js
@@ -2,7 +2,7 @@ const util = require('util');
 
 require('jsdom-global')(undefined, {
   pretendToBeVisual: true,
-  url: 'http://localhost',
+  url: 'http://localhost:8001/',
 });
 global.jQuery = require('jquery');
 global.$ = global.jQuery;

--- a/stuff/bootstrap-environment.py
+++ b/stuff/bootstrap-environment.py
@@ -224,7 +224,9 @@ def main():
     '''Main entrypoint.'''
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--root-url', type=str, default='http://localhost')
+    parser.add_argument('--root-url',
+                        type=str,
+                        default='http://localhost:8001/')
     parser.add_argument('--verbose', action='store_true')
     parser.add_argument(
         '--purge',

--- a/stuff/docker/usr/bin/developer-environment.sh
+++ b/stuff/docker/usr/bin/developer-environment.sh
@@ -30,13 +30,13 @@ define('OMEGAUP_GITSERVER_SECRET_TOKEN', 'secret');
 EOF
 fi
 
-if ! /opt/omegaup/stuff/db-migrate.py --mysql-config-file=/home/ubuntu/.my.cnf exists ; then
+if ! /opt/omegaup/stuff/db-migrate.py --mysql-config-file="${HOME}/.my.cnf" exists ; then
   mysql --defaults-file=/home/ubuntu/.my.cnf \
     -e "CREATE USER IF NOT EXISTS 'omegaup'@'localhost' IDENTIFIED BY 'omegaup';"
-  mysql --defaults-file=/home/ubuntu/.my.cnf \
+  mysql --defaults-file="${HOME}/.my.cnf" \
     -e 'GRANT ALL PRIVILEGES ON `omegaup-test%`.* TO "omegaup"@"%";'
   /opt/omegaup/stuff/bootstrap-environment.py \
-    --mysql-config-file=/home/ubuntu/.my.cnf \
+    --mysql-config-file="${HOME}/.my.cnf" \
     --purge --verbose --root-url=http://localhost:8001/
 else
   /opt/omegaup/stuff/db-migrate.py \

--- a/stuff/replay.py
+++ b/stuff/replay.py
@@ -88,7 +88,7 @@ def main():
     db.commit()
 
     # Allow user to open the contest to see the shiny display
-    print('http://localhost:8080/arena/%s/scoreboard/%s?ws=on' %
+    print('http://localhost:8001/arena/%s/scoreboard/%s?ws=on' %
           (new_alias, scoreboard_token), file=sys.stderr)
     print('Press Enter to continue...', end=' ', file=sys.stderr)
     input()
@@ -138,7 +138,7 @@ def main():
         # Force scoreboard regeneration
         t0 = time.time()
         response = urllib.request.urlopen(
-            'http://localhost/api/scoreboard/refresh/',
+            'http://localhost:8001/api/scoreboard/refresh/',
             urllib.parse.urlencode({'token': 'secret', 'alias': new_alias,
                                     'run': str(run_id)})
         ).read()


### PR DESCRIPTION
Este cambio hace que el puerto que se usa para comunicar con el servidor
HTTP sea 8001 homogéneamente entre Vagrant/Docker adentro/afuera.