### PR TITLE
Arreglando tipos de Problems::apiAddGroupAdmin()

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -2489,10 +2489,10 @@ Adds a group admin to a problem
 
 ### Parameters
 
-| Name            | Type    | Description |
-| --------------- | ------- | ----------- |
-| `group`         | `mixed` |             |
-| `problem_alias` | `mixed` |             |
+| Name            | Type     | Description |
+| --------------- | -------- | ----------- |
+| `group`         | `string` |             |
+| `problem_alias` | `string` |             |
 
 ### Returns
 


### PR DESCRIPTION
Este cambio hace que los errores de /api/problem/addGroupAdmin/ sean más
fáciles de entender qué salió mal.