### PR TITLE
Mostrando los mensajes de diagnóstico en GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           touch 'frontend/server/config.php'
           touch 'frontend/tests/test_config.php'
 
-          ./stuff/lint.sh validate --all < /dev/null
+          ./stuff/lint.sh --diagnostics-output=github validate --all < /dev/null
 
   selenium:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Este cambio hace que todos los mensajes de diagnóstico de los linters se
muestren en GitHub directamente sin necesidad de abrir el log de
errores.