### PR TITLE
Haciendo funcional el filtro de etiquetas para problemas de calidad

### DIFF
--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -4,8 +4,8 @@
     <div class="row">
       <div class="col col-md-4">
         <omegaup-problem-filter-tags
-          :current-tags="currentTags"
-          :tags.sync="availableTags"
+          :selected-tags="currentTags"
+          :tags="availableTags"
           :public-tags="publicTags"
           @new-selected-tag="
             (selectedTags) =>
@@ -101,25 +101,16 @@ export default class CollectionList extends Vue {
   @Prop() sortOrder!: string;
   @Prop() columnName!: string;
   @Prop() difficulty!: string;
-  @Prop({ default: () => [] }) selectedTags!: string[];
 
   T = T;
   level = this.data.level;
 
   get availableTags(): string[] {
-    if (this.currentTags.length == 0) {
-      return this.data.frequentTags.map((element) => element.alias);
-    } else {
-      let tags: string[] = this.data.frequentTags.map(
-        (element) => element.alias,
-      );
-      this.currentTags.forEach((element) => {
-        if (!tags.includes(element)) {
-          tags.push(element);
-        }
-      });
-      return tags;
-    }
+    let tags: Set<string> = new Set(
+      this.data.frequentTags.map((element) => element.alias),
+    );
+    this.currentTags.forEach((element) => tags.add(element));
+    return Array.from(tags);
   }
 
   get publicTags(): string[] {

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -4,7 +4,7 @@
     <div class="row">
       <div class="col col-md-4">
         <omegaup-problem-filter-tags
-          :selected-tags="currentTags"
+          :selected-tags="selectedTags"
           :tags="availableTags"
           :public-tags="publicTags"
           @new-selected-tag="
@@ -27,7 +27,7 @@
                 columnName,
                 sortOrder,
                 difficulty,
-                currentTags,
+                selectedTags,
               )
           "
         ></omegaup-problem-filter-difficulty>
@@ -36,7 +36,7 @@
         <omegaup-problem-base-list
           :problems="problems"
           :logged-in="loggedIn"
-          :current-tags="currentTags"
+          :current-tags="selectedTags"
           :pager-items="pagerItems"
           :wizard-tags="wizardTags"
           :language="language"
@@ -57,7 +57,7 @@
                 columnName,
                 sortOrder,
                 difficulty,
-                currentTags,
+                selectedTags,
               )
           "
         >
