### PR TITLE
Limitando el número de etiquetas frecuentes

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -39,7 +39,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ProblemListPayload=array{currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>}
  * @psalm-type RunsDiff=array{guid: string, new_score: float|null, new_status: null|string, new_verdict: null|string, old_score: float|null, old_status: null|string, old_verdict: null|string, problemset_id: int|null, username: string}
  * @psalm-type CommitRunsDiff=array<string, list<RunsDiff>>
- * @psalm-type CollectionDetailsByLevelPayload=array{collection: list<array{alias: string, name?: string}>, publicTags: list<string>, level: string, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tagsList: list<string>}
+ * @psalm-type CollectionDetailsByLevelPayload=array{frequentTags: list<array{alias: string, name?: string}>, publicTags: list<string>, level: string, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tagsList: list<string>}
  * @psalm-type CollectionDetailsByAuthorPayload=array{authors: list<array{username: string, name?: string}>, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>}
  * @psalm-type Tag=array{name: string}
  * @psalm-type ProblemListCollectionPayload=array{levelTags: list<string>, problemCount: list<array{name: string, problems_per_tag: int}>, allTags: list<Tag>}
@@ -5909,7 +5909,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     public static function getCollectionsDetailsByLevelForSmarty(\OmegaUp\Request $r): array {
         $collectionLevel = $r->ensureString('level');
 
-        $collection = [];
+        $frequentTags = [];
 
         $offset = $r->ensureOptionalInt('offset') ?? 0;
         $pageSize = $r->ensureOptionalInt(
@@ -5949,14 +5949,15 @@ class Problem extends \OmegaUp\Controllers\Controller {
             /*$level=*/$collectionLevel
         );
 
-        $collection = \OmegaUp\Controllers\Tag::getFrequentTagsByLevel(
-            $collectionLevel
+        $frequentTags = \OmegaUp\Controllers\Tag::getFrequentTagsByLevel(
+            $collectionLevel,
+            /*$rows=*/15
         );
 
         return [
             'smartyProperties' => [
                 'payload' => [
-                    'collection' => $collection,
+                    'frequentTags' => $frequentTags,
                     'publicTags' => \OmegaUp\Controllers\Tag::getPublicTags(),
                     'level' => $collectionLevel,
                     'problems' => $result['problems'],

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3717,6 +3717,7 @@ Return most frequent public tags of a certain level
 | Name           | Type     | Description |
 | -------------- | -------- | ----------- |
 | `problemLevel` | `string` |             |
+| `rows`         | `int`    |             |
 
 ### Returns
 

--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -72,13 +72,15 @@ class Tag extends \OmegaUp\Controllers\Controller {
      * @return list<array{alias: string}>
      */
     public static function getFrequentTagsByLevel(
-        string $problemLevel
+        string $problemLevel,
+        int $rows
     ): array {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::TAGS_LIST,
             "level-{$problemLevel}",
             fn () => \OmegaUp\DAO\Tags::getFrequentTagsByLevel(
-                $problemLevel
+                $problemLevel,
+                $rows
             ),
             APC_USER_CACHE_SESSION_TIMEOUT
         );
@@ -90,6 +92,7 @@ class Tag extends \OmegaUp\Controllers\Controller {
      * @return array{frequent_tags: list<array{alias: string}>}
      *
      * @omegaup-request-param string $problemLevel
+     * @omegaup-request-param int $rows
      */
     public static function apiFrequentTags(\OmegaUp\Request $r): array {
         $param = $r->ensureString(
@@ -99,8 +102,12 @@ class Tag extends \OmegaUp\Controllers\Controller {
             )
         );
 
+        $rows = $r->ensureInt(
+            'rows'
+        );
+
         return [
-            'frequent_tags' => self::getFrequentTagsByLevel($param),
+            'frequent_tags' => self::getFrequentTagsByLevel($param, $rows),
         ];
     }
 }

--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -77,7 +77,7 @@ class Tag extends \OmegaUp\Controllers\Controller {
     ): array {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::TAGS_LIST,
-            "level-{$problemLevel}",
+            "level-{$problemLevel}-{$rows}",
             fn () => \OmegaUp\DAO\Tags::getFrequentTagsByLevel(
                 $problemLevel,
                 $rows

--- a/frontend/server/src/DAO/Tags.php
+++ b/frontend/server/src/DAO/Tags.php
@@ -80,7 +80,8 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
      * @return list<array{alias: string}>
      */
     public static function getFrequentTagsByLevel(
-        string $problemLevel
+        string $problemLevel,
+        int $rows
     ) {
         $sql = '
             SELECT
@@ -110,12 +111,16 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
             ORDER BY
                 COUNT(pt.problem_id)
             DESC
+            LIMIT ?
             ';
 
         /** @var list<array{alias: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
-            [$problemLevel]
+            [
+                $problemLevel,
+                $rows
+            ]
         );
     }
 }

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -84,7 +84,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
             ])
-        )['smartyProperties']['payload']['collection'];
+        )['smartyProperties']['payload']['frequentTags'];
 
         $this->assertEquals('problemTagMatrices', $result['0']['alias']);
         $this->assertCount(6, $result);

--- a/frontend/tests/controllers/TagListTest.php
+++ b/frontend/tests/controllers/TagListTest.php
@@ -125,7 +125,8 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
         $request = \OmegaUp\Controllers\Tag::apiFrequentTags(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
-                'problemLevel' => 'problemLevelBasicIntroductionToProgramming'
+                'problemLevel' => 'problemLevelBasicIntroductionToProgramming',
+                'rows' => 15
             ])
         );
 

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1403,10 +1403,10 @@ export namespace types {
   }
 
   export interface CollectionDetailsByLevelPayload {
-    collection: { alias: string; name?: string }[];
     column: string;
     columns: string[];
     currentTags: string[];
+    frequentTags: { alias: string; name?: string }[];
     keyword: string;
     language: string;
     languages: string[];

--- a/frontend/www/js/omegaup/components/problem/CollectionList.test.ts
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.test.ts
@@ -12,7 +12,7 @@ describe('CollectionList.vue', () => {
       propsData: {
         data: {
           level: 'problemLevelBasicIntroductionToProgramming',
-          collection: [
+          frequentTags: [
             { alias: 'problemTagMatrices' },
             { alias: 'problemTagDiophantineEquations' },
             { alias: 'problemTagInputAndOutput' },

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -75,11 +75,11 @@ export default class CollectionList extends Vue {
 
   T = T;
   level = this.data.level;
-  tags: string[] = this.data.collection.map((element) => element.alias);
+  tags: string[] = this.data.frequentTags.map((element) => element.alias);
   selectedDifficulty: null | string = null;
 
   get publicTags(): string[] {
-    let tags: string[] = this.data.collection.map((x) => x.alias);
+    let tags: string[] = this.data.frequentTags.map((x) => x.alias);
     return this.data.publicTags.filter((x) => !tags.includes(x));
   }
 


### PR DESCRIPTION
# Descripción

Se agrega un límite de 15 para las etiquetas frecuentes en la nueva página de colecciones de problemas por nivel.

# Comentarios

Se cambiaron también nombres de variables de `$collection` a `$frequentTags`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
