### PR TITLE
Correcciones en la página problem/collection y problem/collection/author

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4866,7 +4866,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'smartyProperties' => [
                 'payload' => [
                     'levelTags' => \OmegaUp\Controllers\Tag::getLevelTags(),
-                    'problemCount' => \OmegaUp\DAO\Problems::getProblemsPerTagCount(),
+                    'problemCount' => \OmegaUp\DAO\Problems::getQualityProblemsPerTagCount(),
                     'allTags' => $tags,
                 ],
                 'title' => new \OmegaUp\TranslationString(

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1195,6 +1195,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                     t.tag_id = pt.tag_id
                 WHERE
                     t.name LIKE CONCAT('problemLevel','%')
+                    AND p.quality_seal = 1
                 GROUP BY
                     t.name;";
 

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1180,7 +1180,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
     /**
      * @return list<array{name: string, problems_per_tag: int}>
      */
-    final public static function getProblemsPerTagCount(): array {
+    final public static function getQualityProblemsPerTagCount(): array {
         $sql = "SELECT
                     t.name, COUNT(p.problem_id) AS problems_per_tag
                 FROM

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -52,6 +52,12 @@ class ProblemParams {
 
     /**
      * @readonly
+     * @var bool
+     */
+    public $quality_seal;
+
+    /**
+     * @readonly
      * @var string
      */
     public $problemLevel;
@@ -79,6 +85,7 @@ class ProblemParams {
         $this->showDiff = $params['show_diff'] ?? 'none';
         $this->allowUserAddTags = $params['allow_user_add_tags'] ?? false;
         $this->problemLevel = $params['problem_level'] ?? 'problemLevelBasicIntroductionToProgramming';
+        $this->quality_seal = $params['quality_seal'] ?? false;
         $this->selectedTags = $params['selected_tags'] ?? $params['selected_tags'] ?? json_encode([
             [
                 'tagname' => 'problemLevelBasicIntroductionToProgramming',
@@ -255,6 +262,10 @@ class Problem {
                     $problem->visibility = \OmegaUp\ProblemParams::VISIBILITY_PROMOTED;
                     break;
             }
+            \OmegaUp\DAO\Problems::update($problem);
+        }
+        if ($params->quality_seal == true) {
+            $problem->quality_seal = 1;
             \OmegaUp\DAO\Problems::update($problem);
         }
 

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -52,7 +52,7 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var bool
+     * @var int
      */
     public $quality_seal;
 
@@ -85,7 +85,7 @@ class ProblemParams {
         $this->showDiff = $params['show_diff'] ?? 'none';
         $this->allowUserAddTags = $params['allow_user_add_tags'] ?? false;
         $this->problemLevel = $params['problem_level'] ?? 'problemLevelBasicIntroductionToProgramming';
-        $this->quality_seal = $params['quality_seal'] ?? false;
+        $this->quality_seal = $params['quality_seal'] ?? 0;
         $this->selectedTags = $params['selected_tags'] ?? $params['selected_tags'] ?? json_encode([
             [
                 'tagname' => 'problemLevelBasicIntroductionToProgramming',
@@ -264,7 +264,7 @@ class Problem {
             }
             \OmegaUp\DAO\Problems::update($problem);
         }
-        if ($params->quality_seal == true) {
+        if ($params->quality_seal == 1) {
             $problem->quality_seal = 1;
             \OmegaUp\DAO\Problems::update($problem);
         }

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -52,7 +52,7 @@ class ProblemParams {
 
     /**
      * @readonly
-     * @var int
+     * @var bool
      */
     public $quality_seal;
 
@@ -85,7 +85,7 @@ class ProblemParams {
         $this->showDiff = $params['show_diff'] ?? 'none';
         $this->allowUserAddTags = $params['allow_user_add_tags'] ?? false;
         $this->problemLevel = $params['problem_level'] ?? 'problemLevelBasicIntroductionToProgramming';
-        $this->quality_seal = $params['quality_seal'] ?? 0;
+        $this->quality_seal = $params['quality_seal'] ?? false;
         $this->selectedTags = $params['selected_tags'] ?? $params['selected_tags'] ?? json_encode([
             [
                 'tagname' => 'problemLevelBasicIntroductionToProgramming',
@@ -264,8 +264,8 @@ class Problem {
             }
             \OmegaUp\DAO\Problems::update($problem);
         }
-        if ($params->quality_seal == 1) {
-            $problem->quality_seal = 1;
+        if ($params->quality_seal === true) {
+            $problem->quality_seal = true;
             \OmegaUp\DAO\Problems::update($problem);
         }
 

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -165,7 +165,7 @@ class Problem {
             'languages' => $params->languages,
             'show_diff' => $params->showDiff,
             'allow_user_add_tags' => $params->allowUserAddTags,
-            'quality_seal' => $params->qualitySeal;
+            'quality_seal' => $params->qualitySeal,
             'problem_level' => $params->problemLevel,
             'selected_tags' => $params->selectedTags,
         ]);
@@ -265,7 +265,7 @@ class Problem {
             }
             \OmegaUp\DAO\Problems::update($problem);
         }
-        if ($params->qualitySeal === true) {
+        if ($params->qualitySeal) {
             $problem->qualitySeal = true;
             \OmegaUp\DAO\Problems::update($problem);
         }

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -266,7 +266,7 @@ class Problem {
             \OmegaUp\DAO\Problems::update($problem);
         }
         if ($params->qualitySeal) {
-            $problem->qualitySeal = true;
+            $problem->quality_seal = true;
             \OmegaUp\DAO\Problems::update($problem);
         }
 

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -54,7 +54,7 @@ class ProblemParams {
      * @readonly
      * @var bool
      */
-    public $quality_seal;
+    public $qualitySeal;
 
     /**
      * @readonly
@@ -75,7 +75,7 @@ class ProblemParams {
     public $validator;
 
     /**
-     * @param array{allow_user_add_tags?: bool, zipName?: string, title?: string, visibility?: ('deleted'|'private_banned'|'public_banned'|'private_warning'|'private'|'public_warning'|'public'|'promoted'), author?: \OmegaUp\DAO\VO\Identities, authorUser?: \OmegaUp\DAO\VO\Users, languages?: string, show_diff?: string, problem_level?: string, selected_tags?: string, validator?: string} $params
+     * @param array{allow_user_add_tags?: bool, quality_seal?: bool, zipName?: string, title?: string, visibility?: ('deleted'|'private_banned'|'public_banned'|'private_warning'|'private'|'public_warning'|'public'|'promoted'), author?: \OmegaUp\DAO\VO\Identities, authorUser?: \OmegaUp\DAO\VO\Users, languages?: string, show_diff?: string, problem_level?: string, selected_tags?: string, validator?: string} $params
      */
     public function __construct($params = []) {
         $this->zipName = $params['zipName'] ?? (OMEGAUP_TEST_RESOURCES_ROOT . 'testproblem.zip');
@@ -85,7 +85,7 @@ class ProblemParams {
         $this->showDiff = $params['show_diff'] ?? 'none';
         $this->allowUserAddTags = $params['allow_user_add_tags'] ?? false;
         $this->problemLevel = $params['problem_level'] ?? 'problemLevelBasicIntroductionToProgramming';
-        $this->quality_seal = $params['quality_seal'] ?? false;
+        $this->qualitySeal = $params['quality_seal'] ?? false;
         $this->selectedTags = $params['selected_tags'] ?? $params['selected_tags'] ?? json_encode([
             [
                 'tagname' => 'problemLevelBasicIntroductionToProgramming',
@@ -165,6 +165,7 @@ class Problem {
             'languages' => $params->languages,
             'show_diff' => $params->showDiff,
             'allow_user_add_tags' => $params->allowUserAddTags,
+            'quality_seal' => $params->qualitySeal;
             'problem_level' => $params->problemLevel,
             'selected_tags' => $params->selectedTags,
         ]);
@@ -264,8 +265,8 @@ class Problem {
             }
             \OmegaUp\DAO\Problems::update($problem);
         }
-        if ($params->quality_seal === true) {
-            $problem->quality_seal = true;
+        if ($params->qualitySeal === true) {
+            $problem->qualitySeal = true;
             \OmegaUp\DAO\Problems::update($problem);
         }
 

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -598,7 +598,7 @@ if __name__ == \'__main__\':
                 $problemData[] = \OmegaUp\Test\Factories\Problem::createProblem(
                     new \OmegaUp\Test\Factories\ProblemParams([
                         'problem_level' => $level,
-                        'quality_seal' => 1,
+                        'quality_seal' => true,
                     ])
                 );
             }

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -598,6 +598,7 @@ if __name__ == \'__main__\':
                 $problemData[] = \OmegaUp\Test\Factories\Problem::createProblem(
                     new \OmegaUp\Test\Factories\ProblemParams([
                         'problem_level' => $level,
+                        'quality_seal' => 1,
                     ])
                 );
             }

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -598,7 +598,7 @@ if __name__ == \'__main__\':
                 $problemData[] = \OmegaUp\Test\Factories\Problem::createProblem(
                     new \OmegaUp\Test\Factories\ProblemParams([
                         'problem_level' => $level,
-                        'quality_seal' => true,
+                        'quality_seal' => 1,
                     ])
                 );
             }

--- a/frontend/www/js/omegaup/components/problem/Collection.vue
+++ b/frontend/www/js/omegaup/components/problem/Collection.vue
@@ -64,7 +64,7 @@
                 <font-awesome-icon :icon="['fas', 'user']"></font-awesome-icon>
               </template>
               <template #button>
-                <a class="btn btn-primary" href="/problem/author/">{{
+                <a class="btn btn-primary" href="/problem/collection/author/">{{
                   T.problemcollectionViewProblems
                 }}</a>
               </template>

--- a/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
@@ -31,7 +31,7 @@
           :tags="tagsList"
           :sort-order="sortOrder"
           :column-name="columnName"
-          :path="`/problem/collection/author/`"
+          :path="'/problem/collection/author/'"
           @apply-filter="
             (columnName, sortOrder) =>
               $emit('apply-filter', columnName, sortOrder, difficulty)

--- a/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
@@ -31,6 +31,7 @@
           :tags="tagsList"
           :sort-order="sortOrder"
           :column-name="columnName"
+          :path="`/problem/collection/author/`"
           @apply-filter="
             (columnName, sortOrder) =>
               $emit('apply-filter', columnName, sortOrder, difficulty)


### PR DESCRIPTION
# Descripción

- la página solo muestra el numero de problemas de cada categoría que contenga "problemlevel" en alguna de sus etiquetas y que sea de calidad.
- Se arreglo la parte del enlace en el componente de Autores.
- filtro de etiquetas en la pagina  problem/collection/author

# Comentarios


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