@@ -87,7 +87,7 @@ export default class CollectionList extends Vue {
   @Prop() data!: types.CollectionDetailsByLevelPayload;
   @Prop() problems!: omegaup.Problem;
   @Prop() loggedIn!: boolean;
-  @Prop({ default: () => [] }) currentTags!: string[];
+  @Prop({ default: () => [] }) selectedTags!: string[];
   @Prop() pagerItems!: types.PageItem[];
   @Prop() wizardTags!: omegaup.Tag[];
   @Prop() language!: string;
@@ -109,7 +109,7 @@ export default class CollectionList extends Vue {
     let tags: Set<string> = new Set(
       this.data.frequentTags.map((element) => element.alias),
     );
-    this.currentTags.forEach((element) => tags.add(element));
+    this.selectedTags.forEach((element) => tags.add(element));
     return Array.from(tags);
   }
 

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -4,14 +4,31 @@
     <div class="row">
       <div class="col col-md-4">
         <omegaup-problem-filter-tags
-          :tags.sync="tags"
+          :current-tags="currentTags"
+          :tags.sync="availableTags"
           :public-tags="publicTags"
+          @new-selected-tag="
+            (selectedTags) =>
+              $emit(
+                'apply-filter',
+                columnName,
+                sortOrder,
+                difficulty,
+                selectedTags,
+              )
+          "
         ></omegaup-problem-filter-tags>
         <omegaup-problem-filter-difficulty
           :selected-difficulty="difficulty"
           @change-difficulty="
             (difficulty) =>
-              $emit('apply-filter', columnName, sortOrder, difficulty)
+              $emit(
+                'apply-filter',
+                columnName,
+                sortOrder,
+                difficulty,
+                currentTags,
+              )
           "
         ></omegaup-problem-filter-difficulty>
       </div>
@@ -35,7 +52,13 @@
           :path="`/problem/collection/${level}/`"
           @apply-filter="
             (columnName, sortOrder) =>
-              $emit('apply-filter', columnName, sortOrder, difficulty)
+              $emit(
+                'apply-filter',
+                columnName,
+                sortOrder,
+                difficulty,
+                currentTags,
+              )
           "
         >
         </omegaup-problem-base-list>
@@ -64,7 +87,7 @@ export default class CollectionList extends Vue {
   @Prop() data!: types.CollectionDetailsByLevelPayload;
   @Prop() problems!: omegaup.Problem;
   @Prop() loggedIn!: boolean;
-  @Prop() currentTags!: string[];
+  @Prop({ default: () => [] }) currentTags!: string[];
   @Prop() pagerItems!: types.PageItem[];
   @Prop() wizardTags!: omegaup.Tag[];
   @Prop() language!: string;
@@ -78,10 +101,26 @@ export default class CollectionList extends Vue {
   @Prop() sortOrder!: string;
   @Prop() columnName!: string;
   @Prop() difficulty!: string;
+  @Prop({ default: () => [] }) selectedTags!: string[];
 
   T = T;
   level = this.data.level;
-  tags: string[] = this.data.frequentTags.map((element) => element.alias);
+
+  get availableTags(): string[] {
+    if (this.currentTags.length == 0) {
+      return this.data.frequentTags.map((element) => element.alias);
+    } else {
+      let tags: string[] = this.data.frequentTags.map(
+        (element) => element.alias,
+      );
+      this.currentTags.forEach((element) => {
+        if (!tags.includes(element)) {
+          tags.push(element);
+        }
+      });
+      return tags;
+    }
+  }
 
   get publicTags(): string[] {
     let tags: string[] = this.data.frequentTags.map((x) => x.alias);

--- a/frontend/www/js/omegaup/components/problem/FilterTags.vue
+++ b/frontend/www/js/omegaup/components/problem/FilterTags.vue
@@ -43,7 +43,7 @@ export default class FilterTags extends Vue {
   currentSelectedTags = this.selectedTags;
 
   addOtherTag(tag: string): void {
-    if (!this.tags.includes(tag)) {
+    if (!this.currentSelectedTags.includes(tag)) {
       this.currentSelectedTags.push(tag);
     }
   }

--- a/frontend/www/js/omegaup/components/problem/FilterTags.vue
+++ b/frontend/www/js/omegaup/components/problem/FilterTags.vue
@@ -5,7 +5,7 @@
       <div v-for="(tag, index) in tags" :key="index" class="form-check">
         <label class="form-check-label">
           <input
-            v-model="selectedTags"
+            v-model="currentSelectedTags"
             :value="tag"
             class="form-check-input"
             type="checkbox"
@@ -35,17 +35,16 @@ import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
   },
 })
 export default class FilterTags extends Vue {
-  @Prop() tags!: string[];
   @Prop() publicTags!: string[];
-  @Prop({ default: () => [] }) currentTags!: string[];
+  @Prop({ default: () => [] }) tags!: string[];
+  @Prop({ default: () => [] }) selectedTags!: string[];
 
   T = T;
-  selectedTags = this.currentTags;
+  currentSelectedTags = this.selectedTags;
 
   addOtherTag(tag: string): void {
     if (!this.tags.includes(tag)) {
-      this.selectedTags.push(tag);
-      this.tags.push(tag);
+      this.currentSelectedTags.push(tag);
     }
   }
 
@@ -56,9 +55,9 @@ export default class FilterTags extends Vue {
     return tagname;
   }
 
-  @Watch('selectedTags')
+  @Watch('currentSelectedTags')
   onNewTagSelected(): void {
-    this.$emit('new-selected-tag', this.selectedTags);
+    this.$emit('new-selected-tag', this.currentSelectedTags);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/FilterTags.vue
+++ b/frontend/www/js/omegaup/components/problem/FilterTags.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
 import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
 @Component({
@@ -37,9 +37,10 @@ import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
 export default class FilterTags extends Vue {
   @Prop() tags!: string[];
   @Prop() publicTags!: string[];
+  @Prop({ default: () => [] }) currentTags!: string[];
 
   T = T;
-  selectedTags: string[] = [];
+  selectedTags = this.currentTags;
 
   addOtherTag(tag: string): void {
     if (!this.tags.includes(tag)) {
@@ -53,6 +54,11 @@ export default class FilterTags extends Vue {
       return T[tagname];
     }
     return tagname;
+  }
+
+  @Watch('selectedTags')
+  onNewTagSelected(): void {
+    this.$emit('new-selected-tag', this.selectedTags);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/problem/collection_list.ts
+++ b/frontend/www/js/omegaup/problem/collection_list.ts
@@ -72,6 +72,7 @@ OmegaUp.on('ready', () => {
             columnName: string,
             sortOrder: omegaup.SortOrder,
             difficulty: string,
+            tag: string[],
           ): void => {
             const queryParameters = {
               language,
@@ -79,6 +80,7 @@ OmegaUp.on('ready', () => {
               order_by: columnName,
               sort_order: sortOrder,
               difficulty,
+              tag,
             };
             window.location.replace(
               `/problem/collection/${payload.level}/?${ui.buildURLQuery(


### PR DESCRIPTION
# Descripción

Se agrega funcionalidad al componente de [filtro de etiquetas](https://github.com/omegaup/omegaup/pull/4797) para que filtre los problemas que contengan una o más etiquetas seleccionadas.

![tag-filter](https://user-images.githubusercontent.com/37001730/98619967-ea52d500-22c9-11eb-9845-35e3c3c3fd52.gif)

Fixes: #4906 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
