### PR TITLE
Agregando espacio entre los check [Si, No] del formulario de curso

### DIFF
--- a/frontend/www/js/omegaup/components/RadioSwitch.test.ts
+++ b/frontend/www/js/omegaup/components/RadioSwitch.test.ts
@@ -1,0 +1,31 @@
+import { shallowMount } from '@vue/test-utils';
+import expect from 'expect';
+import T from '../lang';
+
+import omegaup_RadioSwitch from './RadioSwitch.vue';
+
+describe('RadioSwitch.vue', () => {
+  it('Should render a simple radio switch with default descriptions', () => {
+    const wrapper = shallowMount(omegaup_RadioSwitch, {
+      propsData: {
+        selectedValue: true,
+      },
+    });
+    expect(wrapper.text()).toContain(T.wordsYes);
+    expect(wrapper.text()).toContain(T.wordsNo);
+  });
+
+  it('Should render a simple radio switch with custom descriptions', () => {
+    const wrapper = shallowMount(omegaup_RadioSwitch, {
+      propsData: {
+        selectedValue: true,
+        textForTrue: 'Red',
+        textForFalse: 'Yellow',
+      },
+    });
+    expect(wrapper.text()).toContain('Red');
+    expect(wrapper.text()).toContain('Yellow');
+    expect(wrapper.text()).not.toContain(T.wordsYes);
+    expect(wrapper.text()).not.toContain(T.wordsNo);
+  });
+});

--- a/frontend/www/js/omegaup/components/RadioSwitch.vue
+++ b/frontend/www/js/omegaup/components/RadioSwitch.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    v-bind:class="{
-      'form-control': inFormControl,
-      'container-fluid': inContainerFluid,
-    }"
-  >
+  <div class="form-control container-fluid">
     <div class="form-check form-check-inline">
       <label class="form-check-label">
         <input
@@ -33,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop, Emit, Watch } from 'vue-property-decorator';
 import T from '../lang';
 
 @Component
