### PR TITLE
Agregando tag público al crear problema en Selenium

### DIFF
--- a/frontend/tests/ui/util.py
+++ b/frontend/tests/ui/util.py
@@ -319,6 +319,12 @@ def create_problem(
     driver.browser.find_element_by_xpath(
         '//input[@type="radio" and @name="visibility" and @value="true"]'
     ).click()
+    driver.wait.until(
+        EC.visibility_of_element_located(
+            (By.XPATH, '//input[@type = "search"]'))).send_keys('Recur')
+    driver.wait.until(
+        EC.element_to_be_clickable((By.CSS_SELECTOR, '.vbt-matched-text'))
+    ).click()
     Select(
         driver.wait.until(
             EC.element_to_be_clickable(


### PR DESCRIPTION
# Descripción

Se agrega un tag público al crear problemas desde las pruebas de Selenium.

Eventualmente este campo será requerido.

Part of: #4564 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.