### PR TITLE
Haciendo que el csv con contraseñas de identidades permita caracteres especiales

### DIFF
--- a/frontend/www/js/omegaup/group/identities.js
+++ b/frontend/www/js/omegaup/group/identities.js
@@ -38,7 +38,7 @@ OmegaUp.on('ready', function () {
               records: identities,
             });
             const hiddenElement = document.createElement('a');
-            hiddenElement.href = `data:text/csv;charset=utf-8,${window.encodeURI(
+            hiddenElement.href = `data:text/csv;charset=utf-8,${window.encodeURIComponent(
               csv,
             )}`;
             hiddenElement.target = '_blank';


### PR DESCRIPTION
# Descripción

Parece que la función que se estaba utilizando para codificar los datos que se
descargan para el archivo de contraseñas de identidades [(encodeURI)](https://www.w3schools.com/jsref/jsref_encodeuri.asp) no permitía el uso 
de caracteres especiales. en vez de esa función, ahora se utiliza [encodeURIComponent](https://www.w3schools.com/jsref/jsref_encodeuricomponent.asp)

![CsvIdentitiesWithSpecialChars](https://user-images.githubusercontent.com/3230352/95378086-0a494000-08a9-11eb-9dbe-a7fd0f65e668.gif)


Fixes: #4788

# Comentarios

Este cambio fue demasiado corto, debido a que no se agregaron pruebas.

Para poder agregar las pruebas habrá que realizar la migración a la plantilla
unificada de varios archivos tpl:

- group.edit.tpl
- group.edit.members.tpl
- group.edit.scoreboards.tpl 

Para que se vayan considerando en los milestones.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.