### PR TITLE
Corrigiendo lista de etiquetas frecuentes

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5970,7 +5970,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $authors
         );
 
-        $frequentTags = \OmegaUp\Controllers\Tag::getFrequentTagsByLevel(
+        $frequentTags = \OmegaUp\Controllers\Tag::getFrequentQualityTagsByLevel(
             $collectionLevel,
             /*$rows=*/15
         );

--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -71,14 +71,14 @@ class Tag extends \OmegaUp\Controllers\Controller {
      *
      * @return list<array{alias: string}>
      */
-    public static function getFrequentTagsByLevel(
+    public static function getFrequentQualityTagsByLevel(
         string $problemLevel,
         int $rows
     ): array {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::TAGS_LIST,
             "level-{$problemLevel}-{$rows}",
-            fn () => \OmegaUp\DAO\Tags::getFrequentTagsByLevel(
+            fn () => \OmegaUp\DAO\Tags::getFrequentQualityTagsByLevel(
                 $problemLevel,
                 $rows
             ),
@@ -107,7 +107,10 @@ class Tag extends \OmegaUp\Controllers\Controller {
         );
 
         return [
-            'frequent_tags' => self::getFrequentTagsByLevel($param, $rows),
+            'frequent_tags' => self::getFrequentQualityTagsByLevel(
+                $param,
+                $rows
+            ),
         ];
     }
 }

--- a/frontend/server/src/DAO/Tags.php
+++ b/frontend/server/src/DAO/Tags.php
@@ -79,7 +79,7 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
     /**
      * @return list<array{alias: string}>
      */
-    public static function getFrequentTagsByLevel(
+    public static function getFrequentQualityTagsByLevel(
         string $problemLevel,
         int $rows
     ) {

--- a/frontend/server/src/DAO/Tags.php
+++ b/frontend/server/src/DAO/Tags.php
@@ -90,6 +90,8 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
                 Problems_Tags pt
             INNER JOIN
                 Tags t ON t.tag_id = pt.tag_id
+            INNER JOIN
+	            Problems p ON p.problem_id = pt.problem_id
             WHERE
                 pt.problem_id
             IN (
@@ -106,6 +108,8 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
                         WHERE name = ? )
             ) AND
                 name LIKE "problemTag%"
+            AND
+                p.quality_seal = 1
             GROUP BY
                 t.name
             ORDER BY

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -21,6 +21,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         $problemsTagsMapping = [
             [
                 'title' => 'problem_1',
+                'alias' => 'problem_1',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -30,6 +31,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_2',
+                'alias' => 'problem_2',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -39,6 +41,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_3',
+                'alias' => 'problem_3',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -47,6 +50,11 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
                 ],
             ],
         ];
+
+        // Reviewer user
+        $reviewerLogin = self::login(
+            \OmegaUp\Test\Factories\QualityNomination::$reviewers[0]
+        );
 
         foreach ($problemsTagsMapping as $problemTags) {
             // Get the problem data
@@ -59,6 +67,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
             // Assign data to the request
             $r = $problemData['request'];
             $r['title'] = $problemTags['title'];
+            $r['problem_alias'] = $problemTags['alias'];
             $problemAuthor = $problemData['author'];
 
             // Login user
@@ -72,7 +81,20 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
             // Call the API
             \OmegaUp\Controllers\Problem::apiCreate($r);
+
+            // Review problem as quality problem
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $reviewerLogin->auth_token,
+                'problem_alias' => $problemTags['alias'],
+                'nomination' => 'quality_tag',
+                'contents' => json_encode([
+                    'quality_seal' => true,
+                    'tag' => $problemTags['level'],
+                ]),
+            ]));
         }
+
+        \OmegaUp\Test\Utils::runAggregateFeedback();
 
         // Create user
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();

--- a/frontend/tests/controllers/TagListTest.php
+++ b/frontend/tests/controllers/TagListTest.php
@@ -8,6 +8,10 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\FileHandler::setFileUploaderForTesting(
             $this->createFileUploaderMock()
         );
+
+        // Reviewers
+        \OmegaUp\Test\Factories\QualityNomination::initQualityReviewers();
+        \OmegaUp\Test\Factories\QualityNomination::initTopicTags();
     }
 
     /**
@@ -34,6 +38,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
         $problemsTagsMapping = [
             [
                 'title' => 'problem_1',
+                'alias' => 'problem_1',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -43,6 +48,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_2',
+                'alias' => 'problem_2',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -51,6 +57,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_3',
+                'alias' => 'problem_3',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -60,6 +67,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_4',
+                'alias' => 'problem_4',
                 'level' => 'problemLevelBasicIntroductionToProgramming',
                 'tags' => [
                     'problemTagMatrices',
@@ -68,6 +76,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_5',
+                'alias' => 'problem_5',
                 'level' => 'problemLevelIntermediateMathsInProgramming',
                 'tags' => [
                     'problemTagModularArithmetic',
@@ -76,6 +85,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_6',
+                'alias' => 'problem_6',
                 'level' => 'problemLevelIntermediateMathsInProgramming',
                 'tags' => [
                     'problemTagModularArithmetic',
@@ -84,12 +94,18 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             ],
             [
                 'title' => 'problem_7',
+                'alias' => 'problem_7',
                 'level' => 'problemLevelIntermediateMathsInProgramming',
                 'tags' => [
                     'problemTagModularArithmetic',
                 ],
             ],
         ];
+
+        // Reviewer user
+        $reviewerLogin = self::login(
+            \OmegaUp\Test\Factories\QualityNomination::$reviewers[0]
+        );
 
         foreach ($problemsTagsMapping as $problemTags) {
             // Get the problem data
@@ -102,6 +118,7 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
             // Assign data to the request
             $r = $problemData['request'];
             $r['title'] = $problemTags['title'];
+            $r['problem_alias'] = $problemTags['alias'];
             $problemAuthor = $problemData['author'];
 
             // Login user
@@ -115,7 +132,20 @@ class TagListTest extends \OmegaUp\Test\ControllerTestCase {
 
             // Call the API
             \OmegaUp\Controllers\Problem::apiCreate($r);
+
+            // Review problem as quality problem
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $reviewerLogin->auth_token,
+                'problem_alias' => $problemTags['alias'],
+                'nomination' => 'quality_tag',
+                'contents' => json_encode([
+                    'quality_seal' => true,
+                    'tag' => $problemTags['level'],
+                ]),
+            ]));
         }
+
+        \OmegaUp\Test\Utils::runAggregateFeedback();
 
         // Create user
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();


### PR DESCRIPTION
# Descripción

Se corrige la lista de etiquetas frecuentes de la página `/problem/collection/LEVEL` para que ahora tome en cuenta sólo las etiquetas frecuentes de los problemas de calidad, no de todos.

# Comentarios

Se corrigió la prueba correspondiente.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