@@ -44,14 +39,13 @@ export default class RadioSwitch extends Vue {
   @Prop({ default: false }) valueForFalse!: any;
   @Prop({ default: T.wordsYes }) textForTrue!: string;
   @Prop({ default: T.wordsNo }) textForFalse!: string;
-  @Prop({ default: true }) inFormControl!: boolean;
-  @Prop({ default: true }) inContainerFluid!: boolean;
 
   radioValue = this.selectedValue ?? false;
 
-  @Emit('input')
-  onUpdateInput(): void {
-    this.$emit('update:value', this.radioValue);
+  @Watch('radioValue')
+  @Emit('update:value')
+  onUpdateInput(newValue: any): any {
+    return newValue;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/RadioSwitch.vue
+++ b/frontend/www/js/omegaup/components/RadioSwitch.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    v-bind:class="{
+      'form-control': inFormControl,
+      'container-fluid': inContainerFluid,
+    }"
+  >
+    <div class="form-check form-check-inline">
+      <label class="form-check-label">
+        <input
+          class="form-check-input"
+          type="radio"
+          v-bind:name="name"
+          v-bind:value="valueForTrue"
+          v-model="radioValue"
+          v-on:change.prevent="onUpdateInput"
+        />{{ textForTrue }}
+      </label>
+    </div>
+    <div class="form-check form-check-inline">
+      <label class="form-check-label">
+        <input
+          class="form-check-input"
+          type="radio"
+          v-bind:name="name"
+          v-bind:value="valueForFalse"
+          v-model="radioValue"
+          v-on:change.prevent="onUpdateInput"
+        />{{ textForFalse }}
+      </label>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import T from '../lang';
+
+@Component
+export default class RadioSwitch extends Vue {
+  @Prop() name!: string;
+  @Prop() selectedValue!: any;
+  @Prop({ default: true }) valueForTrue!: any;
+  @Prop({ default: false }) valueForFalse!: any;
+  @Prop({ default: T.wordsYes }) textForTrue!: string;
+  @Prop({ default: T.wordsNo }) textForFalse!: string;
+  @Prop({ default: true }) inFormControl!: boolean;
+  @Prop({ default: true }) inContainerFluid!: boolean;
+
+  radioValue = this.selectedValue ?? false;
+
+  @Emit('input')
+  onUpdateInput(): void {
+    this.$emit('update:value', this.radioValue);
+  }
+}
+</script>

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -44,24 +44,11 @@
                 icon="info-circle"
               />
             </span>
-            <div class="form-control container-fluid">
-              <label class="radio-inline"
-                ><input
-                  type="radio"
-                  name="show-scoreboard"
-                  v-bind:value="true"
-                  v-model="showScoreboard"
-                />{{ T.wordsYes }}</label
-              >
-              <label class="radio-inline"
-                ><input
-                  type="radio"
-                  name="show-scoreboard"
-                  v-bind:value="false"
-                  v-model="showScoreboard"
-                />{{ T.wordsNo }}</label
-              >
-            </div>
+            <omegaup-radio-switch
+              v-bind:value.sync="showScoreboard"
+              v-bind:selected-value="showScoreboard"
+              name="show-scoreboard"
+            ></omegaup-radio-switch>
           </div>
         </div>
         <div class="row">
@@ -82,22 +69,10 @@
                 icon="info-circle"
               />
             </span>
-            <div class="form-control container-fluid">
-              <label class="radio-inline"
-                ><input
-                  type="radio"
-                  v-bind:value="true"
-                  v-model="unlimitedDuration"
-                />{{ T.wordsYes }}</label
-              >
-              <label class="radio-inline"
-                ><input
-                  type="radio"
-                  v-bind:value="false"
-                  v-model="unlimitedDuration"
-                />{{ T.wordsNo }}</label
-              >
-            </div>
+            <omegaup-radio-switch
+              v-bind:value.sync="unlimitedDuration"
+              v-bind:selected-value="unlimitedDuration"
+            ></omegaup-radio-switch>
           </div>
           <div class="form-group col-md-4">
             <label class="faux-label"
@@ -136,22 +111,10 @@
                 icon="info-circle"
               />
             </span>
-            <div class="form-control container-fluid">
-              <label class="radio-inline"
-                ><input
-                  type="radio"
-                  v-bind:value="true"
-                  v-model="needs_basic_information"
-                />{{ T.wordsYes }}</label
-              >
-              <label class="radio-inline"
-                ><input
-                  type="radio"
-                  v-bind:value="false"
-                  v-model="needs_basic_information"
-                />{{ T.wordsNo }}</label
-              >
-            </div>
+            <omegaup-radio-switch
+              v-bind:value.sync="needsBasicInformation"
+              v-bind:selected-value="needsBasicInformation"
+            ></omegaup-radio-switch>
           </div>
           <div class="form-group col-md-4">
             <span class="faux-label"
@@ -193,7 +156,7 @@
               <template v-if="update">
                 {{ T.courseNewFormUpdateCourse }}
               </template>
-              <template v-else="">
+              <template v-else>
                 {{ T.courseNewFormScheduleCourse }}
               </template>
             </button>
@@ -226,6 +189,7 @@ import { types } from '../../api_types';
 import T from '../../lang';
 import * as typeahead from '../../typeahead';
 import DatePicker from '../DatePicker.vue';
+import RadioSwitch from '../RadioSwitch.vue';
 
 import {
   FontAwesomeIcon,
@@ -239,6 +203,7 @@ library.add(fas);
 @Component({
   components: {
     'omegaup-datepicker': DatePicker,
+    'omegaup-radio-switch': RadioSwitch,
     'font-awesome-icon': FontAwesomeIcon,
     'font-awesome-layers': FontAwesomeLayers,
     'font-awesome-layers-text': FontAwesomeLayersText,
@@ -258,7 +223,7 @@ export default class CourseDetails extends Vue {
   name = this.course.name;
   school_name = this.course.school_name;
   school_id = this.course.school_id;
-  needs_basic_information = this.course.needs_basic_information;
+  needsBasicInformation = this.course.needs_basic_information;
   requests_user_information = this.course.requests_user_information;
   unlimitedDuration = this.course.finish_time === null;
 
@@ -287,7 +252,7 @@ export default class CourseDetails extends Vue {
     this.name = this.course.name;
     this.school_name = this.course.school_name;
     this.school_id = this.course.school_id;
-    this.needs_basic_information = this.course.needs_basic_information;
+    this.needsBasicInformation = this.course.needs_basic_information;
     this.requests_user_information = this.course.requests_user_information;
     this.unlimitedDuration = this.course.finish_time === null;
   }

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -189,7 +189,7 @@ import { types } from '../../api_types';
 import T from '../../lang';
 import * as typeahead from '../../typeahead';
 import DatePicker from '../DatePicker.vue';
-import RadioSwitch from '../RadioSwitch.vue';
+import omegaup_RadioSwitch from '../RadioSwitch.vue';
 
 import {
   FontAwesomeIcon,
@@ -203,7 +203,7 @@ library.add(fas);
 @Component({
   components: {
     'omegaup-datepicker': DatePicker,
-    'omegaup-radio-switch': RadioSwitch,
+    'omegaup-radio-switch': omegaup_RadioSwitch,
     'font-awesome-icon': FontAwesomeIcon,
     'font-awesome-layers': FontAwesomeLayers,
     'font-awesome-layers-text': FontAwesomeLayersText,

--- a/frontend/www/js/omegaup/course/edit.ts
+++ b/frontend/www/js/omegaup/course/edit.ts
@@ -53,7 +53,7 @@ OmegaUp.on('ready', () => {
                   start_time: source.startTime,
                   alias: source.alias,
                   show_scoreboard: source.showScoreboard,
-                  needs_basic_information: source.needs_basic_information,
+                  needs_basic_information: source.needsBasicInformation,
                   requests_user_information: source.requests_user_information,
                   school_id: schoolId ?? undefined,
                   unlimited_duration: source.unlimitedDuration,

--- a/frontend/www/js/omegaup/course/new.ts
+++ b/frontend/www/js/omegaup/course/new.ts
@@ -55,7 +55,7 @@ OmegaUp.on('ready', () => {
                   description: source.description,
                   start_time: source.startTime,
                   show_scoreboard: source.showScoreboard,
-                  needs_basic_information: source.needs_basic_information,
+                  needs_basic_information: source.needsBasicInformation,
                   requests_user_information: source.requests_user_information,
                   school_id: schoolId ?? undefined,
                   unlimited_duration: source.unlimitedDuration,


### PR DESCRIPTION
# Descripción

Resulta que cuando comenzamos la migración de BS3 a BS4 no nos percatamos 
que se habían deprecado algunas clases que ayudaban a separar elementos de un
formulario. Ahora que se reportó que los checks de [Si, No] me doy cuenta que ya 
se migraron varios componentes donde se muestra este caso. 

Para no tener que agregar las nuevas clases a cada uno de estos elementos se 
agrega un componente que ayude a evitar ese retrabajo.

![image](https://user-images.githubusercontent.com/3230352/90178451-90e21500-dd71-11ea-8c02-e4709e34fd7e.png)

Fixes: #4502 

# Comentarios

En este cambio se aprovecha para migrar los tres elementos que se muestran 
en la vista de Cursos. Faltará agregar esto cada que haya una migración o donde
ya se haya migrado, pero se encuentre un elemento de este tipo.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
