### PR TITLE
Agregando componente de Reviewer para Bootstrap 4

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -212,7 +212,7 @@ import problem_SettingsSummary from './SettingsSummaryV2.vue';
 import problem_Solution from './Solution.vue';
 import qualitynomination_Demotion from '../qualitynomination/DemotionPopup.vue';
 import qualitynomination_Promotion from '../qualitynomination/Popup.vue';
-import qualitynomination_QualityReview from '../qualitynomination/ReviewerPopup.vue';
+import qualitynomination_QualityReview from '../qualitynomination/ReviewerPopupv2.vue';
 import user_Username from '../user/Username.vue';
 import omegaup_Markdown from '../Markdown.vue';
 import omegaup_Overlay from '../Overlay.vue';

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopup.vue
@@ -66,7 +66,7 @@
               </th>
             </thead>
             <tbody>
-              <tr v-for="(tag, index) in publicTagsList" :key="index">
+              <tr v-for="tag in publicTagsList" :key="tag">
                 <td>{{ getName(tag) }}</td>
                 <td class="text-center">
                   <button

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopupv2.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopupv2.vue
@@ -16,14 +16,10 @@
           {{ T.reviewerNominationQuality }}
         </label>
         <br />
-        <label class="radio-inline"
-          ><input v-model="qualitySeal" type="radio" :value="true" />
-          {{ T.wordsYes }}</label
-        >
-        <label class="radio-inline"
-          ><input v-model="qualitySeal" type="radio" :value="false" />
-          {{ T.wordsNo }}</label
-        >
+        <omegaup-radio-switch
+          :value.sync="qualitySeal"
+          :selected-value="qualitySeal"
+        ></omegaup-radio-switch>
       </div>
       <div class="form-group">
         <label class="control-label">
@@ -107,6 +103,7 @@
 <script lang="ts">
 import { Vue, Prop, Component } from 'vue-property-decorator';
 import Popup from './Popup.vue';
+import omegaup_RadioSwitch from '../RadioSwitch.vue';
 import T from '../../lang';
 import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
 
@@ -118,6 +115,7 @@ library.add(faTrash);
 @Component({
   components: {
     'omegaup-popup': Popup,
+    'omegaup-radio-switch': omegaup_RadioSwitch,
     'vue-typeahead-bootstrap': VueTypeaheadBootstrap,
     FontAwesomeIcon,
   },

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopupv2.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopupv2.vue
@@ -62,7 +62,7 @@
               </th>
             </thead>
             <tbody>
-              <tr v-for="(tag, index) in publicTagsList" :key="index">
+              <tr v-for="tag in publicTagsList" :key="tag">
                 <td>{{ getName(tag) }}</td>
                 <td class="text-center">
                   <button


### PR DESCRIPTION
# Descripción

Se agrega un componente de ReviewerPopup para que contenga los estilos de
Bootstrap 4 y no afecte la vista del componente que ya se tenía en lo que se 
termina de realizar la migración.

![image](https://user-images.githubusercontent.com/3230352/98201718-ebfd5100-1ef5-11eb-9c14-6845d5f745e3.png)

Fixes: #4886 

# Comentarios

También esto servirá para revisar si se comienza a usar el componente `overlay`
y `overlay-popup` en todos los modals que aparecen en la vista de problemas.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
