### PR TITLE
Habilitando más reglas de eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,6 @@ module.exports = {
     'no-undef': 'off',
     'vue/attribute-hyphenation': 'off',
     'vue/component-tags-order': 'off',
-    'vue/custom-event-name-casing': 'off',
     'vue/no-deprecated-slot-attribute': 'off',
     'vue/no-deprecated-slot-scope-attribute': 'off',
     'vue/no-deprecated-v-bind-sync': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,8 +25,6 @@ module.exports = {
     'no-prototype-builtins': 'off',
     'no-undef': 'off',
     'vue/component-tags-order': 'off',
-    'vue/no-deprecated-slot-attribute': 'off',
-    'vue/no-deprecated-slot-scope-attribute': 'off',
     'vue/no-deprecated-v-bind-sync': 'off',
     'vue/no-v-html': 'off',
     'vue/require-default-prop': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
     '@typescript-eslint/no-namespace': 'off',
     'no-prototype-builtins': 'off',
     'no-undef': 'off',
-    'vue/attribute-hyphenation': 'off',
     'vue/component-tags-order': 'off',
     'vue/no-deprecated-slot-attribute': 'off',
     'vue/no-deprecated-slot-scope-attribute': 'off',

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -137,10 +137,10 @@
         >
           <omegaup-contest-filtered-list
             :contests="contests.participating"
-            :showTimes="true"
-            :showPractice="false"
-            :showVirtual="false"
-            :showPublicUpdated="false"
+            :show-times="true"
+            :show-practice="false"
+            :show-virtual="false"
+            :show-public-updated="false"
             :recommended="false"
           ></omegaup-contest-filtered-list>
         </div>
@@ -150,40 +150,40 @@
         >
           <omegaup-contest-filtered-list
             :contests="contests.recommended_current"
-            :showTimes="true"
-            :showPractice="false"
-            :showVirtual="false"
-            :showPublicUpdated="false"
+            :show-times="true"
+            :show-practice="false"
+            :show-virtual="false"
+            :show-public-updated="false"
             :recommended="true"
           ></omegaup-contest-filtered-list>
         </div>
         <div v-if="showTab === 'current'" class="tab-pane active list-current">
           <omegaup-contest-filtered-list
             :contests="contests.current"
-            :showTimes="true"
-            :showPractice="false"
-            :showVirtual="false"
-            :showPublicUpdated="false"
+            :show-times="true"
+            :show-practice="false"
+            :show-virtual="false"
+            :show-public-updated="false"
             :recommended="false"
           ></omegaup-contest-filtered-list>
         </div>
         <div v-if="showTab === 'public'" class="tab-pane active list-public">
           <omegaup-contest-filtered-list
             :contests="contests.public"
-            :showTimes="true"
-            :showPractice="false"
-            :showVirtual="false"
-            :showPublicUpdated="true"
+            :show-times="true"
+            :show-practice="false"
+            :show-virtual="false"
+            :show-public-updated="true"
             :recommended="false"
           ></omegaup-contest-filtered-list>
         </div>
         <div v-if="showTab === 'future'" class="tab-pane active list-future">
           <omegaup-contest-filtered-list
             :contests="contests.future"
-            :showTimes="true"
-            :showPractice="false"
-            :showVirtual="false"
-            :showPublicUpdated="false"
+            :show-times="true"
+            :show-practice="false"
+            :show-virtual="false"
+            :show-public-updated="false"
             :recommended="false"
           ></omegaup-contest-filtered-list>
         </div>
@@ -193,20 +193,20 @@
         >
           <omegaup-contest-filtered-list
             :contests="contests.recommended_past"
-            :showTimes="false"
-            :showPractice="true"
-            :showVirtual="true"
-            :showPublicUpdated="false"
+            :show-times="false"
+            :show-practice="true"
+            :show-virtual="true"
+            :show-public-updated="false"
             :recommended="true"
           ></omegaup-contest-filtered-list>
         </div>
         <div v-if="showTab === 'past'" class="tab-pane active list-past">
           <omegaup-contest-filtered-list
             :contests="contests.past"
-            :showTimes="false"
-            :showPractice="true"
-            :showVirtual="true"
-            :showPublicUpdated="false"
+            :show-times="false"
+            :show-practice="true"
+            :show-virtual="true"
+            :show-public-updated="false"
             :recommended="false"
           ></omegaup-contest-filtered-list>
         </div>

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -177,7 +177,7 @@
         <ul v-else class="nav navbar-nav navbar-right">
           <omegaup-notifications-clarifications
             v-if="inContest"
-            :initialClarifications="initialClarifications"
+            :initial-clarifications="initialClarifications"
           ></omegaup-notifications-clarifications>
           <li
             class="dropdown nav-user"
@@ -195,7 +195,7 @@
               }}</span>
               <omegaup-common-grader-badge
                 v-show="isAdmin"
