### PR TITLE
Mejorando la consistencia en la creación de envíos

### DIFF
--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -79,6 +79,49 @@ class Run extends \OmegaUp\Controllers\Controller {
     public const STATUS = ['new', 'waiting', 'compiling', 'running', 'ready'];
 
     /**
+     * Validates that a run is happening within the submission gap.
+     *
+     * This needs to be called within the transaction that creates the run to
+     * avoid races where multiple concurrent requests can go in and multiple
+     * runs be created.
+     */
+    private static function validateWithinSubmissionGap(
+        \OmegaUp\DAO\VO\Identities $identity,
+        \OmegaUp\DAO\VO\Problems $problem,
+        ?\OmegaUp\DAO\VO\Contests $contest
+    ): void {
+        if (is_null($contest)) {
+            if (
+                !\OmegaUp\DAO\Submissions::isInsideSubmissionGap(
+                    null,
+                    null,
+                    intval($problem->problem_id),
+                    intval($identity->identity_id)
+                ) &&
+                !\OmegaUp\Authorization::isSystemAdmin($identity)
+            ) {
+                    throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
+                        'runWaitGap'
+                    );
+            }
+        } else {
+            if (
+                !\OmegaUp\DAO\Submissions::isInsideSubmissionGap(
+                    intval($contest->problemset_id),
+                    $contest,
+                    intval($problem->problem_id),
+                    intval($identity->identity_id)
+                ) &&
+                !\OmegaUp\Authorization::isAdmin($identity, $contest)
+            ) {
+                throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
+                    'runWaitGap'
+                );
+            }
+        }
+    }
+
+    /**
      * Validates Create Run request
      *
      * @throws \OmegaUp\Exceptions\ApiException
@@ -186,42 +229,28 @@ class Run extends \OmegaUp\Controllers\Controller {
                 $problem->problem_id
             );
             if (
-                \OmegaUp\DAO\Problems::isVisible($problem) ||
-                \OmegaUp\Authorization::isProblemAdmin(
+                !\OmegaUp\DAO\Problems::isVisible($problem) &&
+                !\OmegaUp\Authorization::isProblemAdmin(
                     $r->identity,
                     $problem
-                ) ||
-                (
+                ) &&
+                !(
                     is_null($practiceDeadline) ||
                     \OmegaUp\Time::get() > $practiceDeadline->time
                 )
             ) {
-                if (
-                    !\OmegaUp\DAO\Runs::isRunInsideSubmissionGap(
-                        null,
-                        null,
-                        intval($problem->problem_id),
-                        intval($r->identity->identity_id)
-                    )
-                        && !\OmegaUp\Authorization::isSystemAdmin($r->identity)
-                ) {
-                        throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
-                            'runWaitGap'
-                        );
-                }
-
-                return [
-                    'isPractice' => true,
-                    'problem' => $problem,
-                    'contest' => null,
-                    'problemsetContainer' => null,
-                    'problemset' => null,
-                ];
-            } else {
                 throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
                     'problemIsNotPublic'
                 );
             }
+
+            return [
+                'isPractice' => true,
+                'problem' => $problem,
+                'contest' => null,
+                'problemsetContainer' => null,
+                'problemset' => null,
+            ];
         }
         if (is_null($problemsetContainer)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
@@ -303,20 +332,6 @@ class Run extends \OmegaUp\Controllers\Controller {
             ) {
                 throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
                     'runNotInsideContest'
-                );
-            }
-
-            // Validate if the user is allowed to submit given the submissions_gap
-            if (
-                !\OmegaUp\DAO\Runs::isRunInsideSubmissionGap(
-                    intval($problemsetId),
-                    $contest,
-                    intval($problem->problem_id),
-                    intval($r->identity->identity_id)
-                )
-            ) {
-                throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
-                    'runWaitGap'
                 );
             }
         }
@@ -475,6 +490,15 @@ class Run extends \OmegaUp\Controllers\Controller {
 
         try {
             \OmegaUp\DAO\DAO::transBegin();
+
+            // _Now_ that we are in a transaction, we can check whether the run
+            // is within the submission gap.
+            self::validateWithinSubmissionGap(
+                $r->identity,
+                $problem,
+                $contest
+            );
+
             // Push run into DB
             \OmegaUp\DAO\Submissions::create($submission);
             $run->submission_id = $submission->submission_id;

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -930,33 +930,6 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 
-    final public static function isRunInsideSubmissionGap(
-        ?int $problemsetId,
-        ?\OmegaUp\DAO\VO\Contests $contest,
-        int $problemId,
-        int $identityId
-    ): bool {
-        $lastRunTime = \OmegaUp\DAO\Submissions::getLastSubmissionTime(
-            $identityId,
-            $problemId,
-            $problemsetId
-        );
-        if (is_null($lastRunTime)) {
-            return true;
-        }
-
-        $submissionGap = \OmegaUp\Controllers\Run::$defaultSubmissionGap;
-        if (!is_null($contest)) {
-            // Get submissions gap
-            $submissionGap = max(
-                $submissionGap,
-                intval($contest->submissions_gap)
-            );
-        }
-
-        return \OmegaUp\Time::get() >= ($lastRunTime->time + $submissionGap);
-    }
-
     /**
      * Returns the time of the next submission to the current problem
      */


### PR DESCRIPTION
Este cambio intenta mejorar la garantía de que múltiples intentos de
envíos concurrentes al mismo problema no resultarán en múltiples envíos.
Notablemente:

a) Ahora valida que el envío esté dentro del submission gap adentro de
   la transacción.
b) Adquirere row locks para los registros considerados, para intentar
   serializar los envíos.

Part of: #4864