### PR TITLE
Evitando que release se haga merge con master al hacer deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
           curl --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/deployments \
             --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            --data "{\"ref\":\"${{ github.ref }}\",\"required_contexts\":[],\"environment\":\"${ENVIRONMENT}\"}"
+            --data "{\"ref\":\"${{ github.ref }}\",\"required_contexts\":[],\"environment\":\"${ENVIRONMENT}\",\"auto_merge\":false}"


### PR DESCRIPTION
Este cambio hace que al momento de intentar hacer un release mediante
GitHub, no se intente hacer merge con master. Esto es innecesario, y si
llegara a haber un commit entre el momento en el que se hace el commit a
la rama release y se termina el deployment, el API falla por culpa del
merge conflict que ocurriría al intentar hacer merge de release a
master.