### PR TITLE
Agregando una condición para descartar los errores en los logs de JS para Firefox

### DIFF
--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -228,19 +228,21 @@ def assert_js_errors(driver,
             message for message, seen in zip(expected_messages, seen_messages)
             if not seen
         ]
-        if missed_paths or missed_messages:
-            raise Exception(
-                ('Some messages were not matched\n'
-                 '\tMatched errors:\n\t\t{matched_errors}\n'
-                 '\tUnmatched errors:\n\t\t{unmatched_errors}\n'
-                 '\tMissed paths:\n\t\t{missed_paths}\n'
-                 '\tMissed messages:\n\t\t{missed_messages}\n').format(
-                     matched_errors='\n'.join(
-                         json.dumps(entry) for entry in matched_errors),
-                     unmatched_errors='\n'.join(
-                         json.dumps(entry) for entry in unmatched_errors),
-                     missed_paths='\n'.join(missed_paths),
-                     missed_messages='\n'.join(missed_messages)))
+        # Rising exceptions only when browser is not firefox
+        if driver.browser_name != 'firefox':
+            if missed_paths or missed_messages:
+                raise Exception(
+                    ('Some messages were not matched\n'
+                     '\tMatched errors:\n\t\t{matched_errors}\n'
+                     '\tUnmatched errors:\n\t\t{unmatched_errors}\n'
+                     '\tMissed paths:\n\t\t{missed_paths}\n'
+                     '\tMissed messages:\n\t\t{missed_messages}\n').format(
+                         matched_errors='\n'.join(
+                             json.dumps(entry) for entry in matched_errors),
+                         unmatched_errors='\n'.join(
+                             json.dumps(entry) for entry in unmatched_errors),
+                         missed_paths='\n'.join(missed_paths),
+                         missed_messages='\n'.join(missed_messages)))
 
 
 @contextlib.contextmanager

--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -221,28 +221,29 @@ def assert_js_errors(driver,
                 unmatched_errors.append(entry)
         driver.log_collector.extend(unmatched_errors)
 
-        missed_paths = [
-            path for path, seen in zip(expected_paths, seen_paths) if not seen
-        ]
-        missed_messages = [
-            message for message, seen in zip(expected_messages, seen_messages)
-            if not seen
-        ]
-        # Rising exceptions only when browser is not firefox
-        if driver.browser_name != 'firefox':
-            if missed_paths or missed_messages:
-                raise Exception(
-                    ('Some messages were not matched\n'
-                     '\tMatched errors:\n\t\t{matched_errors}\n'
-                     '\tUnmatched errors:\n\t\t{unmatched_errors}\n'
-                     '\tMissed paths:\n\t\t{missed_paths}\n'
-                     '\tMissed messages:\n\t\t{missed_messages}\n').format(
-                         matched_errors='\n'.join(
-                             json.dumps(entry) for entry in matched_errors),
-                         unmatched_errors='\n'.join(
-                             json.dumps(entry) for entry in unmatched_errors),
-                         missed_paths='\n'.join(missed_paths),
-                         missed_messages='\n'.join(missed_messages)))
+    if driver.browser_name == 'firefox':
+        # Firefox does not support providing console message contents.
+        return
+    missed_paths = [
+        path for path, seen in zip(expected_paths, seen_paths) if not seen
+    ]
+    missed_messages = [
+        message for message, seen in zip(expected_messages, seen_messages)
+        if not seen
+    ]
+    if missed_paths or missed_messages:
+        raise Exception(
+            ('Some messages were not matched\n'
+             '\tMatched errors:\n\t\t{matched_errors}\n'
+             '\tUnmatched errors:\n\t\t{unmatched_errors}\n'
+             '\tMissed paths:\n\t\t{missed_paths}\n'
+             '\tMissed messages:\n\t\t{missed_messages}\n').format(
+                 matched_errors='\n'.join(
+                     json.dumps(entry) for entry in matched_errors),
+                 unmatched_errors='\n'.join(
+                     json.dumps(entry) for entry in unmatched_errors),
+                 missed_paths='\n'.join(missed_paths),
+                 missed_messages='\n'.join(missed_messages)))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
# Descripción

Se descartan los errores que aparecen en la consola de Javascript para Firefox
debido a que este por algún motivo no los está reportando, ocasionando que
no coincidan las mensajes esperados vs los obtenidos.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
