### PR TITLE
Ocultando las lecturas en la vista de progreso de estudiante

### DIFF
--- a/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 import Vue from 'vue';
 
@@ -25,16 +25,16 @@ describe('ViewStudent.vue', () => {
 
   it('Should handle runs', async () => {
     const expectedDate = new Date('1/1/2020, 12:00:00 AM');
-    const wrapper = shallowMount(course_ViewStudent, {
+    const wrapper = mount(course_ViewStudent, {
       propsData: {
         course: {
           alias: 'hello',
         },
-        assignment: [
+        assignments: [
           {
             alias: 'assignment',
             assignment_type: 'homework',
-            description: 'Assignment',
+            description: 'Assignment description',
             start_time: new Date(0),
             finish_time: new Date(),
             name: 'Assignment',
@@ -60,6 +60,7 @@ describe('ViewStudent.vue', () => {
               } as omegaup.CourseProblemRun,
             ],
             submissions: 1,
+            title: 'problem_1',
             visits: 1,
           } as types.CourseProblem,
         ],
@@ -81,6 +82,15 @@ describe('ViewStudent.vue', () => {
         } as types.CourseStudent,
       },
     });
+
+    const assignments = <HTMLInputElement>(
+      wrapper.find('select[data-assignment]').element
+    );
+    assignments.value = 'assignment';
+    await assignments.dispatchEvent(new Event('change'));
+    expect(wrapper.find('div[data-markdown-statement]').text()).toBe(
+      'Assignment description',
+    );
     await wrapper.find('a[data-problem-alias="problem"]').trigger('click');
 
     expect(wrapper.find('table tbody td').text()).toBe(

--- a/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
@@ -21,7 +21,6 @@ describe('ViewStudent.vue', () => {
 
     expect(wrapper.text()).toContain(T.courseStudentSelectStudent);
     expect(wrapper.text()).toContain(T.courseStudentSelectAssignment);
-    expect(wrapper.text()).toContain(T.courseAssignmentProblemRunsEmpty);
   });
 
   it('Should handle runs', async () => {
@@ -62,7 +61,7 @@ describe('ViewStudent.vue', () => {
             ],
             submissions: 1,
             visits: 1,
-          } as omegaup.CourseProblem,
+          } as types.CourseProblem,
         ],
         students: [
           {

--- a/frontend/www/js/omegaup/course/student.ts
+++ b/frontend/www/js/omegaup/course/student.ts
@@ -32,14 +32,11 @@ OmegaUp.on('ready', () => {
           students: payload.students,
         },
         on: {
-          update: (
-            student: types.StudentProgress,
-            assignment: types.CourseAssignment,
-          ) => {
-            if (assignment == null) return;
+          update: (student: types.StudentProgress, assignmentAlias: string) => {
+            if (assignmentAlias == null) return;
             api.Course.studentProgress({
               course_alias: payload.course.alias,
-              assignment_alias: assignment.alias,
+              assignment_alias: assignmentAlias,
               usernameOrEmail: student.username,
             })
               .then((data) => {


### PR DESCRIPTION
# Descripción

Se ocultan las lecturas en la lista de problemas de un assignment en la vista de 
progreso de estudiante

![StudentProgress](https://user-images.githubusercontent.com/3230352/93826477-efca6200-fc2c-11ea-807c-e7b88a1ce392.gif)

Fixes: #4694

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.