### PR TITLE
Modificando la manera en que se calculan las analíticas de assignments en cursos

### DIFF
--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -47,40 +47,67 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
      * @return list<array{assignment_alias: string, problem_alias: string, variance: float}>
      */
     public static function getAssignmentsProblemsStatistics(
-        int $courseId
+        int $courseId,
+        int $groupId
     ): array {
         $sql = '
             SELECT
-                `a`.`alias` as assignment_alias,
-                `p`.`alias` as problem_alias,
-                COALESCE(
-                    VARIANCE(`r`.`contest_score`),
+                bpr.assignment_alias,
+                bpr.problem_alias,
+                COALESCE (
+                    VARIANCE(bpr.max_user_score_for_problem),
                     0
                 ) AS variance
-            FROM
-                `Assignments` AS `a`
-            INNER JOIN
-                `Problemsets` AS `ps` ON `a`.`problemset_id` = `ps`.`problemset_id`
-            INNER JOIN
-                `Problemset_Problems` AS `psp` ON `psp`.`problemset_id` = `ps`.`problemset_id`
-            INNER JOIN
-                `Problems` AS `p` ON `p`.`problem_id` = `psp`.`problem_id`
-            INNER JOIN
-                `Submissions` AS `s` ON `s`.`problem_id` = `p`.`problem_id` AND `s`.`problemset_id` = `a`.`problemset_id`
-            INNER JOIN
-                `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-            WHERE
-                `a`.`course_id` = ?
+            FROM (
+                SELECT
+                    pr.assignment_alias,
+                    pr.problem_alias,
+                    MAX(`r`.`contest_score`) AS max_user_score_for_problem
+                FROM
+                    `Groups_Identities` AS `gi`
+                CROSS JOIN
+                    (
+                        SELECT
+                            `a`.`assignment_id`,
+                            `a`.`alias` AS assignment_alias,
+                            `a`.`problemset_id`,
+                            `p`.`problem_id`,
+                            `p`.`alias` AS problem_alias
+                        FROM
+                            `Assignments` AS `a`
+                        INNER JOIN
+                            `Problemsets` AS `ps` ON `a`.`problemset_id` = `ps`.`problemset_id`
+                        INNER JOIN
+                            `Problemset_Problems` AS `psp` ON `psp`.`problemset_id` = `ps`.`problemset_id`
+                        INNER JOIN
+                            `Problems` AS `p` ON `p`.`problem_id` = `psp`.`problem_id`
+                        WHERE
+                            `a`.`course_id` = ?
+                        GROUP BY
+                            `a`.`assignment_id`, `p`.`problem_id`
+                    ) AS pr
+                INNER JOIN
+                    `Identities` AS `i` ON `i`.`identity_id` = `gi`.`identity_id`
+                LEFT JOIN
+                    `Submissions` AS `s`
+                ON
+                    `s`.`problem_id` = `pr`.`problem_id`
+                    AND `s`.`identity_id` = `i`.`identity_id`
+                    AND `s`.`problemset_id` = `pr`.`problemset_id`
+                LEFT JOIN
+                    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
+                WHERE
+                    `gi`.`group_id` = ?
+                GROUP BY
+                    `i`.`identity_id`, `pr`.`assignment_id`, `pr`.`problem_id`
+            ) AS bpr
             GROUP BY
-                `a`.`assignment_id`, `p`.`problem_id`
-            ORDER BY
-                `psp`.`order`;
-        ';
+                bpr.problem_alias, bpr.assignment_alias;';
 
         /** @var list<array{assignment_alias: string, problem_alias: string, variance: float}> */
         $results = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
-            [ $courseId ]
+            [ $courseId, $groupId ]
         );
         return $results;
     }

--- a/frontend/tests/controllers/AssignmentProblemsTest.php
+++ b/frontend/tests/controllers/AssignmentProblemsTest.php
@@ -430,6 +430,7 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
 
         $results = \OmegaUp\DAO\Assignments::getAssignmentsProblemsStatistics(
             $courseData['course']->course_id,
+            $courseData['course']->group_id
         );
 
         $this->assertEquals($assignmentAlias, $results[0]['assignment_alias']);


### PR DESCRIPTION
# Descripción

Esto resuelve dos problemas que se tenían antes (por: @heduenas) :

- Se tomaba el promedio/varianza/etc, de TODOS los envíos (en lugar del mejor envío de cada estudiante).
- Se ignoraban las puntuaciones de los estudiantes que no habían realizado envíos

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
