### PR TITLE
Agregando un git hook-tool para cuando se actualizan los archivos

### DIFF
--- a/stuff/docker/usr/bin/developer-environment.sh
+++ b/stuff/docker/usr/bin/developer-environment.sh
@@ -30,6 +30,16 @@ define('OMEGAUP_GITSERVER_SECRET_TOKEN', 'secret');
 EOF
 fi
 
+# Install all the git hooks.
+for hook in /opt/omegaup/stuff/git-hooks/*; do
+	hook_name="$(basename "${hook}")"
+	hook_path="/opt/omegaup/.git/hooks/${hook_name}"
+	if [[ ! -L "${hook_path}" ]]; then
+		ln -sf "../../stuff/git-hooks/${hook_name}" "${hook_path}"
+	fi
+done
+
+# Ensure that the database version is up to date.
 if ! /opt/omegaup/stuff/db-migrate.py --mysql-config-file="${HOME}/.my.cnf" exists ; then
   mysql --defaults-file=/home/ubuntu/.my.cnf \
     -e "CREATE USER IF NOT EXISTS 'omegaup'@'localhost' IDENTIFIED BY 'omegaup';"

--- a/stuff/git-hooks/post-checkout
+++ b/stuff/git-hooks/post-checkout
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+exec < /dev/tty
+
+# Redirect output to stderr.
+exec 1>&2
+
+OLD_HEAD="${1}"
+NEW_HEAD="${2}"
+CHANGING_BRANCHES="${3}"
+
+# Try to avoid having dirty git submodules when checking out branches.
+if ! git diff-tree -r --quiet "${OLD_HEAD}" "${NEW_HEAD}" | grep -q ^:160000; then
+	git submodule update --recursive
+fi
+
+# Whenever composer.lock is changed, `composer install` needs to be run.
+if ! git diff-tree --quiet "${OLD_HEAD}" "${NEW_HEAD}" -- composer.lock; then
+	if [[ -x /usr/bin/composer ]]; then
+		/usr/bin/composer install
+	else
+		echo
+		echo "*****************************************************************"
+		echo
+		echo "composer.lock changed."
+		echo
+		echo "Please run \`/usr/bin/composer install\` inside the VM / container."
+		echo
+		echo "*****************************************************************"
+		echo
+	fi
+fi
+
+# Whenever yarn.lock is changed, `yarn install` needs to be run.
+if ! git diff-tree --quiet "${OLD_HEAD}" "${NEW_HEAD}" -- yarn.lock; then
+	if which yarn >/dev/null ; then
+		yarn install
+		echo
+		echo "*****************************************************************"
+		echo
+		echo "yarn.lock changed."
+		echo
+		echo "Please restart the container OR the \`yarn run dev-all:watch\` command"
+		echo
+		echo "*****************************************************************"
+		echo
+	else
+		echo
+		echo "*****************************************************************"
+		echo
+		echo "yarn.lock changed."
+		echo
+		echo "Please restart the container, OR run \`yarn install\` and"
+		echo "restart \`yarn run dev-all:watch\`"
+		echo
+		echo "*****************************************************************"
+		echo
+	fi
+fi


### PR DESCRIPTION
Este cambio agrega un post-checkout hook tool. Lo que hace:

* Si detecta que hay submódulos cambiados, corre `git submodule update
  --recursive`.
* Si detecta que `composer.lock` cambió, corre `composer install` (o
  indica que hay que correrlo).
* Si detecta que `yarn.lock` cambió, corre `yarn install` (o
  indica que hay que correrlo) e indica que hay que reiniciar el comando
  para compilar los archivos de yarn.