### PR TITLE
Ocultando el botón de clonar curso si no es público

### DIFF
--- a/frontend/www/js/omegaup/components/course/Details.test.ts
+++ b/frontend/www/js/omegaup/components/course/Details.test.ts
@@ -73,6 +73,7 @@ describe('Details.vue', () => {
       wrapper.find('a[data-button-progress-students]').exists(),
     ).toBeFalsy();
     expect(wrapper.find('a[data-button-manage-students]').exists()).toBeFalsy();
+    expect(wrapper.text()).not.toContain(T.wordsCloneThisCourse);
   });
 
   it('Should handle assignments without finish_time', () => {
@@ -80,7 +81,7 @@ describe('Details.vue', () => {
     const wrapper = shallowMount(course_Details, {
       propsData: {
         course: <types.CourseDetails>{
-          admission_mode: 'registration',
+          admission_mode: 'public',
           alias: 'test-course',
           assignments: [
             {
@@ -124,5 +125,6 @@ describe('Details.vue', () => {
     expect(
       wrapper.find('[data-content-alias="test-assignment"]').text(),
     ).toContain('—');
+    expect(wrapper.text()).toContain(T.wordsCloneThisCourse);
   });
 });

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -76,7 +76,7 @@
         </div>
       </div>
     </div>
-    <div class="text-center align-middle" v-else="">
+    <div class="text-center align-middle" v-else>
       <span>
         {{ T.overallCompletedPercentage }}:
         <progress
@@ -110,7 +110,7 @@
               </td>
             </tr>
             <tr
-              v-else=""
+              v-else
               v-bind:key="assignment.alias"
               v-for="assignment in course.assignments"
               v-bind:data-content-alias="assignment.alias"
@@ -124,7 +124,7 @@
                   <font-awesome-icon icon="chalkboard-teacher" />
                   <span class="ml-2">{{ T.wordsLesson }}</span>
                 </template>
-                <template v-else="">
+                <template v-else>
                   <font-awesome-icon icon="list-alt" />
                   <span class="ml-2">{{ T.wordsExam }}</span>
                 </template>
@@ -175,7 +175,11 @@
       </div>
     </div>
 
-    <div class="accordion" data-accordion-clone>
+    <div
+      class="accordion"
+      data-accordion-clone
+      v-if="course.admission_mode === 'public'"
+    >
       <div class="card">
         <div class="card-header" data-heading-clone>
           <h2 class="mb-0">


### PR DESCRIPTION
# Descripción

Se oculta el botón de Clonar curso cuando se muestra alguno que no es público.
Aunque ya existía la validación del lado del servidor, era importante ocultarlo para
evitar confusiones.

![NoPublicCourseNotCloned](https://user-images.githubusercontent.com/3230352/90157566-7d27b600-dd53-11ea-97b0-1c83715badd5.gif)

Fixes: #4508 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
