### PR TITLE
Ajustando ProfileDetailsPayload para Charts.vue

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -24,7 +24,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type UserProfileContests=array<string, array{data: array{alias: string, title: string, start_time: \OmegaUp\Timestamp, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp}, place: int}>
  * @psalm-type UserProfileStats=array{date: null|string, runs: int, verdict: string}
  * @psalm-type UserListItem=array{label: string, value: string}
- * @psalm-type UserProfileDetailsPayload=array{statusError?: string, profile: UserProfileInfo, contests: UserProfileContests, solvedProblems: list<Problem>, unsolvedProblems: list<Problem>, createdProblems: list<Problem>, stats: list<UserProfileStats>, badges: list<string>, ownedBadges: list<Badge>, programmingLanguages: array<string,string>}
+ * @psalm-type UserProfileDetailsPayload=array{statusError?: string, profile: UserProfileInfo, contests: UserProfileContests, solvedProblems: list<Problem>, unsolvedProblems: list<Problem>, createdProblems: list<Problem>, stats: array{runs: list<UserProfileStats>}, badges: list<string>, ownedBadges: list<Badge>}
  */
 class User extends \OmegaUp\Controllers\Controller {
     /** @var bool */

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2230,9 +2230,8 @@ export namespace types {
     createdProblems: types.Problem[];
     ownedBadges: types.Badge[];
     profile: types.UserProfileInfo;
-    programmingLanguages: { [key: string]: string };
     solvedProblems: types.Problem[];
-    stats: types.UserProfileStats[];
+    stats: { runs: types.UserProfileStats[] };
     statusError?: string;
     unsolvedProblems: types.Problem[];
   }


### PR DESCRIPTION
# Descripción

Este cambio fue no se subió en previos PR's. Permite el correcto funcionamiento de la seccion de estadisticas en profile, a su vez permitirá que las pruebas de #4300 puedan pasar y se remueve programmingLanguages por que se dejó de ocupar en el payload, y se pasa junto con la info del usuario.

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
