### PR TITLE
Separando cambios que no tienen que ver con el token de clonar cursos

### DIFF
--- a/frontend/www/js/omegaup/components/course/Clone.test.ts
+++ b/frontend/www/js/omegaup/components/course/Clone.test.ts
@@ -16,7 +16,7 @@ describe('Clone.vue', () => {
     });
 
     expect(
-      wrapper.find('.omegaup-course-clone input[type="date"]').text(),
+      wrapper.find('div[data-course-clone] input[type="date"]').text(),
     ).toBe('');
   });
 });

--- a/frontend/www/js/omegaup/components/course/Clone.vue
+++ b/frontend/www/js/omegaup/components/course/Clone.vue
@@ -1,48 +1,49 @@
 <template>
-  <div class="omegaup-course-clone card">
-    <div class="card-body">
-      <form class="form" v-on:submit.prevent="onSubmit">
-        <div class="row">
-          <div class="form-group col-md-6">
-            <label
-              >{{ T.wordsName }}
-              <input class="form-control" type="text" v-model="name"
-            /></label>
-          </div>
-          <div class="form-group col-md-3">
-            <label
-              >{{ T.courseNewFormShortTitle_alias_ }}
-              <font-awesome-icon
-                v-bind:title="T.courseNewFormShortTitle_alias_Desc"
-                icon="info-circle" />
-              <input class="form-control" type="text" v-model="alias"
-            /></label>
-          </div>
-          <div class="form-group col-md-3">
-            <label
-              >{{ T.courseNewFormStartDate }}
-              <font-awesome-icon
-                v-bind:title="T.courseNewFormStartDateDesc"
-                icon="info-circle" />
-              <omegaup-datepicker v-model="startTime"></omegaup-datepicker
-            ></label>
-          </div>
+  <div data-course-clone>
+    <form
+      class="form"
+      v-on:submit.prevent="$emit('clone', alias, name, startTime)"
+    >
+      <div class="row">
+        <div class="form-group col-md-6">
+          <label
+            >{{ T.wordsName }}
+            <input class="form-control" type="text" v-model="name"
+          /></label>
         </div>
-        <div class="form-group text-right">
-          <button class="btn btn-primary" type="submit">
-            {{ T.wordsCloneCourse }}
-          </button>
+        <div class="form-group col-md-3">
+          <label
+            >{{ T.courseNewFormShortTitle_alias_ }}
+            <font-awesome-icon
+              v-bind:title="T.courseNewFormShortTitle_alias_Desc"
+              icon="info-circle" />
+            <input class="form-control" type="text" v-model="alias"
+          /></label>
         </div>
-      </form>
-    </div>
+        <div class="form-group col-md-3">
+          <label
+            >{{ T.courseNewFormStartDate }}
+            <font-awesome-icon
+              v-bind:title="T.courseNewFormStartDateDesc"
+              icon="info-circle" />
+            <omegaup-datepicker v-model="startTime"></omegaup-datepicker
+          ></label>
+        </div>
+      </div>
+      <div class="form-group text-right">
+        <button class="btn btn-primary" type="submit">
+          {{ T.wordsCloneCourse }}
+        </button>
+      </div>
+    </form>
   </div>
 </template>
 
-<style>
-.omegaup-course-clone .form-group > label {
+<style scoped>
+.form-group > label {
   width: 100%;
 }
-.omegaup-course-clone .faux-label {
+.faux-label {
   font-weight: bold;
 }
 </style>
@@ -77,9 +78,5 @@ export default class CourseClone extends Vue {
   alias = this.initialAlias;
   startTime = new Date();
   name = this.initialName;
-
-  onSubmit(): void {
-    this.$emit('emit-clone', this.alias, this.name, this.startTime);
-  }
 }
 </script>

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -212,7 +212,7 @@
             <omegaup-course-clone
               v-bind:initial-alias="course.alias"
               v-bind:initial-name="course.name"
-              v-on:emit-clone="
+              v-on:clone="
                 (alias, name, startTime) =>
                   $emit('clone', alias, name, startTime)
               "

--- a/frontend/www/js/omegaup/components/course/Edit.vue
+++ b/frontend/www/js/omegaup/components/course/Edit.vue
@@ -232,13 +232,18 @@
       </div>
 
       <div class="tab-pane active" role="tabpanel" v-if="showTab === 'clone'">
-        <omegaup-course-clone
-          v-bind:initial-alias="data.course.alias"
-          v-bind:initial-name="data.course.name"
-          v-on:emit-clone="
-            (alias, name, startTime) => $emit('clone', alias, name, startTime)
-          "
-        ></omegaup-course-clone>
+        <div class="card">
+          <div class="card-body">
+            <omegaup-course-clone
+              v-bind:initial-alias="data.course.alias"
+              v-bind:initial-name="data.course.name"
+              v-on:clone="
+                (alias, name, startTime) =>
+                  $emit('clone', alias, name, startTime)
+              "
+            ></omegaup-course-clone>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Descripción

Se separa el cambio del PR #4570 para que este se enfoque en todo lo que no 
está relacionado con el token.

Part of: #4552

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
