### PR TITLE
Dejando de declarar/importar cosas que no se usan

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-this-alias': 'off',
-    '@typescript-eslint/no-unused-vars': 'off',
     'no-prototype-builtins': 'off',
     'no-self-assign': 'off',
     'no-undef': 'off',

--- a/frontend/www/js/omegaup/arena/admin.ts
+++ b/frontend/www/js/omegaup/arena/admin.ts
@@ -9,9 +9,7 @@ OmegaUp.on('ready', () => {
   const arenaInstance = new Arena(GetOptionsFromLocation(window.location));
   const adminInstance = new ArenaAdmin(arenaInstance);
 
-  window.addEventListener('hashchange', (e: Event) =>
-    arenaInstance.onHashChanged(),
-  );
+  window.addEventListener('hashchange', () => arenaInstance.onHashChanged());
 
   if (arenaInstance.options.contestAlias === 'admin') {
     $('#runs').show();

--- a/frontend/www/js/omegaup/arena/admin_arena.test.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.test.ts
@@ -24,7 +24,7 @@ describe('arena', () => {
       const options = arena.GetDefaultOptions();
 
       const arenaInstance = new arena.Arena(options);
-      const adminInstance = new ArenaAdmin(arenaInstance);
+      new ArenaAdmin(arenaInstance);
       expect(arenaInstance.problemsetAdmin).toEqual(true);
     });
   });

--- a/frontend/www/js/omegaup/arena/admin_arena.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.ts
@@ -48,7 +48,7 @@ export default class ArenaAdmin {
                 return;
               }
               api.Run.disqualify({ run_alias: run.guid })
-                .then((data) => {
+                .then(() => {
                   run.type = 'disqualified';
                   arena.updateRunFallback(run.guid);
                 })
@@ -59,7 +59,7 @@ export default class ArenaAdmin {
             },
             rejudge: (run: types.Run) => {
               api.Run.rejudge({ run_alias: run.guid, debug: false })
-                .then((data) => {
+                .then(() => {
                   run.status = 'rejudging';
                   self.arena.updateRunFallback(run.guid);
                 })
@@ -93,7 +93,7 @@ export default class ArenaAdmin {
       this.refreshClarifications();
     });
 
-    this.arena.elements.clarification.on('submit', (e: Event) => {
+    this.arena.elements.clarification.on('submit', () => {
       $('input', this.arena.elements.clarification).attr(
         'disabled',
         'disabled',
@@ -113,7 +113,7 @@ export default class ArenaAdmin {
           this.arena.elements.clarification,
         ).val(),
       })
-        .then((response) => {
+        .then(() => {
           this.arena.hideOverlay();
           this.refreshClarifications();
         })

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuex, { StoreOptions } from 'vuex';
+import Vuex from 'vuex';
 import * as Highcharts from 'highcharts/highstock';
 
 import * as api from '../api';
@@ -1215,11 +1215,8 @@ export class Arena {
       currentRankingState[username] = { place: rank.place ?? 0 };
 
       // Update problem scores.
-      let totalRuns = 0;
       for (const alias of Object.keys(order)) {
         const problem = rank.problems[order[alias]];
-        totalRuns += problem.runs;
-
         if (
           this.problems[alias] &&
           rank.username == OmegaUp.username &&
@@ -1857,7 +1854,7 @@ export class Arena {
                 nomination: 'dismissal',
                 contents: JSON.stringify(contents),
               })
-                .then((data) => {
+                .then(() => {
                   ui.info(T.qualityNominationRateProblemDesc);
                   ui.reportEvent('quality-nomination', 'dismiss');
                 })
@@ -2061,8 +2058,8 @@ export class Arena {
 
         const currentProblem = this.problems[this.currentProblem.alias];
         if (!this.options.isOnlyProblem) {
-          this.problems[this.currentProblem.alias].lastSubmission = new Date();
-          this.problems[this.currentProblem.alias].nextSubmissionTimestamp =
+          currentProblem.lastSubmission = new Date();
+          currentProblem.nextSubmissionTimestamp =
             response.nextSubmissionTimestamp;
         }
         const run = {
@@ -2109,8 +2106,6 @@ export class Arena {
   }
 
   displayRunDetails(guid: string, data: messages.RunDetailsResponse): void {
-    const problemAdmin = data.admin;
-
     let sourceHTML,
       sourceLink = false;
     if (data.source?.indexOf('data:') === 0) {
@@ -2378,7 +2373,7 @@ export class EventsSocket {
         const socket = new WebSocket(this.uri, 'com.omegaup.events');
 
         socket.onmessage = (message) => this.onmessage(message);
-        socket.onopen = (e: Event) => {
+        socket.onopen = () => {
           this.shouldRetry = true;
           this.arena.elements.socketStatus.html('&bull;').css('color', '#080');
           this.socketKeepalive = setInterval(
@@ -2424,6 +2419,7 @@ export class EventsSocket {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onclose(e: Event) {
     this.socket = null;
     if (this.socketKeepalive) {

--- a/frontend/www/js/omegaup/arena/contest.ts
+++ b/frontend/www/js/omegaup/arena/contest.ts
@@ -48,7 +48,9 @@ OmegaUp.on('ready', () => {
 
   const onlyProblemUpdateRuns = (
     runs: types.Run[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     scoreColumn: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     multiplier: number,
   ): void => {
     for (const run of runs) {
@@ -135,14 +137,14 @@ OmegaUp.on('ready', () => {
     });
   }
 
-  $('#clarification').on('submit', (e) => {
+  $('#clarification').on('submit', () => {
     $('#clarification input').attr('disabled', 'disabled');
     api.Clarification.create({
       contest_alias: arenaInstance.options.contestAlias,
       problem_alias: $('#clarification select[name="problem"]').val(),
       message: $('#clarification textarea[name="message"]').val(),
     })
-      .then((response) => {
+      .then(() => {
         arenaInstance.hideOverlay();
         arenaInstance.refreshClarifications();
       })

--- a/frontend/www/js/omegaup/arena/contest_list.ts
+++ b/frontend/www/js/omegaup/arena/contest_list.ts
@@ -1,7 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import * as time from '../time';
 import { types } from '../api_types';
-import T from '../lang';
 import Vue from 'vue';
 import arena_ContestList from '../components/arena/ContestList.vue';
 
@@ -19,7 +18,7 @@ OmegaUp.on('ready', () => {
       contest.start_time = time.remoteDate(contest.start_time);
     });
   }
-  const contestList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-arena-contestlist', {

--- a/frontend/www/js/omegaup/badge/details.ts
+++ b/frontend/www/js/omegaup/badge/details.ts
@@ -5,7 +5,7 @@ import { types } from '../api_types';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.BadgeDetailsPayload();
-  const badgeDetails = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-badge-details', {

--- a/frontend/www/js/omegaup/badge/list.ts
+++ b/frontend/www/js/omegaup/badge/list.ts
@@ -6,7 +6,7 @@ import badge_List from '../components/badge/List.vue';
 
 OmegaUp.on('ready', function () {
   const payload = types.payloadParsers.BadgeListPayload();
-  const badgeList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-badge-list', {

--- a/frontend/www/js/omegaup/certificate/details.ts
+++ b/frontend/www/js/omegaup/certificate/details.ts
@@ -5,7 +5,7 @@ import { types } from '../api_types';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CertificateDetailsPayload();
-  const certificateDetails = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-certificate-details', {

--- a/frontend/www/js/omegaup/common/footer_v2.ts
+++ b/frontend/www/js/omegaup/common/footer_v2.ts
@@ -6,7 +6,7 @@ import Vue from 'vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CommonPayload();
 
-  const commonFooter = new Vue({
+  new Vue({
     el: '#common-footer',
     render: function (createElement) {
       return createElement('omegaup-common-footer', {

--- a/frontend/www/js/omegaup/common/index.ts
+++ b/frontend/www/js/omegaup/common/index.ts
@@ -15,7 +15,7 @@ OmegaUp.on('ready', () => {
     problems_solved: user.problems_solved,
   }));
 
-  const commonIndex = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-homepage', {

--- a/frontend/www/js/omegaup/common/navbar_v2.ts
+++ b/frontend/www/js/omegaup/common/navbar_v2.ts
@@ -1,8 +1,7 @@
 import common_NavbarV2 from '../components/common/Navbarv2.vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import * as api from '../api';
 import { types } from '../api_types';
-import T from '../lang';
 import * as ui from '../ui';
 import Vue from 'vue';
 

--- a/frontend/www/js/omegaup/components/Autocomplete.vue
+++ b/frontend/www/js/omegaup/components/Autocomplete.vue
@@ -43,7 +43,7 @@ export default class Autocomplete extends Vue {
   }
 
   @Watch('value')
-  onPropertyChanged(newValue: string, oldValue: string) {
+  onPropertyChanged(newValue: string) {
     this.input.value = newValue;
   }
 }

--- a/frontend/www/js/omegaup/components/DateTimePicker.vue
+++ b/frontend/www/js/omegaup/components/DateTimePicker.vue
@@ -55,7 +55,7 @@ export default class DateTimePicker extends Vue {
         defaultDate: self.value,
         locale: T.locale,
       })
-      .on('change', (ev) => {
+      .on('change', () => {
         self.$emit('input', $(self.$el).data('datetimepicker').getDate());
       });
 

--- a/frontend/www/js/omegaup/components/Markdown.test.ts
+++ b/frontend/www/js/omegaup/components/Markdown.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import omegaup_Markdown from './Markdown.vue';
 

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -213,7 +213,7 @@ export default class Markdown extends Vue {
   }
 
   @Watch('markdown')
-  onMarkdownChanged(val: string, oldVal: string) {
+  onMarkdownChanged() {
     this.renderMathJax();
   }
 

--- a/frontend/www/js/omegaup/components/activity/Feed.test.ts
+++ b/frontend/www/js/omegaup/components/activity/Feed.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 

--- a/frontend/www/js/omegaup/components/activity/Feed.vue
+++ b/frontend/www/js/omegaup/components/activity/Feed.vue
@@ -209,8 +209,6 @@ interface Origin {
   }[];
 }
 
-const availableTabs = ['report', 'users', 'origins'];
-
 @Component({
   components: {
     'omegaup-user-username': user_Username,

--- a/frontend/www/js/omegaup/components/arena/Clarification.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Clarification.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import arena_Clarification from './Clarification.vue';
 

--- a/frontend/www/js/omegaup/components/arena/ClarificationList.test.ts
+++ b/frontend/www/js/omegaup/components/arena/ClarificationList.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import arena_ClarificationList from './ClarificationList.vue';
 

--- a/frontend/www/js/omegaup/components/arena/ClarificationList.vue
+++ b/frontend/www/js/omegaup/components/arena/ClarificationList.vue
@@ -124,7 +124,6 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
 import { types } from '../../api_types';
-import * as ui from '../../ui';
 
 import arena_Clarification from './Clarification.vue';
 

--- a/frontend/www/js/omegaup/components/arena/CodeView.vue
+++ b/frontend/www/js/omegaup/components/arena/CodeView.vue
@@ -21,7 +21,6 @@
 <script lang="ts">
 import { Vue, Component, Prop, Ref, Watch } from 'vue-property-decorator';
 import T from '../../lang';
-import * as ui from '../../ui';
 import { codemirror } from 'vue-codemirror-lite';
 
 const languageModeMap: {

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -225,7 +225,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import contest_FilteredList from '../contest/FilteredList.vue';

--- a/frontend/www/js/omegaup/components/arena/ContestSummary.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestSummary.vue
@@ -67,9 +67,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import { types } from '../../api_types';
 import { omegaup } from '../../omegaup';
 import * as ui from '../../ui';
 import * as time from '../../time';

--- a/frontend/www/js/omegaup/components/arena/DiffView.test.ts
+++ b/frontend/www/js/omegaup/components/arena/DiffView.test.ts
@@ -1,8 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
-
-import { omegaup } from '../../omegaup';
 
 import arena_DiffView from './DiffView.vue';
 

--- a/frontend/www/js/omegaup/components/arena/NavbarProblems.test.ts
+++ b/frontend/www/js/omegaup/components/arena/NavbarProblems.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';

--- a/frontend/www/js/omegaup/components/arena/RunDetails.test.ts
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/arena/RunDetails.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.vue
@@ -297,7 +297,6 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { types } from '../../api_types';
-import * as ui from '../../ui';
 import T from '../../lang';
 import arena_CodeView from './CodeView.vue';
 import arena_DiffView from './DiffView.vue';

--- a/frontend/www/js/omegaup/components/arena/RunSubmit.test.ts
+++ b/frontend/www/js/omegaup/components/arena/RunSubmit.test.ts
@@ -1,6 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/arena/RunSubmit.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmit.vue
@@ -228,7 +228,7 @@ export default class ArenaRunSubmit extends Vue {
     this.selectedLanguage = newValue;
   }
 
-  onSubmit(ev: Event): void {
+  onSubmit(): void {
     if (!this.canSubmit) {
       alert(
         ui.formatString(T.arenaRunSubmitWaitBetweenUploads, {

--- a/frontend/www/js/omegaup/components/arena/Runs.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Runs.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import arena_Runs from './Runs.vue';
 

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -348,6 +348,7 @@ library.add(faExternalLinkAlt);
 library.add(faTimes);
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface JQuery {
     popover(action: string): JQuery;
   }
@@ -584,7 +585,7 @@ export default class Runs extends Vue {
   }
 
   @Watch('username')
-  onUsernameChanged(newValue: string | null, oldValue: string | null) {
+  onUsernameChanged(newValue: string | null) {
     if (!newValue) {
       this.filterUsername = '';
     } else {
@@ -593,7 +594,7 @@ export default class Runs extends Vue {
   }
 
   @Watch('problemAlias')
-  onProblemAliasChanged(newValue: string | null, oldValue: string | null) {
+  onProblemAliasChanged(newValue: string | null) {
     if (!newValue) {
       this.filterProblem = '';
     } else {
@@ -602,32 +603,32 @@ export default class Runs extends Vue {
   }
 
   @Watch('filterLanguage')
-  onFilterLanguageChanged(newValue: string, oldValue: string) {
+  onFilterLanguageChanged(newValue: string) {
     this.onEmitFilterChanged(newValue, 'language');
   }
 
   @Watch('filterOffset')
-  onFilterOffsetChanged(newValue: number, oldValue: number) {
+  onFilterOffsetChanged() {
     this.$emit('filter-changed');
   }
 
   @Watch('filterProblem')
-  onFilterProblemChanged(newValue: string, oldValue: number) {
+  onFilterProblemChanged(newValue: string) {
     this.onEmitFilterChanged(newValue, 'problem');
   }
 
   @Watch('filterStatus')
-  onFilterStatusChanged(newValue: string, oldValue: number) {
+  onFilterStatusChanged(newValue: string) {
     this.onEmitFilterChanged(newValue, 'status');
   }
 
   @Watch('filterUsername')
-  onFilterUsernameChanged(newValue: string, oldValue: number) {
+  onFilterUsernameChanged(newValue: string) {
     this.onEmitFilterChanged(newValue, 'username');
   }
 
   @Watch('filterVerdict')
-  onFilterVerdictChanged(newValue: string, oldValue: number) {
+  onFilterVerdictChanged(newValue: string) {
     this.onEmitFilterChanged(newValue, 'verdict');
   }
 

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.test.ts
@@ -1,11 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
-import T from '../../lang';
 import { omegaup } from '../../omegaup';
-import { types } from '../../api_types';
-import * as ui from '../../ui';
 
 import arena_Scoreboard from './Scoreboard.vue';
 

--- a/frontend/www/js/omegaup/components/badge/List.test.ts
+++ b/frontend/www/js/omegaup/components/badge/List.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount, mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';

--- a/frontend/www/js/omegaup/components/common/Admins.test.ts
+++ b/frontend/www/js/omegaup/components/common/Admins.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import common_Admins from './Admins.vue';
 

--- a/frontend/www/js/omegaup/components/common/Confirmation.vue
+++ b/frontend/www/js/omegaup/components/common/Confirmation.vue
@@ -59,8 +59,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
-import T from '../../lang';
 
 @Component
 export default class Paginator extends Vue {

--- a/frontend/www/js/omegaup/components/common/GroupAdmins.test.ts
+++ b/frontend/www/js/omegaup/components/common/GroupAdmins.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import common_GroupAdmins from './GroupAdmins.vue';
 

--- a/frontend/www/js/omegaup/components/common/Navbar.test.ts
+++ b/frontend/www/js/omegaup/components/common/Navbar.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import * as ui from '../../ui';
 
 import common_Navbar from './Navbar.vue';
 

--- a/frontend/www/js/omegaup/components/common/Navbarv2.test.ts
+++ b/frontend/www/js/omegaup/components/common/Navbarv2.test.ts
@@ -1,29 +1,9 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import * as ui from '../../ui';
 
 import common_Navbarv2 from './Navbarv2.vue';
-
-const baseNavbarProps = {
-  currentUsername: 'user',
-  errorMessage: null,
-  graderInfo: null,
-  graderQueueLength: -1,
-  gravatarURL51:
-    'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
-  inContest: true,
-  initialClarifications: [],
-  isAdmin: false,
-  isLoggedIn: true,
-  isMainUserIdentity: true,
-  isReviewer: false,
-  lockDownImage: 'data:image/png;base64...',
-  navbarSection: '',
-  omegaUpLockDown: false,
-};
 
 describe('Navbarv2.vue', () => {
   it('Should handle empty navbar (in contest only)', async () => {

--- a/frontend/www/js/omegaup/components/common/Paginator.vue
+++ b/frontend/www/js/omegaup/components/common/Paginator.vue
@@ -25,7 +25,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import { types } from '../../api_types';
 

--- a/frontend/www/js/omegaup/components/common/Paginatorv2.vue
+++ b/frontend/www/js/omegaup/components/common/Paginatorv2.vue
@@ -28,7 +28,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import { types } from '../../api_types';
 

--- a/frontend/www/js/omegaup/components/common/Publishv2.test.ts
+++ b/frontend/www/js/omegaup/components/common/Publishv2.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import * as ui from '../../ui';
 
 import common_Publish from './Publishv2.vue';
 

--- a/frontend/www/js/omegaup/components/common/SortControls.test.ts
+++ b/frontend/www/js/omegaup/components/common/SortControls.test.ts
@@ -1,9 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
-
-import T from '../../lang';
-import * as ui from '../../ui';
 
 import common_SortControls from './SortControls.vue';
 

--- a/frontend/www/js/omegaup/components/common/Stats.test.ts
+++ b/frontend/www/js/omegaup/components/common/Stats.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/contest/AddProblemv2.test.ts
+++ b/frontend/www/js/omegaup/components/contest/AddProblemv2.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import contest_AddProblem from './AddProblemv2.vue';
 

--- a/frontend/www/js/omegaup/components/contest/Clone.vue
+++ b/frontend/www/js/omegaup/components/contest/Clone.vue
@@ -52,9 +52,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 import T from '../../lang';
-import * as ui from '../../ui';
 import DateTime from '../DateTimePicker.vue';
 
 @Component({

--- a/frontend/www/js/omegaup/components/contest/Contestant.vue
+++ b/frontend/www/js/omegaup/components/contest/Contestant.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Emit, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 
 import { omegaup } from '../../omegaup';
 import T from '../../lang';

--- a/frontend/www/js/omegaup/components/contest/Editv2.vue
+++ b/frontend/www/js/omegaup/components/contest/Editv2.vue
@@ -158,7 +158,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup, OmegaUp } from '../../omegaup';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/contest/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/contest/FilteredList.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/contest/Mine.test.ts
+++ b/frontend/www/js/omegaup/components/contest/Mine.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import contest_Mine from './Mine.vue';
 

--- a/frontend/www/js/omegaup/components/contest/Mine.vue
+++ b/frontend/www/js/omegaup/components/contest/Mine.vue
@@ -179,7 +179,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/course/AddStudents.test.ts
+++ b/frontend/www/js/omegaup/components/course/AddStudents.test.ts
@@ -1,8 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
-import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 

--- a/frontend/www/js/omegaup/components/course/AdmissionMode.vue
+++ b/frontend/www/js/omegaup/components/course/AdmissionMode.vue
@@ -103,7 +103,7 @@ export default class CourseAdmissionMode extends Vue {
   }
 
   @Watch('copiedToClipboard')
-  onPropertyChanged(newValue: boolean): void {
+  onPropertyChanged(): void {
     setTimeout(() => (this.copiedToClipboard = false), 5000);
   }
 

--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.test.ts
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.test.ts
@@ -1,10 +1,8 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';
-import { types } from '../../api_types';
 
 import course_AssignmentDetails from './AssignmentDetails.vue';
 

--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
@@ -314,7 +314,7 @@ export default class CourseAssignmentDetails extends Vue {
   }
 
   @Watch('show')
-  onShowChanged(newValue: boolean): void {
+  onShowChanged(): void {
     this.reset();
   }
 

--- a/frontend/www/js/omegaup/components/course/AssignmentList.test.ts
+++ b/frontend/www/js/omegaup/components/course/AssignmentList.test.ts
@@ -1,6 +1,5 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 import Sortable from 'sortablejs';
 
 import T from '../../lang';

--- a/frontend/www/js/omegaup/components/course/CardsList.test.ts
+++ b/frontend/www/js/omegaup/components/course/CardsList.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/course/Clone.test.ts
+++ b/frontend/www/js/omegaup/components/course/Clone.test.ts
@@ -1,8 +1,5 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
-
-import T from '../../lang';
 
 import course_Clone from './Clone.vue';
 

--- a/frontend/www/js/omegaup/components/course/CloneWithToken.test.ts
+++ b/frontend/www/js/omegaup/components/course/CloneWithToken.test.ts
@@ -1,7 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
-import T from '../../lang';
 import { types } from '../../api_types';
 
 import course_CloneWithToken from './CloneWithToken.vue';

--- a/frontend/www/js/omegaup/components/course/CourseCard.test.ts
+++ b/frontend/www/js/omegaup/components/course/CourseCard.test.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/course/Details.test.ts
+++ b/frontend/www/js/omegaup/components/course/Details.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -226,7 +226,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
 import * as time from '../../time';
@@ -271,6 +270,7 @@ export default class CourseDetails extends Vue {
   get overallCompletedPercentage(): string {
     let score = 0;
     let maxScore = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const [assignment, progress] of Object.entries(this.progress)) {
       score += progress.score;
       maxScore += progress.max_score;

--- a/frontend/www/js/omegaup/components/course/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/course/Edit.test.ts
@@ -1,9 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
-import T from '../../lang';
-import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 
 import course_Edit from './Edit.vue';

--- a/frontend/www/js/omegaup/components/course/FilteredList.test.ts
+++ b/frontend/www/js/omegaup/components/course/FilteredList.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 
 import course_FilteredList from './FilteredList.vue';

--- a/frontend/www/js/omegaup/components/course/FilteredList.vue
+++ b/frontend/www/js/omegaup/components/course/FilteredList.vue
@@ -114,7 +114,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as time from '../../time';

--- a/frontend/www/js/omegaup/components/course/Form.test.ts
+++ b/frontend/www/js/omegaup/components/course/Form.test.ts
@@ -1,7 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import { types } from '../../api_types';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -177,7 +177,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as typeahead from '../../typeahead';

--- a/frontend/www/js/omegaup/components/course/List.test.ts
+++ b/frontend/www/js/omegaup/components/course/List.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/course/Mine.vue
+++ b/frontend/www/js/omegaup/components/course/Mine.vue
@@ -21,7 +21,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import { types } from '../../api_types';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/course/ProblemList.test.ts
+++ b/frontend/www/js/omegaup/components/course/ProblemList.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';

--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -303,7 +303,7 @@ export default class CourseProblemList extends Vue {
   }
 
   @Watch('problems')
-  onProblemsChange(newVal: types.AddedProblem): void {
+  onProblemsChange(): void {
     this.reset();
   }
 

--- a/frontend/www/js/omegaup/components/course/ScheduledProblemList.test.ts
+++ b/frontend/www/js/omegaup/components/course/ScheduledProblemList.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';

--- a/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
@@ -155,7 +155,7 @@ export default class CourseScheduledProblemList extends Vue {
   }
 
   @Watch('problems')
-  onProblemsChange(newVal: types.AddedProblem): void {
+  onProblemsChange(): void {
     this.reset();
   }
 

--- a/frontend/www/js/omegaup/components/course/Statistics.vue
+++ b/frontend/www/js/omegaup/components/course/Statistics.vue
@@ -20,10 +20,9 @@
 
 <script lang="ts">
 import { Chart } from 'highcharts-vue';
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
-import * as ui from '../../ui';
 
 const ORDERED_VERDICTS = [
   'AC',

--- a/frontend/www/js/omegaup/components/course/StudentProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.test.ts
@@ -1,7 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
-import T from '../../lang';
 import { omegaup } from '../../omegaup';
 
 import course_StudentProgress from './StudentProgress.vue';

--- a/frontend/www/js/omegaup/components/course/StudentProgress.vue
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.vue
@@ -65,7 +65,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
@@ -14,6 +14,7 @@ import { types } from '../../api_types';
 describe('ViewProgress.vue', () => {
   if (typeof window.URL.createObjectURL === 'undefined') {
     Object.defineProperty(window.URL, 'createObjectURL', {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       value: (obj: any) => '',
       writable: true,
     });
@@ -70,17 +71,11 @@ describe('ViewProgress.vue', () => {
   });
 
   it('Should handle escaped csv cells', () => {
-    const wrapper = shallowMount(course_ViewProgress, {
-      propsData: baseViewProgressProps,
-    });
     const escapedCell = escapeCsv('Escaped "text"');
     expect(escapedCell).toBe('"Escaped ""text""');
   });
 
   it('Should handle escaped xml cells', () => {
-    const wrapper = shallowMount(course_ViewProgress, {
-      propsData: baseViewProgressProps,
-    });
     const escapedXml = escapeXml('Escaped <text>');
     expect(escapedXml).toBe('Escaped &lt;text&gt;');
   });

--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -75,7 +75,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 import T from '../../lang';

--- a/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
@@ -1,6 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';

--- a/frontend/www/js/omegaup/components/course/ViewStudent.vue
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.vue
@@ -156,6 +156,7 @@ export default class CourseViewStudent extends Vue {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   points(assignmentAlias: string): number {
     return this.problems.reduce(
       (accumulator: number, problem: types.CourseProblem) =>
@@ -230,7 +231,7 @@ export default class CourseViewStudent extends Vue {
   }
 
   @Watch('selectedAssignment')
-  onSelectedAssignmentChange(newVal: string) {
+  onSelectedAssignmentChange() {
     this.$emit('update', this.selectedStudent, this.selectedAssignment);
   }
 

--- a/frontend/www/js/omegaup/components/group/GroupList.vue
+++ b/frontend/www/js/omegaup/components/group/GroupList.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 

--- a/frontend/www/js/omegaup/components/group/Identities.vue
+++ b/frontend/www/js/omegaup/components/group/Identities.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/components/group/Members.vue
+++ b/frontend/www/js/omegaup/components/group/Members.vue
@@ -117,7 +117,7 @@ label {
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as typeahead from '../../typeahead';

--- a/frontend/www/js/omegaup/components/homepage/Carousel.vue
+++ b/frontend/www/js/omegaup/components/homepage/Carousel.vue
@@ -57,7 +57,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 import T from '../../lang';
 import homepageSlide from './Slide.vue';
 import carouselConfig from '../../carousel.config';

--- a/frontend/www/js/omegaup/components/homepage/CoderOfTheMonth.vue
+++ b/frontend/www/js/omegaup/components/homepage/CoderOfTheMonth.vue
@@ -78,7 +78,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import user_Username from '../user/Username.vue';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/homepage/Testimonials.vue
+++ b/frontend/www/js/omegaup/components/homepage/Testimonials.vue
@@ -77,7 +77,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 import T from '../../lang';
 import testimonialsConfig from '../../testimonials.config';
 

--- a/frontend/www/js/omegaup/components/identity/Edit.vue
+++ b/frontend/www/js/omegaup/components/identity/Edit.vue
@@ -137,7 +137,7 @@ export default class IdentityEdit extends Vue {
   T = T;
 
   @Watch('selectedCountry')
-  onPropertyChanged(newContry: string, oldCountry: string) {
+  onPropertyChanged(newContry: string) {
     if (this.identity.country_id == newContry) {
       this.selectedState = this.identity.state_id;
     } else {

--- a/frontend/www/js/omegaup/components/login/PasswordRecover.vue
+++ b/frontend/www/js/omegaup/components/login/PasswordRecover.vue
@@ -24,8 +24,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
+import { Vue, Component } from 'vue-property-decorator';
 import T from '../../lang';
 
 @Component

--- a/frontend/www/js/omegaup/components/login/PasswordReset.vue
+++ b/frontend/www/js/omegaup/components/login/PasswordReset.vue
@@ -44,8 +44,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
 
 @Component

--- a/frontend/www/js/omegaup/components/notification/Clarifications.vue
+++ b/frontend/www/js/omegaup/components/notification/Clarifications.vue
@@ -146,10 +146,7 @@ export default class Clarifications extends Vue {
   clarifications: types.Clarification[] = this.initialClarifications;
 
   @Watch('initialClarifications')
-  onPropertyChanged(
-    newValue: types.Clarification[],
-    oldValue: types.Clarification[],
-  ): void {
+  onPropertyChanged(newValue: types.Clarification[]): void {
     this.clarifications = newValue;
     const audio = <HTMLMediaElement>(
       document.getElementById('notification-audio')
@@ -160,10 +157,7 @@ export default class Clarifications extends Vue {
   }
 
   @Watch('clarifications')
-  onPropertyChange(
-    newValue: types.Clarification[],
-    oldValue: types.Clarification[],
-  ): void {
+  onPropertyChange(newValue: types.Clarification[]): void {
     if (newValue.length > 0) {
       if (this.flashInterval) return;
       this.flashInterval = setInterval(this.flashTitle, 1000);

--- a/frontend/www/js/omegaup/components/notification/Notification.test.ts
+++ b/frontend/www/js/omegaup/components/notification/Notification.test.ts
@@ -1,10 +1,5 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
-
-import T from '../../lang';
-import * as ui from '../../ui';
-import { omegaup } from '../../omegaup';
 
 import notification_Notification from './Notification.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Collection.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Collection.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_collection from './Collection.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Edit.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_Edit from './Edit.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -254,7 +254,6 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import problem_Settings from './Settings.vue';
 import problem_Tags from './Tags.vue';
 import T from '../../lang';
-import * as ui from '../../ui';
 import latinize from 'latinize';
 import { types } from '../../api_types';
 
@@ -364,6 +363,7 @@ export default class ProblemForm extends Vue {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   removeTag(alias: string, tagname: string, isPublic: boolean): void {
     this.selectedTags = this.selectedTags.filter(
       (tag) => tag.tagname !== tagname,

--- a/frontend/www/js/omegaup/components/problem/List.test.ts
+++ b/frontend/www/js/omegaup/components/problem/List.test.ts
@@ -1,9 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
-
-import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_List from './List.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Mine.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Mine.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_Mine from './Mine.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Mine.vue
+++ b/frontend/www/js/omegaup/components/problem/Mine.vue
@@ -146,7 +146,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
 import { types } from '../../api_types';
 import common_Paginator from '../common/Paginatorv2.vue';

--- a/frontend/www/js/omegaup/components/problem/SearchBar.test.ts
+++ b/frontend/www/js/omegaup/components/problem/SearchBar.test.ts
@@ -1,9 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_SearchBar from './SearchBar.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Settings.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Settings.test.ts
@@ -1,8 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
-import { types } from '../../api_types';
 import T from '../../lang';
 
 import problem_Settings from './Settings.vue';

--- a/frontend/www/js/omegaup/components/problem/SettingsSummary.test.ts
+++ b/frontend/www/js/omegaup/components/problem/SettingsSummary.test.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import { types } from '../../api_types';
 import T from '../../lang';

--- a/frontend/www/js/omegaup/components/problem/SettingsSummary.vue
+++ b/frontend/www/js/omegaup/components/problem/SettingsSummary.vue
@@ -82,7 +82,6 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import * as ui from '../../ui';
 import { types } from '../../api_types';
 
 @Component

--- a/frontend/www/js/omegaup/components/problem/SettingsSummaryV2.test.ts
+++ b/frontend/www/js/omegaup/components/problem/SettingsSummaryV2.test.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import { types } from '../../api_types';
 import T from '../../lang';

--- a/frontend/www/js/omegaup/components/problem/SettingsSummaryV2.vue
+++ b/frontend/www/js/omegaup/components/problem/SettingsSummaryV2.vue
@@ -73,7 +73,6 @@ table td {
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
-import * as ui from '../../ui';
 import { types } from '../../api_types';
 
 import { library } from '@fortawesome/fontawesome-svg-core';

--- a/frontend/www/js/omegaup/components/problem/Solution.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Solution.test.ts
@@ -1,10 +1,8 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import { types } from '../../api_types';
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_Solution from './Solution.vue';
 

--- a/frontend/www/js/omegaup/components/problem/StatementEdit.vue
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.vue
@@ -107,7 +107,6 @@
 
 <script lang="ts">
 import { Vue, Component, Emit, Prop, Watch, Ref } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as ui from '../../ui';
@@ -191,10 +190,7 @@ export default class ProblemStatementEdit extends Vue {
 
   @Emit('update:statement')
   @Watch('currentMarkdown')
-  onCurrentMarkdownChange(
-    newMarkdown: string,
-    oldMarkdown: string,
-  ): types.ProblemStatement {
+  onCurrentMarkdownChange(newMarkdown: string): types.ProblemStatement {
     return {
       images: this.statement.images,
       language: this.statement.language,

--- a/frontend/www/js/omegaup/components/problem/Tags.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Tags.test.ts
@@ -1,10 +1,7 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
-import { types } from '../../api_types';
 import T from '../../lang';
-import { omegaup } from '../../omegaup';
 
 import problem_Tags from './Tags.vue';
 

--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -244,18 +244,13 @@ input:checked + .slider:before {
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
 import T from '../../lang';
-import { types } from '../../api_types';
 import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 library.add(faTrash);
-
-import 'v-tooltip/dist/v-tooltip.css';
-import { VTooltip } from 'v-tooltip';
 
 @Component({
   components: {

--- a/frontend/www/js/omegaup/components/problem/Versions.vue
+++ b/frontend/www/js/omegaup/components/problem/Versions.vue
@@ -254,12 +254,12 @@ export default class ProblemVersions extends Vue {
   }
 
   @Watch('value')
-  onValueChange(newValue: omegaup.Commit, oldValue: omegaup.Commit) {
+  onValueChange(newValue: omegaup.Commit) {
     this.selectedRevision = newValue;
   }
 
   @Watch('selectedRevision')
-  onSelectedRevisionChange(newValue: omegaup.Commit, oldValue: omegaup.Commit) {
+  onSelectedRevisionChange(newValue: omegaup.Commit) {
     this.$emit('input', this.selectedRevision);
     if (!newValue || this.runsDiff.hasOwnProperty(newValue.version)) {
       return;

--- a/frontend/www/js/omegaup/components/qualitynomination/DemotionPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/DemotionPopup.vue
@@ -125,7 +125,7 @@
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 import T from '../../lang';
 import * as ui from '../../ui';
 

--- a/frontend/www/js/omegaup/components/qualitynomination/List.test.ts
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.test.ts
@@ -1,7 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 import T from '../../lang';
-import * as ui from '../../ui';
 import qualitynomination_List from './List.vue';
 import { types } from '../../api_types';
 

--- a/frontend/www/js/omegaup/components/qualitynomination/List.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.vue
@@ -123,8 +123,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Emit, Watch } from 'vue-property-decorator';
-import { omegaup } from '../../omegaup';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
 import * as ui from '../../ui';
 import common_Paginator from '../common/Paginatorv2.vue';

--- a/frontend/www/js/omegaup/components/qualitynomination/Popup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/Popup.vue
@@ -362,12 +362,12 @@ export default class QualityNominationPopup extends Vue {
   }
 
   @Watch('dismissed')
-  onDismissedChange(newValue: boolean, oldValue: boolean) {
+  onDismissedChange(newValue: boolean) {
     this.localDismissed = newValue;
   }
 
   @Watch('nominated')
-  onNominatedChange(newValue: boolean, oldValue: boolean) {
+  onNominatedChange(newValue: boolean) {
     this.localNominated = newValue;
   }
 }

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
@@ -64,11 +64,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 import Popup from './Popup.vue';
 import omegaup_RadioSwitch from '../RadioSwitch.vue';
 import T from '../../lang';
-import * as ui from '../../ui';
 
 @Component({
   components: {

--- a/frontend/www/js/omegaup/components/schoolofthemonth/List.test.ts
+++ b/frontend/www/js/omegaup/components/schoolofthemonth/List.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import Vue from 'vue';
 
 import T from '../../lang';
 

--- a/frontend/www/js/omegaup/components/schools/Intro.vue
+++ b/frontend/www/js/omegaup/components/schools/Intro.vue
@@ -62,7 +62,7 @@ body {
 </style>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 import T from '../../lang';
 

--- a/frontend/www/js/omegaup/components/user/AuthorsRank.vue
+++ b/frontend/www/js/omegaup/components/user/AuthorsRank.vue
@@ -51,7 +51,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { OmegaUp } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
 import user_Username from '../user/Username.vue';

--- a/frontend/www/js/omegaup/components/user/Charts.vue
+++ b/frontend/www/js/omegaup/components/user/Charts.vue
@@ -46,7 +46,6 @@
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { Chart } from 'highcharts-vue';
-import * as Highcharts from 'highcharts';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
@@ -157,7 +156,6 @@ export default class UserCharts extends Vue {
   }
 
   get normalizedRunCounts(): NormalizedRunCounts[] {
-    const total = this.totalRuns;
     const stats = this.data.runs;
     const runs = stats.reduce(
       (total: omegaup.Run, amount: omegaup.RunInfo) => {

--- a/frontend/www/js/omegaup/components/user/Chartsv2.vue
+++ b/frontend/www/js/omegaup/components/user/Chartsv2.vue
@@ -46,7 +46,6 @@
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { Chart } from 'highcharts-vue';
-import * as Highcharts from 'highcharts';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
@@ -157,7 +156,6 @@ export default class UserCharts extends Vue {
   }
 
   get normalizedRunCounts(): NormalizedRunCounts[] {
-    const total = this.totalRuns;
     const stats = this.data.runs;
     const runs = stats.reduce(
       (total: omegaup.Run, amount: omegaup.RunInfo) => {

--- a/frontend/www/js/omegaup/components/user/Rank.vue
+++ b/frontend/www/js/omegaup/components/user/Rank.vue
@@ -95,7 +95,6 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import { OmegaUp } from '../../omegaup';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as ui from '../../ui';

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -4,7 +4,6 @@ import Vue from 'vue';
 import T from '../lang';
 import contest_Edit from '../components/contest/Editv2.vue';
 import contest_AddProblem from '../components/contest/AddProblemv2.vue';
-import problem_Versions from '../components/problem/Versions.vue';
 import * as ui from '../ui';
 import * as api from '../api';
 

--- a/frontend/www/js/omegaup/contest/intro.ts
+++ b/frontend/www/js/omegaup/contest/intro.ts
@@ -1,6 +1,5 @@
 import { omegaup, OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import T from '../lang';
 import Vue from 'vue';
 import contest_Intro from '../components/contest/Intro.vue';
 import * as ui from '../ui';
@@ -9,7 +8,7 @@ import * as api from '../api';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ContestIntroPayload();
   const headerPayload = types.payloadParsers.CommonPayload();
-  const contestIntro = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-contest-intro', {

--- a/frontend/www/js/omegaup/contest/new.ts
+++ b/frontend/www/js/omegaup/contest/new.ts
@@ -1,6 +1,5 @@
 import { omegaup, OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import T from '../lang';
 import Vue from 'vue';
 import contest_NewForm from '../components/contest/NewForm.vue';
 import * as ui from '../ui';
@@ -10,7 +9,7 @@ OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ContestNewPayload();
   const startTime = new Date();
   const finishTime = new Date(startTime.getTime() + 5 * 60 * 60 * 1000);
-  const contestNew = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-contest-new', {
@@ -24,7 +23,7 @@ OmegaUp.on('ready', () => {
         on: {
           'create-contest': (contest: omegaup.Contest): void => {
             api.Contest.create(contest)
-              .then((data) => {
+              .then(() => {
                 this.invalidParameterName = null;
                 window.location.replace(
                   `/contest/${contest.alias}/edit/#problems`,

--- a/frontend/www/js/omegaup/contest/print.ts
+++ b/frontend/www/js/omegaup/contest/print.ts
@@ -12,7 +12,7 @@ import omegaup_Markdown from '../components/Markdown.vue';
       )
     );
 
-    const contestIntro = new Vue({
+    new Vue({
       el: <HTMLElement>problem.querySelector('div.statement'),
       render: function (createElement) {
         return createElement('omegaup-markdown', {

--- a/frontend/www/js/omegaup/course/assignment_edit.ts
+++ b/frontend/www/js/omegaup/course/assignment_edit.ts
@@ -1,5 +1,5 @@
 import { omegaup, OmegaUp } from '../omegaup';
-import { messages, types } from '../api_types';
+import { types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
 import T from '../lang';
@@ -9,7 +9,7 @@ import course_AssignmentDetails from '../components/course/AssignmentDetails.vue
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CourseAssignmentEditPayload();
   const courseAlias = payload.course.alias;
-  const courseEdit = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-edit', {

--- a/frontend/www/js/omegaup/course/clone.ts
+++ b/frontend/www/js/omegaup/course/clone.ts
@@ -32,7 +32,7 @@ OmegaUp.on('ready', () => {
               token: token,
               start_time: startTime.getTime() / 1000,
             })
-              .then((data) => {
+              .then(() => {
                 ui.success(
                   ui.formatString(T.courseEditCourseClonedSuccessfully, {
                     course_alias: alias,

--- a/frontend/www/js/omegaup/course/details.ts
+++ b/frontend/www/js/omegaup/course/details.ts
@@ -8,7 +8,7 @@ import T from '../lang';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CourseDetailsPayload();
-  const courseDetails = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-details', {
@@ -24,7 +24,7 @@ OmegaUp.on('ready', () => {
               alias: alias,
               start_time: startTime.getTime() / 1000,
             })
-              .then((data) => {
+              .then(() => {
                 ui.success(
                   ui.formatString(T.courseEditCourseClonedSuccessfully, {
                     course_alias: alias,

--- a/frontend/www/js/omegaup/course/edit.ts
+++ b/frontend/www/js/omegaup/course/edit.ts
@@ -32,7 +32,7 @@ OmegaUp.on('ready', () => {
         },
         on: {
           'submit-edit-course': (source: course_Form) => {
-            new Promise<number | null>((accept, reject) => {
+            new Promise<number | null>((accept) => {
               if (source.school_id !== undefined) {
                 accept(source.school_id);
               } else if (source.school_name) {
@@ -156,7 +156,7 @@ OmegaUp.on('ready', () => {
               course_alias: courseAlias,
               assignment_alias: assignment.alias,
             })
-              .then((data) => {
+              .then(() => {
                 ui.success(T.courseAssignmentDeleted);
                 this.refreshAssignmentsList();
               })
@@ -236,7 +236,7 @@ OmegaUp.on('ready', () => {
               problem_alias: problem.alias,
               assignment_alias: assignment.alias,
             })
-              .then((response) => {
+              .then(() => {
                 ui.success(T.courseAssignmentProblemRemoved);
                 this.refreshProblemList(assignment);
               })
@@ -258,7 +258,7 @@ OmegaUp.on('ready', () => {
           },
           'tags-problems': (tags: string[]) => {
             api.Problem.list({ tag: tags.join() })
-              .then((data) => {
+              .then(() => {
                 //this.data.taggedProblems = data.results;
               })
               .catch(ui.apiError);
@@ -319,7 +319,7 @@ OmegaUp.on('ready', () => {
               course_alias: courseAlias,
               usernameOrEmail: student.username,
             })
-              .then((data) => {
+              .then(() => {
                 this.refreshStudentList();
                 ui.success(T.courseStudentRemoved);
               })
@@ -334,7 +334,7 @@ OmegaUp.on('ready', () => {
               course_alias: courseAlias,
               usernameOrEmail: useradmin,
             })
-              .then((data) => {
+              .then(() => {
                 ui.success(T.adminAdded);
                 this.refreshCourseAdmins();
               })
@@ -345,7 +345,7 @@ OmegaUp.on('ready', () => {
               course_alias: courseAlias,
               usernameOrEmail: username,
             })
-              .then((data) => {
+              .then(() => {
                 this.refreshCourseAdmins();
                 ui.success(T.adminRemoved);
               })
@@ -356,7 +356,7 @@ OmegaUp.on('ready', () => {
               course_alias: courseAlias,
               group: groupAlias,
             })
-              .then((data) => {
+              .then(() => {
                 ui.success(T.groupAdminAdded);
                 this.refreshCourseAdmins();
               })
@@ -367,7 +367,7 @@ OmegaUp.on('ready', () => {
               course_alias: courseAlias,
               group: groupAlias,
             })
-              .then((data) => {
+              .then(() => {
                 this.refreshCourseAdmins();
                 ui.success(T.groupAdminRemoved);
               })
@@ -380,7 +380,7 @@ OmegaUp.on('ready', () => {
               alias: alias,
               start_time: startTime.getTime() / 1000,
             })
-              .then((data) => {
+              .then(() => {
                 ui.success(
                   ui.formatString(T.courseEditCourseClonedSuccessfully, {
                     course_alias: alias,
@@ -454,7 +454,7 @@ OmegaUp.on('ready', () => {
           resolution: resolution,
           note: '',
         })
-          .then((response) => {
+          .then(() => {
             ui.success(T.successfulOperation);
             courseEdit.refreshStudentList();
           })

--- a/frontend/www/js/omegaup/course/intro.ts
+++ b/frontend/www/js/omegaup/course/intro.ts
@@ -34,7 +34,7 @@ OmegaUp.on('ready', () => {
                 payload.statements.acceptTeacher?.gitObjectId,
               statement_type: payload.statements.privacy?.statementType,
             })
-              .then((data) => {
+              .then(() => {
                 window.location.replace(`/course/${payload.alias}/`);
               })
               .catch(ui.apiError);

--- a/frontend/www/js/omegaup/course/list.ts
+++ b/frontend/www/js/omegaup/course/list.ts
@@ -1,14 +1,11 @@
 import course_CardsList from '../components/course/CardsList.vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import * as api from '../api';
-import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CourseListPayload();
-  const courseCardsList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-cards-list', {

--- a/frontend/www/js/omegaup/course/mine.ts
+++ b/frontend/www/js/omegaup/course/mine.ts
@@ -1,15 +1,12 @@
 import course_List from '../components/course/Mine.vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import * as api from '../api';
-import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CourseListMinePayload();
   const headerPayload = types.payloadParsers.CommonPayload();
-  const courseList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-list', {

--- a/frontend/www/js/omegaup/course/new.ts
+++ b/frontend/www/js/omegaup/course/new.ts
@@ -1,9 +1,8 @@
 import course_Form from '../components/course/Form.vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import { messages, types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', () => {
@@ -13,7 +12,7 @@ OmegaUp.on('ready', () => {
   const defaultStartTime = now;
   const defaultFinishTime = finishTime;
   const payload = types.payloadParsers.CourseNewPayload();
-  const details = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-form', {
@@ -35,7 +34,7 @@ OmegaUp.on('ready', () => {
         },
         on: {
           submit: (source: course_Form) => {
-            new Promise<number | null>((accept, reject) => {
+            new Promise<number | null>((accept) => {
               if (source.school_id !== undefined) {
                 accept(source.school_id);
               } else if (source.school_name) {

--- a/frontend/www/js/omegaup/course/single_list.ts
+++ b/frontend/www/js/omegaup/course/single_list.ts
@@ -6,7 +6,7 @@ import Vue from 'vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CourseListPayload();
   const headerPayload = types.payloadParsers.CommonPayload();
-  const courseList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-list', {

--- a/frontend/www/js/omegaup/course/statistics.ts
+++ b/frontend/www/js/omegaup/course/statistics.ts
@@ -1,16 +1,13 @@
 import course_Statistics from '../components/course/Statistics.vue';
 import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import * as api from '../api';
-import * as ui from '../ui';
 import T from '../lang';
 import Vue from 'vue';
-import { numberFormat } from 'highcharts';
 
 OmegaUp.on('ready', function () {
   const payload = types.payloadParsers.CourseStatisticsPayload();
 
-  const viewProgress = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-statistics', {

--- a/frontend/www/js/omegaup/course/student.ts
+++ b/frontend/www/js/omegaup/course/student.ts
@@ -1,9 +1,8 @@
 import course_ViewStudent from '../components/course/ViewStudent.vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', () => {

--- a/frontend/www/js/omegaup/course/students.ts
+++ b/frontend/www/js/omegaup/course/students.ts
@@ -7,7 +7,7 @@ import Vue from 'vue';
 OmegaUp.on('ready', function () {
   const payload = types.payloadParsers.StudentsProgressPayload();
 
-  const viewProgress = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-viewprogress', {

--- a/frontend/www/js/omegaup/course/submissions_list.ts
+++ b/frontend/www/js/omegaup/course/submissions_list.ts
@@ -1,14 +1,11 @@
 import course_SubmissionsList from '../components/activity/SubmissionsList.vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import * as api from '../api';
-import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CourseSubmissionsListPayload();
-  const submissionsList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-course-submissions-list', {

--- a/frontend/www/js/omegaup/grader/SettingsComponent.vue
+++ b/frontend/www/js/omegaup/grader/SettingsComponent.vue
@@ -156,8 +156,6 @@
 </template>
 
 <script>
-import * as Util from './util';
-
 export default {
   props: {
     store: Object,

--- a/frontend/www/js/omegaup/login/logout.ts
+++ b/frontend/www/js/omegaup/login/logout.ts
@@ -27,11 +27,13 @@ OmegaUp.on('ready', () => {
       (auth: gapi.auth2.GoogleAuth) => {
         auth.signOut()['then'](
           () => redirect(),
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           (error: Promise<string>) => {
             redirect();
           },
         );
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (error: { error: string; details: string }) => {
         redirect();
       },

--- a/frontend/www/js/omegaup/login/recover.ts
+++ b/frontend/www/js/omegaup/login/recover.ts
@@ -1,13 +1,11 @@
 import { OmegaUp } from '../omegaup';
-import { types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 import login_PasswordRecover from '../components/login/PasswordRecover.vue';
 
 OmegaUp.on('ready', () => {
-  const loginPaswwordRecover = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-login-password-recover', {

--- a/frontend/www/js/omegaup/login/reset.ts
+++ b/frontend/www/js/omegaup/login/reset.ts
@@ -1,8 +1,6 @@
 import { OmegaUp } from '../omegaup';
-import { types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
-import T from '../lang';
 import Vue from 'vue';
 import login_PasswordReset from '../components/login/PasswordReset.vue';
 

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -430,8 +430,8 @@ export class Converter {
         // GitHub-flavored Markdown table.
         return text.replace(
           /^ {0,3}\|[^\n]*\|[ \t]*(\n {0,3}\|[^\n]*\|[ \t]*)+$/gm,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           (whole: string, inner: string): string => {
-            // eslint-disable-line @typescript-eslint/no-unused-vars
             let cells = whole
               .trim()
               .split('\n')

--- a/frontend/www/js/omegaup/problem/collection.ts
+++ b/frontend/www/js/omegaup/problem/collection.ts
@@ -5,7 +5,7 @@ import { OmegaUp } from '../omegaup';
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ProblemListCollectionPayload();
-  const problemCollection = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-problem-collection', {

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import problem_Details from '../components/problem/Details.vue';
 import qualitynomination_Demotion from '../components/qualitynomination/DemotionPopup.vue';
 import qualitynomination_Promotion from '../components/qualitynomination/Popup.vue';
-import { Arena, GetOptionsFromLocation } from '../arena/arena';
 import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
 import * as api from '../api';
@@ -12,7 +11,7 @@ import T from '../lang';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ProblemDetailsv2Payload();
   const locationHash = window.location.hash.substr(1).split('/');
-  const problemDetails = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-problem-details', {
@@ -91,7 +90,7 @@ OmegaUp.on('ready', () => {
               nomination: 'dismissal',
               contents: JSON.stringify(contents),
             })
-              .then((data) => {
+              .then(() => {
                 ui.info(T.qualityNominationRateProblemDesc);
               })
               .catch(ui.apiError);

--- a/frontend/www/js/omegaup/problem/edit.ts
+++ b/frontend/www/js/omegaup/problem/edit.ts
@@ -14,9 +14,6 @@ OmegaUp.on('ready', () => {
   if (payload.statusSuccess) {
     ui.success(T.problemEditUpdatedSuccessfully);
   }
-  const statements: types.Statements = {
-    [payload.statement.language]: payload.statement.markdown,
-  };
   const solutions: types.Statements = {
     [payload.statement?.language || 'es']: payload.solution?.markdown || '',
   };
@@ -44,7 +41,7 @@ OmegaUp.on('ready', () => {
               problem_alias: payload.alias,
               level_tag: levelTag,
             })
-              .then((response) => {
+              .then(() => {
                 ui.success(T.problemLevelUpdated);
                 this.problemLevel = levelTag;
               })
@@ -167,7 +164,7 @@ OmegaUp.on('ready', () => {
               allow_user_add_tags: allowTags,
               message: `${T.problemEditFormAllowUserAddTags}: ${allowTags}`,
             })
-              .then((response) => {
+              .then(() => {
                 ui.success(T.problemEditUpdatedSuccessfully);
               })
               .catch(ui.apiError);
@@ -225,7 +222,7 @@ OmegaUp.on('ready', () => {
               commit: selectedRevision.commit,
               update_published: updatePublished,
             })
-              .then((response) => {
+              .then(() => {
                 problemEdit.publishedRevision = selectedRevision;
                 ui.success(T.problemVersionUpdated);
               })
@@ -250,7 +247,7 @@ OmegaUp.on('ready', () => {
           },
           remove: (problemAlias: string) => {
             api.Problem.delete({ problem_alias: problemAlias })
-              .then((response) => {
+              .then(() => {
                 window.location.href = '/problem/mine/';
               })
               .catch(ui.apiError);

--- a/frontend/www/js/omegaup/problem/list.ts
+++ b/frontend/www/js/omegaup/problem/list.ts
@@ -2,8 +2,6 @@ import Vue from 'vue';
 import problem_List from '../components/problem/List.vue';
 import { types } from '../api_types';
 import { omegaup, OmegaUp } from '../omegaup';
-import T from '../lang';
-import * as api from '../api';
 import * as ui from '../ui';
 
 OmegaUp.on('ready', () => {
@@ -40,7 +38,7 @@ OmegaUp.on('ready', () => {
       }
     }
   }
-  const problemsList = new Vue({
+  new Vue({
     el: '#main-container',
     render: function (createElement) {
       return createElement('omegaup-problem-list', {

--- a/frontend/www/js/omegaup/problem/new.ts
+++ b/frontend/www/js/omegaup/problem/new.ts
@@ -26,7 +26,7 @@ OmegaUp.on('ready', () => {
               return;
             }
             api.Problem.details({ problem_alias: alias }, { quiet: true })
-              .then((data) => {
+              .then(() => {
                 problemNew.errors.push('problem_alias');
                 ui.error(
                   ui.formatString(T.aliasAlreadyInUse, {

--- a/frontend/www/js/omegaup/problem/print.ts
+++ b/frontend/www/js/omegaup/problem/print.ts
@@ -9,7 +9,7 @@ import omegaup_Markdown from '../components/Markdown.vue';
     JSON.parse((<HTMLElement>document.getElementById('payload')).innerText)
   );
 
-  const contestIntro = new Vue({
+  new Vue({
     el: <HTMLElement>document.querySelector('div.statement'),
     render: function (createElement) {
       return createElement('omegaup-markdown', {

--- a/frontend/www/js/omegaup/problem/settings_summary.ts
+++ b/frontend/www/js/omegaup/problem/settings_summary.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { omegaup, OmegaUp } from '../omegaup';
+import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
 import problem_SettingsSummary from '../components/problem/SettingsSummary.vue';
 
@@ -7,7 +7,7 @@ OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ProblemSettingsSummaryPayload(
     'settings-summary-payload',
   );
-  const problemSettingsSummary = new Vue({
+  new Vue({
     el: '#problem-settings-summary',
     render: function (createElement) {
       return createElement('omegaup-problem-settings-summary', {


### PR DESCRIPTION
Este cambio habilita eslint para que nunca jamás volvamos a
declarar/importar cosas que no se usan.