### PR TITLE
Soportando <summary>/<details> en Markdown

### DIFF
--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -4,6 +4,7 @@
 
 <style lang="scss">
 @import '../../../../../node_modules/prismjs/themes/prism.css';
+@import '../../../sass/main.scss';
 
 [data-markdown-statement] {
   display: block;
@@ -72,6 +73,17 @@
   figure {
     text-align: center;
     page-break-inside: avoid;
+  }
+
+  details {
+    padding: 16px;
+    border: 1px solid #eee;
+    summary {
+      color: $omegaup-blue;
+    }
+    &[open] > summary {
+      margin-bottom: 24px;
+    }
   }
 
   table td {

--- a/frontend/www/js/omegaup/markdown.test.ts
+++ b/frontend/www/js/omegaup/markdown.test.ts
@@ -38,6 +38,12 @@ describe('markdown', () => {
         </figure></p>`);
     });
 
+    it('Should handle details/summary tags', () => {
+      expect(
+        converter.makeHtml('<details><summary>SPOILER</summary>Hi</details>'),
+      ).toEqual('<p><details><summary>SPOILER</summary>Hi</details></p>');
+    });
+
     it('Should handle sample I/O tables', () => {
       expect(
         converter.makeHtml(`# Ejemplo

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -88,7 +88,7 @@ export class Converter {
       </div>`;
     }
 
-    const whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|figure|figcaption|code|i|table|tbody|thead|tr|th(?: align="\w+")?|td(?: align="\w+")?|iframe(?: (?:src="https:\/\/www\.youtube\.com\/embed\/[\w-]+"|(?:width|height|allowfullscreen|frameborder|allow)(?:="[^"]+")?))*|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
+    const whitelist = /^<\/?(a(?: (target|class|href)="[a-z/_-]+")*|details|summary|figure|figcaption|code|i|table|tbody|thead|tr|th(?: align="\w+")?|td(?: align="\w+")?|iframe(?: (?:src="https:\/\/www\.youtube\.com\/embed\/[\w-]+"|(?:width|height|allowfullscreen|frameborder|allow)(?:="[^"]+")?))*|div|h3|span|form(?: role="\w+")*|label|select|option(?: (value|selected)="\w+")*|strong|span|button(?: type="\w+")?)( class="[a-zA-Z0-9 _-]+")?>$/i;
     const imageWhitelist = new RegExp(
       '^<img\\ssrc="data:image/[a-zA-Z0-9/;,=+]+"(\\swidth="\\d{1,3}")?(\\sheight="\\d{1,3}")?(\\salt="[^"<>]*")?(\\stitle="[^"<>]*")?\\s?/?>$',
       'i',


### PR DESCRIPTION
Este cambio agrega los tags `<summary>` y `<details>` al Markdown. Esto hace
que se puedan tener secciones plegables en el Markdown:
https://about.gitlab.com/handbook/markdown-guide/#collapse

Ejemplo:

    <details><summary>SPOILER</summary>
    Hi
    </details>

* Cerrado: ![image](https://user-images.githubusercontent.com/168028/93031852-ca14db80-f5e2-11ea-95be-72c6237b462c.png)
* Abierto: ![image](https://user-images.githubusercontent.com/168028/93031859-db5de800-f5e2-11ea-8b3d-0b3796dbc2fb.png)

Fixes: #4658