### PR TITLE
Filtrando correctamente los concursos en el perfil

### DIFF
--- a/frontend/www/js/omegaup/linkable_resource.ts
+++ b/frontend/www/js/omegaup/linkable_resource.ts
@@ -28,6 +28,9 @@ export class ContestResult implements LinkableResource {
   }
 
   getBadge(): Optional<string> {
+    if (!this.place) {
+      return Optional.ofNonNull('—');
+    }
     return Optional.ofNonNull(`${this.place}`);
   }
 }

--- a/frontend/www/js/omegaup/user/profile.js
+++ b/frontend/www/js/omegaup/user/profile.js
@@ -170,15 +170,10 @@ OmegaUp.on('ready', function () {
 
   api.User.contestStats({ username: profile.username })
     .then((result) => {
+      const now = new Date();
       viewProfile.contests = Object.values(result.contests)
-        .map((contest) => {
-          const now = new Date();
-          if (contest.place === null || now <= contest.data.finish_time) {
-            return null;
-          }
-          return new ContestResult(contest);
-        })
-        .filter((contest) => !!contest);
+        .filter((contest) => contest.place && now > contest.data.finish_time)
+        .map((contest) => new ContestResult(contest));
     })
     .catch(ui.apiError);
 


### PR DESCRIPTION
Este cambio hace que si un usuario no tiene un lugar en un concurso (que
su lugar sea `undefined`), no se muestre en el perfil.