### PR TITLE
Restringiendo los lenguajes que se despliegan al editar concurso

### DIFF
--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -316,6 +316,7 @@ export default class NewForm extends Vue {
   @Prop({ default: '' }) initialAlias!: string;
   @Prop({ default: '' }) initialDescription!: string;
   @Prop({ default: 'none' }) initialFeedback!: string;
+  @Prop() initialLanguages!: string[];
   @Prop() initialFinishTime!: Date;
   @Prop({ default: false }) initialNeedsBasicInformation!: boolean;
   @Prop({ default: 0 }) initialPenalty!: number;
@@ -336,7 +337,7 @@ export default class NewForm extends Vue {
   description = this.initialDescription;
   feedback = this.initialFeedback;
   finishTime = this.initialFinishTime;
-  languages = Object.keys(this.allLanguages);
+  languages = this.initialLanguages;
   needsBasicInformation = this.initialNeedsBasicInformation;
   penalty = this.initialPenalty;
   penaltyType = this.initialPenaltyType;

--- a/frontend/www/js/omegaup/contest/new.ts
+++ b/frontend/www/js/omegaup/contest/new.ts
@@ -21,6 +21,7 @@ OmegaUp.on('ready', () => {
       return createElement('omegaup-contest-new', {
         props: {
           allLanguages: payload.languages,
+          initialLanguages: Object.keys(payload.languages),
           update: false,
           initialStartTime: startTime,
           initialFinishTime: finishTime,


### PR DESCRIPTION
Este cambio le hace caso al servidor para sólo desplegar los lenguajes
que ese concurso debería soportar.

Fixes: #4738