### PR TITLE
Agregadas pruebas de Vue para las páginas de colecciones

### DIFF
--- a/frontend/www/js/omegaup/components/problem/CollectionList.test.ts
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
 import { types } from '../../api_types';
@@ -7,8 +7,8 @@ import T from '../../lang';
 import problem_CollectionList from './CollectionList.vue';
 
 describe('CollectionList.vue', () => {
-  it('Should handle empty details of problem list collection', async () => {
-    const wrapper = shallowMount(problem_CollectionList, {
+  it('Should handle details of problem list collection by level', async () => {
+    const wrapper = mount(problem_CollectionList, {
       propsData: {
         data: {
           level: 'problemLevelBasicIntroductionToProgramming',
@@ -18,20 +18,119 @@ describe('CollectionList.vue', () => {
             { alias: 'problemTagInputAndOutput' },
             { alias: 'problemTagArrays' },
           ],
-          publicTags: <string[]>[
-            'problemTagConditionals',
-            'problemTagLoops',
-            'problemTagFunctions',
-            'problemTagCharsAndStrings',
-            'problemTagSimulation',
-            'problemTagAnalyticGeometry',
-          ],
+          publicTags: <string[]>['problemTagConditionals', 'problemTagLoops'],
         } as types.CollectionDetailsByLevelPayload,
+        difficulty: 'easy',
+        selectedTags: <string[]>[
+          'problemTagMatrices',
+          'problemTagDiophantineEquations',
+        ],
+        problems: [
+          {
+            alias: 'Problem-1',
+            title: 'Problem 1',
+            difficulty: 4,
+            difficulty_histogram: null,
+            points: 100,
+            problem_id: 1,
+            quality: 4,
+            quality_histogram: null,
+            quality_seal: true,
+            ratio: 0,
+            score: 0,
+            visibility: 2,
+            tags: [
+              {
+                name: 'problemLevelBasicIntroductionToProgramming',
+                source: 'owner',
+              },
+            ],
+          },
+        ],
       },
     });
 
     expect(wrapper.text()).toContain(
       T.problemLevelBasicIntroductionToProgramming,
     );
+    expect(wrapper.text()).toContain(T.problemEditAddTags);
+    expect(wrapper.text()).toContain(T.wordsDifficulty);
+    expect(wrapper.text()).toContain('Problem 1');
+    expect(wrapper.text()).not.toContain(T.courseAssignmentProblemsEmpty);
+
+    expect(wrapper.find('input[value="problemTagMatrices"]').exists()).toBe(
+      true,
+    );
+    expect(
+      wrapper.find('input[value="problemTagDiophantineEquations"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('input[value="problemTagInputAndOutput"]').exists(),
+    ).toBe(true);
+    expect(wrapper.find('input[value="problemTagArrays"]').exists()).toBe(true);
+
+    expect(wrapper.find('input[value="problemTagConditionals"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('input[value="problemTagLoops"]').exists()).toBe(false);
+
+    const checkboxInput1 = <HTMLInputElement>(
+      wrapper.find('input[value="problemTagMatrices"]').element
+    );
+    const checkboxInput2 = <HTMLInputElement>(
+      wrapper.find('input[value="problemTagDiophantineEquations"]').element
+    );
+    const checkboxInput3 = <HTMLInputElement>(
+      wrapper.find('input[value="problemTagInputAndOutput"]').element
+    );
+    const checkboxInput4 = <HTMLInputElement>(
+      wrapper.find('input[value="problemTagArrays"]').element
+    );
+    const radioInput1 = <HTMLInputElement>(
+      wrapper.find('input[value="all"]').element
+    );
+    const radioInput2 = <HTMLInputElement>(
+      wrapper.find('input[value="easy"]').element
+    );
+
+    expect(checkboxInput1.checked).toBeTruthy();
+    expect(checkboxInput2.checked).toBeTruthy();
+    expect(checkboxInput3.checked).toBeFalsy();
+    expect(checkboxInput4.checked).toBeFalsy();
+    expect(radioInput1.checked).toBeFalsy();
+    expect(radioInput2.checked).toBeTruthy();
+
+    checkboxInput1.click();
+    checkboxInput2.click();
+    checkboxInput3.click();
+    checkboxInput4.click();
+    radioInput1.click();
+
+    expect(checkboxInput1.checked).toBeFalsy();
+    expect(checkboxInput2.checked).toBeFalsy();
+    expect(checkboxInput3.checked).toBeTruthy();
+    expect(checkboxInput4.checked).toBeTruthy();
+    expect(radioInput1.checked).toBeTruthy();
+    expect(radioInput2.checked).toBeFalsy();
+  });
+
+  it('Should handle empty list of problems in collection by level', async () => {
+    const wrapper = mount(problem_CollectionList, {
+      propsData: {
+        data: {
+          level: 'problemLevelBasicIntroductionToProgramming',
+          frequentTags: [{ alias: 'problemTagMatrices' }],
+          publicTags: <string[]>['problemTagConditionals'],
+        } as types.CollectionDetailsByLevelPayload,
+        difficulty: 'all',
+      },
+    });
+
+    expect(wrapper.text()).toContain(
+      T.problemLevelBasicIntroductionToProgramming,
+    );
+    expect(wrapper.text()).toContain(T.problemEditAddTags);
+    expect(wrapper.text()).toContain(T.wordsDifficulty);
+    expect(wrapper.text()).toContain(T.courseAssignmentProblemsEmpty);
   });
 });

--- a/frontend/www/js/omegaup/components/problem/CollectionListAuthor.test.ts
+++ b/frontend/www/js/omegaup/components/problem/CollectionListAuthor.test.ts
@@ -12,7 +12,7 @@ describe('CollectionListAuthor.vue', () => {
       propsData: {
         data: {
           authorsRanking: {
-            total: 1,
+            total: 3,
             ranking: [
               {
                 author_score: 90,
@@ -35,13 +35,38 @@ describe('CollectionListAuthor.vue', () => {
             ],
           } as types.AuthorsRank,
         } as types.CollectionDetailsByAuthorPayload,
-        difficulty: 'all',
+        difficulty: 'easy',
         selectedAuthors: <string[]>['user3'],
+        problems: [
+          {
+            alias: 'Problem-1',
+            title: 'Problem 1',
+            difficulty: 4,
+            difficulty_histogram: null,
+            points: 100,
+            problem_id: 1,
+            quality: 4,
+            quality_histogram: null,
+            quality_seal: true,
+            ratio: 0,
+            score: 0,
+            visibility: 2,
+            tags: [
+              {
+                name: 'problemLevelBasicIntroductionToProgramming',
+                source: 'owner',
+              },
+            ],
+          },
+        ],
       },
     });
 
     expect(wrapper.text()).toContain(T.omegaupTitleCollectionsByAuthor);
     expect(wrapper.text()).toContain(T.problemCollectionAuthors);
+    expect(wrapper.text()).toContain(T.wordsDifficulty);
+    expect(wrapper.text()).toContain('Problem 1');
+    expect(wrapper.text()).not.toContain(T.courseAssignmentProblemsEmpty);
 
     expect(wrapper.find('input[value="user1"]').exists()).toBe(true);
     expect(wrapper.find('input[value="user2"]').exists()).toBe(true);
@@ -56,17 +81,54 @@ describe('CollectionListAuthor.vue', () => {
     const checkboxInput3 = <HTMLInputElement>(
       wrapper.find('input[value="user3"]').element
     );
+    const radioInput1 = <HTMLInputElement>(
+      wrapper.find('input[value="all"]').element
+    );
+    const radioInput2 = <HTMLInputElement>(
+      wrapper.find('input[value="easy"]').element
+    );
 
     expect(checkboxInput1.checked).toBeFalsy();
     expect(checkboxInput2.checked).toBeFalsy();
     expect(checkboxInput3.checked).toBeTruthy();
+    expect(radioInput1.checked).toBeFalsy();
+    expect(radioInput2.checked).toBeTruthy();
 
     checkboxInput1.click();
     checkboxInput2.click();
     checkboxInput3.click();
+    radioInput1.click();
 
     expect(checkboxInput1.checked).toBeTruthy();
     expect(checkboxInput2.checked).toBeTruthy();
     expect(checkboxInput3.checked).toBeFalsy();
+    expect(radioInput1.checked).toBeTruthy();
+    expect(radioInput2.checked).toBeFalsy();
+  });
+
+  it('Should handle empty list of problems in author collection', async () => {
+    const wrapper = mount(problem_CollectionListAuthor, {
+      propsData: {
+        data: {
+          authorsRanking: {
+            total: 1,
+            ranking: [
+              {
+                author_score: 90,
+                name: 'User 1',
+                username: 'user1',
+                classname: 'user-rank-master',
+              },
+            ],
+          } as types.AuthorsRank,
+        } as types.CollectionDetailsByAuthorPayload,
+        difficulty: 'easy',
+      },
+    });
+
+    expect(wrapper.text()).toContain(T.omegaupTitleCollectionsByAuthor);
+    expect(wrapper.text()).toContain(T.problemCollectionAuthors);
+    expect(wrapper.text()).toContain(T.wordsDifficulty);
+    expect(wrapper.text()).toContain(T.courseAssignmentProblemsEmpty);
   });
 });


### PR DESCRIPTION
# Descripción

Se agregan pruebas de Vue para `CollectionList.vue` y `CollectionListAuthor.vue` para verificar el funcionamiento de los `checkboxes` de los filtros, los `radiobuttons` de dificultad y la lista de problemas.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
