### PR TITLE
Permitiendo descargar las entradas de los problemas de sólo salida

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ frontend/www/img/
 frontend/www/phpminiadmin/
 frontend/www/pmamini.php
 frontend/www/templates/
+frontend/www/probleminput/
 frontend/www/tests/index.html
 
 # Ignore sublime sftp config

--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -84,6 +84,11 @@ try_define(
 );
 try_define('IMAGES_URL_PATH', '/img/');
 try_define(
+    'INPUTS_PATH',
+    sprintf('%s/www/probleminput/', strval(OMEGAUP_ROOT))
+);
+try_define('INPUTS_URL_PATH', '/probleminput/');
+try_define(
     'TEMPLATES_PATH',
     sprintf('%s/www/templates/', strval(OMEGAUP_ROOT))
 );

--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -126,6 +126,28 @@ location ~ '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/([a-zA-Z0-9_.-]+)$' {
   rewrite '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/(.*)$' /problems/template.php?problem_alias=$1&commit=$2&filename=$3? last;
 }
 
+# output-only inputs.
+location ~ '^/probleminput/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/([a-zA-Z0-9_.-]+)$' {
+  if (-f $request_filename) {
+    # Normal case: file is found and nginx can handle it natively.
+    break;
+  }
+  if (-d $document_root/probleminput/$1/$2) {
+    # Directory was found, but file was not. That means that the
+    # re-generation process was already run, so we will never be
+    # able to find that file.
+    return 404;
+  }
+  if ($args != '') {
+    # The re-generation process was already run, and we still
+    # could not find that file. Give up to avoid infinitely
+    # redirecting.
+    return 404;
+  }
+  # Try re-generating the template. Once this is done, it will cause a redirect to nginx.
+  rewrite '^/probleminput/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/(.*)$' /problems/input.php?problem_alias=$1&commit=$2&filename=$3 last;
+}
+
 # problem images
 location ~ '^/img/([a-zA-Z0-9_-]+)/([0-9a-f]{40})\.([a-zA-Z0-9._-]+)$' {
   if (-f $request_filename) {

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5486,6 +5486,122 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * @omegaup-request-param string $commit
+     * @omegaup-request-param string $filename
+     * @omegaup-request-param string $problem_alias
+     */
+    public static function apiInput(\OmegaUp\Request $r): void {
+        $commit = $r->ensureString(
+            'commit',
+            fn (string $commit) => preg_match(
+                '/^[0-9a-f]{40}$/',
+                $commit
+            ) === 1
+        );
+        $problem = \OmegaUp\DAO\Problems::getByAlias(
+            $r->ensureString(
+                'problem_alias',
+                fn (string $problemAlias) => \OmegaUp\Validators::alias(
+                    $problemAlias
+                )
+            )
+        );
+        if (is_null($problem) || is_null($problem->alias)) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'problemNotFound'
+            );
+        }
+        $filename = $r->ensureString('filename');
+
+        self::generateInputZip($problem, $commit, $filename);
+
+        //The noredirect=1 part lets nginx know to not call us again if the file is not found.
+        header(
+            'Location: ' . INPUTS_URL_PATH . "{$problem->alias}/{$commit}/{$filename}?noredirect=1"
+        );
+        header('HTTP/1.1 303 See Other');
+
+        // Since all the headers and response have been sent, make the API
+        // caller to exit quietly.
+        throw new \OmegaUp\Exceptions\ExitException();
+    }
+
+    public static function generateInputZip(
+        \OmegaUp\DAO\VO\Problems $problem,
+        string $commit,
+        string $filename
+    ): void {
+        if ($filename != "{$problem->alias}-input.zip") {
+            throw new \OmegaUp\Exceptions\NotFoundException();
+        }
+        if (!in_array('cat', explode(',', $problem->languages))) {
+            throw new \OmegaUp\Exceptions\NotFoundException();
+        }
+        if (is_null($problem->alias)) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'problemNotFound'
+            );
+        }
+        $problemCases = \OmegaUp\Controllers\Run::getProblemCasesMetadata(
+            'cases',
+            $problem->alias,
+            $commit
+        );
+        $problemArtifacts = new \OmegaUp\ProblemArtifacts(
+            $problem->alias,
+            $commit
+        );
+
+        $tmpDir = \OmegaUp\FileHandler::tempDir(
+            '/tmp',
+            'InputZip',
+            0755
+        );
+
+        try {
+            $tmpPath = "{$tmpDir}/{$problem->alias}-input.zip";
+            $zipArchive = new \ZipArchive();
+            /** @var true|int */
+            $err = $zipArchive->open(
+                $tmpPath,
+                \ZipArchive::CREATE
+            );
+            if ($err !== true) {
+                throw new \OmegaUp\Exceptions\ProblemDeploymentFailedException(
+                    'problemDeployerInternalError',
+                    $err
+                );
+            }
+
+            foreach ($problemCases as $file) {
+                if (pathinfo($file['path'], PATHINFO_EXTENSION) !== 'in') {
+                    continue;
+                }
+                $zipArchive->addFromString(
+                    basename($file['path']),
+                    $problemArtifacts->get($file['path'])
+                );
+            }
+            $zipArchive->close();
+
+            $zipPath = INPUTS_PATH . "{$problem->alias}/{$commit}/{$problem->alias}-input.zip";
+            @mkdir(dirname($zipPath), 0755, true);
+            rename($tmpPath, $zipPath);
+        } catch (\Exception $e) {
+            self::$log->error(
+                "Failed to create input .zip for {$problem->alias}",
+                $e
+            );
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'problemDeployerLibinteractiveValidationError',
+                $e->getMessage()
+            );
+        } finally {
+            \OmegaUp\FileHandler::deleteDirRecursively($tmpDir);
+        }
+    }
+
+    /**
      * @omegaup-request-param 'bmp'|'gif'|'ico'|'jpe'|'jpeg'|'jpg'|'png'|'svg'|'svgz'|'tif'|'tiff' $extension
      * @omegaup-request-param null|string $object_id
      * @omegaup-request-param string $problem_alias

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1052,7 +1052,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * @return list<array{mode: int, type: string, id: string, size: int, path: string}>
      */
