### PR TITLE
Evitando hacer un request cuando el alias está vacío

### DIFF
--- a/frontend/www/js/omegaup/problem/new.ts
+++ b/frontend/www/js/omegaup/problem/new.ts
@@ -20,6 +20,9 @@ OmegaUp.on('ready', () => {
         },
         on: {
           'alias-changed': (alias: string): void => {
+            if (!alias) {
+              return;
+            }
             api.Problem.details({ problem_alias: alias }, { quiet: true })
               .then((data) => {
                 ui.error(


### PR DESCRIPTION
Este cambio hace que `/api/problem/details/` no se invoque si el alias
está vacío, porque ya sabemos que esta petición va a fallar y va a
confundir a la raza.

Esto _no_ arregla el problema, simplemente evita que este error sea
visible porque nada más está causando ruido.

Part of: #4427