### PR TITLE
Cambio cronjob de update_ranks

### DIFF
--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -702,17 +702,18 @@ def update_users_stats(
         try:
             scores = update_user_rank(cur)
             update_user_rank_cutoffs(cur, scores)
-            dbconn.commit()
         except:  # noqa: bare-except
             logging.exception('Failed to update user ranking')
             raise
 
         try:
             update_author_rank(cur)
-            dbconn.commit()
         except:  # noqa: bare-except
             logging.exception('Failed to update authors ranking')
             raise
+        # We update both the general rank and the author's rank in the same
+        # transaction since both are stored in the same DB table.
+        dbconn.commit()
 
         if update_coder_of_the_month:
             try:


### PR DESCRIPTION
# Descripción

Cambio cronjob de update_ranks.py para la parte del ranking de autores

Fixes: #4888

# Comentarios



# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
