### PR TITLE
Agregando un índice para los envíos

### DIFF
--- a/frontend/database/163_runs_index.sql
+++ b/frontend/database/163_runs_index.sql
@@ -1,0 +1,2 @@
+-- Create an index to make querying pending runs faster.
+CREATE INDEX `status_submission_id` ON `Runs` (`status`, `submission_id`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -833,6 +833,7 @@ CREATE TABLE `Runs` (
   PRIMARY KEY (`run_id`),
   UNIQUE KEY `runs_versions` (`submission_id`,`version`),
   KEY `submission_id` (`submission_id`),
+  KEY `status_submission_id` (`status`,`submission_id`),
   CONSTRAINT `fk_r_submission_id` FOREIGN KEY (`submission_id`) REFERENCES `Submissions` (`submission_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Estado de todas las ejecuciones.';
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
Este cambio hace que el grader sea un poco más eficiente al momento de
obtener los envíos pendientes.