### PR TITLE
Arreglando progreso general en listado de cursos

### DIFF
--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -175,9 +175,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
             $row['counts'] = \OmegaUp\DAO\Assignments::getAssignmentCountsForCourse(
                 $row['course_id']
             );
-            if (is_null($row['progress'])) {
-                unset($row['progress']);
-            }
+            $row['progress'] = $row['progress'] ?: 0.0;
             unset($row['last_submission_time']);
             unset($row['course_id']);
             $courses[] = $row;

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -105,7 +105,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                     s.name AS school_name,
                     start_time,
                     accept_teacher,
-                    pr.progress,
+                    IFNULL(pr.progress, 0.0) AS progress,
                     pr.last_submission_time
                 FROM Courses c
                 INNER JOIN (
@@ -162,7 +162,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                 ON c.school_id = s.school_id
                 ORDER BY
                     pr.last_submission_time DESC;';
-        /** @var list<array{accept_teacher: bool|null, admission_mode: string, alias: string, course_id: int, finish_time: \OmegaUp\Timestamp|null, last_submission_time: \OmegaUp\Timestamp|null, name: string, progress: float|null, school_name: null|string, start_time: \OmegaUp\Timestamp}> */
+        /** @var list<array{accept_teacher: bool|null, admission_mode: string, alias: string, course_id: int, finish_time: \OmegaUp\Timestamp|null, last_submission_time: \OmegaUp\Timestamp|null, name: string, progress: float, school_name: null|string, start_time: \OmegaUp\Timestamp}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$identityId, $identityId]
@@ -175,7 +175,6 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
             $row['counts'] = \OmegaUp\DAO\Assignments::getAssignmentCountsForCourse(
                 $row['course_id']
             );
-            $row['progress'] = $row['progress'] ?: 0.0;
             unset($row['last_submission_time']);
             unset($row['course_id']);
             $courses[] = $row;

--- a/frontend/www/js/omegaup/components/course/FilteredList.test.ts
+++ b/frontend/www/js/omegaup/components/course/FilteredList.test.ts
@@ -9,56 +9,68 @@ import { types } from '../../api_types';
 import course_FilteredList from './FilteredList.vue';
 
 const noop = () => {};
+const baseFilteredCoursesListProps = {
+  activeTab: 'past',
+  courses: <types.CoursesByAccessMode>{
+    accessMode: 'public',
+    activeTab: 'current',
+    filteredCourses: {
+      current: {
+        courses: [
+          {
+            alias: 'CC',
+            counts: {
+              homework: 2,
+              lesson: 2,
+              test: 1,
+            },
+            finish_time: null,
+            name: 'Curso de introducción',
+            start_time: new Date(),
+            admission_mode: 'public',
+            assignments: [],
+            is_open: true,
+          },
+          {
+            alias: 'cpluplus',
+            counts: {},
+            finish_time: new Date(),
+            name: 'Introducción a C++',
+            start_time: new Date(),
+            admission_mode: 'public',
+            assignments: [],
+            is_open: true,
+          },
+        ],
+        timeType: 'current',
+      },
+      past: {
+        courses: [],
+        timeType: 'past',
+      },
+    },
+  },
+};
 Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });
 
 describe('FilteredList.vue', () => {
-  it('Should handle filtered courses', async () => {
-    const courseName = 'Test course';
+  it('Should handle filtered courses for student', () => {
     const wrapper = shallowMount(course_FilteredList, {
-      propsData: {
-        activeTab: 'past',
-        courses: <types.CoursesByAccessMode>{
-          accessMode: 'public',
-          activeTab: 'current',
-          filteredCourses: {
-            current: {
-              courses: [
-                {
-                  alias: 'CC',
-                  counts: {
-                    homework: 2,
-                    lesson: 2,
-                    test: 1,
-                  },
-                  finish_time: null,
-                  name: 'Curso de introducción',
-                  start_time: new Date(),
-                  admission_mode: 'public',
-                  assignments: [],
-                  is_open: true,
-                },
-                {
-                  alias: 'cpluplus',
-                  counts: {},
-                  finish_time: new Date(),
-                  name: 'Introducción a C++',
-                  start_time: new Date(),
-                  admission_mode: 'public',
-                  assignments: [],
-                  is_open: true,
-                },
-              ],
-              timeType: 'current',
-            },
-            past: {
-              courses: [],
-              timeType: 'past',
-            },
-          },
-        },
-      },
+      propsData: baseFilteredCoursesListProps,
     });
 
     expect(wrapper.text()).toContain(T.courseListPastCourses);
+    expect(wrapper.text()).toContain(T.wordsCompletedPercentage);
+  });
+
+  it('Should handle filtered courses for admin', () => {
+    const wrapper = shallowMount(course_FilteredList, {
+      propsData: Object.assign({}, baseFilteredCoursesListProps, {
+        showPercentage: false,
+      }),
+    });
+
+    expect(wrapper.text()).toContain(T.courseListPastCourses);
+    expect(wrapper.text()).not.toContain(T.wordsCompletedPercentage);
   });
 });

--- a/frontend/www/js/omegaup/components/course/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/course/FilteredList.vue
@@ -29,7 +29,9 @@
               <thead>
                 <tr>
                   <th>{{ T.wordsName }}</th>
-                  <th>{{ T.wordsCompletedPercentage }}</th>
+                  <th v-if="showPercentage">
+                    {{ T.wordsCompletedPercentage }}
+                  </th>
                   <th>{{ T.wordsDueDate }}</th>
                   <th>{{ T.wordsNumHomeworks }}</th>
                   <th>{{ T.wordsNumTests }}</th>
@@ -45,7 +47,7 @@
                       course.name
                     }}</a>
                   </td>
-                  <td>
+                  <td v-if="showPercentage">
                     {{ `${course.progress}%` }}
                   </td>
                   <td>
@@ -136,6 +138,7 @@ library.add(fas);
 export default class CourseFilteredList extends Vue {
   @Prop() courses!: types.CoursesByAccessMode;
   @Prop() activeTab!: string;
+  @Prop({ default: true }) showPercentage!: boolean;
 
   T = T;
   time = time;

--- a/frontend/www/js/omegaup/components/course/Mine.vue
+++ b/frontend/www/js/omegaup/components/course/Mine.vue
@@ -13,6 +13,7 @@
       <omegaup-course-filtered-list
         v-bind:courses="courses.admin"
         v-bind:activeTab="courses.admin.activeTab"
+        v-bind:showPercentage="false"
       ></omegaup-course-filtered-list>
     </template>
   </div>


### PR DESCRIPTION
# Descripción

Se arregla el porcentaje completado en el listado de cursos que estudia el usuario.
Se había agregado una condición de que si el avance era nulo se eliminara el indice 
`progress` y debido a eso el cliente no encontraba definido dicho progreso y mandaba
ese texto de error.

También se quita ese porcentaje completado del listado de los cursos que administro
debido a que no es necesario tenerlo ahí.

![image](https://user-images.githubusercontent.com/3230352/89214880-3b498380-d58d-11ea-8bcf-01d354500ffe.png)


Fixes: #4451 


# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
