### PR TITLE
Permitiendo mayúsculas en los nombres de los archivos transcluídos

### DIFF
--- a/frontend/www/js/omegaup/markdown.test.ts
+++ b/frontend/www/js/omegaup/markdown.test.ts
@@ -567,9 +567,9 @@ Tags &lt;b&gt;hello&lt;/b&gt;
       // All Markdown special characters should be escaped.
       expect(
         converter.makeHtmlWithImages(
-          '{{sample.in}}',
+          '{{Sample.in}}',
           {},
-          { 'sample.in': '<>&\n*foo* _bar_\n[img](img)\n\\\n' },
+          { 'Sample.in': '<>&\n*foo* _bar_\n[img](img)\n\\\n' },
         ),
       ).toEqual(
         '<p><pre><code class="language-in">&lt;&gt;&amp;\n*foo* _bar_\n[img](img)\n\\\n</code></pre></p>',

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -198,7 +198,7 @@ export class Converter {
       // File transclusion.
       const sourceMapping: ImageMapping = this._sourceMapping || {};
       text = text.replace(
-        /^\s*\{\{([a-z0-9_-]+\.[a-z]{1,4})\}\}\s*$/g,
+        /^\s*\{\{([a-z0-9_-]+\.[a-z]{1,4})\}\}\s*$/gi,
         (wholematch: string, m1: string): string => {
           if (!sourceMapping.hasOwnProperty(m1)) {
             return `<span class="alert alert-danger" role="alert">Unrecognized source filename: ${m1}</span>`;


### PR DESCRIPTION
Este cambio hace que sea posible tener mayúsculas en los nombre de los
archivos transcluídos en las redacciones / soluciones.