### PR TITLE
Agregando manera de obtener parámetros Y validarlos al mismo tiempo

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3914,9 +3914,9 @@ Gets extra information of the identity:
 
 ### Parameters
 
-| Name    | Type    | Description |
-| ------- | ------- | ----------- |
-| `email` | `mixed` |             |
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `email` | `string` |             |
 
 ### Returns
 
@@ -4237,9 +4237,9 @@ Gets verify status of a user
 
 ### Parameters
 
-| Name    | Type    | Description |
-| ------- | ------- | ----------- |
-| `email` | `mixed` |             |
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `email` | `string` |             |
 
 ### Returns
 
@@ -4302,9 +4302,9 @@ Updates the main email of the current user
 
 ### Parameters
 
-| Name    | Type    | Description |
-| ------- | ------- | ----------- |
-| `email` | `mixed` |             |
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `email` | `string` |             |
 
 ### Returns
 

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -186,26 +186,39 @@ class Request extends \ArrayObject {
 
     /**
      * Ensures that the value associated with the key is a string.
+     *
+     * @param null|callable(string):bool $validator
      */
-    public function ensureString(string $key): string {
+    public function ensureString(
+        string $key,
+        ?callable $validator = null
+    ): string {
         if (!self::offsetExists($key)) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterEmpty',
                 $key
             );
         }
-        /** @var mixed */
-        $val = $this->offsetGet($key);
-        $this[$key] = strval($val);
-        return strval($val);
+        $val = strval($this->offsetGet($key));
+        if (!is_null($validator) && !$validator($val)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                $key
+            );
+        }
+        $this[$key] = $val;
+        return $val;
     }
 
     /**
      * Ensures that the value associated with the key is a string or null
+     *
+     * @param null|callable(string):bool $validator
      */
     public function ensureOptionalString(
         string $key,
-        bool $required = false
+        bool $required = false,
+        ?callable $validator = null
     ): ?string {
         if (!self::offsetExists($key)) {
             if (!$required) {
@@ -216,7 +229,7 @@ class Request extends \ArrayObject {
                 $key
             );
         }
-        return $this->ensureString($key);
+        return $this->ensureString($key, $validator);
     }
 
     /**

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -10,6 +10,13 @@ namespace OmegaUp;
 class Validators {
     /**
      * Check if email is valid
+     */
+    public static function email(string $email): bool {
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
+     * Check if email is valid
      *
      * @param mixed $parameter
      * @param string $parameterName Name of parameter that will appear en error message

--- a/frontend/tests/controllers/UserProfileTest.php
+++ b/frontend/tests/controllers/UserProfileTest.php
@@ -389,11 +389,12 @@ class UserProfileTest extends \OmegaUp\Test\ControllerTestCase {
         ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = self::login($identity);
-        $r = new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'email' => 'new@email.com'
-        ]);
-        $response = \OmegaUp\Controllers\User::apiUpdateMainEmail($r);
+        $response = \OmegaUp\Controllers\User::apiUpdateMainEmail(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'email' => 'new@email.com'
+            ])
+        );
 
         // Check email in db
         $user_in_db = \OmegaUp\DAO\Users::findByEmail('new@email.com');


### PR DESCRIPTION
Este cambio agrega un parámetro callable a `Request::ensureString()` que
se puede usar para validar. así ya no hay necesidad de referirse a la
variable mediante su nombre `$r['...']` en ningún momento!