### PR TITLE
Filtrar etiquetas en la pagina de colecciones

### DIFF
--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -164,7 +164,7 @@
                     ? 'custom-badge-quality'
                     : ''
                 } m-1 p-2`"
-                :href="hrefForProblemTag(currentTags, tag.name, rute)"
+                :href="hrefForProblemTag(currentTags, tag.name)"
                 >{{
                   Object.prototype.hasOwnProperty.call(T, tag.name)
                     ? T[tag.name]
@@ -267,7 +267,7 @@ export default class BaseList extends Vue {
   @Prop() tags!: string[];
   @Prop() sortOrder!: string;
   @Prop() columnName!: string;
-  @Prop() rute!: string;
+  @Prop() path!: string;
 
   T = T;
   ui = ui;
@@ -288,15 +288,11 @@ export default class BaseList extends Vue {
     T.qualityFormDifficultyVeryHard,
   ];
 
-  hrefForProblemTag(
-    currentTags: string[],
-    problemTag: string,
-    rute: string,
-  ): string {
-    if (!currentTags) return `${rute}?tag[]=${problemTag}`;
+  hrefForProblemTag(currentTags: string[], problemTag: string): string {
+    if (!currentTags) return `${this.path}?tag[]=${problemTag}`;
     let tags = currentTags.slice();
     if (!tags.includes(problemTag)) tags.push(problemTag);
-    return `${rute}?tag[]=${tags.join('&tag[]=')}`;
+    return `${this.path}?tag[]=${tags.join('&tag[]=')}`;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -164,7 +164,15 @@
                     ? 'custom-badge-quality'
                     : ''
                 } m-1 p-2`"
-                :href="`${collections ? hrefForProblemTagCollection(currentTags, tag.name) : hrefForProblemTag(currentTags, tag.name)}`"
+                :href="`${
+                  collections
+                    ? hrefForProblemTagCollection(
+                        currentTags,
+                        tag.name,
+                        collectionTitle,
+                      )
+                    : hrefForProblemTag(currentTags, tag.name)
+                }`"
                 >{{
                   Object.prototype.hasOwnProperty.call(T, tag.name)
                     ? T[tag.name]
@@ -296,11 +304,16 @@ export default class BaseList extends Vue {
     return `/problem/?tag[]=${tags.join('&tag[]=')}`;
   }
 
-  hrefForProblemTagCollection(currentTags: string[], problemTag: string): string {
-    if (!currentTags) return `/problem/collection/${this.collectionTitle}/?tag[]=${problemTag}`;
+  hrefForProblemTagCollection(
+    currentTags: string[],
+    problemTag: string,
+    title: string,
+  ): string {
+    if (!currentTags)
+      return `/problem/collection/${title}/?tag[]=${problemTag}`;
     let tags = currentTags.slice();
     if (!tags.includes(problemTag)) tags.push(problemTag);
-    return `/problem/collection/${this.collectionTitle}/?tag[]=${tags.join('&tag[]=')}`;
+    return `/problem/collection/${title}/?tag[]=${tags.join('&tag[]=')}`;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -164,15 +164,7 @@
                     ? 'custom-badge-quality'
                     : ''
                 } m-1 p-2`"
-                :href="`${
-                  collections
-                    ? hrefForProblemTagCollection(
-                        currentTags,
-                        tag.name,
-                        collectionTitle,
-                      )
-                    : hrefForProblemTag(currentTags, tag.name)
-                }`"
+                :href="hrefForProblemTag(currentTags, tag.name, rute)"
                 >{{
                   Object.prototype.hasOwnProperty.call(T, tag.name)
                     ? T[tag.name]
@@ -275,8 +267,7 @@ export default class BaseList extends Vue {
   @Prop() tags!: string[];
   @Prop() sortOrder!: string;
   @Prop() columnName!: string;
-  @Prop({ default: false }) collections!: boolean;
-  @Prop() collectionTitle!: string;
+  @Prop() rute!: string;
 
   T = T;
   ui = ui;
@@ -297,23 +288,15 @@ export default class BaseList extends Vue {
     T.qualityFormDifficultyVeryHard,
   ];
 
-  hrefForProblemTag(currentTags: string[], problemTag: string): string {
-    if (!currentTags) return `/problem/?tag[]=${problemTag}`;
-    let tags = currentTags.slice();
-    if (!tags.includes(problemTag)) tags.push(problemTag);
-    return `/problem/?tag[]=${tags.join('&tag[]=')}`;
-  }
-
-  hrefForProblemTagCollection(
+  hrefForProblemTag(
     currentTags: string[],
     problemTag: string,
-    title: string,
+    rute: string,
   ): string {
-    if (!currentTags)
-      return `/problem/collection/${title}/?tag[]=${problemTag}`;
+    if (!currentTags) return `${rute}?tag[]=${problemTag}`;
     let tags = currentTags.slice();
     if (!tags.includes(problemTag)) tags.push(problemTag);
-    return `/problem/collection/${title}/?tag[]=${tags.join('&tag[]=')}`;
+    return `${rute}?tag[]=${tags.join('&tag[]=')}`;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -164,7 +164,7 @@
                     ? 'custom-badge-quality'
                     : ''
                 } m-1 p-2`"
