### PR TITLE
Agregando estilo de markdown a la descripción del curso a clonar

### DIFF
--- a/frontend/www/js/omegaup/components/course/CloneWithToken.vue
+++ b/frontend/www/js/omegaup/components/course/CloneWithToken.vue
@@ -19,7 +19,9 @@
         </p>
         <p>
           <span class="font-weight-bold">{{ T.wordsDescription }}: </span>
-          {{ course.description }}
+          <omegaup-markdown
+            v-bind:markdown="course.description"
+          ></omegaup-markdown>
         </p>
         <li
           v-for="assignment of course.assignments"
@@ -47,6 +49,7 @@ import { types } from '../../api_types';
 import course_Clone from './Clone.vue';
 import DatePicker from '../DatePicker.vue';
 import omegaup_Username from '../user/Username.vue';
+import omegaup_Markdown from '../Markdown.vue';
 
 import {
   FontAwesomeIcon,
@@ -61,6 +64,7 @@ library.add(fas);
   components: {
     'omegaup-course-clone': course_Clone,
     'omegaup-datepicker': DatePicker,
+    'omegaup-markdown': omegaup_Markdown,
     'omegaup-username': omegaup_Username,
     'font-awesome-icon': FontAwesomeIcon,
     'font-awesome-layers': FontAwesomeLayers,


### PR DESCRIPTION
# Descripción

Se agregan estilos de Markdown a la descripción del curso en los detalles al 
intentar ser clonado.

Fixes: #4625 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
