### PR TITLE
Arreglando bug que no permitía mostrar las clarificaciones

### DIFF
--- a/frontend/templates/arena.clarification.tpl
+++ b/frontend/templates/arena.clarification.tpl
@@ -1,12 +1,14 @@
 <form id="clarification" method="POST">
-  <button class="close">&times;</button>
+  <div class="close-container">
+    <button class="close">&times;</button>
+  </div>
   <label>{#wordsProblem#} <select name="problem"></select></label>
   {if $admin}
   <label>{#wordsMessageTo#} <select name="user"></select></label>
   {/if}
   <br/>
   <label>{#arenaClarificationCreateMaxLength#}
-    <textarea name="message" maxlength="200"></textarea>
+    <textarea name="message" maxlength="200" style="width: 100%; resize: none;" rows="10"></textarea>
   </label><br/>
   <input type="submit" />
 </form>

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -266,6 +266,8 @@ export class Arena {
     socketStatus: JQuery;
   };
 
+  initialClarifications: types.Clarification[] = [];
+
   navbarAssignments: Vue | null = null;
 
   navbarProblems:
@@ -1400,17 +1402,18 @@ export class Arena {
   updateClarification(clarification: types.Clarification): void {
     let r: JQuery | null = null;
     const anchor = `clarifications/clarification-${clarification.clarification_id}`;
-    if (this.commonNavbar === null) {
-      return;
-    }
-    const clarifications = this.commonNavbar.initialClarifications;
+    const clarifications =
+      this.commonNavbar?.initialClarifications ?? this.initialClarifications;
     if (this.clarifications[clarification.clarification_id]) {
       r = this.clarifications[clarification.clarification_id];
       if (this.problemsetAdmin) {
-        this.commonNavbar.initialClarifications = clarifications.filter(
+        this.initialClarifications = clarifications.filter(
           (notification) =>
             notification.clarification_id !== clarification.clarification_id,
         );
+        if (this.commonNavbar !== null) {
+          this.commonNavbar.initialClarifications = this.initialClarifications;
+        }
       } else {
         clarifications.push(clarification);
       }
@@ -1536,6 +1539,19 @@ export class Arena {
 
     if (this.commonNavbar !== null) {
       this.commonNavbar.initialClarifications = clarifications
+        .filter((clarification) =>
+          // Removing all unsolved clarifications.
+          this.problemsetAdmin
+            ? clarification.answer === null
+            : clarification.answer !== null &&
+              // Removing all unanswered clarifications.
+              localStorage.getItem(
+                `clarification-${clarification.clarification_id}`,
+              ) === null,
+        )
+        .reverse();
+    } else {
+      this.initialClarifications = clarifications
         .filter((clarification) =>
           // Removing all unsolved clarifications.
           this.problemsetAdmin


### PR DESCRIPTION
# Descripción

Se arregla falla en las clarificaciones que evitaba que se mostrara el listado en 
arena.

Ya se muestra tanto para administradores: 
![image](https://user-images.githubusercontent.com/3230352/88834314-479e9c80-d199-11ea-8074-4c37807f8d4b.png)

como para participantes:
![image](https://user-images.githubusercontent.com/3230352/88834408-669d2e80-d199-11ea-8d34-56b0c862c191.png)


Fixes: #4433 

# Comentarios

No sé si la solución sea la correcta, pero al menos sirve para que puedan ver las
clarificaciones del concurso.

Resulta que las clarificaciones iniciales se estaban almacenando dentro de un
componente (commonNavbar) que no siempre se crea, de ahí viene la falla
porque no se está creando, desconozco en que punto se rompió eso. Así que por 
el momento creé otra propiedad que pertenece Arena (que siempre existe) para 
que ahí se almacene esta información y de ahí obtenerla

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
