### PR TITLE
Eliminando un archivo que ya no se usa

### DIFF
--- a/frontend/www/recent.php
+++ b/frontend/www/recent.php
@@ -1,5 +1,0 @@
-<?php
-
-    require_once('../server/bootstrap_smarty.php');
-
-    $smarty->display('../templates/index.tpl');


### PR DESCRIPTION
Este cambio elimina recent.php. Únicamente causa errores cuando los bots
de bing/Google lo visitan, así que es mejor que regrese un 404
normalito.