-    private static function getProblemCasesMetadata(
+    public static function getProblemCasesMetadata(
         string $directory,
         string $problemAlias,
         string $revision

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -732,6 +732,60 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
         );
     }
 
+    /**
+     * Test that we are able to generate the input .zip of a problem that
+     * admits an output-only solution.
+     */
+    public function testGenerateInputZip() {
+        // Get the problem data
+        $problemData = \OmegaUp\Test\Factories\Problem::getRequest(new \OmegaUp\Test\Factories\ProblemParams([
+            'zipName' => OMEGAUP_TEST_RESOURCES_ROOT . 'triangulos.zip',
+            'languages' => 'cat',
+        ]));
+        $r = $problemData['request'];
+        $problemAuthor = $problemData['author'];
+
+        // Login user
+        $login = self::login($problemAuthor);
+        $r['auth_token'] = $login->auth_token;
+
+        // Call the API
+        $response = \OmegaUp\Controllers\Problem::apiCreate($r);
+        $this->assertEquals('ok', $response['status']);
+
+        $problem = \OmegaUp\DAO\Problems::getByTitle($r['title'])[0];
+
+        $filename = "{$problem->alias}-input.zip";
+        \OmegaUp\Controllers\Problem::generateInputZip(
+            $problem,
+            $problem->commit,
+            $filename
+        );
+
+        // Verify that the templates were generated.
+        $zipPath = INPUTS_PATH . "{$problem->alias}/{$problem->commit}/{$filename}";
+        $this->assertTrue(file_exists($zipPath));
+
+        $zipArchive = new \ZipArchive();
+        try {
+            /** @var true|int */
+            $err = $zipArchive->open($zipPath, \ZipArchive::RDONLY);
+            $this->assertTrue($err);
+
+            /** @var list<string> */
+            $filenames = [];
+            for ($i = 0; $i < $zipArchive->numFiles; ++$i) {
+                $filenames[] = $zipArchive->getNameIndex($i);
+            }
+            $this->assertEqualsCanonicalizing(
+                $filenames,
+                ['1.in', '2.in', '3.in', '4.in']
+            );
+        } finally {
+            $zipArchive->close();
+        }
+    }
+
     public function testProblemParams() {
         $problemParams = new \OmegaUp\ProblemParams([
             'problem_alias' => \OmegaUp\Test\Utils::createRandomString(),

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -62,6 +62,7 @@ try_define(
 );
 try_define('OMEGAUP_SSLCERT_URL', "{$_omegaUpRoot}/omegaup.pem");
 try_define('TEMPLATES_PATH', OMEGAUP_TEST_ROOT . '/templates/');
+try_define('INPUTS_PATH', OMEGAUP_TEST_ROOT . '/probleminput/');
 
 # #########################
 # CACHE CONFIG

--- a/frontend/www/problems/input.php
+++ b/frontend/www/problems/input.php
@@ -1,0 +1,13 @@
+<?php
+namespace OmegaUp;
+require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
+
+try {
+    \OmegaUp\Controllers\Problem::apiInput(
+        new \OmegaUp\Request($_REQUEST)
+    );
+} catch (\OmegaUp\Exceptions\ExitException $e) {
+    exit;
+} catch (\Exception $e) {
+    \OmegaUp\ApiCaller::handleException($e);
+}


### PR DESCRIPTION
Este cambio agrega un HTTP endpoint que permite descargar las entradas
de un problema de sólo salida, como un .zip.

El URL para descargarlo es

```
/probleminput/${problemAlias}/${problemCommit}/${problemAlias}-input.zip
```

Part of: #1660