### PR TITLE
Evitando errores al actualizar el perfil

### DIFF
--- a/frontend/www/js/user.edit.js
+++ b/frontend/www/js/user.edit.js
@@ -126,7 +126,7 @@ omegaup.OmegaUp.on('ready', function () {
       graduation_date: graduation_date.getTime() / 1000,
       school_name: $('#school').val(),
       locale: $('#locale').val(),
-      preferred_language: $('#programming_language').val(),
+      preferred_language: $('#programming_language').val() || undefined,
       is_private: $('#is_private').prop('checked'),
       hide_problem_tags: $('#hide_problem_tags').prop('checked'),
     };


### PR DESCRIPTION
Este cambio hace que no se envíe el lenguaje de programación preferido
si no se elige uno explícitamente. Esto evita errores al momento de
actualizar el perfil.

Fixes: #4520