### PR TITLE
Creando un nuevo estado para los envíos

### DIFF
--- a/.lint.config.json
+++ b/.lint.config.json
@@ -111,7 +111,8 @@
 		"dao": {
 			"allowlist": [
 				"frontend/database/schema.sql",
-				"frontend/server/libs/dao/base/.*\\.base\\.php$"
+				"frontend/server/src/DAO/Base/.*\\.php$",
+				"frontend/server/src/DAO/VO/.*\\.php$"
 			]
 		},
 		"translation_strings": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     build:
       dockerfile: ./Dockerfile.broadcaster
       context: ./stuff/docker/
-    image: omegaup/dev-broadcaster:20201018
+    image: omegaup/dev-broadcaster:20201107
     user: "${UID_GID}"
     restart: always
     depends_on:
@@ -60,7 +60,7 @@ services:
     build:
       dockerfile: ./Dockerfile.grader
       context: ./stuff/docker/
-    image: omegaup/dev-grader:20201018
+    image: omegaup/dev-grader:20201107
     user: "${UID_GID}"
     restart: always
     depends_on:
@@ -75,7 +75,7 @@ services:
     build:
       dockerfile: ./Dockerfile.runner
       context: ./stuff/docker/
-    image: omegaup/dev-runner:20201018
+    image: omegaup/dev-runner:20201107
     user: "${UID_GID}"
     restart: always
     depends_on:

--- a/frontend/database/165_add_run_waiting_status.sql
+++ b/frontend/database/165_add_run_waiting_status.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  `Runs`
+MODIFY COLUMN
+  `status` enum('new','waiting','compiling','running','ready','uploading') NOT NULL DEFAULT 'new';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -825,7 +825,7 @@ CREATE TABLE `Runs` (
   `submission_id` int NOT NULL COMMENT 'El envío',
   `version` char(40) NOT NULL COMMENT 'El hash SHA1 del árbol de la rama private.',
   `commit` char(40) NOT NULL COMMENT 'El hash SHA1 del commit en la rama master del problema con el que se realizó el envío.',
-  `status` enum('new','waiting','compiling','running','ready') NOT NULL DEFAULT 'new',
+  `status` enum('new','waiting','compiling','running','ready','uploading') NOT NULL DEFAULT 'new',
   `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL,
   `runtime` int NOT NULL DEFAULT '0',
   `penalty` int NOT NULL DEFAULT '0',

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -478,7 +478,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         $run = new \OmegaUp\DAO\VO\Runs([
             'version' => $problem->current_version,
             'commit' => $problem->commit,
-            'status' => 'new',
+            'status' => 'uploading',
             'runtime' => 0,
             'penalty' => $submitDelay,
             'time' => \OmegaUp\Time::get(),

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -164,7 +164,7 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Validate defaults
         $run = \OmegaUp\DAO\Runs::getByPK($submission->current_run_id);
-        $this->assertEquals('new', $run->status);
+        $this->assertEquals('uploading', $run->status);
         $this->assertEquals(0, $run->runtime);
         $this->assertEquals(0, $run->memory);
         $this->assertEquals(0, $run->score);

--- a/frontend/tests/controllers/RunStatusTest.php
+++ b/frontend/tests/controllers/RunStatusTest.php
@@ -38,7 +38,7 @@ class RunStatusTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertEquals($runData['response']['guid'], $response['guid']);
         $this->assertEquals('JE', $response['verdict']);
-        $this->assertEquals('new', $response['status']);
+        $this->assertEquals('uploading', $response['status']);
     }
 
     /**

--- a/stuff/docker/Dockerfile.broadcaster
+++ b/stuff/docker/Dockerfile.broadcaster
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.2.16/omegaup-backend.tar.xz | tar xJ -C /
+RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.2.17/omegaup-backend.tar.xz | tar xJ -C /
 RUN mkdir -p /etc/omegaup/broadcaster
 
 RUN useradd --create-home --shell=/bin/bash ubuntu

--- a/stuff/docker/Dockerfile.grader
+++ b/stuff/docker/Dockerfile.grader
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.2.16/omegaup-backend.tar.xz | tar xJ -C /
+RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.2.17/omegaup-backend.tar.xz | tar xJ -C /
 RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.27/libinteractive.jar -o /usr/share/java/libinteractive.jar
 RUN mkdir -p /etc/omegaup/grader
 

--- a/stuff/docker/Dockerfile.runner
+++ b/stuff/docker/Dockerfile.runner
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.2.16/omegaup-runner.tar.xz | tar xJ -C /
+RUN curl -sL https://github.com/omegaup/quark/releases/download/v1.2.17/omegaup-runner.tar.xz | tar xJ -C /
 RUN mkdir -p /etc/omegaup/runner
 
 RUN useradd --create-home --shell=/bin/bash ubuntu


### PR DESCRIPTION
Este cambio hace que los envíos estén en el estado `'uploading'` antes
de subir el código fuente al Grader. Esto es para evitar una carrera
entre que se crea el envío y se envía el fuente.