### PR TITLE
Agregando componente Signin

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -26,7 +26,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type UserProfileStats=array{date: null|string, runs: int, verdict: string}
  * @psalm-type UserListItem=array{label: string, value: string}
  * @psalm-type UserProfileDetailsPayload=array{statusError?: string, profile: UserProfileInfo, contests: UserProfileContests, solvedProblems: list<Problem>, unsolvedProblems: list<Problem>, createdProblems: list<Problem>, stats: list<UserProfileStats>, badges: list<string>, ownedBadges: list<Badge>, programmingLanguages: array<string,string>}
- * @psalm-type LoginDetailsPayload=array{facebookURL: string, linkedinURL: string, validateRecaptcha: string}
+ * @psalm-type LoginDetailsPayload=array{facebookURL: string, linkedinURL: string, validateRecaptcha: bool}
  */
 class User extends \OmegaUp\Controllers\Controller {
     /** @var bool */

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -26,6 +26,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type UserProfileStats=array{date: null|string, runs: int, verdict: string}
  * @psalm-type UserListItem=array{label: string, value: string}
  * @psalm-type UserProfileDetailsPayload=array{statusError?: string, profile: UserProfileInfo, contests: UserProfileContests, solvedProblems: list<Problem>, unsolvedProblems: list<Problem>, createdProblems: list<Problem>, stats: list<UserProfileStats>, badges: list<string>, ownedBadges: list<Badge>, programmingLanguages: array<string,string>}
+ * @psalm-type LoginDetailsPayload=array{facebookURL: string, linkedinURL: string, validateRecaptcha: string}
  */
 class User extends \OmegaUp\Controllers\Controller {
     /** @var bool */
@@ -3900,6 +3901,25 @@ class User extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         return strpos($identity->username, ':') !== false;
+    }
+
+    /**
+     * @return array{smartyProperties: array{payload: LoginDetailsPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
+     */
+    public static function getLoginDetailsForSmarty(\OmegaUp\Request $r) {
+        $triedToLogin = false;
+        $emailVerified = true;
+        return [
+            'smartyProperties' => [
+                'payload' => [
+                    'validateRecaptcha' => OMEGAUP_VALIDATE_CAPTCHA,
+                    'facebookURL' => \OmegaUp\Controllers\Session::getFacebookLoginUrl(),
+                    'linkedinURL' => \OmegaUp\Controllers\Session::getLinkedInLoginUrl(),
+                ],
+                'title' => new \OmegaUp\TranslationString('omegaupTitleLogin'),
+            ],
+            'entrypoint' => 'login_signin',
+        ];
     }
 }
 

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -811,6 +811,14 @@ export namespace types {
       );
     }
 