-                :queueLength="graderQueueLength"
+                :queue-length="graderQueueLength"
                 :error="errorMessage !== null"
               ></omegaup-common-grader-badge>
               <span class="caret"></span
@@ -241,7 +241,7 @@
                 v-show="isAdmin"
                 :status="errorMessage !== null ? 'down' : 'ok'"
                 :error="errorMessage"
-                :graderInfo="graderInfo"
+                :grader-info="graderInfo"
               ></omegaup-common-grader-status>
             </ul>
           </li>

--- a/frontend/www/js/omegaup/components/common/Navbarv2.vue
+++ b/frontend/www/js/omegaup/components/common/Navbarv2.vue
@@ -243,7 +243,7 @@
                 >
                 <omegaup-common-grader-badge
                   v-show="isAdmin"
-                  :queueLength="graderQueueLength"
+                  :queue-length="graderQueueLength"
                   :error="errorMessage !== null"
                 ></omegaup-common-grader-badge>
               </a>
@@ -304,7 +304,7 @@
                   v-show="isAdmin"
                   :status="errorMessage !== null ? 'down' : 'ok'"
                   :error="errorMessage"
-                  :graderInfo="graderInfo"
+                  :grader-info="graderInfo"
                 ></omegaup-common-grader-status>
               </div>
             </li>

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -75,7 +75,7 @@
       <div v-if="showTab === 'problems'" class="tab-pane active problems">
         <omegaup-contest-add-problem
           :contest-alias="contest.alias"
-          :initialPoints="contest.partial_score ? 100 : 1"
+          :initial-points="contest.partial_score ? 100 : 1"
           :data="problems"
           @emit-add-problem="
             (addProblemComponent) => $emit('add-problem', addProblemComponent)
@@ -97,9 +97,9 @@
       </div>
       <div v-if="showTab === 'publish'" class="tab-pane active">
         <omegaup-common-publish
-          :initialAdmissionMode="contest.admission_mode"
-          :shouldShowPublicOption="true"
-          :admissionModeDescription="T.contestNewFormAdmissionModeDescription"
+          :initial-admission-mode="contest.admission_mode"
+          :should-show-public-option="true"
+          :admission-mode-description="T.contestNewFormAdmissionModeDescription"
           @emit-update-admission-mode="
             (publishComponent) =>
               $emit('update-admission-mode', publishComponent)

--- a/frontend/www/js/omegaup/components/course/Edit.vue
+++ b/frontend/www/js/omegaup/components/course/Edit.vue
@@ -143,8 +143,8 @@
               $emit('get-versions', newProblemAlias, addProblemComponent)
           "
         >
-          <template slot="page-header"><span></span></template>
-          <template slot="cancel-button">
+          <template #page-header><span></span></template>
+          <template #cancel-button>
             <button
               class="btn btn-secondary"
               type="reset"

--- a/frontend/www/js/omegaup/components/course/List.vue
+++ b/frontend/www/js/omegaup/components/course/List.vue
@@ -13,7 +13,7 @@
 
         <omegaup-course-filtered-list
           :courses="typeCourses"
-          :activeTab="typeCourses.activeTab"
+          :active-tab="typeCourses.activeTab"
         ></omegaup-course-filtered-list>
       </div>
     </template>

--- a/frontend/www/js/omegaup/components/course/Mine.vue
+++ b/frontend/www/js/omegaup/components/course/Mine.vue
@@ -12,8 +12,8 @@
     <template v-if="courses.admin.activeTab !== ''">
       <omegaup-course-filtered-list
         :courses="courses.admin"
-        :activeTab="courses.admin.activeTab"
-        :showPercentage="false"
+        :active-tab="courses.admin.activeTab"
+        :show-percentage="false"
       ></omegaup-course-filtered-list>
     </template>
   </div>

--- a/frontend/www/js/omegaup/components/homepage/Homepage.vue
+++ b/frontend/www/js/omegaup/components/homepage/Homepage.vue
@@ -8,7 +8,7 @@
           (coderOfTheMonthFemale &&
             coderOfTheMonthFemale.username == currentUserInfo.username))
       "
