### PR TITLE
Haciendo más robusta la inserción de envíos

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -118,28 +118,26 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
         if (is_null($problemsetId)) {
             $sql = '
                 SELECT
-                    MAX(s.time) AS time
+                    MAX(s.time)
                 FROM
-                    Submissions s
+                    Identities AS i
+                LEFT JOIN
+                    Submissions s ON s.identity_id = i.identity_id
                 WHERE
-                    s.identity_id = ? AND s.problem_id = ?
-                ORDER BY
-                    s.time DESC
-                LIMIT 1
+                    i.identity_id = ? AND s.problem_id = ?
                 FOR UPDATE;
             ';
             $val = [$identityId, $problemId];
         } else {
             $sql = '
                 SELECT
-                    MAX(s.time) AS time
+                    MAX(s.time)
                 FROM
-                    Submissions s
+                    Identities AS i
+                LEFT JOIN
+                    Submissions s ON s.identity_id = i.identity_id
                 WHERE
-                    s.identity_id = ? AND s.problem_id = ? AND s.problemset_id = ?
-                ORDER BY
-                    s.time DESC
-                LIMIT 1
+                    i.identity_id = ? AND s.problem_id = ? AND s.problemset_id = ?
                 FOR UPDATE;
             ';
             $val = [$identityId, $problemId, $problemsetId];


### PR DESCRIPTION
Este cambio hace que el locking de las tablas al insertar envíos se haga
sobre los índices, no sobre los registros. Esto es porque cuando un
usuario no ha hecho envíos a un problema, no se hace locking a ningún
registro!

Part of: #4864