### PR TITLE
Cambiando currentTags por selectedTags en las listas de problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -36,11 +36,11 @@ namespace OmegaUp\Controllers;
  * @psalm-type ProblemDetailsv2Payload=array{allRuns?: list<Run>, problemLevel?: null|string, publicTags?: list<string>, levelTags?: list<string>, allowUserAddTags?: bool, selectedPublicTags?: list<string>, selectedPrivateTags?: list<string>,clarifications?: list<Clarification>, histogram: Histogram, nominationStatus?: NominationStatus, problem: ProblemInfo, runs?: list<Run>, solutionStatus?: string, solvers?: list<BestSolvers>, user: UserInfoForProblem}
  * @psalm-type ProblemFormPayload=array{alias: string, allowUserAddTags: true, emailClarifications: bool, extraWallTime: int|string, inputLimit: int|string, languages: string, levelTags: list<string>, memoryLimit: int|string, message?: string, outputLimit: int|string, overallWallTimeLimit: int|string, parameter: null|string, problem_level: string, publicTags: list<string>, selectedTags: list<SelectedTag>|null, showDiff: string, source: string, statusError: string, tags: list<array{name: null|string}>, timeLimit: int|string, title: string, validLanguages: array<string, string>, validator: string, validatorTimeLimit: int|string, validatorTypes: array<string, null|string>, visibility: int, visibilityStatuses: array<string, int>}
  * @psalm-type ProblemsMineInfoPayload=array{isSysadmin: bool, privateProblemsAlert: bool, visibilityStatuses: array<string, int>}
- * @psalm-type ProblemListPayload=array{currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>}
+ * @psalm-type ProblemListPayload=array{selectedTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>}
  * @psalm-type RunsDiff=array{guid: string, new_score: float|null, new_status: null|string, new_verdict: null|string, old_score: float|null, old_status: null|string, old_verdict: null|string, problemset_id: int|null, username: string}
  * @psalm-type CommitRunsDiff=array<string, list<RunsDiff>>
  * @psalm-type AuthorsRank=array{ranking: list<array{author_ranking: int|null, author_score: float, classname: string, country_id: null|string, name: null|string, username: string}>, total: int}
- * @psalm-type CollectionDetailsByAuthorPayload=array{authorsRanking: AuthorsRank, currentTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>, authors: list<string>}
+ * @psalm-type CollectionDetailsByAuthorPayload=array{authorsRanking: AuthorsRank, selectedTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tags: list<string>, authors: list<string>}
  * @psalm-type CollectionDetailsByLevelPayload=array{frequentTags: list<array{alias: string, name?: string}>, publicTags: list<string>, level: string, selectedTags: list<string>, loggedIn: bool, pagerItems: list<PageItem>, problems: list<ProblemListItem>, keyword: string, language: string, mode: string, column: string, languages: list<string>, columns: list<string>, modes: list<string>, tagData: list<array{name: null|string}>, tagsList: list<string>, difficulty: string}
  * @psalm-type Tag=array{name: string}
  * @psalm-type ProblemListCollectionPayload=array{levelTags: list<string>, problemCount: list<array{name: string, problems_per_tag: int}>, allTags: list<Tag>}
