### PR TITLE
Copiando omegaup-gitserver en Docker local-backend

### DIFF
--- a/docker-compose.local-backend.yml
+++ b/docker-compose.local-backend.yml
@@ -7,7 +7,14 @@ services:
       dockerfile: ./Dockerfile.local-backend
       context: ./stuff/docker/
     image: omegaup/local-backend
-    entrypoint: ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-gitserver"]
+    entrypoint: [
+      "wait-for-it",
+      "mysql:3306",
+      "--",
+      "/bin/bash",
+      "-c",
+      "cp /usr/bin/omegaup-gitserver /var/lib/omegaup/omegaup-gitserver && exec /usr/bin/omegaup-gitserver",
+    ]
 
   grader:
     build:

--- a/stuff/docker/usr/bin/developer-environment.sh
+++ b/stuff/docker/usr/bin/developer-environment.sh
@@ -53,4 +53,10 @@ else
     --mysql-config-file=/home/ubuntu/.my.cnf migrate
 fi
 
+# If this is a local-backend build, ensure that the built omegaup-gitserver is
+# copied.
+if [[ -x /var/lib/omegaup/omegaup-gitserver ]]; then
+	sudo mv /var/lib/omegaup/omegaup-gitserver /usr/bin/omegaup-gitserver
+fi
+
 exec /usr/bin/composer install


### PR DESCRIPTION
Este cambio copia el binario omegaup-gitserver cuando
docker-compose.local-backend.yml se invoca.