### PR TITLE
Validación del lado del cliente en campo de lenguajes al crear concurso.

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1959,25 +1959,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $r->ensureOptionalBool('show_scoreboard_after');
 
         // languages is always optional
-        if (empty($r['languages'])) {
-            throw new \OmegaUp\Exceptions\InvalidParameterException(
-                'parameterEmpty',
-                'languages'
-            );
-        }
-
-        if (is_string($r['languages'])) {
-            $r['languages'] = explode(',', $r['languages']);
-        }
-        if (is_array($r['languages'])) {
-            foreach ($r['languages'] as $language) {
-                \OmegaUp\Validators::validateOptionalInEnum(
-                    $language,
-                    'languages',
-                    array_keys(
-                        \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
-                    )
-                );
+        if (!empty($r['languages'])) {
+            if (is_string($r['languages'])) {
+                $r['languages'] = explode(',', $r['languages']);
+            }
+            if (is_array($r['languages'])) {
+                foreach ($r['languages'] as $language) {
+                    \OmegaUp\Validators::validateOptionalInEnum(
+                        $language,
+                        'languages',
+                        array_keys(
+                            \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                        )
+                    );
+                }
             }
         }
     }

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1959,20 +1959,25 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $r->ensureOptionalBool('show_scoreboard_after');
 
         // languages is always optional
-        if (!empty($r['languages'])) {
-            if (is_string($r['languages'])) {
-                $r['languages'] = explode(',', $r['languages']);
-            }
-            if (is_array($r['languages'])) {
-                foreach ($r['languages'] as $language) {
-                    \OmegaUp\Validators::validateOptionalInEnum(
-                        $language,
-                        'languages',
-                        array_keys(
-                            \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
-                        )
-                    );
-                }
+        if (empty($r['languages'])) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                'languages'
+            );
+        }
+
+        if (is_string($r['languages'])) {
+            $r['languages'] = explode(',', $r['languages']);
+        }
+        if (is_array($r['languages'])) {
+            foreach ($r['languages'] as $language) {
+                \OmegaUp\Validators::validateOptionalInEnum(
+                    $language,
+                    'languages',
+                    array_keys(
+                        \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                    )
+                );
             }
         }
     }

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -213,6 +213,7 @@
               v-bind:multiple="true"
               v-bind:placeholder="T.contestNewFormLanguages"
               v-bind:close-on-select="false"
+              v-bind:allow-empty="false"
             >
             </multiselect>
             <p class="help-block">{{ T.contestNewFormLanguages }}</p>
@@ -292,7 +293,6 @@ export default class NewForm extends Vue {
   @Prop({ default: '' }) initialDescription!: string;
   @Prop({ default: 'none' }) initialFeedback!: string;
   @Prop() initialFinishTime!: Date;
-  @Prop({ default: () => [] }) initialLanguages!: Array<string>;
   @Prop({ default: false }) initialNeedsBasicInformation!: boolean;
   @Prop({ default: 0 }) initialPenalty!: number;
   @Prop({ default: 'none' }) initialPenaltyType!: string;
@@ -337,7 +337,7 @@ export default class NewForm extends Vue {
   }
 
   fillOmi(): void {
-    this.languages = [];
+    this.languages = Object.keys(this.allLanguages);
     this.titlePlaceHolder = T.contestNewFormTitlePlaceholderOmiStyle;
     this.windowLengthEnabled = false;
     this.windowLength = 0;
@@ -351,7 +351,7 @@ export default class NewForm extends Vue {
   }
 
   fillPreIoi(): void {
-    this.languages = [];
+    this.languages = Object.keys(this.allLanguages);
     this.titlePlaceHolder = T.contestNewFormTitlePlaceholderIoiStyle;
     this.windowLengthEnabled = true;
     this.windowLength = 180;
@@ -365,7 +365,7 @@ export default class NewForm extends Vue {
   }
 
   fillConacup(): void {
-    this.languages = [];
+    this.languages = Object.keys(this.allLanguages);
     this.titlePlaceHolder = T.contestNewFormTitlePlaceholderConacupStyle;
     this.windowLengthEnabled = false;
     this.windowLength = 0;

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -311,7 +311,7 @@ export default class NewForm extends Vue {
   description = this.initialDescription;
   feedback = this.initialFeedback;
   finishTime = this.initialFinishTime;
-  languages = this.initialLanguages;
+  languages = Object.keys(this.allLanguages);
   needsBasicInformation = this.initialNeedsBasicInformation;
   penalty = this.initialPenalty;
   penaltyType = this.initialPenaltyType;


### PR DESCRIPTION
# Descripción

De manera predeterminada se cargan todos los lenguajes al crear un nuevo concurso.
Valida que al menos tenga seleccionado un lenguaje para el concurso y si no manda una alerta al presionar el botón "Agendar concurso" 

Part of: #4308

# Comentarios


También si faltan cosas por hacer, se puede hacer un checklist en esta sección.

Si no se utiliza, esta sección se puede eliminar.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
