### PR TITLE
Agregando más métodos de validación

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -1005,7 +1005,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $assignment_alias
      * @omegaup-request-param mixed $commit
      * @omegaup-request-param mixed $course_alias
-     * @omegaup-request-param mixed $points
+     * @omegaup-request-param float $points
      * @omegaup-request-param mixed $problem_alias
      *
      * @return array{status: 'ok'}
@@ -1062,7 +1062,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $problemset->problemset_id,
             $r->identity,
             true, /* validateVisibility */
-            is_numeric($r['points']) ? floatval($r['points']) : 100.0,
+            $r->ensureOptionalFloat('points') ?? 100.0,
             $r['commit']
         );
 

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -83,7 +83,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $group_alias
      * @omegaup-request-param bool|null $only_ac
      * @omegaup-request-param mixed $scoreboard_alias
-     * @omegaup-request-param float|null $weight
+     * @omegaup-request-param float $weight
      */
     public static function apiAddContest(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -106,13 +106,11 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
             $r['contest_alias']
         );
 
-        $r->ensureFloat('weight');
-
         \OmegaUp\DAO\GroupsScoreboardsProblemsets::create(new \OmegaUp\DAO\VO\GroupsScoreboardsProblemsets([
             'group_scoreboard_id' => $contestScoreboard['scoreboard']->group_scoreboard_id,
             'problemset_id' => $contestScoreboard['contest']->problemset_id,
             'only_ac' => $r->ensureBool('only_ac'),
-            'weight' => $r['weight'],
+            'weight' => $r->ensureFloat('weight'),
         ]));
 
         self::$log->info(

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4940,7 +4940,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      * @omegaup-request-param bool $allow_user_add_tags
-     * @omegaup-request-param mixed $email_clarifications
+     * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param mixed $extra_wall_time
      * @omegaup-request-param mixed $input_limit
      * @omegaup-request-param mixed $languages
@@ -5012,9 +5012,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                             [
                                 'title' => strval($r['title']),
                                 'alias' => strval($r['problem_alias']),
-                                'emailClarifications' => boolval(
-                                    $r['email_clarifications']
-                                ),
+                                'emailClarifications' => $r->ensureOptionalBool(
+                                    'email_clarifications'
+                                ) ?? false,
                                 'source' => strval($r['source']),
                                 'visibility' => intval($r['visibility']),
                                 'statusError' => $statusError,

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -502,13 +502,13 @@ Adds a problem to a contest
 
 ### Parameters
 
-| Name               | Type         | Description |
-| ------------------ | ------------ | ----------- |
-| `commit`           | `mixed`      |             |
-| `contest_alias`    | `mixed`      |             |
-| `order_in_contest` | `int`        |             |
-| `points`           | `float|null` |             |
-| `problem_alias`    | `mixed`      |             |
+| Name               | Type    | Description |
+| ------------------ | ------- | ----------- |
+| `commit`           | `mixed` |             |
+| `contest_alias`    | `mixed` |             |
+| `order_in_contest` | `int`   |             |
+| `points`           | `float` |             |
+| `problem_alias`    | `mixed` |             |
 
 ### Returns
 
@@ -1394,7 +1394,7 @@ Adds a problem to an assignment
 | `assignment_alias` | `mixed` |             |
 | `commit`           | `mixed` |             |
 | `course_alias`     | `mixed` |             |
-| `points`           | `mixed` |             |
+| `points`           | `float` |             |
 | `problem_alias`    | `mixed` |             |
 
 ### Returns
@@ -2213,13 +2213,13 @@ Add contest to a group scoreboard
 
 ### Parameters
 
-| Name               | Type         | Description |
-| ------------------ | ------------ | ----------- |
-| `contest_alias`    | `mixed`      |             |
-| `group_alias`      | `mixed`      |             |
-| `only_ac`          | `bool|null`  |             |
-| `scoreboard_alias` | `mixed`      |             |
-| `weight`           | `float|null` |             |
+| Name               | Type        | Description |
+| ------------------ | ----------- | ----------- |
+| `contest_alias`    | `mixed`     |             |
+| `group_alias`      | `mixed`     |             |
+| `only_ac`          | `bool|null` |             |
+| `scoreboard_alias` | `mixed`     |             |
+| `weight`           | `float`     |             |
 
 ### Returns
 

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -30,7 +30,10 @@ class RequestParamChecker implements
         'OmegaUp\\Request::ensureoptionalbool' => 'bool|null',
         'OmegaUp\\Request::ensureint' => 'int',
         'OmegaUp\\Request::ensureoptionalint' => 'int|null',
-        'OmegaUp\\Request::ensurefloat' => 'float|null',
+        'OmegaUp\\Request::ensurefloat' => 'float',
+        'OmegaUp\\Request::ensureoptionalfloat' => 'float|null',
+        'OmegaUp\\Request::ensurestring' => 'string',
+        'OmegaUp\\Request::ensureoptionalstring' => 'string|null',
         'OmegaUp\\Request::ensuretimestamp' => '\\OmegaUp\\Timestamp',
         'OmegaUp\\Request::ensureoptionaltimestamp' => '\\OmegaUp\\Timestamp|null',
     ];

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -133,7 +133,7 @@ class Request extends \ArrayObject {
                 $key
             );
         }
