### PR TITLE
Agregando el nombre del estudiante en la lista de solicitudes a un curso

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -9,7 +9,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type AssignmentProgress=array<string, Progress>
  * @psalm-type ProblemQualityPayload=array{canNominateProblem: bool, dismissed: bool, dismissedBeforeAC: bool, language?: string, nominated: bool, nominatedBeforeAC: bool, problemAlias: string, solved: bool, tried: bool}
  * @psalm-type ProblemsetProblem=array{accepts_submissions: bool, accepted: int, alias: string, commit: string, difficulty: float, input_limit: int, languages: string, letter: string, order: int, points: float, quality_payload?: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
- * @psalm-type IdentityRequest=array{accepted: bool|null, admin?: array{name: null|string, username: string}, country: null|string, country_id: null|string, last_update: \OmegaUp\Timestamp|null, request_time: \OmegaUp\Timestamp, username: string}
+ * @psalm-type IdentityRequest=array{accepted: bool|null, admin?: array{name: null|string, username: string}, classname: string, country: null|string, country_id: null|string, last_update: \OmegaUp\Timestamp|null, name: null|string, request_time: \OmegaUp\Timestamp, username: string}
  * @psalm-type CourseAdmin=array{role: string, username: string}
  * @psalm-type CourseGroupAdmin=array{alias: string, name: string, role: string}
  * @psalm-type CourseAssignment=array{alias: string, assignment_type: string, description: string, finish_time: \OmegaUp\Timestamp|null, has_runs: bool, max_points: float, name: string, order: int, problemset_id: int, publish_time_delay: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: \OmegaUp\Timestamp}

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1885,9 +1885,11 @@ export namespace types {
   export interface IdentityRequest {
     accepted?: boolean;
     admin?: { name?: string; username: string };
+    classname: string;
     country?: string;
     country_id?: string;
     last_update?: Date;
+    name?: string;
     request_time: Date;
     username: string;
   }

--- a/frontend/www/js/omegaup/components/common/Requests.vue
+++ b/frontend/www/js/omegaup/components/common/Requests.vue
@@ -15,8 +15,16 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="request in requests">
-          <td>{{ request.username }}</td>
+        <tr v-for="request in requests" :key="request.username">
+          <td>
+            <omegaup-username
+              :classname="request.classname"
+              :username="request.username"
+              :name="request.name"
+              :linkify="true"
+              :show-name-with-username="true"
+            ></omegaup-username>
+          </td>
           <td>{{ request.country }}</td>
           <td>{{ time.formatTimestamp(request.request_time) }}</td>
           <td v-if="request.last_update === null">{{ T.wordsPending }}</td>
@@ -58,8 +66,13 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
 import * as time from '../../time';
+import omegaup_Username from '../user/Username.vue';
 
-@Component
+@Component({
+  components: {
+    'omegaup-username': omegaup_Username,
+  },
+})
 export default class Requests extends Vue {
   @Prop() data!: types.IdentityRequest[];
   @Prop() textAddParticipant!: string;

--- a/frontend/www/js/omegaup/components/common/Requests.vue
+++ b/frontend/www/js/omegaup/components/common/Requests.vue
@@ -22,7 +22,6 @@
               :username="request.username"
               :name="request.name"
               :linkify="true"
-              :show-name-with-username="true"
             ></omegaup-username>
           </td>
           <td>{{ request.country }}</td>

--- a/frontend/www/js/omegaup/components/course/AddStudents.vue
+++ b/frontend/www/js/omegaup/components/course/AddStudents.vue
@@ -56,7 +56,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="student in students">
+          <tr v-for="student in students" :key="student.username">
             <td>
               <a :href="studentProgressUrl(student)">{{
                 student.name || student.username

--- a/frontend/www/js/omegaup/components/user/Username.vue
+++ b/frontend/www/js/omegaup/components/user/Username.vue
@@ -42,12 +42,8 @@ export default class Username extends Vue {
   @Prop() linkify!: boolean;
   @Prop() country!: string;
   @Prop({ default: false }) emitClickEvent!: boolean;
-  @Prop({ default: false }) showNameWithUsername!: boolean;
 
   get nameWithUsername(): string {
-    if (!this.showNameWithUsername) {
-      return this.name || this.username;
-    }
     if (this.name) {
       return `${this.name} (${this.username})`;
     }

--- a/frontend/www/js/omegaup/components/user/Username.vue
+++ b/frontend/www/js/omegaup/components/user/Username.vue
@@ -12,17 +12,17 @@
         :class="classname"
         :title="username"
         @click="$emit('click', username)"
-        >{{ name || username }}</a
+        >{{ nameWithUsername }}</a
       >
       <a
         v-else
         :class="classname"
         :title="username"
         :href="`/profile/${username}/`"
-        >{{ name || username }}</a
+        >{{ nameWithUsername }}</a
       >
     </template>
-    <template v-else> {{ name || username }}</template>
+    <template v-else> {{ nameWithUsername }}</template>
   </span>
 </template>
 
@@ -42,6 +42,17 @@ export default class Username extends Vue {
   @Prop() linkify!: boolean;
   @Prop() country!: string;
   @Prop({ default: false }) emitClickEvent!: boolean;
+  @Prop({ default: false }) showNameWithUsername!: boolean;
+
+  get nameWithUsername(): string {
+    if (!this.showNameWithUsername) {
+      return this.name || this.username;
+    }
+    if (this.name) {
+      return `${this.name} (${this.username})`;
+    }
+    return this.username;
+  }
 }
 </script>
 


### PR DESCRIPTION
# Descripción

Se agrega el nombre del estudiante en la lista de solicitudes para ingresar a 
un curso. Se aprovecha que ahora se manda llamar el componente `username`
para también agregar el link para visitar su perfil.

![image](https://user-images.githubusercontent.com/3230352/95129052-06d67d00-0720-11eb-924d-35f4db33fbe7.png)


Fixes: #4690 


# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
