### PR TITLE
Contexto para «Sí» y «No» en creación de concurso

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Intro.vue
+++ b/frontend/www/js/omegaup/components/contest/Intro.vue
@@ -143,10 +143,12 @@ import { types } from '../../api_types';
 import T from '../../lang';
 import * as ui from '../../ui';
 import omegaup_Countdown from '../Countdown.vue';
+import omegaup_Markdown from '../Markdown.vue';
 
 @Component({
   components: {
     'omegaup-countdown': omegaup_Countdown,
+    'omegaup-markdown': omegaup_Markdown,
   },
 })
 export default class ContestIntro extends Vue {


### PR DESCRIPTION
# Descripción

Al crear un concurso con la opción «Solicitar acceso a información de participantes» en Requerido, se mostraba un «Sí» y «No» en _radiobuttons_. Ahora se muestra el texto faltante que da contexto para esos elementos.

![image](https://user-images.githubusercontent.com/37001730/89951049-556c0d00-dbf0-11ea-9576-2e73d70207a7.png)

Fixes: #4351 

# Comentarios

El idioma en que se muestra el texto es Español en todos los casos. El problema se reportará en otro _Issue_ por su complejidad.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
