### PR TITLE
cambio de link a botón en página 'problem/collection'

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Collection.vue
+++ b/frontend/www/js/omegaup/components/problem/Collection.vue
@@ -5,7 +5,9 @@
         <h1 class="card-title">{{ T.collectionTitle }}</h1>
       </div>
       <div class="col-md-5 text-right align-self-end">
-        <a href="/problem/" data-nav-problems-all>{{ T.navAllProblems }}</a>
+        <a class="btn btn-primary" href="/problem/" data-nav-problems-all>{{
+          T.navAllProblems
+        }}</a>
       </div>
     </div>
     <div class="card panel panel-default">


### PR DESCRIPTION
# Descripción

Se cambió el link que redirige a todos los problemas por un botón.

![image](https://user-images.githubusercontent.com/43051192/99981291-d3eb5580-2d6e-11eb-8743-1944fff86489.png)

Fixes: #4935

# Comentarios


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
