### PR TITLE
cambio a etiquetas en problemMine

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Mine.vue
+++ b/frontend/www/js/omegaup/components/problem/Mine.vue
@@ -110,7 +110,13 @@
                   <div v-if="problem.tags.length" class="tags-badges">
                     <a
                       v-for="tag in problem.tags"
-                      :class="`badge custom-badge custom-badge-${tag.source} m-1 p-2`"
+                      :class="`badge custom-badge custom-badge-${
+                        tag.source.includes('quality') ? 'owner' : tag.source
+                      } ${
+                        tag.name.includes('problemLevel')
+                          ? 'custom-badge-quality'
+                          : ''
+                      } m-1 p-2`"
                       :href="`/problem/?tag[]=${tag.name}`"
                       >{{
                         Object.prototype.hasOwnProperty.call(T, tag.name)

--- a/frontend/www/js/omegaup/components/problem/Mine.vue
+++ b/frontend/www/js/omegaup/components/problem/Mine.vue
@@ -110,13 +110,17 @@
                   <div v-if="problem.tags.length" class="tags-badges">
                     <a
                       v-for="tag in problem.tags"
-                      :class="`badge custom-badge custom-badge-${
-                        tag.source.includes('quality') ? 'owner' : tag.source
-                      } ${
-                        tag.name.includes('problemLevel')
-                          ? 'custom-badge-quality'
-                          : ''
-                      } m-1 p-2`"
+                      class="badge custom-badge m-1 p-2"
+                      :class="[
+                        {
+                          'custom-badge-quality': tag.name.includes(
+                            'problemLevel',
+                          ),
+                        },
+                        `custom-badge-${
+                          tag.source.includes('quality') ? 'owner' : tag.source
+                        }`,
+                      ]"
                       :href="`/problem/?tag[]=${tag.name}`"
                       >{{
                         Object.prototype.hasOwnProperty.call(T, tag.name)


### PR DESCRIPTION
# Descripción

Se cambia la parte del color de las etiquetas en la sección de problem/mine para que solo muestre en amarillo las etiquetas de nivel.

![Captura de pantalla (2388)](https://user-images.githubusercontent.com/43051192/98426750-baa09480-205f-11eb-9871-fa49d2fdbd6f.png)
![Captura de pantalla (2387)](https://user-images.githubusercontent.com/43051192/98426761-c3916600-205f-11eb-83dd-6ab10ba12b92.png)

Fixes: #4901

# Comentarios

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
