### PR TITLE
Agregando botón de copiar a portapapeles en todos los <pre>

### DIFF
--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -231,7 +231,6 @@ contestUpdateAlreadyHasRuns = "Length of a contest can't be changed once a solut
 contestWillBeginIn = "This contest will begin in "
 contestsCreateNew = "Create a new contest"
 contestsJoinScoreboards = "Merge scoreboards"
-copySampleCaseTooltip = "Copy this sample input"
 courseAddContent = "Add content"
 courseAddProblemsAdd = "Add problems"
 courseAddProblemsAddAssignmentDesc = "Add all the problems that you want include to the assignment. These problems will be stored until you press Schedule assignment button. If you do not want to decide which problems to use right now, you can add them later."

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -231,7 +231,6 @@ contestUpdateAlreadyHasRuns = "La duración del concurso no se puede cambiar si 
 contestWillBeginIn = "Este concurso iniciará en "
 contestsCreateNew = "Crear un concurso"
 contestsJoinScoreboards = "Unir scoreboards"
-copySampleCaseTooltip = "Copia este caso de ejemplo"
 courseAddContent = "Añadir contenido"
 courseAddProblemsAdd = "Agregar problemas"
 courseAddProblemsAddAssignmentDesc = "Agrega los problemas que quieras incluir a esta tarea, estos se guardarán hasta que presiones el botón de Agendar tarea. Si aún no decides que problemas utilizarás, puedes agregarlos más tarde."

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -231,7 +231,6 @@ contestUpdateAlreadyHasRuns = "(L3ng7h 0f a c0n7357 can'7 b3 chang3d 0nc3 a 501u
 contestWillBeginIn = "(Thi5 c0n7357 wi11 b3gin in )"
 contestsCreateNew = "(Cr3a73 a n3w c0n7357)"
 contestsJoinScoreboards = "(M3rg3 5c0r3b0ard5)"
-copySampleCaseTooltip = "(C0py 7hi5 5amp13 inpu7)"
 courseAddContent = "(Add c0n73n7)"
 courseAddProblemsAdd = "(Add pr0b13m5)"
 courseAddProblemsAddAssignmentDesc = "(Add a11 7h3 pr0b13m5 7ha7 y0u wan7 inc1ud3 70 7h3 a55ignm3n7. Th353 pr0b13m5 wi11 b3 570r3d un7i1 y0u pr355 Sch3du13 a55ignm3n7 bu770n. If y0u d0 n07 wan7 70 d3cid3 which pr0b13m5 70 u53 righ7 n0w, y0u can add 7h3m 1a73r.)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -231,7 +231,6 @@ contestUpdateAlreadyHasRuns = "A duração do concurso não pode ser alterada se
 contestWillBeginIn = "Concurso inciará em "
 contestsCreateNew = "Criar um novo concurso"
 contestsJoinScoreboards = "Juntar paineis de avaliação"
-copySampleCaseTooltip = "Copie esta entrada de amostra"
 courseAddContent = "Adicionar conteúdo"
 courseAddProblemsAdd = "Adicionar problemas"
 courseAddProblemsAddAssignmentDesc = "Adicione todos os problemas que você deseja incluir na tarefa. Esses problemas serão armazenados até você pressionar o botão Agendar atribuição. Se você ainda não decidir quais problemas usar, poderá adicioná-los mais tarde."

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1884,8 +1884,6 @@ export class Arena {
   }
 
   onProblemRendered(): void {
-    ui.renderSampleToClipboardButton();
-
     const libinteractiveInterfaceNameElement = <HTMLElement>(
       this.markdownView.$el.querySelector('span.libinteractive-interface-name')
     );

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -57,6 +57,16 @@
     border-radius: 6px;
     display: block;
     line-height: 125%;
+    & > button.clipboard {
+      float: right;
+      border-color: rgb(218, 224, 229);
+    }
+  }
+  & > pre > button {
+    margin-right: -16px;
+    margin-top: -16px;
+    padding: 6px;
+    font-size: 90%;
   }
 
   figure {
@@ -100,6 +110,11 @@
       border: 0px;
       padding: 0px;
       margin: inherit;
+      & > button {
+        margin-left: 2em;
+        padding: 3px;
+        font-size: 80%;
+      }
     }
   }
 
@@ -134,7 +149,10 @@
 <script lang="ts">
 import { Vue, Component, Emit, Prop, Ref, Watch } from 'vue-property-decorator';
 import * as markdown from '../markdown';
+import * as ui from '../ui';
 import { types } from '../api_types';