-                :href="hrefForProblemTag(currentTags, tag.name)"
+                :href="`${collections ? hrefForProblemTagCollection(currentTags, tag.name) : hrefForProblemTag(currentTags, tag.name)}`"
                 >{{
                   Object.prototype.hasOwnProperty.call(T, tag.name)
                     ? T[tag.name]
@@ -267,6 +267,8 @@ export default class BaseList extends Vue {
   @Prop() tags!: string[];
   @Prop() sortOrder!: string;
   @Prop() columnName!: string;
+  @Prop({ default: false }) collections!: boolean;
+  @Prop() collectionTitle!: string;
 
   T = T;
   ui = ui;
@@ -292,6 +294,13 @@ export default class BaseList extends Vue {
     let tags = currentTags.slice();
     if (!tags.includes(problemTag)) tags.push(problemTag);
     return `/problem/?tag[]=${tags.join('&tag[]=')}`;
+  }
+
+  hrefForProblemTagCollection(currentTags: string[], problemTag: string): string {
+    if (!currentTags) return `/problem/collection/${this.collectionTitle}/?tag[]=${problemTag}`;
+    let tags = currentTags.slice();
+    if (!tags.includes(problemTag)) tags.push(problemTag);
+    return `/problem/collection/${this.collectionTitle}/?tag[]=${tags.join('&tag[]=')}`;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -28,8 +28,7 @@
           :tags="tagsList"
           :sort-order="sortOrder"
           :column-name="columnName"
-          :collections="true"
-          :collection-title="level"
+          :rute="`/problem/collection/${level}/`"
           @apply-filter="
             (columnName, sortOrder) =>
               $emit('apply-filter', columnName, sortOrder)

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -29,7 +29,7 @@
           :sort-order="sortOrder"
           :column-name="columnName"
           :collections="true"
-          :collectionTitle="this.level"
+          :collection-title="level"
           @apply-filter="
             (columnName, sortOrder) =>
               $emit('apply-filter', columnName, sortOrder)

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -28,6 +28,8 @@
           :tags="tagsList"
           :sort-order="sortOrder"
           :column-name="columnName"
+          :collections="true"
+          :collectionTitle="this.level"
           @apply-filter="
             (columnName, sortOrder) =>
               $emit('apply-filter', columnName, sortOrder)

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -28,7 +28,7 @@
           :tags="tagsList"
           :sort-order="sortOrder"
           :column-name="columnName"
-          :rute="`/problem/collection/${level}/`"
+          :path="`/problem/collection/${level}/`"
           @apply-filter="
             (columnName, sortOrder) =>
               $emit('apply-filter', columnName, sortOrder)

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -36,7 +36,7 @@
       :tags="tags"
       :sort-order="sortOrder"
       :column-name="columnName"
-      :rute="'/problem/'"
+      :path="'/problem/'"
       @apply-filter="
         (columnName, sortOrder) => $emit('apply-filter', columnName, sortOrder)
       "

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -36,6 +36,7 @@
       :tags="tags"
       :sort-order="sortOrder"
       :column-name="columnName"
+      :rute="'/problem/'"
       @apply-filter="
         (columnName, sortOrder) => $emit('apply-filter', columnName, sortOrder)
       "


### PR DESCRIPTION
# Descripción

Al dar clic en una etiqueta de la tabla filtra por esa etiqueta dentro de la misma página y ya no redirecciona a otra.

![image](https://user-images.githubusercontent.com/43051192/98152112-cf7dfc00-1e96-11eb-8af3-671ce4fda820.png)

Fixes: #4890 

# Comentarios

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
