### PR TITLE
Corrección en DAO getRandomProblemAlias

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1172,7 +1172,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                     Problems
                 WHERE
                     quality_seal = 1
-                GROUP BY
+                ORDER BY
                     RAND() LIMIT 1;';
 
         /** @var string */


### PR DESCRIPTION
# Descripción

Se corrige la consulta de getRandomProblemAlias para que devuelva correctamente un problema aleatorio dado que en la página solo devuelve un solo problema cada que se manda llamar.

Fixes: #(issue)

# Comentarios


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
