### PR TITLE
Mejorando logging en controladores que manejan excepciones

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -46,17 +46,11 @@ class ApiCaller {
             );
         }
 
-        self::$log->error($apiException);
+        self::logException($apiException);
         \OmegaUp\Metrics::getInstance()->apiStatus(
             strval($request->methodName),
             intval($apiException->getCode())
         );
-        if (
-            extension_loaded('newrelic') &&
-            $apiException->getCode() == 500
-        ) {
-            newrelic_notice_error(strval($apiException));
-        }
         /** @var array<string, mixed> */
         return $apiException->asResponseArray();
     }
@@ -98,14 +92,8 @@ class ApiCaller {
             $response = self::call($r);
         } catch (\OmegaUp\Exceptions\ApiException $apiException) {
             $r = null;
+            self::logException($apiException);
             $response = $apiException->asResponseArray();
-            self::$log->error($apiException);
-            if (
-                extension_loaded('newrelic') &&
-                $apiException->getCode() == 500
-            ) {
-                newrelic_notice_error(strval($apiException));
-            }
         }
         return self::render($response, $r);
     }
@@ -171,10 +159,7 @@ class ApiCaller {
             }
             if ($jsonResult === false) {
                 $apiException = new \OmegaUp\Exceptions\InternalServerErrorException();
-                self::$log->error($apiException);
-                if (extension_loaded('newrelic')) {
-                    newrelic_notice_error(strval($apiException));
-                }
+                self::logException($apiException);
                 $jsonResult = json_encode($apiException->asResponseArray());
             }
         }
@@ -301,8 +286,9 @@ class ApiCaller {
             );
         }
 
+        self::logException($apiException);
+
         if ($apiException->getcode() == 400) {
-            self::$log->info("{$apiException}");
             header('HTTP/1.1 400 Bad Request');
             die(
                 file_get_contents(
@@ -311,7 +297,6 @@ class ApiCaller {
             );
         }
         if ($apiException->getCode() == 401) {
-            self::$log->info("{$apiException}");
             header(
                 'Location: /login/?redirect=' . urlencode(
                     strval(
@@ -322,7 +307,6 @@ class ApiCaller {
             die();
         }
         if ($apiException->getCode() == 403) {
-            self::$log->info("{$apiException}");
             // Even though this is forbidden, we pretend the resource did not
             // exist.
             header('HTTP/1.1 404 Not Found');
@@ -333,7 +317,6 @@ class ApiCaller {
             );
         }
         if ($apiException->getcode() == 404) {
-            self::$log->info("{$apiException}");
             header('HTTP/1.1 404 Not Found');
             die(
                 file_get_contents(
@@ -341,16 +324,26 @@ class ApiCaller {
                 )
             );
         }
-        self::$log->error("{$apiException}");
-        if (extension_loaded('newrelic') && $apiException->getCode() == 500) {
-            newrelic_notice_error(strval($apiException));
-        }
         header('HTTP/1.1 500 Internal Server Error');
         die(
             file_get_contents(
                 sprintf('%s/www/500.html', strval(OMEGAUP_ROOT))
             )
         );
+    }
+
+    public static function logException(
+        \OmegaUp\Exceptions\ApiException $apiException
+    ): void {
+        $stringifiedException = strval($apiException);
+        if ($apiException->getCode() >= 500 && $apiException->getCode() < 600) {
+            self::$log->error($stringifiedException);
+            if (extension_loaded('newrelic')) {
+                newrelic_notice_error($stringifiedException);
+            }
+        } else {
+            self::$log->info($stringifiedException);
+        }
     }
 }
 

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4817,6 +4817,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     $result['smartyProperties']['payload']
                 );
             } catch (\OmegaUp\Exceptions\ApiException $e) {
+                \OmegaUp\ApiCaller::logException($e);
                 /** @var array{error?: string} */
                 $response = $e->asResponseArray();
                 if (empty($response['error'])) {
@@ -4990,6 +4991,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             } catch (\OmegaUp\Exceptions\ExitException $e) {
                 throw $e;
             } catch (\OmegaUp\Exceptions\ApiException $e) {
+                \OmegaUp\ApiCaller::logException($e);
                 /** @var array{error?: string} */
                 $response = $e->asResponseArray();
                 if (empty($response['error'])) {

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -3680,6 +3680,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 'template' => 'user.profile.tpl',
             ];
         } catch (\OmegaUp\Exceptions\ApiException $e) {
+            \OmegaUp\ApiCaller::logException($e);
             return [
                 'smartyProperties' => [
                     'payload' => ['statusError' => $e->getErrorMessage()],
@@ -3716,6 +3717,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 ),
             ];
         } catch (\OmegaUp\Exceptions\ApiException $e) {
+            \OmegaUp\ApiCaller::logException($e);
             $smartyProperties = [
                 'STATUS_ERROR' => $e->getErrorMessage(),
             ];
@@ -3759,6 +3761,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 ),
             ];
         } catch (\OmegaUp\Exceptions\ApiException $e) {
+            \OmegaUp\ApiCaller::logException($e);
             $smartyProperties = [
                 'STATUS_ERROR' => $e->getErrorMessage(),
             ];
@@ -3794,6 +3797,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 'practice' => false,
             ];
         } catch (\OmegaUp\Exceptions\ApiException $e) {
+            \OmegaUp\ApiCaller::logException($e);
             $smartyProperties = [
                 'STATUS_ERROR' => $e->getErrorMessage(),
             ];


### PR DESCRIPTION
Este cambio hace que si un controlador tiene un método de Smarty que
maneja excepciones por sí mismo, haga log de la excepción que se envía
al usuario.