### PR TITLE
Evitando división entre cero

### DIFF
--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -331,11 +331,9 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
             }
 
             $allProgress[$username]['progress'][$assignmentAlias][$problemAlias] = (
-                $row['problem_score'] == 0
+                $row['problem_points'] == 0
             ) ? 0 :
-            floatval(
-                $row['problem_score']
-            ) / $row['problem_points'] * 100;
+            floatval($row['problem_score']) / $row['problem_points'] * 100;
         }
 
         usort(

--- a/frontend/tests/Factories/Course.php
+++ b/frontend/tests/Factories/Course.php
@@ -268,7 +268,7 @@ class Course {
     }
 
     /**
-     * @param list<array{author: \OmegaUp\DAO\VO\Identities, authorUser: \OmegaUp\DAO\VO\Users, problem: \OmegaUp\DAO\VO\Problems, request: \OmegaUp\Request}> $problems
+     * @param list<array{author: \OmegaUp\DAO\VO\Identities, authorUser: \OmegaUp\DAO\VO\Users, problem: \OmegaUp\DAO\VO\Problems, request: \OmegaUp\Request, points?: float}> $problems
      * @return list<array{status: 'ok'}>
      */
     public static function addProblemsToAssignment(
@@ -285,6 +285,7 @@ class Course {
                 'course_alias' => $courseAlias,
                 'assignment_alias' => $assignmentAlias,
                 'problem_alias' => $problem['problem']->alias,
+                'points' => $problem['points'] ?? 100.0,
             ]));
         }
 


### PR DESCRIPTION
Este cambio hace que ya no se esté diviendo entre cero en problemas que
no tienen puntuación.

Fixes: #4576