### PR TITLE
Cambio al tamaño de barras de estadísticas de un curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/Statistics.vue
+++ b/frontend/www/js/omegaup/components/course/Statistics.vue
@@ -295,6 +295,7 @@ export default class Statistics extends Vue {
     return {
       chart: {
         type: 'bar',
+        height: `${data.length < 10 ? null : (data.length * 10) / 2}%`,
       },
       title: {
         text: title,
@@ -322,6 +323,7 @@ export default class Statistics extends Vue {
         {
           name: yName,
           data: data,
+          pointWidth: 15,
         },
       ],
     };

--- a/frontend/www/js/omegaup/components/course/Statistics.vue
+++ b/frontend/www/js/omegaup/components/course/Statistics.vue
@@ -142,6 +142,8 @@ export default class Statistics extends Vue {
     return {
       chart: {
         type: 'bar',
+        height:
+          this.problems.length < 15 ? null : `${this.problems.length * 3}%`,
       },
       title: {
         text: T.courseStatisticsVerdicts,
@@ -161,6 +163,7 @@ export default class Statistics extends Vue {
       plotOptions: {
         series: {
           stacking: 'normal',
+          pointWidth: 15,
         },
         bar: {
           dataLabels: {
@@ -295,7 +298,7 @@ export default class Statistics extends Vue {
     return {
       chart: {
         type: 'bar',
-        height: `${data.length < 10 ? null : (data.length * 10) / 2}%`,
+        height: data.length < 15 ? null : `${data.length * 3}%`,
       },
       title: {
         text: title,


### PR DESCRIPTION
# Descripción

Se cambia el tamaño de las barras en las estadísticas de un curso para que sean de tamaño fijo de 15 px cuando se despliegan más de 15 a la vez.

![Captura de pantalla (2408)](https://user-images.githubusercontent.com/43051192/98712151-8c66d180-234b-11eb-9c81-14a6168aabb8.png)

![Captura de pantalla (2407)](https://user-images.githubusercontent.com/43051192/98712164-925cb280-234b-11eb-8b36-7188b396ea4d.png)

Fixes: #4650 

# Comentarios


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
