### PR TITLE
Dejando de usar `$_REQUEST`/`$_GET`

### DIFF
--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -788,10 +788,9 @@ class Identity extends \OmegaUp\Controllers\Controller {
                 strval($request['lang'])
             );
         }
-        if (isset($_GET['lang'])) {
-            return self::convertToSupportedLanguage(
-                strval($_GET['lang'])
-            );
+        $requestLang = \OmegaUp\Request::getRequestVar('lang');
+        if (!empty($requestLang)) {
+            return self::convertToSupportedLanguage($requestLang);
         }
 
         try {

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -88,15 +88,12 @@ class Session extends \OmegaUp\Controllers\Controller {
         if (!is_null($authToken) && self::isAuthTokenValid($authToken)) {
             return $authToken;
         }
-        if (
-            isset($_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME])
-                && self::isAuthTokenValid(
-                    strval(
-                        $_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME]
-                    )
-                )
-        ) {
-            return strval($_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME]);
+
+        $cookie = \OmegaUp\Request::getRequestVar(
+            OMEGAUP_AUTH_TOKEN_COOKIE_NAME
+        );
+        if (!empty($cookie) && self::isAuthTokenValid($cookie)) {
+            return $cookie;
         }
         return null;
     }
@@ -527,7 +524,7 @@ class Session extends \OmegaUp\Controllers\Controller {
             OMEGAUP_LINKEDIN_CLIENTID,
             OMEGAUP_LINKEDIN_SECRET,
             OMEGAUP_URL . '/login?linkedin',
-            isset($_GET['redirect']) ? strval($_GET['redirect']) : null
+            \OmegaUp\Request::getRequestVar('redirect')
         );
     }
     public static function getLinkedInLoginUrl(): string {
@@ -538,18 +535,17 @@ class Session extends \OmegaUp\Controllers\Controller {
      * @return array<string, mixed>
      */
     public static function LoginViaLinkedIn(): array {
-        if (empty($_GET['code']) || empty($_GET['state'])) {
+        $code = \OmegaUp\Request::getRequestVar('code');
+        $state = \OmegaUp\Request::getRequestVar('state');
+        if (empty($code) || empty($state)) {
             return ['status' => 'error'];
         }
 
         try {
             $li = self::getLinkedInInstance();
-            $authToken = $li->getAuthToken(
-                strval($_GET['code']),
-                strval($_GET['state'])
-            );
+            $authToken = $li->getAuthToken($code, $state);
             $profile = $li->getProfileInfo($authToken);
-            $redirect = $li->extractRedirect(strval($_GET['state']));
+            $redirect = $li->extractRedirect($state);
             if (!is_null($redirect)) {
                 $_GET['redirect'] = $redirect;
             }

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -500,6 +500,16 @@ class Request extends \ArrayObject {
         }
         return $_SERVER[$name];
     }
+
+    /**
+     * Returns the content of $_REQUEST[$name] as a string (or null).
+     */
+    public static function getRequestVar(string $name): ?string {
+        if (!isset($_REQUEST[$name]) || !is_string($_REQUEST[$name])) {
+            return null;
+        }
+        return $_REQUEST[$name];
+    }
 }
 
 \OmegaUp\Request::$_requestId = str_replace('.', '', uniqid('', true));

--- a/frontend/www/admin/user.php
+++ b/frontend/www/admin/user.php
@@ -7,7 +7,11 @@ require_once('../../server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 \OmegaUp\UITools::redirectIfNoAdmin();
 
-$username = strval($_REQUEST['username']);
+$username = \OmegaUp\Request::getRequestVar('username');
+if (is_null($username)) {
+    header('HTTP/1.1 404 Not found');
+    die();
+}
 $user = \OmegaUp\DAO\Users::FindByUsername($username);
 if (is_null($user) || is_null($user->user_id)) {
     header('HTTP/1.1 404 Not found');

--- a/frontend/www/userverifyemail.php
+++ b/frontend/www/userverifyemail.php
@@ -3,13 +3,14 @@
 require_once('../server/bootstrap_smarty.php');
 
 try {
-    \OmegaUp\Controllers\User::apiVerifyEmail(new \OmegaUp\Request($_REQUEST));
+    $r = new \OmegaUp\Request($_REQUEST);
+    \OmegaUp\Controllers\User::apiVerifyEmail($r);
 
-    if (!empty($_REQUEST['redirecttointerview'])) {
-        /** @psalm-suppress MixedArrayAccess $_REQUEST is okay. */
+    $redirectToInterview = $r->ensureOptionalString('redirecttointerview');
+    if (!empty($redirectToInterview)) {
         header(
             'Location: /login/?redirect=/interview/' .
-            urlencode(strval($_REQUEST['redirecttointerview'])) .
+            urlencode($redirectToInterview) .
             '/arena/'
         );
     } else {

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -76,13 +76,12 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Identity.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$r['country_id']</code>
       <code>$r['state_id']</code>
       <code>$r['country_id']</code>
       <code>$r['state_id']</code>
       <code>$request['lang']</code>
-      <code>$_GET['lang']</code>
     </MixedArgument>
     <PossiblyNullArgument occurrences="2">
       <code>$identity-&gt;username</code>
@@ -217,16 +216,10 @@
     </PossiblyNullArgument>
   </file>
   <file src="frontend/server/src/Controllers/Session.php">
-    <MixedArgument occurrences="9">
-      <code>$r['auth_token']</code>
-      <code>$_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME]</code>
-      <code>$_REQUEST[OMEGAUP_AUTH_TOKEN_COOKIE_NAME]</code>
+    <MixedArgument occurrences="3">
       <code>$r['auth_token']</code>
       <code>$r['auth_token']</code>
-      <code>$_GET['redirect']</code>
-      <code>$_GET['code']</code>
-      <code>$_GET['state']</code>
-      <code>$_GET['state']</code>
+      <code>$r['auth_token']</code>
     </MixedArgument>
     <PossiblyNullArgument occurrences="3">
       <code>$helper-&gt;getError()</code>
@@ -371,19 +364,9 @@
       <code>$r['name']</code>
     </MixedArgument>
   </file>
-  <file src="frontend/www/admin/user.php">
-    <MixedArgument occurrences="1">
-      <code>$_REQUEST['username']</code>
-    </MixedArgument>
-  </file>
   <file src="frontend/www/arena/problemprint.php">
     <MixedArgument occurrences="1">
       <code>$r['problem_alias']</code>
-    </MixedArgument>
-  </file>
-  <file src="frontend/www/userverifyemail.php">
-    <MixedArgument occurrences="1">
-      <code>$_REQUEST['redirecttointerview']</code>
     </MixedArgument>
   </file>
 </files>


### PR DESCRIPTION
Este cambio agrega `\OmegaUp\Request::getRequestVar()`, que permite
acceder a miembros de `$_REQUEST`/`$_GET` de manera segura.