### PR TITLE
Ignorar acentos en buscador de etiquetas

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -237,7 +237,7 @@ export default class ProblemTags extends Vue {
 
   publicTagsSerializer(tagname: string): string {
     if (Object.prototype.hasOwnProperty.call(T, tagname)) {
-      return T[tagname];
+      return `${T[tagname]} (${this.removeSpecialCharacters(T[tagname])})`;
     }
     return tagname;
   }
@@ -253,6 +253,16 @@ export default class ProblemTags extends Vue {
       this.title,
       newValue,
     );
+  }
+
+  removeSpecialCharacters(cadena: string): string {
+    let de = 'ÁÃÀÄÂÉËÈÊÍÏÌÎÓÖÒÔÚÜÙÛÑÇáãàäâéëèêíïìîóöòôúüùûñç',
+      a = 'AAAAAEEEEIIIIOOOOUUUUNCaaaaaeeeeiiiioooouuuunc',
+      re = new RegExp('[' + de + ']', 'ug');
+
+    cadena = cadena.replace(re, (match) => a.charAt(de.indexOf(match)));
+
+    return cadena;
   }
 }
 </script>


### PR DESCRIPTION
# Descripción

se cambia la información del buscador de etiquetas para que se pueda buscar etiquetas con o sin acentos al momento de crear o editar un problema.

![Captura de pantalla (2374)](https://user-images.githubusercontent.com/43051192/97724793-0026f580-1a93-11eb-9f33-0e60cb7ed721.png)

![Captura de pantalla (2375)](https://user-images.githubusercontent.com/43051192/97724810-05844000-1a93-11eb-86ad-f30bdbb3af7a.png)

Fixes: #4849 

# Comentarios

se aumentó la parte de poner la misma etiqueta sin acentos en todos los casos para que se obtuvieran los mismos resultados al buscar.

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
