### PR TITLE
Agregando el campo de acting_identity_id en la tabla Auth_Tokens

### DIFF
--- a/frontend/database/164_add_acting_identity_in_auth_tokens.sql
+++ b/frontend/database/164_add_acting_identity_in_auth_tokens.sql
@@ -1,0 +1,5 @@
+-- Auth_Tokens: addin acting identity id for no main identities for a user
+ALTER TABLE `Auth_Tokens`
+  ADD COLUMN `acting_identity_id` int(11) DEFAULT NULL COMMENT 'Identidad del usuario que indica que no está actuando como identidad principal' AFTER `identity_id`,
+  ADD KEY `acting_identity_id` (`identity_id`),
+  ADD CONSTRAINT `fk_ati_acting_identity_id` FOREIGN KEY (`acting_identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -56,10 +56,14 @@ CREATE TABLE `Assignments` (
 CREATE TABLE `Auth_Tokens` (
   `user_id` int DEFAULT NULL,
   `identity_id` int NOT NULL COMMENT 'Identidad del usuario',
+  `acting_identity_id` int DEFAULT NULL COMMENT 'Identidad del usuario que indica que no está actuando como identidad principal',
   `token` varchar(128) NOT NULL,
   `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`token`),
   KEY `identity_id` (`identity_id`),
+  KEY `acting_identity_id` (`identity_id`),
+  KEY `fk_ati_acting_identity_id` (`acting_identity_id`),
+  CONSTRAINT `fk_ati_acting_identity_id` FOREIGN KEY (`acting_identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_ati_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Tokens de autorización para los logins.';
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/frontend/server/src/DAO/AuthTokens.php
+++ b/frontend/server/src/DAO/AuthTokens.php
@@ -97,7 +97,7 @@ class AuthTokens extends \OmegaUp\DAO\Base\AuthTokens {
                     `Auth_Tokens` at
                 WHERE
                     at.identity_id = ?;';
-        /** @var list<array{create_time: \OmegaUp\Timestamp, identity_id: int, token: string, user_id: int|null}> */
+        /** @var list<array{acting_identity_id: int|null, create_time: \OmegaUp\Timestamp, identity_id: int, token: string, user_id: int|null}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$identityId]

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -48,9 +48,11 @@ abstract class AuthTokens {
                 Auth_Tokens (
                     `user_id`,
                     `identity_id`,
+                    `acting_identity_id`,
                     `token`,
                     `create_time`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -65,6 +67,11 @@ abstract class AuthTokens {
             (
                 !is_null($Auth_Tokens->identity_id) ?
                 intval($Auth_Tokens->identity_id) :
+                null
+            ),
+            (
+                !is_null($Auth_Tokens->acting_identity_id) ?
+                intval($Auth_Tokens->acting_identity_id) :
                 null
             ),
             $Auth_Tokens->token,
@@ -92,6 +99,7 @@ abstract class AuthTokens {
             SET
                 `user_id` = ?,
                 `identity_id` = ?,
+                `acting_identity_id` = ?,
                 `create_time` = ?
             WHERE
                 (
@@ -107,6 +115,11 @@ abstract class AuthTokens {
                 is_null($Auth_Tokens->identity_id) ?
                 null :
                 intval($Auth_Tokens->identity_id)
+            ),
+            (
+                is_null($Auth_Tokens->acting_identity_id) ?
+                null :
+                intval($Auth_Tokens->acting_identity_id)
             ),
             \OmegaUp\DAO\DAO::toMySQLTimestamp(
                 $Auth_Tokens->create_time
@@ -134,6 +147,7 @@ abstract class AuthTokens {
             SELECT
                 `Auth_Tokens`.`user_id`,
                 `Auth_Tokens`.`identity_id`,
+                `Auth_Tokens`.`acting_identity_id`,
                 `Auth_Tokens`.`token`,
                 `Auth_Tokens`.`create_time`
             FROM
@@ -219,6 +233,7 @@ abstract class AuthTokens {
             SELECT
                 `Auth_Tokens`.`user_id`,
                 `Auth_Tokens`.`identity_id`,
+                `Auth_Tokens`.`acting_identity_id`,
                 `Auth_Tokens`.`token`,
                 `Auth_Tokens`.`create_time`
             FROM
@@ -273,9 +288,11 @@ abstract class AuthTokens {
                 `Auth_Tokens` (
                     `user_id`,
                     `identity_id`,
+                    `acting_identity_id`,
                     `token`,
                     `create_time`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -291,6 +308,11 @@ abstract class AuthTokens {
                 is_null($Auth_Tokens->identity_id) ?
                 null :
                 intval($Auth_Tokens->identity_id)
+            ),
+            (
+                is_null($Auth_Tokens->acting_identity_id) ?
+                null :
+                intval($Auth_Tokens->acting_identity_id)
             ),
             $Auth_Tokens->token,
             \OmegaUp\DAO\DAO::toMySQLTimestamp(

--- a/frontend/server/src/DAO/VO/AuthTokens.php
+++ b/frontend/server/src/DAO/VO/AuthTokens.php
@@ -18,6 +18,7 @@ class AuthTokens extends \OmegaUp\DAO\VO\VO {
     const FIELD_NAMES = [
         'user_id' => true,
         'identity_id' => true,
+        'acting_identity_id' => true,
         'token' => true,
         'create_time' => true,
     ];
@@ -40,6 +41,11 @@ class AuthTokens extends \OmegaUp\DAO\VO\VO {
         if (isset($data['identity_id'])) {
             $this->identity_id = intval(
                 $data['identity_id']
+            );
+        }
+        if (isset($data['acting_identity_id'])) {
+            $this->acting_identity_id = intval(
+                $data['acting_identity_id']
             );
         }
         if (isset($data['token'])) {
@@ -77,6 +83,13 @@ class AuthTokens extends \OmegaUp\DAO\VO\VO {
      * @var int|null
      */
     public $identity_id = null;
+
+    /**
+     * Identidad del usuario que indica que no está actuando como identidad principal
+     *
+     * @var int|null
+     */
+    public $acting_identity_id = null;
 
     /**
      * [Campo no documentado]


### PR DESCRIPTION
# Descripción

Se agrega este PR para partir #4884. en este cambio se agrega el campo en la
tabla de `Auth_Tokens` llamado `acting_identity_id`, el cual se va a ocupar para
poder identificar si un usuario se logueo con una identidad principal o una no
principal.

Part of: #4872 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
