### PR TITLE
Evitando que las advertencias maten `yarn run test:watch`

### DIFF
--- a/frontend/www/js/omegaup/test.setup.js
+++ b/frontend/www/js/omegaup/test.setup.js
@@ -1,4 +1,5 @@
 const util = require('util');
+const process = require('process');
 
 require('jsdom-global')(undefined, {
   pretendToBeVisual: true,
@@ -24,6 +25,14 @@ console.error = function () {
   originalConsoleError(...arguments);
   throw new Error('Unexpected call to console.error(). Failing test.');
 };
+
+// Make sure that warnings will not cause test termination. This is because
+// warnings are always emitted in the next tick, which will cause an unhandled
+// exception and kill the node process altogether.
+process.removeAllListeners('warning');
+process.on('warning', (warning) => {
+  originalConsoleError(warning.stack);
+});
 
 // https://github.com/vuejs/vue-test-utils/issues/936
 window.Date = Date;


### PR DESCRIPTION
Este cambio hace que si hay una advertencia dentro de una prueba, el
proceso no se muera. Esto es porque la manera en la que
mochapack/webpack procesa los archivos no siempre atrapa los errores de
archivos no encontrados (causados por enlaces simbólicos rotos). eso
causa advertencias, y las advertencias imprimen a consola en otro stack
que no está controlado por mocha, Y ESO está arrojando una excepción.