### PR TITLE
Haciendo explícitas más cadenas de traducción

### DIFF
--- a/frontend/server/src/Controllers/Badge.php
+++ b/frontend/server/src/Controllers/Badge.php
@@ -160,7 +160,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
                     'badges' => $badges,
                     'ownedBadges' => $ownedBadges['badges']
                 ],
-                'title' => 'omegaupTitleBadges'
+                'title' => new \OmegaUp\TranslationString('omegaupTitleBadges')
             ],
             'entrypoint' => 'badge_list',
         ];
@@ -197,7 +197,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
                         ]
                     ),
                 ],
-                'title' => 'omegaupTitleBadges'
+                'title' => new \OmegaUp\TranslationString('omegaupTitleBadges')
             ],
             'entrypoint' => 'badge_details',
         ];

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1,6 +1,6 @@
 <?php
 
- namespace OmegaUp\Controllers;
+namespace OmegaUp\Controllers;
 
 /**
  * ContestController
@@ -549,7 +549,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     'shouldShowFirstAssociatedIdentityRunWarning' => false,
                     'contest' => self::getPublicDetails($contest, $r->identity),
                 ],
-                'title' => 'enterContest',
+                'title' => new \OmegaUp\TranslationString('enterContest'),
             ],
             'entrypoint' => 'contest_intro',
         ];
@@ -711,7 +711,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     'isLogged' => !is_null($r->identity),
                     'contests' => $contests,
                 ],
-                'title' => 'wordsContests',
+                'title' => new \OmegaUp\TranslationString('wordsContests'),
             ],
             'entrypoint' => 'arena_contest_list',
         ];
@@ -766,7 +766,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     'contests' => $contestsList['contests'],
                     'privateContestsAlert' => $privateContestsAlert,
                 ],
-                'title' => 'omegaupTitleMyContests',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleMyContests'
+                ),
             ],
             'entrypoint' => 'contest_mine',
         ];
@@ -4135,7 +4137,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     ],
                     self::getStats($contest, $r->identity)
                 ),
-                'title' => 'omegaupTitleContestStats',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleContestStats'
+                ),
             ],
             'entrypoint' => 'common_stats',
         ];

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -1,6 +1,6 @@
 <?php
 
- namespace OmegaUp\Controllers;
+namespace OmegaUp\Controllers;
 
 /**
  *  CourseController
@@ -1793,8 +1793,12 @@ class Course extends \OmegaUp\Controllers\Controller {
                             'body' => [
                                 'localizationString' => (
                                     $request->accepted ?
-                                    'notificationCourseRegistrationAccepted' :
-                                    'notificationCourseRegistrationRejected'
+                                    new \OmegaUp\TranslationString(
+                                        'notificationCourseRegistrationAccepted'
+                                    ) :
+                                    new \OmegaUp\TranslationString(
+                                        'notificationCourseRegistrationRejected'
+                                    )
                                 ),
                                 'localizationParams' => [
                                     'courseName' => $course->name,
@@ -2540,7 +2544,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                     ),
                     'is_admin' => true,
                 ],
-                'title' => 'omegaupTitleCourseNew',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleCourseNew'
+                ),
             ],
             'entrypoint' => 'course_new',
         ];
@@ -2575,7 +2581,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         return [
             'smartyProperties' => [
                 'payload' => $courseEditDetails,
-                'title' => 'courseEdit',
+                'title' => new \OmegaUp\TranslationString('courseEdit'),
             ],
             'entrypoint' => 'course_edit',
         ];
@@ -2621,7 +2627,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'course' => $courseEditDetails,
                     'assignment' => $assignment,
                 ],
-                'title' => 'courseAssignmentEdit',
+                'title' => new \OmegaUp\TranslationString(
+                    'courseAssignmentEdit'
+                ),
             ],
             'entrypoint' => 'course_assignment_edit',
         ];
@@ -2705,7 +2713,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'solvedProblems' => $userSolvedProblems,
                     'unsolvedProblems' => $userUnsolvedProblems,
                 ],
-                'title' => 'courseSubmissionsList',
+                'title' => new \OmegaUp\TranslationString(
+                    'courseSubmissionsList'
+                ),
             ],
             'entrypoint' => 'course_submissions_list',
         ];
@@ -2744,7 +2754,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                         $course->group_id
                     ),
                 ],
-                'title' => 'omegaupTitleStudentsProgress',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleStudentsProgress'
+                ),
             ],
             'entrypoint' => 'course_students'
         ];
@@ -2787,7 +2799,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                     ),
                     'student' => $r['student']
                 ],
-                'title' => 'omegaupTitleStudentsProgress',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleStudentsProgress'
+                ),
             ],
             'entrypoint' => 'course_student'
         ];
@@ -2849,7 +2863,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'payload' => [
                     'courses' => $filteredCourses,
                 ],
-                'title' => 'courseList',
+                'title' => new \OmegaUp\TranslationString('courseList'),
             ],
             'entrypoint' => 'course_mine',
         ];
@@ -2890,7 +2904,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'courses' => $filteredCourses,
                     'course_type' => $courseType
                 ],
-                'title' => 'courseList',
+                'title' => new \OmegaUp\TranslationString('courseList'),
             ],
             'entrypoint' => 'course_single_list',
         ];
@@ -2929,7 +2943,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                         'courses' => $filteredCourses,
                         'course_type' => null,
                     ],
-                    'title' => 'courseList',
+                    'title' => new \OmegaUp\TranslationString('courseList'),
                 ],
                 'entrypoint' => 'course_list',
             ];
@@ -2973,7 +2987,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'courses' => $filteredCourses,
                     'course_type' => null,
                 ],
-                'title' => 'courseList',
+                'title' => new \OmegaUp\TranslationString('courseList'),
             ],
             'entrypoint' => 'course_list',
         ];
@@ -3107,7 +3121,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                         $r->identity->identity_id
                     ),
                 ],
-                'title' => 'omegaupTitleCourseDetails',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleCourseDetails'
+                ),
             ],
             'entrypoint' => 'course_details',
         ];
@@ -3285,7 +3301,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                         [
                             'type' => \OmegaUp\DAO\Notifications::COURSE_REGISTRATION_REQUEST,
                             'body' => [
-                                'localizationString' => 'notificationCourseRegistrationRequest',
+                                'localizationString' => new \OmegaUp\TranslationString(
+                                    'notificationCourseRegistrationRequest'
+                                ),
                                 'localizationParams' => [
                                     'username' => $r->identity->username,
                                     'courseName' => $course->name,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1,6 +1,6 @@
 <?php
 
- namespace OmegaUp\Controllers;
+namespace OmegaUp\Controllers;
 
 /**
  * ProblemsController
@@ -3324,7 +3324,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     ],
                     self::getStats($problem, $r->identity)
                 ),
-                'title' => 'omegaupTitleProblemStats',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleProblemStats'
+                ),
             ],
             'entrypoint' => 'common_stats',
         ];
@@ -4129,7 +4131,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'privateProblemsAlert' => $privateProblemsAlert,
                     'visibilityStatuses' => $visibilityStatuses,
                 ],
-                'title' => 'omegaupTitleMyProblemsList',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleMyProblemsList'
+                ),
             ],
             'entrypoint' => 'problem_mine',
         ];
@@ -4432,7 +4436,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                         'reviewer' => false,
                     ],
                 ],
-                'title' => 'omegaupTitleProblem',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleProblem'
+                ),
             ],
             'entrypoint' => 'problem_details',
         ];
@@ -4607,7 +4613,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'tags' => $tags,
                     'tagData' => $tagData,
                 ],
-                'title' => 'omegaupTitleProblems',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleProblems'
+                ),
             ],
             'entrypoint' => 'problem_list',
         ];
@@ -4788,7 +4796,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     self::getCommonPayloadForSmarty(),
                     $extraInfo
                 ),
-                'title' => 'problemEditEditProblem',
+                'title' => new \OmegaUp\TranslationString(
+                    'problemEditEditProblem'
+                ),
             ],
             'entrypoint' => 'problem_edit',
         ];

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -1,6 +1,6 @@
 <?php
 
- namespace OmegaUp\Controllers;
+namespace OmegaUp\Controllers;
 
 /**
  * SubmissionController
@@ -51,7 +51,9 @@ class Submission extends \OmegaUp\Controllers\Controller {
                         []
                     ),
                 ],
-                'title' => 'omegaupTitleLatestSubmissions',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleLatestSubmissions'
+                ),
             ],
             'entrypoint' => 'submissions_list',
         ];
@@ -120,7 +122,9 @@ class Submission extends \OmegaUp\Controllers\Controller {
                         []
                     ),
                 ],
-                'title' => 'omegaupTitleLatestSubmissions',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleLatestSubmissions'
+                ),
             ],
             'entrypoint' => 'submissions_list',
         ];

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2582,7 +2582,9 @@ class User extends \OmegaUp\Controllers\Controller {
                         /*$params=*/[]
                     ),
                 ],