-      :coderUsername="currentUserInfo.username"
+      :coder-username="currentUserInfo.username"
     ></omegaup-coder-of-the-month-notice>
     <omegaup-carousel></omegaup-carousel>
     <div
@@ -56,12 +56,12 @@
           <omegaup-user-rank
             :page="rankTable.page"
             :length="rankTable.length"
-            :isIndex="rankTable.isIndex"
-            :isLogged="rankTable.isLogged"
-            :availableFilters="rankTable.availableFilters"
+            :is-index="rankTable.isIndex"
+            :is-logged="rankTable.isLogged"
+            :available-filters="rankTable.availableFilters"
             :filter="rankTable.filter"
             :ranking="rankTable.ranking"
-            :resultTotal="rankTable.resultTotal"
+            :result-total="rankTable.resultTotal"
           ></omegaup-user-rank>
         </div>
         <div
@@ -71,8 +71,8 @@
           <omegaup-school-rank
             :page="schoolsRank.page"
             :length="schoolsRank.length"
-            :showHeader="schoolsRank.showHeader"
-            :totalRows="schoolsRank.totalRows"
+            :show-header="schoolsRank.showHeader"
+            :total-rows="schoolsRank.totalRows"
             :rank="schoolsRank.rank"
           ></omegaup-school-rank>
         </div>

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -116,16 +116,18 @@
           :show-overlay="showOverlay"
           @overlay-hidden="onPopupDismissed"
         >
-          <omegaup-arena-runsubmit
-            slot="popup-content"
-            :preferred-language="problem.preferred_language"
-            :languages="problem.languages"
-            :initial-show-form="showFormRunSubmit"
-            @dismiss="onPopupDismissed"
-            @submit-run="
-              (code, selectedLanguage) => onRunSubmitted(code, selectedLanguage)
-            "
-          ></omegaup-arena-runsubmit>
+          <template #popup-content>
+            <omegaup-arena-runsubmit
+              :preferred-language="problem.preferred_language"
+              :languages="problem.languages"
+              :initial-show-form="showFormRunSubmit"
+              @dismiss="onPopupDismissed"
+              @submit-run="
+                (code, selectedLanguage) =>
+                  onRunSubmitted(code, selectedLanguage)
+              "
+            ></omegaup-arena-runsubmit>
+          </template>
         </omegaup-overlay>
         <omegaup-arena-runs
           :problem-alias="problem.alias"

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -48,17 +48,17 @@
 
         <omegaup-problem-settings
           :errors="errors"
-          :timeLimit="timeLimit"
-          :extraWallTime="extraWallTime"
-          :memoryLimit="memoryLimit"
-          :outputLimit="outputLimit"
-          :inputLimit="inputLimit"
-          :initialValidator="validator"
-          :initialLanguage="languages"
-          :overallWallTimeLimit="overallWallTimeLimit"
-          :validatorTimeLimit="validatorTimeLimit"
-          :validLanguages="data.validLanguages"
-          :validatorTypes="data.validatorTypes"
+          :time-limit="timeLimit"
+          :extra-wall-time="extraWallTime"
+          :memory-limit="memoryLimit"
+          :output-limit="outputLimit"
+          :input-limit="inputLimit"
+          :initial-validator="validator"
+          :initial-language="languages"
+          :overall-wall-time-limit="overallWallTimeLimit"
+          :validator-time-limit="validatorTimeLimit"
+          :valid-languages="data.validLanguages"
+          :validator-types="data.validatorTypes"
         ></omegaup-problem-settings>
 
         <div class="row">

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <omegaup-problem-search-bar
-      :initialLanguage="language"
+      :initial-language="language"
       :languages="languages"
-      :initialKeyword="keyword"
+      :initial-keyword="keyword"
       :tags="tags"
     ></omegaup-problem-search-bar>
     <a
@@ -228,7 +228,7 @@
       </div>
       <div class="card-footer">
         <omegaup-common-paginator
-          :pagerItems="pagerItems"
+          :pager-items="pagerItems"
         ></omegaup-common-paginator>
       </div>
     </div>

--- a/frontend/www/js/omegaup/components/problem/Mine.vue
+++ b/frontend/www/js/omegaup/components/problem/Mine.vue
@@ -135,7 +135,7 @@
       </div>
       <div class="card-footer">
         <omegaup-common-paginator
