### PR TITLE
Agregando el orden de los assignments desde el momento de ser creados

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -841,7 +841,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $finish_time
      * @omegaup-request-param mixed $name
-     * @omegaup-request-param mixed $order
+     * @omegaup-request-param int|null $order
      * @omegaup-request-param mixed $problems
      * @omegaup-request-param mixed $publish_time_delay
      * @omegaup-request-param mixed $start_time
@@ -857,10 +857,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $r['course_alias'],
             'course_alias'
         );
-        \OmegaUp\Validators::validateOptionalNumber(
-            $r['order'],
-            'order'
-        );
+        $order = $r->ensureOptionalInt('order');
         $course = self::validateCourseExists($r['course_alias']);
         [
             'addedProblems' => $addedProblems,
@@ -887,9 +884,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'assignment_type' => $r['assignment_type'],
                 'start_time' => $r['start_time'],
                 'finish_time' => $r['finish_time'],
-                'order' => !empty($r['order'])
-                  ? intval($r['order'])
-                : \OmegaUp\DAO\Assignments::getNextPositionOrder(
+                'order' => $order ?? \OmegaUp\DAO\Assignments::getNextPositionOrder(
                     $course->course_id
                 ),
             ]),

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -866,6 +866,11 @@ class Course extends \OmegaUp\Controllers\Controller {
             'addedProblems' => $addedProblems,
         ] = self::validateCreateAssignment($r, $course);
 
+        if (is_null($course->course_id)) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'courseNotFound'
+            );
+        }
         if (!\OmegaUp\Authorization::isCourseAdmin($r->identity, $course)) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
@@ -882,7 +887,11 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'assignment_type' => $r['assignment_type'],
                 'start_time' => $r['start_time'],
                 'finish_time' => $r['finish_time'],
-                'order' => intval($r['order']),
+                'order' => !empty($r['order'])
+                  ? intval($r['order'])
+                : \OmegaUp\DAO\Assignments::getNextPositionOrder(
+                    $course->course_id
+                ),
             ]),
             $r->identity,
             $addedProblems

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1613,7 +1613,7 @@ API to Create an assignment
 | `description`        | `mixed`     |             |
 | `finish_time`        | `mixed`     |             |
 | `name`               | `mixed`     |             |
-| `order`              | `mixed`     |             |
+| `order`              | `int|null`  |             |
 | `problems`           | `mixed`     |             |
 | `publish_time_delay` | `mixed`     |             |
 | `start_time`         | `mixed`     |             |

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -240,6 +240,6 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
             $sql,
             [$courseId]
         );
-        return is_null($numberOfAssignments) ? 1 : $numberOfAssignments + 1;
+        return intval($numberOfAssignments) + 1;
     }
 }

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -224,4 +224,22 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
             [$problemset->problemset_id]
         );
     }
+
+    public static function getNextPositionOrder(int $courseId): int {
+        $sql = '
+            SELECT
+                COUNT(a.assignment_id)
+            FROM
+                Assignments a
+            WHERE
+                a.course_id = ?;
+            ';
+
+        /** @var int|null */
+        $numberOfAssignments = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            $sql,
+            [$courseId]
+        );
+        return is_null($numberOfAssignments) ? 1 : $numberOfAssignments + 1;
+    }
 }

--- a/frontend/tests/controllers/CourseAssignmentsTest.php
+++ b/frontend/tests/controllers/CourseAssignmentsTest.php
@@ -5,7 +5,6 @@ class CourseAssignmentsTest extends \OmegaUp\Test\ControllerTestCase {
         // Create a course with 5 assignments
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
 
-        // Login admin and getting assignments list
         $adminLogin = self::login($courseData['admin']);
         foreach (range(1, 5) as $index) {
             \OmegaUp\Controllers\Course::apiCreateAssignment(

--- a/frontend/tests/controllers/CourseAssignmentsTest.php
+++ b/frontend/tests/controllers/CourseAssignmentsTest.php
@@ -1,6 +1,41 @@
 <?php
 
 class CourseAssignmentsTest extends \OmegaUp\Test\ControllerTestCase {
+    public function testAssignmentsWithOriginalOrder() {
+        // Create a course with 5 assignments
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
+
+        // Login admin and getting assignments list
+        $adminLogin = self::login($courseData['admin']);
+        foreach (range(1, 5) as $index) {
+            \OmegaUp\Controllers\Course::apiCreateAssignment(
+                new \OmegaUp\Request([
+                    'auth_token' => $adminLogin->auth_token,
+                    'name' => "AssignmentNo {$index}",
+                    'alias' => \OmegaUp\Test\Utils::createRandomString(),
+                    'description' => \OmegaUp\Test\Utils::createRandomString(),
+                    'start_time' => (\OmegaUp\Time::get() + 60),
+                    'finish_time' => (\OmegaUp\Time::get() + 120),
+                    'course_alias' => $courseData['course_alias'],
+                    'assignment_type' => 'homework'
+                ])
+            );
+        }
+
+        [
+            'assignments' => $assignments
+        ] = \OmegaUp\Controllers\Course::apiListAssignments(
+            new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course_alias' => $courseData['course_alias']
+            ])
+        );
+
+        foreach ($assignments as $index => $assignment) {
+            $this->assertEquals($assignment['order'], $index + 1);
+        }
+    }
+
     public function testOrderAssignments() {
         // Create a course with 5 assignments
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithAssignments(


### PR DESCRIPTION
# Descripción

Se agrega la funcionalidad de asignar el orden de una tarea/examen de un curso
justo en el momento de que sea creada. En caso de no recibir un valor en `order`
cuando se realiza la petición, el controlador obtiene el número de orden que le 
corresponde. 

Anteriormente los nuevos assignments se creaban con 0 en `order`, pero eso 
ocasionaba que al momento de ordenarlos manualmente y agregar una nueva
tarea, esta apareciera como el primer elemento en los contenidos del curso.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
