### PR TITLE
Corrigiendo carga de problemas de calidad

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3719,7 +3719,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
      * @omegaup-request-param bool $only_quality_seal
-     * @omegaup-request-param int|null $level
+     * @omegaup-request-param null|string $level
      */
     public static function apiList(\OmegaUp\Request $r) {
         // Authenticate request
@@ -3734,7 +3734,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $rowcount = \OmegaUp\Controllers\Problem::PAGE_SIZE;
 
         $onlyQualitySeal = $r->ensureOptionalBool('only_quality_seal') ?? false;
-        $level = null;
+        $level = $r->ensureOptionalString('level');
 
         if (is_null($r['page'])) {
             $offset = is_null($r['offset']) ? 0 : intval($r['offset']);
@@ -3743,7 +3743,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $rowcount = intval($r['rowcount']);
         }
         if (!is_null($r['level'])) {
-            $level = intval($r['level']);
+            $level = strval($r['level']);
         }
 
         [
@@ -3801,9 +3801,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Identities $identity,
         ?\OmegaUp\DAO\VO\Users $user,
         bool $onlyQualitySeal,
-        ?int $level
+        ?string $level
     ) {
-//print_r($page . '   <---page|');print_r($language . '   <----language|');print_r($orderBy . '   <----orderBy|');print_r($sortOrder . '   <----sortOrder|');print_r($offset . '   <----offset|');print_r($rowcount . '   <----rowcount|');print_r($tags);print_r($keyword . '   <----keyword|');print_r($requireAllTags . '   <----requireAllTags|');print_r($programmingLanguages);print_r($minVisibility . '   <----minVisibility|');print_r($difficultyRange . '   <----difficultyRange|');print_r($identity . '   <----identity|');print_r($user . '   <----user|');print_r($onlyQualitySeal . '   <----onlyQualitySeal|');print_r($level . '   <----level|');
         $authorIdentityId = null;
         $authorUserId = null;
         // There are basically three types of users:
@@ -5933,9 +5932,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'minVisibility' => $minVisibility,
         ] = self::validateListParams($r);
 
-        $tag = \OmegaUp\DAO\Tags::getByName($collectionLevel);
-        $tagId = !is_null($tag) ? $tag->tag_id : null;
-
         $result = self::getList(
             $page,
             $language,
@@ -5953,7 +5949,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             /*$onlyQualitySeal=*/true,
             /*$url=*/"/problem/collection/{$collectionLevel}/",
-            /*$level=*/$tagId
+            /*$level=*/$collectionLevel
         );
 
         $collection = \OmegaUp\Controllers\Tag::getFrequentTagsByLevel(
@@ -6021,7 +6017,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Users $user,
         bool $onlyQualitySeal,
         string $url,
-        ?int $level
+        ?string $level
     ) {
         $response = self::getListImpl(
             $page ?: 1,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3742,7 +3742,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         if (!is_null($r['rowcount'])) {
             $rowcount = intval($r['rowcount']);
         }
-        if (!is_null($r['level'])){
+        if (!is_null($r['level'])) {
             $level = intval($r['level']);
         }
 
@@ -3802,7 +3802,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Users $user,
         bool $onlyQualitySeal,
         ?int $level
-    ) {//print_r($page . '   <---page|');print_r($language . '   <----language|');print_r($orderBy . '   <----orderBy|');print_r($sortOrder . '   <----sortOrder|');print_r($offset . '   <----offset|');print_r($rowcount . '   <----rowcount|');print_r($tags);print_r($keyword . '   <----keyword|');print_r($requireAllTags . '   <----requireAllTags|');print_r($programmingLanguages);print_r($minVisibility . '   <----minVisibility|');print_r($difficultyRange . '   <----difficultyRange|');print_r($identity . '   <----identity|');print_r($user . '   <----user|');print_r($onlyQualitySeal . '   <----onlyQualitySeal|');print_r($level . '   <----level|');
+    ) {
+//print_r($page . '   <---page|');print_r($language . '   <----language|');print_r($orderBy . '   <----orderBy|');print_r($sortOrder . '   <----sortOrder|');print_r($offset . '   <----offset|');print_r($rowcount . '   <----rowcount|');print_r($tags);print_r($keyword . '   <----keyword|');print_r($requireAllTags . '   <----requireAllTags|');print_r($programmingLanguages);print_r($minVisibility . '   <----minVisibility|');print_r($difficultyRange . '   <----difficultyRange|');print_r($identity . '   <----identity|');print_r($user . '   <----user|');print_r($onlyQualitySeal . '   <----onlyQualitySeal|');print_r($level . '   <----level|');
         $authorIdentityId = null;
         $authorUserId = null;
         // There are basically three types of users:

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3742,9 +3742,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
         if (!is_null($r['rowcount'])) {
             $rowcount = intval($r['rowcount']);
         }
-        if (!is_null($r['level'])) {
-            $level = strval($r['level']);
-        }
 
         [
             'sortOrder' => $sortOrder,

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -2679,7 +2679,7 @@ List of public and user's private problems
 | `only_quality_seal`     | `bool`         |             |
 | `difficulty_range`      | `null\|string` |             |
 | `language`              | `mixed`        |             |
-| `level`                 | `int\|null`    |             |
+| `level`                 | `null\|string` |             |
 | `max_difficulty`        | `int\|null`    |             |
 | `min_difficulty`        | `int\|null`    |             |
 | `min_visibility`        | `int\|null`    |             |

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -2679,6 +2679,7 @@ List of public and user's private problems
 | `only_quality_seal`     | `bool`         |             |
 | `difficulty_range`      | `null\|string` |             |
 | `language`              | `mixed`        |             |
+| `level`                 | `int\|null`    |             |
 | `max_difficulty`        | `int\|null`    |             |
 | `min_difficulty`        | `int\|null`    |             |
 | `min_visibility`        | `int\|null`    |             |

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -107,7 +107,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         if ($order !== 'asc' && $order !== 'desc') {
             $order = 'desc';
         }
-        
+
         $languageJoin = '';
         if (!is_null($language) && $language !== 'all') {
             $languageJoin = '
@@ -118,13 +118,13 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                     AND Languages.name = \'' . $language . '\'
             ';
         }
-        
+
         $levelJoin = '';
         if (!is_null($level)) {
             $levelJoin = '
-            INNER JOIN 
-                Problems_Tags pt ON p.problem_id = pt.problem_id 
-            INNER JOIN 
+            INNER JOIN
+                Problems_Tags pt ON p.problem_id = pt.problem_id
+            INNER JOIN
                 Tags t ON t.tag_id = pt.tag_id
             ';
         }
@@ -338,7 +338,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             "SELECT COUNT(*) $sql",
             $args
         );
-        
+
         // Reset the offset to 0 if out of bounds.
         if ($offset < 0 || $offset > $count) {
             $offset = 0;

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -101,7 +101,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         array $programmingLanguages,
         ?array $difficultyRange,
         bool $onlyQualitySeal,
-        ?int $level
+        ?string $level
     ) {
         // Just in case.
         if ($order !== 'asc' && $order !== 'desc') {
@@ -119,6 +119,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             ';
         }
 
+        $clauses = [];
+
         $levelJoin = '';
         if (!is_null($level)) {
             $levelJoin = '
@@ -127,6 +129,9 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             INNER JOIN
                 Tags t ON t.tag_id = pt.tag_id
             ';
+            $clauses[] = [
+                't.name = ?', [$level]
+            ];
         }
 
         // Use BINARY mode to force case sensitive comparisons when ordering by title.
@@ -138,7 +143,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         // Clauses is an array of 2-tuples that contains a chunk of SQL and the
         // arguments that are needed for that chunk.
         /** @var list<array{0: string, 1: list<string>}> */
-        $clauses = [];
+
         foreach ($programmingLanguages as $programmingLanguage) {
             $clauses[] = [
                 'FIND_IN_SET(?, p.languages) > 0',
@@ -308,12 +313,6 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         if ($onlyQualitySeal) {
             $clauses[] = [
                 'p.quality_seal = ?', [1]
-            ];
-        }
-
-        if (!is_null($level)) {
-            $clauses[] = [
-                't.tag_id = ?', [$level]
             ];
         }
 

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -180,7 +180,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 'auth_token' => $login->auth_token,
             ])
         )['smartyProperties']['payload']['authors'];
-        
+
         foreach ($result as $key) {
             $this->assertArrayHasKey('username', $key);
             $this->assertArrayHasKey('name', $key);

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -180,7 +180,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 'auth_token' => $login->auth_token,
             ])
         )['smartyProperties']['payload']['authors'];
-
+        
         foreach ($result as $key) {
             $this->assertArrayHasKey('username', $key);
             $this->assertArrayHasKey('name', $key);

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1300,7 +1300,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
                 'level' => 'problemLevelBasicIntroductionToProgramming',
             ])
         )['smartyProperties']['payload']['problems'];
