### PR TITLE
Arreglando el score de los envíos en apiStatus

### DIFF
--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -680,7 +680,6 @@ class Run extends \OmegaUp\Controllers\Controller {
                     floatval($filtered['contest_score']),
                     2
                 );
-                $result['score'] = 1;
             } else {
                 $result['contest_score'] = 0;
                 $result['score'] = 0;

--- a/frontend/tests/controllers/RunStatusTest.php
+++ b/frontend/tests/controllers/RunStatusTest.php
@@ -42,6 +42,46 @@ class RunStatusTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
+     * Basic test of viewing run details with grade run
+     */
+    public function testShowRunDetailsValidWithGradeRun() {
+        // Get a problem
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+
+        // Get a contest
+        $contestData = \OmegaUp\Test\Factories\Contest::createContest();
+
+        // Add the problem to the contest
+        \OmegaUp\Test\Factories\Contest::addProblemToContest(
+            $problemData,
+            $contestData
+        );
+
+        // Create our contestant
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+
+        // Create a run
+        $runData = \OmegaUp\Test\Factories\Run::createRun(
+            $problemData,
+            $contestData,
+            $identity
+        );
+        \OmegaUp\Test\Factories\Run::gradeRun($runData, 0.05, 'PA');
+
+        $login = self::login($identity);
+        $response = \OmegaUp\Controllers\Run::apiStatus(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'run_alias' => $runData['response']['guid'],
+        ]));
+
+        $this->assertEquals($runData['response']['guid'], $response['guid']);
+        $this->assertEquals('PA', $response['verdict']);
+        $this->assertEquals('ready', $response['status']);
+        $this->assertEquals(5, $response['contest_score']);
+        $this->assertEquals(0.05, $response['score']);
+    }
+
+    /**
      * Basic test of downloading a full run.
      */
     public function testDownload() {


### PR DESCRIPTION
# Descripción

Se arregla el score que estaba mostrando 100% cuando se realizaba un nuevo
envío, aún cuando la respuesta era incorrecta.

Resulta que `Run::apiStatus` estaba setteando siempre el valor de `1` en score, 
así que siempre que había un nuevo envío se ignoraba el puntaje real que se
había obtenido.

Fixes: #4632 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