-                'title' => 'omegaupTitleAuthorsRank',
+                'title' => new \OmegaUp\TranslationString(
+                    'omegaupTitleAuthorsRank'
+                ),
             ],
             'entrypoint' => 'authors_rank',
         ];
@@ -3620,8 +3622,12 @@ class User extends \OmegaUp\Controllers\Controller {
                 'payload' => $response,
                 'title' => (
                     (strval($category) === 'female') ?
-                    'omegaupTitleCodersofthemonthFemale' :
-                    'omegaupTitleCodersofthemonth'
+                    new \OmegaUp\TranslationString(
+                        'omegaupTitleCodersofthemonthFemale'
+                    ) :
+                    new \OmegaUp\TranslationString(
+                        'omegaupTitleCodersofthemonth'
+                    )
                 ),
             ],
             'entrypoint' => 'coder_of_the_month',
@@ -3673,7 +3679,9 @@ class User extends \OmegaUp\Controllers\Controller {
                             )
                         ),
                     ],
-                    'title' => 'omegaupTitleProfile',
+                    'title' => new \OmegaUp\TranslationString(
+                        'omegaupTitleProfile'
+                    ),
                 ],
                 'template' => 'user.profile.tpl',
             ];
@@ -3682,7 +3690,9 @@ class User extends \OmegaUp\Controllers\Controller {
             return [
                 'smartyProperties' => [
                     'payload' => ['statusError' => $e->getErrorMessage()],
-                    'title' => 'omegaupTitleProfile'
+                    'title' => new \OmegaUp\TranslationString(
+                        'omegaupTitleProfile'
+                    )
                 ],
                 'template' => 'user.profile.tpl',
             ];

--- a/frontend/server/src/Psalm/TranslationStringChecker.php
+++ b/frontend/server/src/Psalm/TranslationStringChecker.php
@@ -41,6 +41,29 @@ class TranslationStringChecker implements
     }
 
     /**
+     * Returns whether the provided class name is a class that receives a
+     * translation string name as first parameter.
+     */
+    private static function isSupportedConstructor(
+        string $constructorClassName
+    ): bool {
+        if ($constructorClassName === 'omegaup\\translationstring') {
+            // This is the class that indicates that this is a translation
+            // string.
+            return true;
+        }
+        if (strpos($constructorClassName, 'omegaup\\exceptions\\') !== 0) {
+            // Not the constructor of an exception.
+            return false;
+        }
+        if ($constructorClassName == 'omegaup\\exceptions\\databaseoperationexception') {
+            // This one class does not use translation strings.
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Called after a statement has been checked
      *
      * @param \Psalm\FileManipulation[] $fileReplacements
@@ -61,13 +84,7 @@ class TranslationStringChecker implements
             // Not something we can reason about.
             return;
         }
-        $constructorClassName = $expr->class->toLowerString();
-        if (strpos($constructorClassName, 'omegaup\\exceptions\\') !== 0) {
-            // Not the constructor of an exception.
-            return;
-        }
-        if ($constructorClassName == 'omegaup\\exceptions\\databaseoperationexception') {
-            // This one class does not use translation strings.
+        if (!self::isSupportedConstructor($expr->class->toLowerString())) {
             return;
         }
         if (empty($expr->args)) {

--- a/frontend/server/src/TranslationString.php
+++ b/frontend/server/src/TranslationString.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * Class to identify a string as being a translation string.
+ */
+class TranslationString implements \JsonSerializable {
+    /**
+     * @var string
+     * @readonly
+     */
+    public $message;
+
+    public function __construct(string $message) {
+        $this->message = $message;
+    }
+
+    public function __toString(): string {
+        return $this->message;
+    }
+
+    public function jsonSerialize(): string {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
Este cambio hace que los títulos y los nombres de las notificaciones
estén anotadas como \OmegaUp\TranslationString, para poder validar que
son cadenas de traducción válidas.