+
+import T from '../lang';
 
 declare global {
   interface Window {
@@ -187,6 +205,30 @@ export default class Markdown extends Vue {
   @Emit('rendered')
   private renderMathJax(): void {
     this.root.innerHTML = this.html;
+    this.root
+      .querySelectorAll(
+        '[data-markdown-statement] > pre, .sample_io > tbody > tr > td:first-of-type > pre',
+      )
+      .forEach((preElement) => {
+        if (!preElement.firstChild) {
+          return;
+        }
+        const inputValue = (<HTMLPreElement>preElement).innerText;
+
+        const clipboardButton = document.createElement('button');
+        clipboardButton.appendChild(document.createTextNode('📋'));
+        clipboardButton.title = T.wordsCopyToClipboard;
+        clipboardButton.className =
+          'glyphicon glyphicon-copy clipboard btn btn-light';
+
+        clipboardButton.addEventListener('click', (event: Event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          ui.copyToClipboard(inputValue);
+        });
+
+        preElement.insertBefore(clipboardButton, preElement.firstChild);
+      });
     if (!window.MathJax?.startup) {
       window.MathJax = {
         tex: {

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -232,7 +232,6 @@
 	"contestWillBeginIn": "This contest will begin in ",
 	"contestsCreateNew": "Create a new contest",
 	"contestsJoinScoreboards": "Merge scoreboards",
-	"copySampleCaseTooltip": "Copy this sample input",
 	"courseAddContent": "Add content",
 	"courseAddProblemsAdd": "Add problems",
 	"courseAddProblemsAddAssignmentDesc": "Add all the problems that you want include to the assignment. These problems will be stored until you press Schedule assignment button. If you do not want to decide which problems to use right now, you can add them later.",

--- a/frontend/www/js/omegaup/lang.en.ts
+++ b/frontend/www/js/omegaup/lang.en.ts
@@ -233,7 +233,6 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "This contest will begin in ",
   contestsCreateNew: "Create a new contest",
   contestsJoinScoreboards: "Merge scoreboards",
-  copySampleCaseTooltip: "Copy this sample input",
   courseAddContent: "Add content",
   courseAddProblemsAdd: "Add problems",
   courseAddProblemsAddAssignmentDesc: "Add all the problems that you want include to the assignment. These problems will be stored until you press Schedule assignment button. If you do not want to decide which problems to use right now, you can add them later.",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -232,7 +232,6 @@
 	"contestWillBeginIn": "Este concurso iniciar\u00e1 en ",
 	"contestsCreateNew": "Crear un concurso",
 	"contestsJoinScoreboards": "Unir scoreboards",
-	"copySampleCaseTooltip": "Copia este caso de ejemplo",
 	"courseAddContent": "A\u00f1adir contenido",
 	"courseAddProblemsAdd": "Agregar problemas",
 	"courseAddProblemsAddAssignmentDesc": "Agrega los problemas que quieras incluir a esta tarea, estos se guardar\u00e1n hasta que presiones el bot\u00f3n de Agendar tarea. Si a\u00fan no decides que problemas utilizar\u00e1s, puedes agregarlos m\u00e1s tarde.",

--- a/frontend/www/js/omegaup/lang.es.ts
+++ b/frontend/www/js/omegaup/lang.es.ts
@@ -233,7 +233,6 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "Este concurso iniciar\u00e1 en ",
   contestsCreateNew: "Crear un concurso",
   contestsJoinScoreboards: "Unir scoreboards",
-  copySampleCaseTooltip: "Copia este caso de ejemplo",
   courseAddContent: "A\u00f1adir contenido",
   courseAddProblemsAdd: "Agregar problemas",
   courseAddProblemsAddAssignmentDesc: "Agrega los problemas que quieras incluir a esta tarea, estos se guardar\u00e1n hasta que presiones el bot\u00f3n de Agendar tarea. Si a\u00fan no decides que problemas utilizar\u00e1s, puedes agregarlos m\u00e1s tarde.",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -232,7 +232,6 @@
 	"contestWillBeginIn": "(Thi5 c0n7357 wi11 b3gin in )",
 	"contestsCreateNew": "(Cr3a73 a n3w c0n7357)",
 	"contestsJoinScoreboards": "(M3rg3 5c0r3b0ard5)",
-	"copySampleCaseTooltip": "(C0py 7hi5 5amp13 inpu7)",
 	"courseAddContent": "(Add c0n73n7)",
 	"courseAddProblemsAdd": "(Add pr0b13m5)",
 	"courseAddProblemsAddAssignmentDesc": "(Add a11 7h3 pr0b13m5 7ha7 y0u wan7 inc1ud3 70 7h3 a55ignm3n7. Th353 pr0b13m5 wi11 b3 570r3d un7i1 y0u pr355 Sch3du13 a55ignm3n7 bu770n. If y0u d0 n07 wan7 70 d3cid3 which pr0b13m5 70 u53 righ7 n0w, y0u can add 7h3m 1a73r.)",

--- a/frontend/www/js/omegaup/lang.pseudo.ts
+++ b/frontend/www/js/omegaup/lang.pseudo.ts
@@ -233,7 +233,6 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "(Thi5 c0n7357 wi11 b3gin in )",
   contestsCreateNew: "(Cr3a73 a n3w c0n7357)",
   contestsJoinScoreboards: "(M3rg3 5c0r3b0ard5)",
-  copySampleCaseTooltip: "(C0py 7hi5 5amp13 inpu7)",
   courseAddContent: "(Add c0n73n7)",
   courseAddProblemsAdd: "(Add pr0b13m5)",
   courseAddProblemsAddAssignmentDesc: "(Add a11 7h3 pr0b13m5 7ha7 y0u wan7 inc1ud3 70 7h3 a55ignm3n7. Th353 pr0b13m5 wi11 b3 570r3d un7i1 y0u pr355 Sch3du13 a55ignm3n7 bu770n. If y0u d0 n07 wan7 70 d3cid3 which pr0b13m5 70 u53 righ7 n0w, y0u can add 7h3m 1a73r.)",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -232,7 +232,6 @@
 	"contestWillBeginIn": "Concurso inciar\u00e1 em ",
 	"contestsCreateNew": "Criar um novo concurso",
 	"contestsJoinScoreboards": "Juntar paineis de avalia\u00e7\u00e3o",
-	"copySampleCaseTooltip": "Copie esta entrada de amostra",
 	"courseAddContent": "Adicionar conte\u00fado",
 	"courseAddProblemsAdd": "Adicionar problemas",
 	"courseAddProblemsAddAssignmentDesc": "Adicione todos os problemas que voc\u00ea deseja incluir na tarefa. Esses problemas ser\u00e3o armazenados at\u00e9 voc\u00ea pressionar o bot\u00e3o Agendar atribui\u00e7\u00e3o. Se voc\u00ea ainda n\u00e3o decidir quais problemas usar, poder\u00e1 adicion\u00e1-los mais tarde.",

--- a/frontend/www/js/omegaup/lang.pt.ts
+++ b/frontend/www/js/omegaup/lang.pt.ts
@@ -233,7 +233,6 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "Concurso inciar\u00e1 em ",
   contestsCreateNew: "Criar um novo concurso",
   contestsJoinScoreboards: "Juntar paineis de avalia\u00e7\u00e3o",
-  copySampleCaseTooltip: "Copie esta entrada de amostra",
   courseAddContent: "Adicionar conte\u00fado",
   courseAddProblemsAdd: "Adicionar problemas",
   courseAddProblemsAddAssignmentDesc: "Adicione todos os problemas que voc\u00ea deseja incluir na tarefa. Esses problemas ser\u00e3o armazenados at\u00e9 voc\u00ea pressionar o bot\u00e3o Agendar atribui\u00e7\u00e3o. Se voc\u00ea ainda n\u00e3o decidir quais problemas usar, poder\u00e1 adicion\u00e1-los mais tarde.",

--- a/frontend/www/js/omegaup/ui.ts
+++ b/frontend/www/js/omegaup/ui.ts
@@ -228,32 +228,6 @@ export function copyToClipboard(value: string): void {
   }
 }
 
-export function renderSampleToClipboardButton(): void {
-  document
-    .querySelectorAll('.sample_io > tbody > tr > td:first-of-type')
-    .forEach(function (item, index) {
-      const preElement = item.querySelector('pre');
-      if (!preElement) {
-        // This can only happen if a user messed up with the markdown of a
-        // problem.
-        return;
-      }
-      const inputValue = preElement.innerHTML;
-
-      const clipboardButton = document.createElement('button');
-      clipboardButton.title = T.copySampleCaseTooltip;
-      clipboardButton.className = 'glyphicon glyphicon-copy clipboard';
-
-      clipboardButton.addEventListener('click', (event: Event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        copyToClipboard(inputValue);
-      });
-
-      item.appendChild(clipboardButton);
-    });
-}
-
 declare global {
   interface Window {
     ga?: (command: string, ...fields: any[]) => void;


### PR DESCRIPTION
Este cambio mueve la responsabilidad de dibujar el botón de copiar a
portapapeles a Markdown.vue en vez de que esté en arena.ts. De paso se
usa el emoji del portapapeles en vez del ícono de Bootstrap 3 porque ya
no estaba funcionando con Bootstrap 4.

Adiós monito sorprendido, vivirás para siempre en nuestros corazones :'(

![image](https://user-images.githubusercontent.com/168028/93028680-43540480-f5ca-11ea-839e-5da9472f178e.png)

Fixes: #4658