@@ -4836,7 +4836,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'payload' => [
                     'problems' => $result['problems'],
                     'loggedIn' => !is_null($r->identity),
-                    'currentTags' => $result['currentTags'],
+                    'selectedTags' => $result['selectedTags'],
                     'pagerItems' => $result['pagerItems'],
                     'keyword' => $result['keyword'],
                     'mode' => $result['mode'],
@@ -5983,7 +5983,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'level' => $collectionLevel,
                     'problems' => $result['problems'],
                     'loggedIn' => !is_null($r->identity),
-                    'selectedTags' => $result['currentTags'],
+                    'selectedTags' => $result['selectedTags'],
                     'pagerItems' => $result['pagerItems'],
                     'keyword' => $result['keyword'],
                     'mode' => $result['mode'],
@@ -6028,7 +6028,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @param array{0: int, 1: int}|null $difficultyRange
      * @param list<string> $authors
      *
-     * @return array{column: string, columns: list<string>, currentTags: list<string>, keyword: string, language: string, languages: list<string>, mode: string, modes: list<string>, problems: list<ProblemListItem>, pagerItems: list<PageItem>, tagData: list<Tag>, tags: list<string>, difficulty: string, authors: list<string>}
+     * @return array{column: string, columns: list<string>, selectedTags: list<string>, keyword: string, language: string, languages: list<string>, mode: string, modes: list<string>, problems: list<ProblemListItem>, pagerItems: list<PageItem>, tagData: list<Tag>, tags: list<string>, difficulty: string, authors: list<string>}
      */
     private static function getList(
         int $page,
@@ -6105,7 +6105,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         return [
             'problems' => $response['results'],
-            'currentTags' => $tags,
+            'selectedTags' => $tags,
             'pagerItems' => $pagerItems,
             'keyword' => $keyword,
             'mode' => $sortOrder,
@@ -6202,7 +6202,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'authorsRanking' => $authorsRanking,
                     'problems' => $result['problems'],
                     'loggedIn' => !is_null($r->identity),
-                    'currentTags' => $result['currentTags'],
+                    'selectedTags' => $result['selectedTags'],
                     'pagerItems' => $result['pagerItems'],
                     'keyword' => $result['keyword'],
                     'mode' => $result['mode'],

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1391,7 +1391,6 @@ export namespace types {
     authorsRanking: types.AuthorsRank;
     column: string;
     columns: string[];
-    currentTags: string[];
     keyword: string;
     language: string;
     languages: string[];
@@ -1400,6 +1399,7 @@ export namespace types {
     modes: string[];
     pagerItems: types.PageItem[];
     problems: types.ProblemListItem[];
+    selectedTags: string[];
     tagData: { name?: string }[];
     tags: string[];
   }
@@ -2374,7 +2374,6 @@ export namespace types {
   export interface ProblemListPayload {
     column: string;
     columns: string[];
-    currentTags: string[];
     keyword: string;
     language: string;
     languages: string[];
@@ -2383,6 +2382,7 @@ export namespace types {
     modes: string[];
     pagerItems: types.PageItem[];
     problems: types.ProblemListItem[];
+    selectedTags: string[];
     tagData: { name?: string }[];
     tags: string[];
   }

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -164,7 +164,7 @@
                     ? 'custom-badge-quality'
                     : ''
                 } m-1 p-2`"
-                :href="hrefForProblemTag(currentTags, tag.name)"
+                :href="hrefForProblemTag(selectedTags, tag.name)"
                 >{{
                   Object.prototype.hasOwnProperty.call(T, tag.name)
                     ? T[tag.name]
@@ -254,7 +254,7 @@ library.add(faEyeSlash, faMedal, faExclamationTriangle, faBan);
 export default class BaseList extends Vue {
   @Prop() problems!: omegaup.Problem[];
   @Prop() loggedIn!: boolean;
-  @Prop() currentTags!: string[];
+  @Prop() selectedTags!: string[];
   @Prop() pagerItems!: types.PageItem[];
   @Prop() wizardTags!: omegaup.Tag[];
   @Prop() language!: string;
@@ -288,9 +288,9 @@ export default class BaseList extends Vue {
     T.qualityFormDifficultyVeryHard,
   ];
 
-  hrefForProblemTag(currentTags: string[], problemTag: string): string {
-    if (!currentTags) return `${this.path}?tag[]=${problemTag}`;
-    let tags = currentTags.slice();
+  hrefForProblemTag(selectedTags: string[], problemTag: string): string {
+    if (!selectedTags) return `${this.path}?tag[]=${problemTag}`;
+    let tags = selectedTags.slice();
     if (!tags.includes(problemTag)) tags.push(problemTag);
     return `${this.path}?tag[]=${tags.join('&tag[]=')}`;
   }

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -42,7 +42,7 @@
           v-else
           :problems="problems"
           :logged-in="loggedIn"
-          :current-tags="selectedTags"
+          :selected-tags="selectedTags"
           :pager-items="pagerItems"
           :wizard-tags="wizardTags"
           :language="language"

--- a/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
@@ -41,7 +41,7 @@
           v-else
           :problems="problems"
           :logged-in="loggedIn"
-          :current-tags="currentTags"
+          :selected-tags="selectedTags"
           :pager-items="pagerItems"
           :wizard-tags="wizardTags"
           :language="language"
@@ -92,7 +92,7 @@ export default class CollectionList extends Vue {
   @Prop() data!: types.CollectionDetailsByAuthorPayload;
   @Prop() problems!: omegaup.Problem;
   @Prop() loggedIn!: boolean;
-  @Prop() currentTags!: string[];
+  @Prop() selectedTags!: string[];
   @Prop() pagerItems!: types.PageItem[];
   @Prop() wizardTags!: omegaup.Tag[];
   @Prop() language!: string;

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -23,7 +23,7 @@
     <omegaup-problem-base-list
       :problems="problems"
       :logged-in="loggedIn"
-      :current-tags="currentTags"
+      :selected-tags="selectedTags"
       :pager-items="pagerItems"
       :wizard-tags="wizardTags"
       :language="language"
@@ -65,7 +65,7 @@ import problem_BaseList from './BaseList.vue';
 export default class List extends Vue {
   @Prop() problems!: omegaup.Problem;
   @Prop() loggedIn!: boolean;
-  @Prop() currentTags!: string[];
+  @Prop() selectedTags!: string[];
   @Prop() pagerItems!: types.PageItem[];
   @Prop() wizardTags!: omegaup.Tag[];
   @Prop() language!: string;

--- a/frontend/www/js/omegaup/problem/collection_list_by_author.ts
+++ b/frontend/www/js/omegaup/problem/collection_list_by_author.ts
@@ -56,7 +56,7 @@ OmegaUp.on('ready', () => {
           data: payload,
           problems: payload.problems,
           loggedIn: payload.loggedIn,
-          currentTags: payload.currentTags,
+          selectedTags: payload.selectedTags,
           pagerItems: payload.pagerItems,
           wizardTags: payload.tagData,
           language: payload.language,

--- a/frontend/www/js/omegaup/problem/list.ts
+++ b/frontend/www/js/omegaup/problem/list.ts
@@ -48,7 +48,7 @@ OmegaUp.on('ready', () => {
         props: {
           problems: payload.problems,
           loggedIn: payload.loggedIn,
-          currentTags: payload.currentTags,
+          selectedTags: payload.selectedTags,
           pagerItems: payload.pagerItems,
           wizardTags: payload.tagData,
           language: payload.language,


### PR DESCRIPTION
# Descripción

Se renombra `currentTags` por `selectedTags` en los archivos relacionados a las listas de problemas.

`selectedTags` contiene la lista de etiquetas activas en la página si se ha seleccionado alguna desde un checkbox en `problem/collection/LEVEL` o dando clic directamente en la etiqueta en `problem/collection/LEVEL`, `problem/collection/author` o `/problem`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
