### PR TITLE
Redirigiendo a la página de login cuando se ingresa link de curso privado

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -3586,6 +3586,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $courseDetails = self::getBasicCourseDetails($course);
         $commonDetails = [];
         if (
+            is_null($identity) &&
             $shouldShowIntro &&
             $course->admission_mode === self::ADMISSION_MODE_PRIVATE
         ) {

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -3589,7 +3589,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $shouldShowIntro &&
             $course->admission_mode === self::ADMISSION_MODE_PRIVATE
         ) {
-            throw new \OmegaUp\Exceptions\ForbiddenAccessException();
+            \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
         }
         if ($course->admission_mode !== self::ADMISSION_MODE_PRIVATE) {
             $commonDetails = [

--- a/frontend/tests/controllers/CourseStudentsTest.php
+++ b/frontend/tests/controllers/CourseStudentsTest.php
@@ -140,8 +140,8 @@ class CourseStudentsTest extends \OmegaUp\Test\ControllerTestCase {
             );
             $this->fail('Unassociated identity group should not join the course' .
                         'without an explicit invitation');
-        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
-            $this->assertEquals('userNotAllowed', $e->getMessage());
+        } catch (\OmegaUp\Exceptions\NotAllowedToSubmitException $e) {
+            $this->assertEquals('runNotEvenOpened', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
# Descripción

Se regresa la funcionalidad de redireccionar a la página de login cuando un 
usuario no logueado ingresa la url de un curso privado.

![RedirectPublicCourseNotLoggedFull](https://user-images.githubusercontent.com/3230352/98398036-e6068d80-2025-11eb-85b4-416afb9e1421.gif)

Fixes: #4896 

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
