### PR TITLE
Más mejoras a la detección de cadenas de traducción

### DIFF
--- a/frontend/server/src/Broadcaster.php
+++ b/frontend/server/src/Broadcaster.php
@@ -82,15 +82,13 @@ class Broadcaster {
             $subject = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'clarificationEmailSubject'
-                )
-                    ?: 'clarificationEmailSubject',
+                ),
                 $emailParams
             );
             $body = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'clarificationEmailBody'
-                )
-                    ?: 'clarificationEmailBody',
+                ),
                 $emailParams
             );
 

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2617,7 +2617,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $time = \OmegaUp\Time::get();
         $note = \OmegaUp\Translations::getInstance()->get(
             'wordsAutoAccepted'
-        ) ?: 'wordsAutoAccepted';
+        );
         foreach ($identitiesIDs as $identityID) {
             if (
                 \OmegaUp\DAO\ProblemsetIdentityRequest::replace(

--- a/frontend/server/src/Controllers/Interview.php
+++ b/frontend/server/src/Controllers/Interview.php
@@ -158,8 +158,7 @@ class Interview extends \OmegaUp\Controllers\Controller {
 
         $subject = \OmegaUp\Translations::getInstance()->get(
             'interviewInvitationEmailSubject'
-        )
-            ?: 'interviewInvitationEmailSubject';
+        );
 
         if (is_null($user)) {
             // create a new user
@@ -189,30 +188,27 @@ class Interview extends \OmegaUp\Controllers\Controller {
             // Email to new OmegaUp users
             $body = \OmegaUp\Translations::getInstance()->get(
                 'interviewInvitationEmailBodyIntro'
-            ) ?: 'interviewInvitationEmailBodyIntro'
-               . '<br>'
+            )  . '<br>'
                . " <a href=\"https://omegaup.com/user/verifyemail/{$user->verification_id}/redirecttointerview/{$interview->alias}/\">"
                . " https://omegaup.com/user/verifyemail/{$user->verification_id}/redirecttointerview/{$interview->alias}/</a>"
                . '<br>';
 
             $body .= \OmegaUp\Translations::getInstance()->get(
                 'interviewEmailDraft'
-            ) ?: 'interviewEmailDraft'
-                . '<br>'
-                . (\OmegaUp\Translations::getInstance()->get(
+            )   . '<br>'
+                . \OmegaUp\Translations::getInstance()->get(
                     'profileUsername'
-                ) ?: 'profileUsername')
+                )
                 . " : {$username}<br>"
-                . (\OmegaUp\Translations::getInstance()->get(
+                . \OmegaUp\Translations::getInstance()->get(
                     'loginPassword'
-                ) ?: 'loginPassword')
+                )
                 . " : {$password}<br>";
         } else {
             // Email to current OmegaUp user
             $body = \OmegaUp\Translations::getInstance()->get(
                 'interviewInvitationEmailBodyIntro'
-            ) ?: 'interviewInvitationEmailBodyIntro'
-               . " <a href=\"https://omegaup.com/interview/{$interview->alias}/arena/\">"
+            )  . " <a href=\"https://omegaup.com/interview/{$interview->alias}/arena/\">"
                . "https://omegaup.com/interview/{$interview->alias}/arena/</a>";
         }
 

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5381,7 +5381,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'smartyProperties' => [
                     'error' => \OmegaUp\Translations::getInstance()->get(
                         'parameterInvalid'
-                    ) ?? 'parameterInvalid',
+                    ),
                     'error_field' => strval($e->parameter),
                 ],
                 'template' => 'libinteractive.gen.tpl',

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -606,7 +606,13 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 break;
         }
 
-        $message = ($r['status'] === 'banned') ? 'banningProblemDueToReport' : 'banningDeclinedByReviewer';
+        $message = ($r['status'] === 'banned') ?
+            \OmegaUp\Translations::getInstance()->get(
+                'banningProblemDueToReport'
+            ) :
+            \OmegaUp\Translations::getInstance()->get(
+                'banningDeclinedByReviewer'
+            );
 
         if ($r->ensureOptionalBool('all') ?? false) {
             $nominations = \OmegaUp\DAO\QualityNominations::getAllDemotionsForProblem(
@@ -707,44 +713,38 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             $notificationContents = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'demotionProblemNotificationBanned'
-                )
-                    ?: 'demotionProblemNotificationBanned',
+                ),
                 ['problem_name' => strval($problem->title)]
             );
             $subject = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'demotionProblemEmailBannedSubject'
-                )
-                    ?: 'demotionProblemEmailBannedSubject',
+                ),
                 $emailParams
             );
             $body = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'demotionProblemEmailBannedBody'
-                )
-                    ?: 'demotionProblemEmailBannedBody',
+                ),
                 $emailParams
             );
         } else {
             $notificationContents = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'demotionProblemNotificationWarning'
-                )
-                    ?: 'demotionProblemNotificationWarning',
+                ),
                 ['problem_name' => strval($problem->title)]
             );
             $subject = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'demotionProblemEmailWarningSubject'
-                )
-                    ?: 'demotionProblemEmailWarningSubject',
+                ),
                 $emailParams
             );
             $body = \OmegaUp\ApiUtils::formatString(
                 \OmegaUp\Translations::getInstance()->get(
                     'demotionProblemEmailWarningBody'
-                )
-                    ?: 'demotionProblemEmailWarningBody',
+                ),
                 $emailParams
             );
         }

--- a/frontend/server/src/Controllers/Reset.php
+++ b/frontend/server/src/Controllers/Reset.php
@@ -40,14 +40,12 @@ class Reset extends \OmegaUp\Controllers\Controller {
             return ['token' => $token];
         }
 
