### PR TITLE
Restringiendo los casos en los que se va a intentar reconectar

### DIFF
--- a/frontend/server/src/MySQLConnection.php
+++ b/frontend/server/src/MySQLConnection.php
@@ -340,8 +340,13 @@ class MySQLConnection {
     ): ?\mysqli_result {
         $query = $this->BindQueryParams($sql, $params);
         $result = $this->_connection->query($query, $resultmode);
-        if ($result === false && $this->_connection->errno == 2006) {
-            // Let's try to reconnect and do this one more time.
+        if (
+            $result === false &&
+            $this->_needsFlushing === false &&
+            $this->_connection->errno == 2006
+        ) {
+            // If there have not been any non-committed updates to the
+            // database, let's try to reconnect and do this one more time.
             $this->connect();
             $result = $this->_connection->query($query, $resultmode);
         }


### PR DESCRIPTION
Este cambio hace que únicamente se intente reconectar a MySQL cuando no
haya cambios que necesiten ser ejecutados en una transacción. Esto
evita que si se va la conexión a mitad de una transacción, no se
intenten ejecutar cosas que estarían violando la transacción.

Part of: #4538