### PR TITLE
Agregando función para obtener Problem Settings

### DIFF
--- a/frontend/server/src/Cache.php
+++ b/frontend/server/src/Cache.php
@@ -209,6 +209,7 @@ class Cache {
     const ADMIN_SCOREBOARD_EVENTS_PREFIX = 'scoreboard-events-admin-';
     const CODERS_OF_THE_MONTH = 'coders-of-the-month';
     const CONTEST_INFO = 'contest-info-';
+    const PROBLEM_SETTINGS = 'problem-settings-json-';
     const PROBLEM_SETTINGS_DISTRIB = 'problem-settings-distrib-json-';
     const PROBLEM_STATEMENT = 'statement-';
     const PROBLEM_SOLUTION = 'solution-';

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2173,6 +2173,46 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * Gets the problem settings for the problem, using the cache if needed.
+     *
+     * @return ProblemSettings
+     */
+    private static function getProblemSettings(
+        \OmegaUp\DAO\VO\Problems $problem,
+        string $commit
+    ): array {
+        return \OmegaUp\Cache::getFromCacheOrSet(
+            \OmegaUp\Cache::PROBLEM_SETTINGS,
+            "{$problem->alias}-{$problem->commit}",
+            fn () => \OmegaUp\Controllers\Problem::getProblemSettingsImpl([
+                'alias' => strval($problem->alias),
+                'commit' => $problem->commit,
+            ]),
+            APC_USER_CACHE_PROBLEM_STATEMENT_TIMEOUT
+        );
+    }
+
+    /**
+     * Gets the problem settings for the problem.
+     *
+     * @param array{alias: string, commit: string} $params
+     *
+     * @return ProblemSettings
+     */
+    public static function getProblemSettingsImpl(array $params): array {
+        /** @var ProblemSettings */
+        return json_decode(
+            (new \OmegaUp\ProblemArtifacts(
+                $params['alias'],
+                $params['commit']
+            ))->get(
+                'settings.json'
+            ),
+            /*assoc=*/true
+        );
+    }
+
+    /**
      * Gets the distributable problem settings for the problem, using the cache
      * if needed.
      *


### PR DESCRIPTION
# Descripción

Agregando función para obtener los settings de un problema.

Part of: #4227
Part of: #4640

# Comentarios

No utilicé la función donde pretendía usarla (`getProblemDetails`), porque seguía
sin obtener los limites del validador personalizado. Pero quiero saber si es un 
buen comienzo, o revertimos este cambio.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
