### PR TITLE
Mostrando la descripción de los concursos en Markdown

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Intro.vue
+++ b/frontend/www/js/omegaup/components/contest/Intro.vue
@@ -111,7 +111,7 @@
       <hr />
       <div>
         <h1>{{ T.registerForContestChallenges }}</h1>
-        <p>{{ contest.description }}</p>
+        <omegaup-markdown :markdown="contest.description"></omegaup-markdown>
       </div>
       <div>
         <h1>{{ T.registerForContestRules }}</h1>


### PR DESCRIPTION
Este cambio hace que los concursos muestren su descripción en Markdown
para que se entienda lo que dicen.