### PR TITLE
Arreglando algunos Tags amarillos

### DIFF
--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -157,7 +157,9 @@
               />
               <a
                 v-for="tag in problem.tags"
-                :class="`badge custom-badge custom-badge-${tag.source} ${
+                :class="`badge custom-badge custom-badge-${
+                  tag.source.includes('quality') ? 'owner' : tag.source
+                } ${
                   tag.name.includes('problemLevel')
                     ? 'custom-badge-quality'
                     : ''


### PR DESCRIPTION
# Descripción

Evitando que algunos tags se pinten de amarillo por ser parte de un revisor

![image](https://user-images.githubusercontent.com/43051192/97515542-dd8fc200-1956-11eb-90a8-cea413fafa8c.png)

![image](https://user-images.githubusercontent.com/43051192/97515566-eb454780-1956-11eb-8398-baec51d55484.png)

Fixes: #4695

# Comentarios


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