-          :pagerItems="pagerItems"
+          :pager-items="pagerItems"
           @page-changed="(page) => $emit('go-to-page', page)"
         ></omegaup-common-paginator>
       </div>

--- a/frontend/www/js/omegaup/components/qualitynomination/List.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.vue
@@ -17,17 +17,17 @@
           <omegaup-autocomplete
             v-show="selectColumn == 'problem_alias'"
             v-model="queryProblem"
-            :init="(el) => typeahead.problemTypeahead(el)"
+            :init="el => typeahead.problemTypeahead(el)"
             :placeholder="T.wordsKeyword"
             class="form-control"
           ></omegaup-autocomplete>
           <omegaup-autocomplete
             v-show="
               selectColumn == 'nominator_username' ||
-              selectColumn == 'author_username'
+                selectColumn == 'author_username'
             "
             v-model="queryUsername"
-            :init="(el) => typeahead.userTypeahead(el)"
+            :init="el => typeahead.userTypeahead(el)"
             :placeholder="T.wordsKeyword"
             class="form-control"
           ></omegaup-autocomplete>
@@ -36,7 +36,7 @@
       <button
         class="btn btn-primary"
         @click.prevent="
-          $emit('goToPage', 1, getStatus(), getQuery(), selectColumn)
+          $emit('go-to-page', 1, getStatus(), getQuery(), selectColumn)
         "
       >
         {{ T.wordsSearch }}
@@ -61,7 +61,7 @@
               v-model="showAll"
               type="checkbox"
               @change="
-                $emit('goToPage', 1, getStatus(), getQuery(), selectColumn)
+                $emit('go-to-page', 1, getStatus(), getQuery(), selectColumn)
               "
             />
             {{ T.qualityNominationShowAll }}
@@ -112,8 +112,8 @@
       <omegaup-common-paginator
         :pager-items="pagerItems"
         @page-changed="
-          (page) =>
-            $emit('goToPage', page, getStatus(), getQuery(), selectColumn)
+          page =>
+            $emit('go-to-page', page, getStatus(), getQuery(), selectColumn)
         "
       ></omegaup-common-paginator>
     </div>

--- a/frontend/www/js/omegaup/components/qualitynomination/List.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.vue
@@ -17,17 +17,17 @@
           <omegaup-autocomplete
             v-show="selectColumn == 'problem_alias'"
             v-model="queryProblem"
-            :init="el => typeahead.problemTypeahead(el)"
+            :init="(el) => typeahead.problemTypeahead(el)"
             :placeholder="T.wordsKeyword"
             class="form-control"
           ></omegaup-autocomplete>
           <omegaup-autocomplete
             v-show="
               selectColumn == 'nominator_username' ||
-                selectColumn == 'author_username'
+              selectColumn == 'author_username'
             "
             v-model="queryUsername"
-            :init="el => typeahead.userTypeahead(el)"
+            :init="(el) => typeahead.userTypeahead(el)"
             :placeholder="T.wordsKeyword"
             class="form-control"
           ></omegaup-autocomplete>
@@ -112,7 +112,7 @@
       <omegaup-common-paginator
         :pager-items="pagerItems"
         @page-changed="
-          page =>
+          (page) =>
             $emit('go-to-page', page, getStatus(), getQuery(), selectColumn)
         "
       ></omegaup-common-paginator>

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
@@ -4,10 +4,10 @@
     :possible-tags="PROBLEM_CATEGORIES"
     @submit="$emit('submit', tag, qualitySeal)"
   >
-    <template slot="link-title">
+    <template #link-title>
       {{ T.reviewerNomination }}
     </template>
-    <template slot="popup-content" slot-scope="slotProps">
+    <template #popup-content="slotProps">
       <div class="title-text">
         {{ T.reviewerNominationFormTitle }}
       </div>

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -22,7 +22,7 @@
           :items-per-page="5"
           :title="T.codersOfTheMonth"
         >
-          <template slot="table-header">
+          <template #table-header>
             <thead>
               <tr>
                 <th>{{ T.codersOfTheMonthUser }}</th>
@@ -51,7 +51,7 @@
           :sort-options="sortOptions"
           @sort-option-change="updateUsers"
         >
-          <template slot="table-header">
+          <template #table-header>
             <thead>
               <tr>
                 <th scope="col" class="text-center">
@@ -62,7 +62,7 @@
               </tr>
             </thead>
           </template>
-          <template slot="item-data" slot-scope="slotProps">
+          <template #item-data="slotProps">
             <omegaup-username
               :username="slotProps.item.toString()"
               :classname="slotProps.item.classname"

