### PR TITLE
Eliminado botón Cancelar en Nuevo Curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -160,13 +160,6 @@
                 {{ T.courseNewFormScheduleCourse }}
               </template>
             </button>
-            <button
-              class="btn btn-secondary"
-              type="reset"
-              v-on:click.prevent="onCancel"
-            >
-              {{ T.wordsCancel }}
-            </button>
           </div>
         </div>
       </form>


### PR DESCRIPTION
# Descripción

El botón de Cancelar en la ventana de Nuevo Curso no hacía nada y no era necesario, fue eliminado

![image](https://user-images.githubusercontent.com/37001730/90297451-1f2ec780-de54-11ea-802c-8a4c011c68f2.png)

Fixes: #4501 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
