### PR TITLE
Traducción de "output only" en la lista de lenguajes en el modal de enviar un problema

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunSubmit.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmit.vue
@@ -118,7 +118,7 @@ export default class ArenaRunSubmit extends Vue {
       { language: 'rb', name: 'Ruby (2.7)' },
       { language: 'cs', name: 'C# (8.0, dotnet 3.1)' },
       { language: 'pas', name: 'Pascal (fpc 3.0)' },
-      { language: 'cat', name: 'Output Only' },
+      { language: 'cat', name: T.outputOnly },
       { language: 'hs', name: 'Haskell (ghc 8.6)' },
       { language: 'lua', name: 'Lua (5.3)' },
     ];


### PR DESCRIPTION
# Descripción

Traducción de "output only" en la lista de lenguajes en el modal de enviar un problema.

![image](https://user-images.githubusercontent.com/5167417/95206707-9fb2da00-07ac-11eb-8a8d-9e7ced782cc6.png)

![image](https://user-images.githubusercontent.com/5167417/95206841-c8d36a80-07ac-11eb-8f4a-4beb9898817d.png)

![image](https://user-images.githubusercontent.com/5167417/95206887-da1c7700-07ac-11eb-8c57-f7afa9ec478a.png)

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