+    export function LoginDetailsPayload(
+      elementId: string = 'payload',
+    ): types.LoginDetailsPayload {
+      return JSON.parse(
+        (<HTMLElement>document.getElementById(elementId)).innerText,
+      );
+    }
+
     export function ProblemDetailsPayload(
       elementId: string = 'payload',
     ): types.ProblemDetailsPayload {
@@ -2036,6 +2044,12 @@ export namespace types {
     OutputLimit: number | string;
     OverallWallTimeLimit: string;
     TimeLimit: string;
+  }
+
+  export interface LoginDetailsPayload {
+    facebookURL: string;
+    linkedinURL: string;
+    validateRecaptcha: string;
   }
 
   export interface NominationListItem {

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2049,7 +2049,7 @@ export namespace types {
   export interface LoginDetailsPayload {
     facebookURL: string;
     linkedinURL: string;
-    validateRecaptcha: string;
+    validateRecaptcha: boolean;
   }
 
   export interface NominationListItem {

--- a/frontend/www/js/omegaup/components/login/Login.vue
+++ b/frontend/www/js/omegaup/components/login/Login.vue
@@ -14,12 +14,12 @@
               <!-- id-lint on -->
             </div>
             <div class="col-xs-12 col-sm-4 text-center py-2">
-              <a :href="facebookURL" :title="T.loginWithFacebook">
+              <a :href="facebookUrl" :title="T.loginWithFacebook">
                 <img src="/css/fb-oauth.png" height="45px" width="45px" />
               </a>
             </div>
             <div class="col-xs-12 col-sm-4 text-center py-2">
-              <a :href="linkedinURL" :title="T.loginWithLinkedIn">
+              <a :href="linkedinUrl" :title="T.loginWithLinkedIn">
                 <img src="/css/ln-oauth.png" height="45px" width="45px" />
               </a>
             </div>
@@ -80,8 +80,8 @@ import T from '../../lang';
 
 @Component
 export default class Login extends Vue {
-  @Prop() facebookURL!: string;
-  @Prop() linkedinURL!: string;
+  @Prop() facebookUrl!: string;
+  @Prop() linkedinUrl!: string;
   usernameOrEmail: string = '';
   password: string = '';
   T = T;

--- a/frontend/www/js/omegaup/components/login/Signin.vue
+++ b/frontend/www/js/omegaup/components/login/Signin.vue
@@ -1,14 +1,24 @@
 <template>
   <div>
     <omegaup-login
-      :facebook-u-r-l="facebookURL"
-      :linkedin-u-r-l="linkedinURL"
-      @login="loginAndRedirect"
+      :facebook-url="facebookUrl"
+      :linkedin-url="linkedinUrl"
+      @login="(username, password) => $emit('login', username, password)"
     >
     </omegaup-login>
     <omegaup-signup
       :validate-recaptcha="validateRecaptcha"
-      @register-and-login="registerAndLogin"
+      @register-and-login="
+        (username, email, password, passwordConfirmation, recaptchaResponse) =>
+          $emit(
+            'register-and-login',
+            username,
+            email,
+            password,
+            passwordConfirmation,
+            recaptchaResponse,
+          )
+      "
     >
     </omegaup-signup>
   </div>
@@ -30,31 +40,9 @@ import omegaup_Signup from './Signup.vue';
 })
 export default class Signin extends Vue {
   @Prop() validateRecaptcha!: boolean;
-  @Prop() facebookURL!: string;
-  @Prop() linkedinURL!: string;
+  @Prop() facebookUrl!: string;
+  @Prop() linkedinUrl!: string;
 
-  tem = this.facebookURL;
   T = T;
-
-  loginAndRedirect(usernameOrEmail: string, password: string) {
-    this.$emit('login', usernameOrEmail, password);
-  }
-
-  registerAndLogin(
-    username: string,
-    email: string,
-    password: string,
-    passwordConfirmation: string,
-    recaptchaResponse: string,
-  ) {
-    this.$emit(
-      'register-and-login',
-      username,
-      email,
-      password,
-      passwordConfirmation,
-      recaptchaResponse,
-    );
-  }
 }
 </script>

--- a/frontend/www/js/omegaup/components/login/Signin.vue
+++ b/frontend/www/js/omegaup/components/login/Signin.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <omegaup-login
+      :facebook-u-r-l="facebookURL"
+      :linkedin-u-r-l="linkedinURL"
+      @login="loginAndRedirect"
+    >
+    </omegaup-login>
+    <omegaup-signup
+      :validate-recaptcha="validateRecaptcha"
+      @register-and-login="registerAndLogin"
+    >
+    </omegaup-signup>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import T from '../../lang';
+import VueRecaptcha from 'vue-recaptcha';
+import omegaup_Login from './Login.vue';
+import omegaup_Signup from './Signup.vue';
+
+@Component({
+  components: {
+    'omegaup-login': omegaup_Login,
+    'omegaup-signup': omegaup_Signup,
+    'vue-recaptcha': VueRecaptcha,
+  },
+})
+export default class Signin extends Vue {
+  @Prop() validateRecaptcha!: boolean;
+  @Prop() facebookURL!: string;
+  @Prop() linkedinURL!: string;
+
+  tem = this.facebookURL;
+  T = T;
+
+  loginAndRedirect(usernameOrEmail: string, password: string) {
+    console.log(usernameOrEmail);
+    console.log(password);
+    this.$emit('login', usernameOrEmail, password);
+  }
+
+  registerAndLogin(
+    username: string,
+    email: string,
+    password: string,
+    passwordConfirmation: string,
+    recaptchaResponse: string,
+  ) {
+    console.log(username);
+    console.log(email);
+    console.log(password);
+    console.log(passwordConfirmation);
+    this.$emit(
+      'register-and-login',
+      username,
+      email,
+      password,
+      passwordConfirmation,
+      recaptchaResponse,
+    );
+  }
+}
+</script>

--- a/frontend/www/js/omegaup/components/login/Signin.vue
+++ b/frontend/www/js/omegaup/components/login/Signin.vue
@@ -37,8 +37,6 @@ export default class Signin extends Vue {
   T = T;
 
   loginAndRedirect(usernameOrEmail: string, password: string) {
-    console.log(usernameOrEmail);
-    console.log(password);
     this.$emit('login', usernameOrEmail, password);
   }
 
@@ -49,10 +47,6 @@ export default class Signin extends Vue {
     passwordConfirmation: string,
     recaptchaResponse: string,
   ) {
-    console.log(username);
-    console.log(email);
-    console.log(password);
-    console.log(passwordConfirmation);
     this.$emit(
       'register-and-login',
       username,

--- a/frontend/www/js/omegaup/login/signin.ts
+++ b/frontend/www/js/omegaup/login/signin.ts
@@ -1,0 +1,89 @@
+import { OmegaUp } from '../omegaup';
+import { types } from '../api_types';
+import * as api from '../api';
+import * as ui from '../ui';
+import T from '../lang';
+import Vue from 'vue';
+import login_Signin from '../components/login/Signin.vue';
+import VueRecaptcha from 'vue-recaptcha';
+
+OmegaUp.on('ready', () => {
+  const payload = types.payloadParsers.LoginDetailsPayload();
+  new Vue({
+    el: '#main-container',
+    components: {
+      'omegaup-login-signin': login_Signin,
+      'vue-recaptcha': VueRecaptcha,
+    },
+    methods: {
+      loginAndredirect: (
+        usernameOrEmail: string,
+        password: string,
+        type: string,
+      ): void => {
+        api.User.login({
+          usernameOrEmail: usernameOrEmail,
+          password: password,
+        })
+          .then(() => {
+            const params = new URL(document.location.toString()).searchParams;
+            let pathname = params.get('redirect');
+            if (
+              !pathname ||
+              (pathname.indexOf('/') === 0 && type === 'register')
+            ) {
+              pathname = '/profile/';
+            } else if (
+              !pathname ||
+              (pathname.indexOf('/') === 0 && type === 'login')
+            ) {
+              pathname = '/';
+            }
+            window.location.href = pathname;
+          })
+          .catch(ui.apiError);
+      },
+    },
+    render: function (createElement) {
+      return createElement('omegaup-login-signin', {
+        props: {
+          validateRecaptcha: payload.validateRecaptcha,
+          facebookURL: payload.facebookURL,
+          linkedinURL: payload.linkedinURL,
+        },
+        on: {
+          'register-and-login': (
+            username: string,
+            email: string,
+            password: string,
+            passwordConfirmation: string,
+            recaptchaResponse: string,
+          ) => {
+            if (password != passwordConfirmation) {
+              ui.error(T.passwordMismatch);
+              return;
+            }
+            if (password.length < 8) {
+              ui.error(T.loginPasswordTooShort);
+              return;
+            }
+
+            api.User.create({
+              username: username,
+              email: email,
+              password: password,
+              recaptcha: recaptchaResponse,
+            })
+              .then(() => {
+                this.loginAndredirect(username, password, 'register');
+              })
+              .catch(ui.apiError);
+          },
+          login: (usernameOrEmail: string, password: string) => {
+            this.loginAndredirect(usernameOrEmail, password, 'login');
+          },
+        },
+      });
+    },
+  });
+});


### PR DESCRIPTION
# Descripción

Segunda parte de la migración de login.tpl a la plantilla unificada.

En este cambio se incluye el componente `Signin.vue` que sirve como wrapper
de los componentes `Login.vue` y `Signup.vue`. También se agrega la 
anotación del payload que se va a requerir y sus respectivos cambios
en el controlador.

Aún falta agregar la funcionalidad de los botones de RRSS.

Part of: #3950 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