--- a/frontend/www/js/omegaup/components/schools/Rank.vue
+++ b/frontend/www/js/omegaup/components/schools/Rank.vue
@@ -44,7 +44,7 @@
     </div>
     <div v-else class="card-footer">
       <omegaup-common-paginator
-        :pagerItems="pagerItems"
+        :pager-items="pagerItems"
       ></omegaup-common-paginator>
     </div>
   </div>

--- a/frontend/www/js/omegaup/components/submissions/List.vue
+++ b/frontend/www/js/omegaup/components/submissions/List.vue
@@ -121,7 +121,7 @@
       </div>
       <div class="card-footer">
         <omegaup-common-paginator
-          :pagerItems="pagerItems"
+          :pager-items="pagerItems"
         ></omegaup-common-paginator>
       </div>
     </div>

--- a/frontend/www/js/omegaup/components/user/AuthorsRank.vue
+++ b/frontend/www/js/omegaup/components/user/AuthorsRank.vue
@@ -42,7 +42,7 @@
       </table>
       <div class="card-footer">
         <omegaup-common-paginator
-          :pagerItems="pagerItems"
+          :pager-items="pagerItems"
         ></omegaup-common-paginator>
       </div>
     </div>

--- a/frontend/www/js/omegaup/components/user/Charts.vue
+++ b/frontend/www/js/omegaup/components/user/Charts.vue
@@ -33,12 +33,12 @@
     <highcharts
       v-if="type !== 'total'"
       :options="periodStatisticOptions"
-      :updateArgs="updateArgs"
+      :update-args="updateArgs"
     ></highcharts>
     <highcharts
       v-else
       :options="aggregateStatisticOptions"
-      :updateArgs="updateArgs"
+      :update-args="updateArgs"
     ></highcharts>
   </div>
 </template>

--- a/frontend/www/js/omegaup/components/user/Chartsv2.vue
+++ b/frontend/www/js/omegaup/components/user/Chartsv2.vue
@@ -33,12 +33,12 @@
     <highcharts
       v-if="type !== 'total'"
       :options="periodStatisticOptions"
-      :updateArgs="updateArgs"
+      :update-args="updateArgs"
     ></highcharts>
     <highcharts
       v-else
       :options="aggregateStatisticOptions"
-      :updateArgs="updateArgs"
+      :update-args="updateArgs"
     ></highcharts>
   </div>
 </template>

--- a/frontend/www/js/omegaup/components/user/Profile.vue
+++ b/frontend/www/js/omegaup/components/user/Profile.vue
@@ -84,8 +84,8 @@
           v-if="charts"
           :data="charts"
           :username="profile.username"
-          :periodStatisticOptions="periodStatisticOptions"
-          :aggregateStatisticOptions="aggregateStatisticOptions"
+          :period-statistic-options="periodStatisticOptions"
+          :aggregate-statistic-options="aggregateStatisticOptions"
           @emit-update-period-statistics="
             (profileComponent, categories, data) =>
               $emit(

--- a/frontend/www/js/omegaup/components/user/Profile.vue
+++ b/frontend/www/js/omegaup/components/user/Profile.vue
@@ -44,7 +44,7 @@
         :items-per-page="15"
         :title="T.profileContests"
       >
-        <template slot="table-header">
+        <template #table-header>
           <thead>
             <tr>
               <th>{{ T.profileContestsTableContest }}</th>

--- a/frontend/www/js/omegaup/components/user/Rank.vue
+++ b/frontend/www/js/omegaup/components/user/Rank.vue
@@ -84,7 +84,7 @@
     </div>
     <div v-else class="card-footer">
       <omegaup-common-paginator
-        :pagerItems="pagerItems"
+        :pager-items="pagerItems"
       ></omegaup-common-paginator>
     </div>
   </div>

--- a/frontend/www/js/omegaup/qualitynomination/list.ts
+++ b/frontend/www/js/omegaup/qualitynomination/list.ts
@@ -34,7 +34,7 @@ OmegaUp.on('ready', function () {
           isAdmin: headerPayload.isAdmin,
         },
         on: {
-          goToPage: (
+          'go-to-page': (
             pageNumber: number,
             status: string,
             query: string,


### PR DESCRIPTION
Este cambio habilita:

- `vue/attribute-hyphenation`
- `vue/custom-event-name-casing`
- `vue/no-deprecated-slot-attribute`
- `vue/no-deprecated-slot-scope-attribute`