### PR TITLE
Reportando tipos de `\OmegaUp\Request::ensure{,Optional}Enum()`

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -83,7 +83,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
      * @omegaup-request-param mixed $alias
-     * @omegaup-request-param mixed $assignment_type
+     * @omegaup-request-param 'homework'|'lesson'|'test' $assignment_type
      * @omegaup-request-param mixed $description
      * @omegaup-request-param OmegaUp\Timestamp|null $finish_time
      * @omegaup-request-param mixed $name
@@ -135,8 +135,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        \OmegaUp\Validators::validateInEnum(
-            $r['assignment_type'],
+        $r->ensureEnum(
             'assignment_type',
             ['test', 'lesson', 'homework']
         );
@@ -273,13 +272,13 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param mixed $finish_time
      * @omegaup-request-param mixed $name
      * @omegaup-request-param bool|null $needs_basic_information
-     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param 'no'|'optional'|'required'|null $requests_user_information
      * @omegaup-request-param int $school_id
      * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param mixed $start_time
@@ -307,13 +306,13 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param OmegaUp\Timestamp|null $finish_time
      * @omegaup-request-param mixed $name
      * @omegaup-request-param bool|null $needs_basic_information
-     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param 'no'|'optional'|'required'|null $requests_user_information
      * @omegaup-request-param int $school_id
      * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param OmegaUp\Timestamp|null $start_time
@@ -360,13 +359,13 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param int|null $finish_time
      * @omegaup-request-param mixed $name
      * @omegaup-request-param bool|null $needs_basic_information
-     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param 'no'|'optional'|'required'|null $requests_user_information
      * @omegaup-request-param int $school_id
      * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param int $start_time
@@ -410,12 +409,10 @@ class Course extends \OmegaUp\Controllers\Controller {
         // Show scoreboard, needs basic information and request user information are always optional
         $r->ensureOptionalBool('needs_basic_information');
         $r->ensureOptionalBool('show_scoreboard');
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['requests_user_information'],
+        $r->ensureOptionalEnum(
             'requests_user_information',
             ['no', 'optional', 'required']
         );
-
         $r->ensureOptionalInt('school_id');
 
         if (is_null($r['school_id'])) {
@@ -429,8 +426,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             }
         }
 
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['admission_mode'],
+        $r->ensureOptionalEnum(
             'admission_mode',
             [
                 self::ADMISSION_MODE_PUBLIC,
@@ -2859,7 +2855,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @omegaup-request-param mixed $course_type
+     * @omegaup-request-param 'student'|'public' $course_type
      * @omegaup-request-param int $page
      * @omegaup-request-param int $page_size
      *
@@ -2872,14 +2868,11 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         $page = (isset($r['page']) ? intval($r['page']) : 1);
         $pageSize = (isset($r['page_size']) ? intval($r['page_size']) : 1000);
-        $coursesTypes = ['student', 'public'];
 
-        \OmegaUp\Validators::validateInEnum(
-            $r['course_type'],
+        $courseType = $r->ensureEnum(
             'course_type',
-            $coursesTypes
+            ['student', 'public']
         );
-        $courseType = strval($r['course_type']);
 
         $courses = self::getCoursesList(
             $r->identity,
@@ -3761,13 +3754,13 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param mixed $assignment_alias
      * @omegaup-request-param mixed $course_alias
-     * @omegaup-request-param mixed $language
+     * @omegaup-request-param 'c11-clang'|'c11-gcc'|'cat'|'cpp11-clang'|'cpp11-gcc'|'cpp17-clang'|'cpp17-gcc'|'cs'|'hs'|'java'|'kj'|'kp'|'lua'|'pas'|'py2'|'py3'|'rb'|null $language
      * @omegaup-request-param mixed $offset
      * @omegaup-request-param mixed $problem_alias
      * @omegaup-request-param mixed $rowcount
-     * @omegaup-request-param mixed $status
+     * @omegaup-request-param 'compiling'|'new'|'ready'|'running'|'waiting'|null $status
      * @omegaup-request-param mixed $username
-     * @omegaup-request-param mixed $verdict
+     * @omegaup-request-param 'AC'|'CE'|'JE'|'MLE'|'NO-AC'|'OLE'|'PA'|'RFE'|'RTE'|'TLE'|'VE'|'WA'|null $verdict
      *
      * @return array{runs: list<Run>}
      */
@@ -3780,15 +3773,18 @@ class Course extends \OmegaUp\Controllers\Controller {
             'assignment' => $assignment,
             'problem' => $problem,
             'identity' => $identity,
+            'language' => $language,
+            'status' => $status,
+            'verdict' => $verdict,
         ] = self::validateRuns($r);
 
         // Get our runs
         $runs = \OmegaUp\DAO\Runs::getAllRuns(
             $assignment->problemset_id,
-            !is_null($r['status']) ? strval($r['status']) : null,
-            !is_null($r['verdict']) ? strval($r['verdict']) : null,
+            $status,
+            $verdict,
             !is_null($problem) ? $problem->problem_id : null,
-            !is_null($r['language']) ? strval($r['language']) : null,
+            $language,
             !is_null($identity) ? $identity->identity_id : null,
             !is_null($r['offset']) ? intval($r['offset']) : null,
             !is_null($r['rowcount']) ? intval($r['rowcount']) : null
@@ -3809,20 +3805,20 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Validates runs API
      *
-     * @return array{assignment: \OmegaUp\DAO\VO\Assignments, problem: \OmegaUp\DAO\VO\Problems|null, identity: \OmegaUp\DAO\VO\Identities|null}
+     * @return array{assignment: \OmegaUp\DAO\VO\Assignments, identity: \OmegaUp\DAO\VO\Identities|null, language: 'c11-clang'|'c11-gcc'|'cat'|'cpp11-clang'|'cpp11-gcc'|'cpp17-clang'|'cpp17-gcc'|'cs'|'hs'|'java'|'kj'|'kp'|'lua'|'pas'|'py2'|'py3'|'rb'|null, problem: \OmegaUp\DAO\VO\Problems|null, status:'compiling'|'new'|'ready'|'running'|'waiting'|null, verdict:'AC'|'CE'|'JE'|'MLE'|'NO-AC'|'OLE'|'PA'|'RFE'|'RTE'|'TLE'|'VE'|'WA'|null}
      *
      * @throws \OmegaUp\Exceptions\NotFoundException
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
      * @omegaup-request-param mixed $assignment_alias
      * @omegaup-request-param mixed $course_alias
-     * @omegaup-request-param mixed $language
+     * @omegaup-request-param 'c11-clang'|'c11-gcc'|'cat'|'cpp11-clang'|'cpp11-gcc'|'cpp17-clang'|'cpp17-gcc'|'cs'|'hs'|'java'|'kj'|'kp'|'lua'|'pas'|'py2'|'py3'|'rb'|null $language
      * @omegaup-request-param int $offset
      * @omegaup-request-param mixed $problem_alias
      * @omegaup-request-param int $rowcount
-     * @omegaup-request-param mixed $status
+     * @omegaup-request-param 'compiling'|'new'|'ready'|'running'|'waiting'|null $status
      * @omegaup-request-param mixed $username
-     * @omegaup-request-param mixed $verdict
+     * @omegaup-request-param 'AC'|'CE'|'JE'|'MLE'|'NO-AC'|'OLE'|'PA'|'RFE'|'RTE'|'TLE'|'VE'|'WA'|null $verdict
      */
     private static function validateRuns(
         \OmegaUp\Request $r
@@ -3868,13 +3864,11 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         $r->ensureOptionalInt('offset');
         $r->ensureOptionalInt('rowcount');
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['status'],
+        $status = $r->ensureOptionalEnum(
             'status',
             ['new', 'waiting', 'compiling', 'running', 'ready']
         );
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['verdict'],
+        $verdict = $r->ensureOptionalEnum(
             'verdict',
             \OmegaUp\Controllers\Run::VERDICTS
         );
@@ -3893,8 +3887,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             }
         }
 
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['language'],
+        $language = $r->ensureOptionalEnum(
             'language',
             array_keys(\OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES)
         );
@@ -3911,6 +3904,9 @@ class Course extends \OmegaUp\Controllers\Controller {
             'assignment' => $assignment,
             'problem' => $problem,
             'identity' => $identity,
+            'language' => $language,
+            'status' => $status,
+            'verdict' => $verdict,
         ];
     }
 
@@ -3953,13 +3949,13 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @return array{status: string}
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param mixed $alias
      * @omegaup-request-param mixed $description
      * @omegaup-request-param OmegaUp\Timestamp|null $finish_time
      * @omegaup-request-param mixed $name
      * @omegaup-request-param bool|null $needs_basic_information
-     * @omegaup-request-param mixed $requests_user_information
+     * @omegaup-request-param 'no'|'optional'|'required'|null $requests_user_information
      * @omegaup-request-param int $school_id
      * @omegaup-request-param bool|null $show_scoreboard
      * @omegaup-request-param OmegaUp\Timestamp|null $start_time

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1925,17 +1925,17 @@ Returns all runs for a course
 
 ### Parameters
 
-| Name               | Type    | Description |
-| ------------------ | ------- | ----------- |
-| `assignment_alias` | `mixed` |             |
-| `course_alias`     | `mixed` |             |
-| `language`         | `mixed` |             |
-| `offset`           | `mixed` |             |
-| `problem_alias`    | `mixed` |             |
-| `rowcount`         | `mixed` |             |
-| `status`           | `mixed` |             |
-| `username`         | `mixed` |             |
-| `verdict`          | `mixed` |             |
+| Name               | Type                                                                                                                                           | Description |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `assignment_alias` | `mixed`                                                                                                                                        |             |
+| `course_alias`     | `mixed`                                                                                                                                        |             |
+| `language`         | `'c11-clang'|'c11-gcc'|'cat'|'cpp11-clang'|'cpp11-gcc'|'cpp17-clang'|'cpp17-gcc'|'cs'|'hs'|'java'|'kj'|'kp'|'lua'|'pas'|'py2'|'py3'|'rb'|null` |             |
+| `offset`           | `mixed`                                                                                                                                        |             |
+| `problem_alias`    | `mixed`                                                                                                                                        |             |
+| `rowcount`         | `mixed`                                                                                                                                        |             |
+| `status`           | `'compiling'|'new'|'ready'|'running'|'waiting'|null`                                                                                           |             |
+| `username`         | `mixed`                                                                                                                                        |             |
+| `verdict`          | `'AC'|'CE'|'JE'|'MLE'|'NO-AC'|'OLE'|'PA'|'RFE'|'RTE'|'TLE'|'VE'|'WA'|null`                                                                     |             |
 
 ### Returns
 
@@ -1969,19 +1969,19 @@ Edit Course contents
 
 ### Parameters
 
-| Name                        | Type                     | Description |
-| --------------------------- | ------------------------ | ----------- |
-| `admission_mode`            | `mixed`                  |             |
-| `alias`                     | `mixed`                  |             |
-| `description`               | `mixed`                  |             |
-| `finish_time`               | `OmegaUp\Timestamp|null` |             |
-| `name`                      | `mixed`                  |             |
-| `needs_basic_information`   | `bool|null`              |             |
-| `requests_user_information` | `mixed`                  |             |
-| `school_id`                 | `int`                    |             |
-| `show_scoreboard`           | `bool|null`              |             |
-| `start_time`                | `OmegaUp\Timestamp|null` |             |
-| `unlimited_duration`        | `bool|null`              |             |
+| Name                        | Type                                     | Description |
+| --------------------------- | ---------------------------------------- | ----------- |
+| `admission_mode`            | `'private'|'public'|'registration'|null` |             |
+| `alias`                     | `mixed`                                  |             |
+| `description`               | `mixed`                                  |             |
+| `finish_time`               | `OmegaUp\Timestamp|null`                 |             |
+| `name`                      | `mixed`                                  |             |
+| `needs_basic_information`   | `bool|null`                              |             |
+| `requests_user_information` | `'no'|'optional'|'required'|null`        |             |
+| `school_id`                 | `int`                                    |             |
+| `show_scoreboard`           | `bool|null`                              |             |
+| `start_time`                | `OmegaUp\Timestamp|null`                 |             |
+| `unlimited_duration`        | `bool|null`                              |             |
 
 ### Returns
 

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -150,6 +150,105 @@ class RequestParamChecker implements
     }
 
     /**
+     * Called for every Request ensureEnum/ensureOptionalEnum.
+     *
+     * @param \Psalm\FileManipulation[] $fileReplacements
+     *
+     * @return null|false
+     */
+    private static function processRequestEnum(
+        \PhpParser\Node\Expr\MethodCall $expr,
+        \Psalm\Context $context,
+        \Psalm\StatementsSource $statementsSource,
+        \Psalm\Codebase $codebase,
+        array &$fileReplacements = []
+    ) {
+        $varType = $statementsSource->getNodeTypeProvider()->getType(
+            $expr->var
+        );
+        if (is_null($varType)) {
+            return null;
+        }
+        $foundRequest = false;
+        foreach ($varType->getAtomicTypes() as $typeName => $type) {
+            if (
+                $type instanceof \Psalm\Type\Atomic\TNamedObject &&
+                $type->value == 'OmegaUp\\Request'
+            ) {
+                $foundRequest = true;
+                break;
+            }
+        }
+        if (!$foundRequest) {
+            return null;
+        }
+
+        /** @var \PhpParser\Node\Identifier $expr->name */
+        $methodId = 'OmegaUp\\Request::' . strtolower($expr->name->name);
+
+        if (
+            $methodId !== 'OmegaUp\\Request::ensureenum' &&
+            $methodId !== 'OmegaUp\\Request::ensureoptionalenum'
+        ) {
+            return null;
+        }
+
+        if (!is_null($context->calling_function_id)) {
+            $functionId = strtolower($context->calling_function_id);
+        } elseif (!is_null($context->calling_method_id)) {
+            $functionId = $context->calling_method_id;
+        } else {
+            throw new \Exception('Empty calling method/function id');
+        }
+
+        if (count($expr->args) < 2) {
+            if (
+                \Psalm\IssueBuffer::accepts(
+                    new EnumMissingArguments(
+                        "{$methodId}() missing some arguments",
+                        new \Psalm\CodeLocation($statementsSource, $expr)
+                    ),
+                    $statementsSource->getSuppressedIssues()
+                )
+            ) {
+                return false;
+            }
+            return null;
+        }
+        if (!$expr->args[0]->value instanceof \PhpParser\Node\Scalar\String_) {
+            if (
+                // Methods within \OmegaUp\Request are exempt
+                strpos($functionId, 'omegaup\\request::') !== 0 &&
+                \Psalm\IssueBuffer::accepts(
+                    new RequestAccessNotALiteralString(
+                        "{$methodId}() argument not a literal string",
+                        new \Psalm\CodeLocation($statementsSource, $expr)
+                    ),
+                    $statementsSource->getSuppressedIssues()
+                )
+            ) {
+                return false;
+            }
+            return null;
+        }
+
+        $returnType = $statementsSource->getNodeTypeProvider()->getType(
+            $expr
+        );
+        if (is_null($returnType)) {
+            return null;
+        }
+
+        self::processParameter(
+            $functionId,
+            $expr->args[0]->value->value,
+            $returnType,
+            $codebase
+        );
+        return null;
+    }
+
+    /**
      * Called after a statement has been checked
      *
      * @param \Psalm\FileManipulation[] $fileReplacements
@@ -171,6 +270,14 @@ class RequestParamChecker implements
         }
         if ($expr instanceof \PhpParser\Node\Expr\ArrayDimFetch) {
             return self::processRequestPropertyFetch(
+                $expr,
+                $context,
+                $statementsSource,
+                $codebase,
+                $fileReplacements
+            );
+        } elseif ($expr instanceof \PhpParser\Node\Expr\MethodCall) {
+            return self::processRequestEnum(
                 $expr,
                 $context,
                 $statementsSource,
@@ -579,15 +686,39 @@ class RequestParamDescription {
     }
 
     public function __toString(): string {
-        if (is_null($this->description)) {
-            return "{$this->type} \${$this->name}";
+        $result = $this->stringifyType() . " \${$this->name}";
+        if (!is_null($this->description)) {
+            $result .= " {$this->description}";
         }
-        return "{$this->type} \${$this->name} {$this->description}";
+        return $result;
+    }
+
+    private function stringifyType(): string {
+        if ($this->type->hasLiteralValue()) {
+            $types = [];
+            foreach ($this->type->getAtomicTypes() as $type) {
+                if ($type instanceof \Psalm\Type\Atomic\TLiteralFloat) {
+                    $types[] = strval($type->value);
+                } elseif ($type instanceof \Psalm\Type\Atomic\TLiteralString) {
+                    $types[] = "'" . strval($type->value) . "'";
+                } elseif ($type instanceof \Psalm\Type\Atomic\TLiteralInt) {
+                    $types[] = strval($type->value);
+                } else {
+                    $types[] = strval($type);
+                }
+            }
+            sort($types);
+            return implode('|', $types);
+        }
+        return strval($this->type);
     }
 }
 
-class RequestAccessNotALiteralString extends \Psalm\Issue\PluginIssue {
+class EnumMissingArguments extends \Psalm\Issue\PluginIssue {
 }
 
 class MismatchingDocblockOmegaUpRequestParamAnnotation extends \Psalm\Issue\PluginIssue {
+}
+
+class RequestAccessNotALiteralString extends \Psalm\Issue\PluginIssue {
 }


### PR DESCRIPTION
Este cambio hace que `\OmegaUp\Request::ensure{,Optional}Enum()` reporte
los tipos que acepta. Esto hace que la documentación de los APIs
contenga exactamente qué valores acepta un API en vez de un tipo burdo
como `string` o `int`.