### PR TITLE
Dejando de usar `$_SERVER`

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -62,14 +62,12 @@ class ApiCaller {
      * @return bool whether this was a CSRF attempt.
      */
     private static function isCSRFAttempt(): bool {
-        if (empty($_SERVER['HTTP_REFERER'])) {
+        $httpReferer = \OmegaUp\Request::getServerVar('HTTP_REFERER');
+        if (empty($httpReferer)) {
             // This API request was explicitly created.
             return false;
         }
-        $referrerHost = parse_url(
-            strval($_SERVER['HTTP_REFERER']),
-            PHP_URL_HOST
-        );
+        $referrerHost = parse_url($httpReferer, PHP_URL_HOST);
         if (is_null($referrerHost)) {
             // Malformed referrer. Fail closed and prefer to not allow this.
             return true;
@@ -175,7 +173,7 @@ class ApiCaller {
      * @throws \OmegaUp\Exceptions\NotFoundException
      */
     private static function createRequest() {
-        $apiAsUrl = strval($_SERVER['REQUEST_URI']);
+        $apiAsUrl = \OmegaUp\Request::getServerVar('REQUEST_URI') ?? '/';
         // Spliting only by '/' results in URIs with parameters like this:
         //      /api/problem/list/?page=1
         //                       ^^
@@ -301,9 +299,7 @@ class ApiCaller {
         if ($apiException->getCode() == 401) {
             header(
                 'Location: /login/?redirect=' . urlencode(
-                    strval(
-                        $_SERVER['REQUEST_URI']
-                    )
+                    \OmegaUp\Request::getServerVar('REQUEST_URI') ?? '/'
                 )
             );
             die();

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1398,7 +1398,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\ProblemsetAccessLog::create(new \OmegaUp\DAO\VO\ProblemsetAccessLog([
             'identity_id' => $r->identity->identity_id,
             'problemset_id' => $response['contest']->problemset_id,
-            'ip' => ip2long(strval($_SERVER['REMOTE_ADDR'])),
+            'ip' => ip2long(
+                \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
+            ),
         ]));
 
         return $result;

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -645,7 +645,9 @@ class Course extends \OmegaUp\Controllers\Controller {
         } finally {
             \OmegaUp\DAO\CourseCloneLog::create(
                 new \OmegaUp\DAO\VO\CourseCloneLog([
-                    'ip' => strval($_SERVER['REMOTE_ADDR']),
+                    'ip' => (
+                        \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
+                    ),
                     'course_id' => $originalCourse->course_id,
                     'new_course_id' => !is_null(
                         $course
@@ -3730,7 +3732,9 @@ class Course extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\ProblemsetAccessLog::create(new \OmegaUp\DAO\VO\ProblemsetAccessLog([
                 'identity_id' => $r->identity->identity_id,
                 'problemset_id' => $tokenAuthenticationResult['assignment']->problemset_id,
-                'ip' => ip2long(strval($_SERVER['REMOTE_ADDR'])),
+                'ip' => ip2long(
+                    \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
+                ),
             ]));
         }
 

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -816,12 +816,15 @@ class Identity extends \OmegaUp\Controllers\Controller {
         /** @var array<string, float> */
         $langs = [];
 
-        if (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+        $acceptLanguage = \OmegaUp\Request::getServerVar(
+            'HTTP_ACCEPT_LANGUAGE'
+        );
+        if (!empty($acceptLanguage)) {
             // break up string into pieces (languages and q factors)
             if (
                 preg_match_all(
                     '/([a-z]{1,8}(?:-[a-z]{1,8})?)\s*(?:;\s*q\s*=\s*(1|0\.[0-9]+))?/i',
-                    strval($_SERVER['HTTP_ACCEPT_LANGUAGE']),
+                    $acceptLanguage,
                     $langParse
                 ) !== false &&
                 !empty($langParse[1])

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1573,7 +1573,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         if ($redirect === true) {
-            header("Location: {$_SERVER['HTTP_REFERER']}");
+            header('Location: ' . (
+                \OmegaUp\Request::getServerVar('HTTP_REFERER') ?? '/'
+            ));
         }
 
         self::invalidateCache($problem, $updatedStatementLanguages);

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -512,7 +512,9 @@ class Run extends \OmegaUp\Controllers\Controller {
             'identity_id' => $r->identity->identity_id,
             'submission_id' => $submission->submission_id,
             'problemset_id' => $submission->problemset_id,
-            'ip' => ip2long(strval($_SERVER['REMOTE_ADDR']))
+            'ip' => ip2long(
+                \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
+            ),
         ]));
 
         $problem->submissions++;

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -258,7 +258,9 @@ class Session extends \OmegaUp\Controllers\Controller {
         // Log the login.
         \OmegaUp\DAO\IdentityLoginLog::create(new \OmegaUp\DAO\VO\IdentityLoginLog([
             'identity_id' => intval($identity->identity_id),
-            'ip' => ip2long(strval($_SERVER['REMOTE_ADDR'])),
+            'ip' => ip2long(
+                \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
+            ),
         ]));
 
         self::invalidateLocalCache();

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -165,7 +165,9 @@ class User extends \OmegaUp\Controllers\Controller {
             $data = [
                 'secret' => OMEGAUP_RECAPTCHA_SECRET,
                 'response' => $createUserParams->recaptcha,
-                'remoteip' => $_SERVER['REMOTE_ADDR'],
+                'remoteip' => (
+                    \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
+                ),
             ];
 
             // use key 'http' even if you send the request to https://...

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -490,6 +490,16 @@ class Request extends \ArrayObject {
         }
         return $result;
     }
+
+    /**
+     * Returns the content of $_SERVER[$name] as a string (or null).
+     */
+    public static function getServerVar(string $name): ?string {
+        if (!isset($_SERVER[$name]) || !is_string($_SERVER[$name])) {
+            return null;
+        }
+        return $_SERVER[$name];
+    }
 }
 
 \OmegaUp\Request::$_requestId = str_replace('.', '', uniqid('', true));

--- a/frontend/server/src/SessionManager.php
+++ b/frontend/server/src/SessionManager.php
@@ -38,8 +38,9 @@ class SessionManager {
         string $path
     ): void {
         // Expire all old cookies
-        if (isset($_SERVER['HTTP_COOKIE'])) {
-            $cookies = explode(';', strval($_SERVER['HTTP_COOKIE']));
+        $httpCookie = \OmegaUp\Request::getServerVar('HTTP_COOKIE');
+        if (!empty($httpCookie)) {
+            $cookies = explode(';', $httpCookie);
             foreach ($cookies as $cookie) {
                 $parts = explode('=', $cookie);
                 $oldName = trim($parts[0]);
@@ -50,6 +51,7 @@ class SessionManager {
 
         // Set the new one
         $domain = OMEGAUP_COOKIE_DOMAIN;
+        $secure = !empty(\OmegaUp\Request::getServerVar('HTTPS'));
         $_COOKIE[$name] = $value;
         if (PHP_VERSION_ID < 70300) {
             setcookie(
@@ -58,7 +60,7 @@ class SessionManager {
                 $expire,
                 "{$path}; SameSite=Lax",  // This hack only works for PHP < 7.3.
                 $domain,
-                /*secure=*/!empty($_SERVER['HTTPS']),
+                /*secure=*/$secure,
                 /*httponly=*/true
             );
         } elseif (PHP_VERSION_ID < 70400) {
@@ -72,7 +74,7 @@ class SessionManager {
                 $expire,
                 $path,
                 $domain,
-                /*secure=*/!empty($_SERVER['HTTPS']),
+                /*secure=*/$secure,
                 /*httponly=*/true,
                 /*samesite=*/'Lax'
             );
@@ -84,7 +86,7 @@ class SessionManager {
                     'expires' => $expire,
                     'path' => $path,
                     'domain' => $domain,
-                    'secure' => !empty($_SERVER['HTTPS']),
+                    'secure' => $secure,
                     'httponly' => true,
                     'samesite' => 'Lax',
                 ]

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -22,9 +22,7 @@ class UITools {
         }
         header(
             'Location: /login.php?redirect=' . urlencode(
-                strval(
-                    $_SERVER['REQUEST_URI']
-                )
+                \OmegaUp\Request::getServerVar('REQUEST_URI') ?? '/'
             )
         );
         die();

--- a/frontend/www/libinteractive/index.php
+++ b/frontend/www/libinteractive/index.php
@@ -47,14 +47,20 @@ function preferredLanguage(
 $languages = ['en', 'es'];
 $preferred = $languages[0];
 
-if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+if (
+    isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) &&
+    is_string($_SERVER['HTTP_ACCEPT_LANGUAGE'])
+) {
     $preferred = preferredLanguage(
         $languages,
         strval($_SERVER['HTTP_ACCEPT_LANGUAGE'])
     );
 }
 
-$location = strval($_SERVER['REQUEST_URI']);
+$location = (
+    isset($_SERVER['REQUEST_URI']) &&
+    is_string($_SERVER['REQUEST_URI'])
+) ? $_SERVER['REQUEST_URI'] : '';
 if ($location[strlen($location) - 1] != '/') {
     $location .= '/';
 }

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.14.2@3538fe1955d47f6ee926c0769d71af6db08aa488">
   <file src="frontend/server/src/ApiCaller.php">
-    <MixedArgument occurrences="3">
-      <code>$_SERVER['HTTP_REFERER']</code>
-      <code>$_SERVER['REQUEST_URI']</code>
-      <code>$_SERVER['REQUEST_URI']</code>
-    </MixedArgument>
     <PossiblyNullArgument occurrences="2">
       <code>$request-&gt;methodName</code>
       <code>$request-&gt;methodName</code>
@@ -37,9 +32,8 @@
     </MixedArgument>
   </file>
   <file src="frontend/server/src/Controllers/Contest.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="3">
       <code>$r['query']</code>
-      <code>$_SERVER['REMOTE_ADDR']</code>
       <code>$field</code>
       <code>$r['contest_alias']</code>
     </MixedArgument>
@@ -49,11 +43,9 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Course.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="4">
       <code>$r['problems']</code>
-      <code>$_SERVER['REMOTE_ADDR']</code>
       <code>$r['alias']</code>
-      <code>$_SERVER['REMOTE_ADDR']</code>
       <code>$r['problem_alias']</code>
       <code>$r['username']</code>
     </MixedArgument>
@@ -84,14 +76,13 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Identity.php">
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="6">
       <code>$r['country_id']</code>
       <code>$r['state_id']</code>
       <code>$r['country_id']</code>
       <code>$r['state_id']</code>
       <code>$request['lang']</code>
       <code>$_GET['lang']</code>
-      <code>$_SERVER['HTTP_ACCEPT_LANGUAGE']</code>
     </MixedArgument>
     <PossiblyNullArgument occurrences="2">
       <code>$identity-&gt;username</code>
@@ -195,8 +186,7 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Run.php">
-    <MixedArgument occurrences="6">
-      <code>$_SERVER['REMOTE_ADDR']</code>
+    <MixedArgument occurrences="5">
       <code>$filtered['guid']</code>
       <code>$filtered['language']</code>
       <code>$filtered['status']</code>
@@ -227,13 +217,12 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Session.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="9">
       <code>$r['auth_token']</code>
       <code>$_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME]</code>
       <code>$_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME]</code>
       <code>$r['auth_token']</code>
       <code>$r['auth_token']</code>
-      <code>$_SERVER['REMOTE_ADDR']</code>
       <code>$_GET['redirect']</code>
       <code>$_GET['code']</code>
       <code>$_GET['state']</code>
@@ -333,14 +322,12 @@
     </MixedArgument>
   </file>
   <file src="frontend/server/src/SessionManager.php">
-    <MixedArgument occurrences="2">
-      <code>$_SERVER['HTTP_COOKIE']</code>
+    <MixedArgument occurrences="1">
       <code>$_COOKIE[$name]</code>
     </MixedArgument>
   </file>
   <file src="frontend/server/src/UITools.php">
-    <MixedArgument occurrences="3">
-      <code>$_SERVER['REQUEST_URI']</code>
+    <MixedArgument occurrences="2">
       <code>$smartyProperties['title']</code>
       <code>$smarty-&gt;getConfigVars($titleVar)</code>
     </MixedArgument>
@@ -392,12 +379,6 @@
   <file src="frontend/www/arena/problemprint.php">
     <MixedArgument occurrences="1">
       <code>$r['problem_alias']</code>
-    </MixedArgument>
-  </file>
-  <file src="frontend/www/libinteractive/index.php">
-    <MixedArgument occurrences="2">
-      <code>$_SERVER['HTTP_ACCEPT_LANGUAGE']</code>
-      <code>$_SERVER['REQUEST_URI']</code>
     </MixedArgument>
   </file>
   <file src="frontend/www/userverifyemail.php">


### PR DESCRIPTION
Este cambio agrega `\OmegaUp\Request::getServerVar()`, que permite
acceder a miembros de `$_SERVER` de manera segura.