-
+        
         foreach ($result as $problem) {
             $this->assertEquals(
                 $problem['tags'][0]['name'],

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1325,7 +1325,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'only_quality_seal' => true,
-                'level' => 3
+                'level' => 'problemLevelBasicIntroductionToProgramming'
             ])
         );
 
@@ -1335,7 +1335,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'only_quality_seal' => true,
-                'level' => 2
+                'level' => 'problemLevelBasicKarel'
             ])
         );
 

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1300,7 +1300,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
                 'level' => 'problemLevelBasicIntroductionToProgramming',
             ])
         )['smartyProperties']['payload']['problems'];
-        
+
         foreach ($result as $problem) {
             $this->assertEquals(
                 $problem['tags'][0]['name'],
@@ -1319,5 +1319,26 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
             $result[0]['tags'][0]['name'],
             'problemLevelBasicKarel'
         );
+
+        // Test count of problems
+        $apiListResponse = \OmegaUp\Controllers\Problem::apiList(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'only_quality_seal' => true,
+                'level' => 3
+            ])
+        );
+
+        $this->assertEquals(2, $apiListResponse['total']);
+
+        $apiListResponse = \OmegaUp\Controllers\Problem::apiList(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'only_quality_seal' => true,
+                'level' => 2
+            ])
+        );
+
+        $this->assertEquals(1, $apiListResponse['total']);
     }
 }


### PR DESCRIPTION
# Descripción

Se cambió la consulta `sql` para evitar inconsistencias entre los problemas, el paginador y el nivel en `problem/collection/{level}/`.

Fixes: #4868 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
