### PR TITLE
Agregando el botón de Cursos en el navbar de usuario no logueado

### DIFF
--- a/frontend/www/course/list.php
+++ b/frontend/www/course/list.php
@@ -1,7 +1,6 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-\OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
     function (\OmegaUp\Request $r): array {

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -84,6 +84,9 @@
               </template>
             </ul>
           </li>
+          <li v-bind:class="{ active: navbarSection === 'courses' }" v-else="">
+            <a href="/course/">{{ T.navCourses }}</a>
+          </li>
           <li
             class="dropdown nav-problems"
             v-bind:class="{ active: navbarSection === 'problems' }"

--- a/frontend/www/js/omegaup/components/common/Navbarv2.test.ts
+++ b/frontend/www/js/omegaup/components/common/Navbarv2.test.ts
@@ -1,0 +1,109 @@
+import { shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import Vue from 'vue';
+
+import T from '../../lang';
+import * as ui from '../../ui';
+
+import common_Navbarv2 from './Navbarv2.vue';
+
+const baseNavbarProps = {
+  currentUsername: 'user',
+  errorMessage: null,
+  graderInfo: null,
+  graderQueueLength: -1,
+  gravatarURL51:
+    'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+  inContest: true,
+  initialClarifications: [],
+  isAdmin: false,
+  isLoggedIn: true,
+  isMainUserIdentity: true,
+  isReviewer: false,
+  lockDownImage: 'data:image/png;base64...',
+  navbarSection: '',
+  omegaUpLockDown: false,
+};
+
+describe('Navbarv2.vue', () => {
+  it('Should handle empty navbar (in contest only)', async () => {
+    const wrapper = shallowMount(common_Navbarv2, {
+      propsData: {
+        currentUsername: 'user',
+        errorMessage: null,
+        graderInfo: null,
+        graderQueueLength: -1,
+        gravatarURL51:
+          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+        inContest: true,
+        initialClarifications: [],
+        isAdmin: false,
+        isLoggedIn: true,
+        isMainUserIdentity: true,
+        isReviewer: false,
+        lockDownImage: 'data:image/png;base64...',
+        navbarSection: '',
+        omegaUpLockDown: false,
+      },
+    });
+
+    expect(wrapper.find('.nav-contests').exists()).toBe(false);
+    expect(wrapper.find('.nav-courses').exists()).toBe(false);
+    expect(wrapper.find('.nav-problems').exists()).toBe(false);
+    expect(wrapper.find('.nav-rank').exists()).toBe(false);
+  });
+
+  it('Should handle common navbar to logged user', async () => {
+    const wrapper = shallowMount(common_Navbarv2, {
+      propsData: {
+        currentUsername: 'user',
+        errorMessage: null,
+        graderInfo: null,
+        graderQueueLength: -1,
+        gravatarURL51:
+          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+        inContest: false,
+        initialClarifications: [],
+        isAdmin: false,
+        isLoggedIn: true,
+        isMainUserIdentity: true,
+        isReviewer: false,
+        lockDownImage: 'data:image/png;base64...',
+        navbarSection: '',
+        omegaUpLockDown: false,
+      },
+    });
+
+    expect(wrapper.find('.nav-contests').exists()).toBe(true);
+    expect(wrapper.find('.nav-courses').exists()).toBe(true);
+    expect(wrapper.find('.nav-problems').exists()).toBe(true);
+    expect(wrapper.find('.nav-rank').exists()).toBe(true);
+  });
+
+  it('Should handle common navbar to not-logged user', async () => {
+    const wrapper = shallowMount(common_Navbarv2, {
+      propsData: {
+        currentUsername: 'user',
+        errorMessage: null,
+        graderInfo: null,
+        graderQueueLength: -1,
+        gravatarURL51:
+          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+        inContest: false,
+        initialClarifications: [],
+        isAdmin: false,
+        isLoggedIn: false,
+        isMainUserIdentity: true,
+        isReviewer: false,
+        lockDownImage: 'data:image/png;base64...',
+        navbarSection: '',
+        omegaUpLockDown: false,
+      },
+    });
+
+    expect(wrapper.find('.nav-problems').exists()).toBe(true);
+    expect(wrapper.find('[data-nav-course]').exists()).toBe(true);
+    expect(wrapper.find('.nav-rank').exists()).toBe(true);
+    expect(wrapper.find('.navbar-right').text()).toBe(T.navLogIn);
+  });
+});

--- a/frontend/www/js/omegaup/components/common/Navbarv2.vue
+++ b/frontend/www/js/omegaup/components/common/Navbarv2.vue
@@ -104,6 +104,13 @@
               </div>
             </li>
             <li
+              v-bind:class="{ active: navbarSection === 'course' }"
+              data-nav-course
+              v-else=""
+            >
+              <a class="nav-link px-2" href="/course/">{{ T.navCourses }}</a>
+            </li>
+            <li
               class="nav-item dropdown nav-problems"
               v-bind:class="{ active: navbarSection === 'problems' }"
             >


### PR DESCRIPTION
# Descripción

Se agrega el botón de Cursos en el navbar cuando no hay una sesión activa. El
comportamiento del botón es que al presionarse manda a la vista de cursos
públicos y cuando el usuario presiona el botón de comenzar alguno de ellos, 
se redirecciona a la página de login.

![CourseButtonWhenNotLogged](https://user-images.githubusercontent.com/3230352/89238167-ca20c500-d5ba-11ea-8bda-bc19d7379691.gif)


Fixes: #4400 


# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
