### PR TITLE
Filtro de dificultad para problemas de calidad

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3775,7 +3775,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             $onlyQualitySeal,
             $level,
-            $difficulty ?: 'all'
+            $difficulty ?? 'all'
         );
     }
 
@@ -6045,7 +6045,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $user,
             $onlyQualitySeal,
             $level,
-            $difficulty ?: 'all'
+            $difficulty ?? 'all'
         );
 
         $params = [

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3775,7 +3775,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             $onlyQualitySeal,
             $level,
-            $difficulty ?? 'all'
+            $difficulty ?: 'all'
         );
     }
 
@@ -5922,7 +5922,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
-        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
+        $difficulty = $r->ensureOptionalString('difficulty') ?: 'all';
 
         [
             'sortOrder' => $sortOrder,
@@ -6045,7 +6045,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $user,
             $onlyQualitySeal,
             $level,
-            $difficulty ?? 'all'
+            $difficulty ?: 'all'
         );
 
         $params = [
@@ -6128,7 +6128,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
-        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
+        $difficulty = $r->ensureOptionalString('difficulty') ?: 'all';
 
         [
             'sortOrder' => $sortOrder,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3736,7 +3736,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $onlyQualitySeal = $r->ensureOptionalBool('only_quality_seal') ?? false;
         $level = $r->ensureOptionalString('level');
-        $difficulty = $r->ensureOptionalString('difficulty');
+        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
 
         if (is_null($r['page'])) {
             $offset = is_null($r['offset']) ? 0 : intval($r['offset']);
@@ -3775,7 +3775,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             $onlyQualitySeal,
             $level,
-            $difficulty ?: 'all'
+            $difficulty
         );
     }
 
@@ -5922,7 +5922,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
-        $difficulty = $r->ensureOptionalString('difficulty') ?: 'all';
+        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
 
         [
             'sortOrder' => $sortOrder,
@@ -6045,7 +6045,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $user,
             $onlyQualitySeal,
             $level,
-            $difficulty ?: 'all'
+            $difficulty
         );
 
         $params = [
@@ -6128,7 +6128,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
-        $difficulty = $r->ensureOptionalString('difficulty') ?: 'all';
+        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
 
         [
             'sortOrder' => $sortOrder,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3603,7 +3603,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $require_all_tags
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
-     * @omegaup-request-param mixed $difficulty
      */
     private static function validateListParams(\OmegaUp\Request $r) {
         \OmegaUp\Validators::validateOptionalInEnum(
@@ -3681,10 +3680,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $programmingLanguages = [];
         }
 
-        $difficulty = $r->ensureOptionalString(
-            'difficulty'
-        );
-
         return [
             'sortOrder' => strval($r['sort_order']),
             'page' => intval($r['page']),
@@ -3700,7 +3695,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'programmingLanguages' => $programmingLanguages,
             'difficultyRange' => $difficultyRange,
             'minVisibility' => $minVisibility,
-            'difficulty' => $difficulty,
         ];
     }
 
@@ -3709,6 +3703,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      *
      * @return array{results: list<ProblemListItem>, total: int}
      *
+     * @omegaup-request-param null|string $difficulty
      * @omegaup-request-param null|string $difficulty_range
      * @omegaup-request-param mixed $language
      * @omegaup-request-param int|null $max_difficulty
@@ -3741,6 +3736,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $onlyQualitySeal = $r->ensureOptionalBool('only_quality_seal') ?? false;
         $level = $r->ensureOptionalString('level');
+        $difficulty = $r->ensureOptionalString('difficulty');
 
         if (is_null($r['page'])) {
             $offset = is_null($r['offset']) ? 0 : intval($r['offset']);
@@ -3778,7 +3774,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->identity,
             $r->user,
             $onlyQualitySeal,
-            $level
+            $level,
+            $difficulty ?: 'all'
         );
     }
 
@@ -4820,7 +4817,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             /*$onlyQualitySeal=*/false,
             /*$url=*/'/problem/list/',
-            /*$level=*/null
+            /*$level=*/null,
+            /*$difficulty=*/'all'
         );
 
         return [
@@ -5898,6 +5896,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @return array{smartyProperties: array{payload: CollectionDetailsByLevelPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      *
      * @omegaup-request-param string $level
+     * @omegaup-request-param null|string $difficulty
      * @omegaup-request-param null|string $difficulty_range
      * @omegaup-request-param mixed $language
      * @omegaup-request-param int|null $max_difficulty
@@ -5913,7 +5912,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $rowcount
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
-     * @omegaup-request-param mixed $difficulty
      */
     public static function getCollectionsDetailsByLevelForSmarty(\OmegaUp\Request $r): array {
         $collectionLevel = $r->ensureString('level');
@@ -5924,6 +5922,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
+        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
 
         [
             'sortOrder' => $sortOrder,
@@ -5936,7 +5935,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'programmingLanguages' => $programmingLanguages,
             'difficultyRange' => $difficultyRange,
             'minVisibility' => $minVisibility,
-            'difficulty' => $difficulty,
         ] = self::validateListParams($r);
 
         $result = self::getList(
@@ -6105,6 +6103,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      *
      * @return array{smartyProperties: array{payload: CollectionDetailsByAuthorPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      *
+     * @omegaup-request-param null|string $difficulty
      * @omegaup-request-param null|string $difficulty_range
      * @omegaup-request-param mixed $language
      * @omegaup-request-param int|null $max_difficulty
@@ -6129,6 +6128,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
+        $difficulty = $r->ensureOptionalString('difficulty') ?? 'all';
 
         [
             'sortOrder' => $sortOrder,
@@ -6160,7 +6160,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             /*$onlyQualitySeal=*/true,
             /*$url=*/'/problem/collection/author/',
-            /*$level=*/null
+            /*$level=*/null,
+            $difficulty
         );
 
         $response = \OmegaUp\Controllers\User::getAuthorsRankWithQualityProblems(

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3603,6 +3603,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $require_all_tags
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
+     * @omegaup-request-param mixed $difficulty
      */
     private static function validateListParams(\OmegaUp\Request $r) {
         \OmegaUp\Validators::validateOptionalInEnum(
@@ -3680,6 +3681,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $programmingLanguages = [];
         }
 
+        $difficulty = $r->ensureOptionalString(
+            'difficulty'
+        );        
+
         return [
             'sortOrder' => strval($r['sort_order']),
             'page' => intval($r['page']),
@@ -3695,6 +3700,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'programmingLanguages' => $programmingLanguages,
             'difficultyRange' => $difficultyRange,
             'minVisibility' => $minVisibility,
+            'difficulty' => $difficulty,
         ];
     }
 
@@ -3798,7 +3804,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Identities $identity,
         ?\OmegaUp\DAO\VO\Users $user,
         bool $onlyQualitySeal,
-        ?string $level
+        ?string $level,
+        string $difficulty
     ) {
         $authorIdentityId = null;
         $authorUserId = null;
@@ -3850,7 +3857,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $programmingLanguages,
             $difficultyRange,
             $onlyQualitySeal,
-            $level
+            $level,
+            $difficulty
         );
         return [
             'total' => $count,
@@ -5905,6 +5913,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $rowcount
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
+     * @omegaup-request-param mixed $difficulty
      */
     public static function getCollectionsDetailsByLevelForSmarty(\OmegaUp\Request $r): array {
         $collectionLevel = $r->ensureString('level');
@@ -5927,6 +5936,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'programmingLanguages' => $programmingLanguages,
             'difficultyRange' => $difficultyRange,
             'minVisibility' => $minVisibility,
+            'difficulty' => $difficulty, 
         ] = self::validateListParams($r);
 
         $result = self::getList(
@@ -5946,7 +5956,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->user,
             /*$onlyQualitySeal=*/true,
             /*$url=*/"/problem/collection/{$collectionLevel}/",
-            /*$level=*/$collectionLevel
+            /*$level=*/$collectionLevel,
+            $difficulty
         );
 
         $frequentTags = \OmegaUp\Controllers\Tag::getFrequentTagsByLevel(
@@ -5973,6 +5984,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'columns' => $result['columns'],
                     'tagsList' => $result['tags'],
                     'tagData' => $result['tagData'],
+                    'difficulty' => $result['difficulty'],
                 ],
                 'title' => new \OmegaUp\TranslationString(
                     'omegaupTitleCollectionsByLevel'
@@ -5996,7 +6008,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @param list<string> $programmingLanguages
      * @param array{0: int, 1: int}|null $difficultyRange
      *
-     * @return array{column: string, columns: list<string>, currentTags: list<string>, keyword: string, language: string, languages: list<string>, mode: string, modes: list<string>, problems: list<ProblemListItem>, pagerItems: list<PageItem>, tagData: list<Tag>, tags: list<string>}
+     * @return array{column: string, columns: list<string>, currentTags: list<string>, keyword: string, language: string, languages: list<string>, mode: string, modes: list<string>, problems: list<ProblemListItem>, pagerItems: list<PageItem>, tagData: list<Tag>, tags: list<string>, difficulty: string}
      */
     private static function getList(
         int $page,
@@ -6015,7 +6027,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Users $user,
         bool $onlyQualitySeal,
         string $url,
-        ?string $level
+        ?string $level,
+        string $difficulty
     ) {
         $response = self::getListImpl(
             $page ?: 1,
@@ -6033,7 +6046,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $identity,
             $user,
             $onlyQualitySeal,
-            $level
+            $level,
+            $difficulty ?: 'all'
         );
 
         $params = [
@@ -6041,7 +6055,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'language' => $language,
             'order_by' => $orderBy,
             'sort_order' => $sortOrder,
-            'tag' => $tags
+            'tag' => $tags,
+            'difficulty' => $difficulty
         ];
 
         $pagerItems = \OmegaUp\Pager::paginateWithUrl(
@@ -6082,6 +6097,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'columns' => \OmegaUp\Controllers\Problem::VALID_SORTING_COLUMNS,
             'tags' => $tags,
             'tagData' => $tagData,
+            'difficulty', => $difficulty
         ];
     }
 

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -39,7 +39,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ProblemListPayload=array{currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>}
  * @psalm-type RunsDiff=array{guid: string, new_score: float|null, new_status: null|string, new_verdict: null|string, old_score: float|null, old_status: null|string, old_verdict: null|string, problemset_id: int|null, username: string}
  * @psalm-type CommitRunsDiff=array<string, list<RunsDiff>>
- * @psalm-type CollectionDetailsByLevelPayload=array{frequentTags: list<array{alias: string, name?: string}>, publicTags: list<string>, level: string, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tagsList: list<string>}
+ * @psalm-type CollectionDetailsByLevelPayload=array{frequentTags: list<array{alias: string, name?: string}>, publicTags: list<string>, level: string, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tagsList: list<string>, difficulty: string}
  * @psalm-type CollectionDetailsByAuthorPayload=array{authors: list<array{username: string, name?: string}>, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>}
  * @psalm-type Tag=array{name: string}
  * @psalm-type ProblemListCollectionPayload=array{levelTags: list<string>, problemCount: list<array{name: string, problems_per_tag: int}>, allTags: list<Tag>}
@@ -3683,7 +3683,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $difficulty = $r->ensureOptionalString(
             'difficulty'
-        );        
+        );
 
         return [
             'sortOrder' => strval($r['sort_order']),
@@ -5936,7 +5936,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'programmingLanguages' => $programmingLanguages,
             'difficultyRange' => $difficultyRange,
             'minVisibility' => $minVisibility,
-            'difficulty' => $difficulty, 
+            'difficulty' => $difficulty,
         ] = self::validateListParams($r);
 
         $result = self::getList(
@@ -6097,7 +6097,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'columns' => \OmegaUp\Controllers\Problem::VALID_SORTING_COLUMNS,
             'tags' => $tags,
             'tagData' => $tagData,
-            'difficulty', => $difficulty
+            'difficulty' => $difficulty,
         ];
     }
 

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -2677,6 +2677,7 @@ List of public and user's private problems
 | Name                    | Type           | Description |
 | ----------------------- | -------------- | ----------- |
 | `only_quality_seal`     | `bool`         |             |
+| `difficulty`            | `null\|string` |             |
 | `difficulty_range`      | `null\|string` |             |
 | `language`              | `mixed`        |             |
 | `level`                 | `null\|string` |             |

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -167,18 +167,18 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         if (in_array($difficulty, $difficulties, true)) {
             if ($difficulty === $difficulties[0]) {
                 $clauses[] = [
-                    'p.difficulty < ?',
-                    ['1.34'],
+                    'p.difficulty < 1.34',
+                    [],
                 ];
             } elseif ($difficulty === $difficulties[1]) {
                 $clauses[] = [
-                    'p.difficulty >= ? AND p.difficulty < ?',
-                    ['1.34', '2.66'],
+                    'p.difficulty >= 1.34 AND p.difficulty < 2.66',
+                    [],
                 ];
             } else {
                 $clauses[] = [
-                    'p.difficulty >= ?',
-                    ['2.67'],
+                    'p.difficulty >= 2.67',
+                    [],
                 ];
             }
         }

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -173,7 +173,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             } elseif ($difficulty === $difficulties[1]) {
                 $clauses[] = [
                     'p.difficulty >= ? AND p.difficulty < ?',
-                    ['1.34', '2.67'],
+                    ['1.34', '2.66'],
                 ];
             } else {
                 $clauses[] = [

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -101,7 +101,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         array $programmingLanguages,
         ?array $difficultyRange,
         bool $onlyQualitySeal,
-        ?string $level
+        ?string $level,
+        string $difficulty
     ) {
         // Just in case.
         if ($order !== 'asc' && $order !== 'desc') {
@@ -143,7 +144,6 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         // Clauses is an array of 2-tuples that contains a chunk of SQL and the
         // arguments that are needed for that chunk.
         /** @var list<array{0: string, 1: list<string>}> */
-
         foreach ($programmingLanguages as $programmingLanguage) {
             $clauses[] = [
                 'FIND_IN_SET(?, p.languages) > 0',
@@ -160,6 +160,28 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 $conditions,
                 $difficultyRange,
             ];
+        }
+
+        $difficulties = array('easy', 'medium', 'hard');
+        $difficultyConditions = 'p.difficulty >= ? AND p.difficulty <= ?';
+
+        if($difficulty !== 'all' || !in_array($difficulty, $difficulties, true)){
+            if($difficulty === $difficulties[0]){
+                $clauses[] = [
+                    $difficultyConditions,
+                    [0, 1.33],
+                ];
+            } else if($difficulty === $difficulties[1]){
+                $clauses[] = [
+                    $difficultyConditions,
+                    [1.34, 2.66],
+                ];
+            } else {
+                $clauses[] = [
+                    $difficultyConditions,
+                    [2.67, 4],
+                ];
+            }
         }
 
         if (!is_null($query)) {

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -163,23 +163,22 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         }
 
         $difficulties = ['easy', 'medium', 'hard'];
-        $difficultyConditions = 'p.difficulty >= ? AND p.difficulty <= ?';
 
         if (in_array($difficulty, $difficulties, true)) {
             if ($difficulty === $difficulties[0]) {
                 $clauses[] = [
-                    $difficultyConditions,
-                    ['0', '1.33'],
+                    'p.difficulty < ?',
+                    ['1.34'],
                 ];
             } elseif ($difficulty === $difficulties[1]) {
                 $clauses[] = [
-                    $difficultyConditions,
-                    ['1.34', '2.66'],
+                    'p.difficulty >= ? AND p.difficulty < ?',
+                    ['1.34', '2.67'],
                 ];
             } else {
                 $clauses[] = [
-                    $difficultyConditions,
-                    ['2.67', '4'],
+                    'p.difficulty >= ?',
+                    ['2.67'],
                 ];
             }
         }

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -165,27 +165,21 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         $difficulties = ['easy', 'medium', 'hard'];
         $difficultyConditions = 'p.difficulty >= ? AND p.difficulty <= ?';
 
-        if (
-            $difficulty !== 'all' || !in_array(
-                $difficulty,
-                $difficulties,
-                true
-            )
-        ) {
+        if (in_array($difficulty, $difficulties, true)) {
             if ($difficulty === $difficulties[0]) {
                 $clauses[] = [
                     $difficultyConditions,
-                    [0, 1.33],
+                    ['0', '1.33'],
                 ];
             } elseif ($difficulty === $difficulties[1]) {
                 $clauses[] = [
                     $difficultyConditions,
-                    [1.34, 2.66],
+                    ['1.34', '2.66'],
                 ];
             } else {
                 $clauses[] = [
                     $difficultyConditions,
-                    [2.67, 4],
+                    ['2.67', '4'],
                 ];
             }
         }

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -162,16 +162,22 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             ];
         }
 
-        $difficulties = array('easy', 'medium', 'hard');
+        $difficulties = ['easy', 'medium', 'hard'];
         $difficultyConditions = 'p.difficulty >= ? AND p.difficulty <= ?';
 
-        if($difficulty !== 'all' || !in_array($difficulty, $difficulties, true)){
-            if($difficulty === $difficulties[0]){
+        if (
+            $difficulty !== 'all' || !in_array(
+                $difficulty,
+                $difficulties,
+                true
+            )
+        ) {
+            if ($difficulty === $difficulties[0]) {
                 $clauses[] = [
                     $difficultyConditions,
                     [0, 1.33],
                 ];
-            } else if($difficulty === $difficulties[1]){
+            } elseif ($difficulty === $difficulties[1]) {
                 $clauses[] = [
                     $difficultyConditions,
                     [1.34, 2.66],

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -188,4 +188,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(4, $result);
     }
+
+    public function testDifficultyOfQualityProblems(){
+        
+    }
 }

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -119,8 +119,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 \OmegaUp\Test\Factories\QualityNomination::createSuggestion(
                     $identities[$i],
                     $problems[$j]['request']['problem_alias'],
-                    1, /* difficulty */
-                    4, /* quality */
+                    /*$difficulty=*/1,
+                    /*$quality=*/4,
                     [],
                     false
                 );
@@ -140,8 +140,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 \OmegaUp\Test\Factories\QualityNomination::createSuggestion(
                     $identities[$i],
                     $problems[$j]['request']['problem_alias'],
-                    1, /* difficulty */
-                    3, /* quality */
+                    /*$difficulty=*/1,
+                    /*$quality=*/3,
                     [],
                     false
                 );
@@ -218,8 +218,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 \OmegaUp\Test\Factories\QualityNomination::createSuggestion(
                     $identities[$j],
                     $problems[$i]['request']['problem_alias'],
-                    $i, /* difficulty */
-                    3, /* quality */
+                    /*$difficulty=*/$i,
+                    /*$quality=*/3,
                     [],
                     false
                 );

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1406,6 +1406,7 @@ export namespace types {
     column: string;
     columns: string[];
     currentTags: string[];
+    difficulty: string;
     frequentTags: { alias: string; name?: string }[];
     keyword: string;
     language: string;


### PR DESCRIPTION
# Descripción

Agregado parámetro para permitir filtrar problemas por dificultad `Fácil`, `Medio` y `Difícil`.

Part of: #4891 

# Comentarios

Cambiada solo la parte del servidor.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