-        $subject = \OmegaUp\Translations::getInstance()->get('wordsReset')
-            ?: 'wordsReset';
+        $subject = \OmegaUp\Translations::getInstance()->get('wordsReset');
         $link = OMEGAUP_URL . '/login/password/reset/?';
         $link .= 'email=' . rawurlencode($email) . '&reset_token=' . $token;
         $message = \OmegaUp\Translations::getInstance()->get(
             'wordsResetMessage'
-        )
-            ?: 'wordsResetMessage';
+        );
         $body = str_replace('[link]', $link, $message);
 
         try {
@@ -64,7 +62,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
         return [
             'message' => \OmegaUp\Translations::getInstance()->get(
                 'passwordResetRequestSuccess'
-            ) ?? 'passwordResetRequestSuccess'
+            )
         ];
     }
 
@@ -226,7 +224,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
                 'message' :
                     \OmegaUp\Translations::getInstance()->get(
                         'passwordResetResetSuccess'
-                    ) ?? 'passwordResetResetSuccess'
+                    )
         ];
     }
 

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -338,11 +338,9 @@ class User extends \OmegaUp\Controllers\Controller {
 
         $subject = \OmegaUp\Translations::getInstance()->get(
             'verificationEmailSubject'
-        )
-            ?: 'verificationEmailSubject';
+        );
         $body = \OmegaUp\ApiUtils::formatString(
-            \OmegaUp\Translations::getInstance()->get('verificationEmailBody')
-                ?: 'verificationEmailBody',
+            \OmegaUp\Translations::getInstance()->get('verificationEmailBody'),
             [
                 'verification_id' => strval($user->verification_id),
             ]

--- a/frontend/server/src/Exceptions/ApiException.php
+++ b/frontend/server/src/Exceptions/ApiException.php
@@ -77,13 +77,13 @@ abstract class ApiException extends \Exception {
     }
 
     public function getErrorMessage(): string {
+        /**
+         * @psalm-suppress TranslationStringNotALiteralString this is being
+         * checked from the constructor of the exception
+         */
         $localizedText = \OmegaUp\Translations::getInstance()->get(
             $this->message
         );
-        if (is_null($localizedText)) {
-            self::$log->error("Untranslated error message: {$this->message}");
-            return "{untranslated:{$this->message}}";
-        }
         return \OmegaUp\ApiUtils::formatString(
             $localizedText,
             $this->_customMessage

--- a/frontend/server/src/Exceptions/DatabaseOperationException.php
+++ b/frontend/server/src/Exceptions/DatabaseOperationException.php
@@ -16,9 +16,7 @@ class DatabaseOperationException extends \OmegaUp\Exceptions\ApiException {
     }
 
     public function getErrorMessage(): string {
-        return \OmegaUp\Translations::getInstance()->get(
-            'generalError'
-        ) ?: 'generalError';
+        return \OmegaUp\Translations::getInstance()->get('generalError');
     }
 
     public function isDuplicate(): bool {

--- a/frontend/server/src/Exceptions/InvalidParameterException.php
+++ b/frontend/server/src/Exceptions/InvalidParameterException.php
@@ -29,6 +29,10 @@ class InvalidParameterException extends \OmegaUp\Exceptions\ApiException {
     }
 
     public function getErrorMessage(): string {
+        /**
+         * @psalm-suppress TranslationStringNotALiteralString this is being
+         * checked from the constructor of the exception
+         */
         $localizedText = \OmegaUp\Translations::getInstance()->get(
             $this->message
         );

--- a/frontend/server/src/Translations.php
+++ b/frontend/server/src/Translations.php
@@ -62,11 +62,14 @@ class Translations {
      *
      * @param string $key the translation string to look up.
      *
-     * @return null|string the translated string.
+     * @return string the translated string.
      */
-    public function get(string $key): ?string {
+    public function get(string $key): string {
         if (!array_key_exists($key, $this->_translations)) {
-            return null;
+            \Logger::getLogger('Translations')->error(
+                "Untranslated error message: {$key}"
+            );
+            return "{untranslated:{$key}}";
         }
         return $this->_translations[$key];
     }

--- a/frontend/www/js/omegaup/components/badge/Details.vue
+++ b/frontend/www/js/omegaup/components/badge/Details.vue
@@ -20,7 +20,7 @@
         </div>
         <div class="badge-text">
           <span class="badge-text-icon">👥</span>
-          {{ T['badgeOwnersMessage'] }}
+          {{ T.badgeOwnersMessage }}
         </div>
       </div>
       <div class="col-sm-6 col-md-4 mt-3 mt-md-0">
@@ -29,7 +29,7 @@
         </div>
         <div class="badge-text">
           <span class="badge-text-icon">📅</span>
-          {{ T['badgeFirstAssignationMessage'] }}
+          {{ T.badgeFirstAssignationMessage }}
         </div>
       </div>
       <div class="col-sm-6 col-md-4 mt-3 mt-md-0">
@@ -97,8 +97,8 @@ export default class BadgeDetails extends Vue {
 
   get ownedMessage(): string {
     return !!this.badge.assignation_time
-      ? `<span class="badge-text-icon">😁</span> ${T['badgeAssignationTimeMessage']}`
-      : `<span class="badge-text-icon">😞</span> ${T['badgeNotAssignedMessage']}`;
+      ? `<span class="badge-text-icon">😁</span> ${T.badgeAssignationTimeMessage}`
+      : `<span class="badge-text-icon">😞</span> ${T.badgeNotAssignedMessage}`;
   }
 
   get firstAssignationDate(): string {


### PR DESCRIPTION
Este cambio ahora también valida las llamadas a
\OmegaUp\Translation::get() para asegurarnos que las cadenas de
traducción provistas existan.