### PR TITLE
Permitiendo crear excepciones en \OmegaUp\Exceptions que no son ApiException

### DIFF
--- a/frontend/server/src/Psalm/TranslationStringChecker.php
+++ b/frontend/server/src/Psalm/TranslationStringChecker.php
@@ -45,6 +45,7 @@ class TranslationStringChecker implements
      * translation string name as first parameter.
      */
     private static function isSupportedConstructor(
+        \Psalm\Codebase $codebase,
         string $constructorClassName
     ): bool {
         if ($constructorClassName === 'omegaup\\translationstring') {
@@ -60,7 +61,13 @@ class TranslationStringChecker implements
             // This one class does not use translation strings.
             return false;
         }
-        return true;
+        return (
+            $constructorClassName === 'omegaup\\exceptions\\apiexception' ||
+            $codebase->classExtends(
+                $constructorClassName,
+                'omegaup\\exceptions\\apiexception'
+            )
+        );
     }
 
     /**
@@ -84,7 +91,12 @@ class TranslationStringChecker implements
             // Not something we can reason about.
             return;
         }
-        if (!self::isSupportedConstructor($expr->class->toLowerString())) {
+        if (
+            !self::isSupportedConstructor(
+                $codebase,
+                $expr->class->toLowerString()
+            )
+        ) {
             return;
         }
         if (empty($expr->args)) {


### PR DESCRIPTION
Este cambio hace que el validador de psalm de las cadenas de traducción
relaje la condición necesaria para ser una excepción que _requiere_ que
se pase una cadena de traducción como primer parámetro. Ahora el
requisito es extender a \OmegaUp\Exceptions\ApiException en vez de sólo
estar en el namespace \OmegaUp\Exceptions.