### PR TITLE
Arreglando bug que no permitía ingresar a curso con información básica

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -3364,13 +3364,14 @@ class Course extends \OmegaUp\Controllers\Controller {
             && $requestUserInformation !== 'no'
             )
         ) {
-            $needsBasicInformation = $courseDetails['needs_basic_information']
-                && (!is_null($r->identity->country_id)
-                || !is_null(
-                    $r->identity->state_id
-                ) || !is_null(
-                    $r->identity->current_identity_school_id
-                ));
+            $needsBasicInformation = (
+                $courseDetails['needs_basic_information']
+                && (
+                    is_null($r->identity->country_id)
+                    || is_null($r->identity->state_id)
+                    || is_null($r->identity->current_identity_school_id)
+                )
+            );
 
             // Privacy Statement Information
             $privacyStatementMarkdown = \OmegaUp\PrivacyStatement::getForProblemset(

--- a/frontend/tests/Factories/Course.php
+++ b/frontend/tests/Factories/Course.php
@@ -13,7 +13,8 @@ class Course {
         string $requestsUserInformation = 'no',
         string $showScoreboard = 'false',
         ?int $courseDuration = 120,
-        ?string $courseAlias = null
+        ?string $courseAlias = null,
+        ?bool $needsBasicInformation = false
     ): array {
         if (is_null($admin)) {
             ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
@@ -53,6 +54,7 @@ class Course {
             'admission_mode' => $admissionMode,
             'requests_user_information' => $requestsUserInformation,
             'show_scoreboard' => $showScoreboard,
+            'needs_basic_information' => $needsBasicInformation,
         ]);
 
         \OmegaUp\Controllers\Course::apiCreate($r);
@@ -76,7 +78,8 @@ class Course {
         int $startTimeDelay = 0,
         ?int $courseDuration = 120,
         ?int $assignmentDuration = 120,
-        ?string $courseAlias = null
+        ?string $courseAlias = null,
+        ?bool $needsBasicInformation = false
     ) {
         if (is_null($admin)) {
             ['user' => $user, 'identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
@@ -91,7 +94,8 @@ class Course {
             $requestsUserInformation,
             $showScoreboard,
             $courseDuration,
-            $courseAlias
+            $courseAlias,
+            $needsBasicInformation
         );
         $courseAlias = $courseFactoryResult['course_alias'];
         $courseStartTime = intval(


### PR DESCRIPTION
# Descripción

Se arregla un bug que no permitía ingresar a los alumnos de un curso que se
configuró con la bandera de "Información básica es requerida". Justamente 
estaba haciendo lo contrario, dejaba accedes a los usuarios que no habían 
registrado su información básica (país, estado, escuela).

Se agregó prueba unitaria para que esto no vuelva a ocurrir

![StartCourseBasicInformation](https://user-images.githubusercontent.com/3230352/93534401-a4514480-f90a-11ea-8d6b-b8bfe0ba060a.gif)


Fixes: #4671 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.