### PR TITLE
Arreglando comentario incorrecto al generar llaves para clonar cursos

### DIFF
--- a/frontend/server/src/SecurityTools.php
+++ b/frontend/server/src/SecurityTools.php
@@ -244,8 +244,8 @@ class SecurityTools {
     }
 
     /**
-     * Gets a Bearer authorization token for a particular user to be used the
-     * gitserver that is valid for a single problem for 5 minutes.
+     * Gets a Bearer authorization token for any user to clone a given course
+     * that is valid for 7 days.
      *
      * @param array<string, string> $claims
      * @param string $issuer


### PR DESCRIPTION
# Descripción

Corrección a lo que parece haber sido un error al copiar y pegar el código para generar tokens seguras.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.