-        return self::ensureBool($key);
+        return $this->ensureBool($key);
     }
 
     /**
@@ -180,7 +180,42 @@ class Request extends \ArrayObject {
                 $key
             );
         }
-        return self::ensureInt($key, $lowerBound, $upperBound);
+        return $this->ensureInt($key, $lowerBound, $upperBound);
+    }
+
+    /**
+     * Ensures that the value associated with the key is a string.
+     */
+    public function ensureString(string $key): string {
+        if (!self::offsetExists($key)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                $key
+            );
+        }
+        /** @var mixed */
+        $val = $this->offsetGet($key);
+        $this[$key] = strval($val);
+        return strval($val);
+    }
+
+    /**
+     * Ensures that the value associated with the key is a string or null
+     */
+    public function ensureOptionalString(
+        string $key,
+        bool $required = false
+    ): ?string {
+        if (!self::offsetExists($key)) {
+            if (!$required) {
+                return null;
+            }
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                $key
+            );
+        }
+        return $this->ensureString($key);
     }
 
     /**
@@ -238,13 +273,9 @@ class Request extends \ArrayObject {
     public function ensureFloat(
         string $key,
         ?float $lowerBound = null,
-        ?float $upperBound = null,
-        bool $required = true
-    ): void {
+        ?float $upperBound = null
+    ): float {
         if (!self::offsetExists($key)) {
-            if (!$required) {
-                return;
-            }
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterEmpty',
                 $key
@@ -259,6 +290,86 @@ class Request extends \ArrayObject {
             $upperBound
         );
         $this[$key] = floatval($val);
+        return floatval($this[$key]);
+    }
+
+    /**
+     * Ensures that the value associated with the key is a float.
+     */
+    public function ensureOptionalFloat(
+        string $key,
+        ?float $lowerBound = null,
+        ?float $upperBound = null,
+        bool $required = false
+    ): ?float {
+        if (!self::offsetExists($key)) {
+            if (!$required) {
+                return null;
+            }
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                $key
+            );
+        }
+        return $this->ensureFloat($key, $lowerBound, $upperBound);
+    }
+
+    /**
+     * Ensures that the value associated with the key is in an enum.
+     *
+     * @psalm-template TValue
+     * @param array<int, TValue> $enumValues
+     * @return TValue
+     */
+    public function ensureEnum(
+        string $key,
+        array $enumValues
+    ) {
+        if (!self::offsetExists($key)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                $key
+            );
+        }
+        /** @var mixed */
+        $val = $this->offsetGet($key);
+        foreach ($enumValues as $enumValue) {
+            if ($val == $enumValue) {
+                return $enumValue;
+            }
+        }
+        throw new \OmegaUp\Exceptions\InvalidParameterException(
+            'parameterNotInExpectedSet',
+            $key,
+            [
+                'bad_elements' => strval($val),
+                'expected_set' => implode(', ', $enumValues),
+            ]
+        );
+    }
+
+    /**
+     * Ensures that the value associated with the key is in an enum.
+     *
+     * @psalm-template TValue
+     * @param array<int, TValue> $enumValues
+     * @return TValue|null
+     */
+    public function ensureOptionalEnum(
+        string $key,
+        array $enumValues,
+        bool $required = false
+    ) {
+        if (!self::offsetExists($key)) {
+            if (!$required) {
+                return null;
+            }
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                $key
+            );
+        }
+        return $this->ensureEnum($key, $enumValues);
     }
 
     /**


### PR DESCRIPTION
Este cambio hace que `Request` tenga más métodos de validación para
aseverar los tipos. Esto es en preparación para dejar de usar `$r` como
un arreglo asociativo normal, y así vamos a poder tener tipos correctos
para los requests también.