### PR TITLE
Deshabilitando botón de envíos cuando el servidor aún no ha respondido

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunSubmit.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmit.vue
@@ -48,7 +48,7 @@
         <button
           type="submit"
           class="btn btn-primary"
-          :disabled="!canSubmit || awaitForServerResponse"
+          :disabled="!canSubmit || waitingForServerResponse"
         >
           <omegaup-countdown
             v-if="!canSubmit"
@@ -91,7 +91,7 @@ export default class ArenaRunSubmit extends Vue {
   selectedLanguage = '';
   code = '';
   now: number = Date.now();
-  awaitForServerResponse = false;
+  waitingForServerResponse = false;
 
   get canSubmit(): boolean {
     return this.nextSubmissionTimestamp.getTime() < this.now;
@@ -179,11 +179,11 @@ export default class ArenaRunSubmit extends Vue {
     const file = this.inputFile.files?.[0];
     if (file) {
       const reader = new FileReader();
-      this.awaitForServerResponse = true;
 
       reader.onload = (e) => {
         const result = e.target?.result ?? null;
         if (result === null) return;
+        this.waitingForServerResponse = true;
         this.$emit('submit-run', result as string, this.selectedLanguage);
       };
 
@@ -233,7 +233,7 @@ export default class ArenaRunSubmit extends Vue {
       alert(T.arenaRunSubmitEmptyCode);
       return;
     }
-    this.awaitForServerResponse = true;
+    this.waitingForServerResponse = true;
     this.$emit('submit-run', this.code, this.selectedLanguage);
   }
 
@@ -241,7 +241,7 @@ export default class ArenaRunSubmit extends Vue {
     this.code = '';
     this.inputFile.type = 'text';
     this.inputFile.type = 'file';
-    this.awaitForServerResponse = false;
+    this.waitingForServerResponse = false;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/arena/RunSubmit.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmit.vue
@@ -45,7 +45,11 @@
     </div>
     <div class="form-group row">
       <div class="col-sm-10">
-        <button type="submit" class="btn btn-primary" :disabled="!canSubmit">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          :disabled="!canSubmit || awaitForServerResponse"
+        >
           <omegaup-countdown
             v-if="!canSubmit"
             :target-time="nextSubmissionTimestamp"
@@ -87,6 +91,7 @@ export default class ArenaRunSubmit extends Vue {
   selectedLanguage = '';
   code = '';
   now: number = Date.now();
+  awaitForServerResponse = false;
 
   get canSubmit(): boolean {
     return this.nextSubmissionTimestamp.getTime() < this.now;
@@ -174,6 +179,7 @@ export default class ArenaRunSubmit extends Vue {
     const file = this.inputFile.files?.[0];
     if (file) {
       const reader = new FileReader();
+      this.awaitForServerResponse = true;
 
       reader.onload = (e) => {
         const result = e.target?.result ?? null;
@@ -227,6 +233,7 @@ export default class ArenaRunSubmit extends Vue {
       alert(T.arenaRunSubmitEmptyCode);
       return;
     }
+    this.awaitForServerResponse = true;
     this.$emit('submit-run', this.code, this.selectedLanguage);
   }
 
@@ -234,6 +241,7 @@ export default class ArenaRunSubmit extends Vue {
     this.code = '';
     this.inputFile.type = 'text';
     this.inputFile.type = 'file';
+    this.awaitForServerResponse = false;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
@@ -53,7 +53,11 @@
       </div>
       <div class="form-group row">
         <div class="col-sm-10">
-          <button type="submit" class="btn btn-primary" :disabled="!canSubmit">
+          <button
+            type="submit"
+            class="btn btn-primary"
+            :disabled="!canSubmit || awaitForServerResponse"
+          >
             <omegaup-countdown
               v-if="!canSubmit"
               :target-time="nextSubmissionTimestamp"
@@ -98,6 +102,7 @@ export default class ArenaRunSubmitPopup extends Vue {
   selectedLanguage = '';
   code = '';
   now: number = Date.now();
+  awaitForServerResponse = false;
 
   get canSubmit(): boolean {
     return this.nextSubmissionTimestamp.getTime() < this.now;
@@ -185,6 +190,7 @@ export default class ArenaRunSubmitPopup extends Vue {
     const file = this.inputFile.files?.[0];
     if (file) {
       const reader = new FileReader();
+      this.awaitForServerResponse = true;
 
       reader.onload = (e) => {
         const result = e.target?.result ?? null;
@@ -238,6 +244,7 @@ export default class ArenaRunSubmitPopup extends Vue {
       alert(T.arenaRunSubmitEmptyCode);
       return;
     }
+    this.awaitForServerResponse = true;
     this.$emit('submit-run', this.code, this.selectedLanguage);
   }
 
@@ -245,6 +252,7 @@ export default class ArenaRunSubmitPopup extends Vue {
     this.code = '';
     this.inputFile.type = 'text';
     this.inputFile.type = 'file';
+    this.awaitForServerResponse = false;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
@@ -53,11 +53,7 @@
       </div>
       <div class="form-group row">
         <div class="col-sm-10">
-          <button
-            type="submit"
-            class="btn btn-primary"
-            :disabled="!canSubmit || awaitForServerResponse"
-          >
+          <button type="submit" class="btn btn-primary" :disabled="!canSubmit">
             <omegaup-countdown
               v-if="!canSubmit"
               :target-time="nextSubmissionTimestamp"
@@ -102,7 +98,6 @@ export default class ArenaRunSubmitPopup extends Vue {
   selectedLanguage = '';
   code = '';
   now: number = Date.now();
-  awaitForServerResponse = false;
 
   get canSubmit(): boolean {
     return this.nextSubmissionTimestamp.getTime() < this.now;
@@ -190,7 +185,6 @@ export default class ArenaRunSubmitPopup extends Vue {
     const file = this.inputFile.files?.[0];
     if (file) {
       const reader = new FileReader();
-      this.awaitForServerResponse = true;
 
       reader.onload = (e) => {
         const result = e.target?.result ?? null;
@@ -244,7 +238,6 @@ export default class ArenaRunSubmitPopup extends Vue {
       alert(T.arenaRunSubmitEmptyCode);
       return;
     }
-    this.awaitForServerResponse = true;
     this.$emit('submit-run', this.code, this.selectedLanguage);
   }
 
@@ -252,7 +245,6 @@ export default class ArenaRunSubmitPopup extends Vue {
     this.code = '';
     this.inputFile.type = 'text';
     this.inputFile.type = 'file';
-    this.awaitForServerResponse = false;
   }
 }
 </script>


### PR DESCRIPTION
# Descripción

Se evita que el botón de envíos permanezca habilitado hasta que el servidor 
envía una respuesta para cada envío.

Fixes: #4864 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.