### PR TITLE
Evitando que un envío que está siendo reejecutado se re-reejecute

### DIFF
--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -719,7 +719,12 @@ class Run extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        self::$log->info('Run being rejudged!!');
+        if ($run->status == 'new' || $run->status == 'waiting') {
+            self::$log->info('Run already in the rejudge queue. Ignoring');
+            return ['status' => 'ok'];
+        }
+
+        self::$log->info("Run {$run->run_id} being rejudged");
 
         // Reset fields.
         try {

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -2174,10 +2174,11 @@ export class Arena {
             'detailed')
         ),
       });
+      const runDetailsView = <HTMLElement | null>(
+        document.querySelector('[data-run-details-view]')
+      );
+      if (runDetailsView) runDetailsView.style.display = 'block';
     }
-    (<HTMLElement>(
-      document.querySelector('[data-run-details-view]')
-    )).style.display = 'block';
   }
 
   trackRun(run: types.Run): void {


### PR DESCRIPTION
Este cambio hace que si un envío ya tiene status `'new'` o `'waiting'`,
no se vuelva a marcar como `'new'`. Esto evita que los envíos en la cola
se agreguen más veces de las necesarias.