### PR TITLE
 Agregando componente para BS4 de ReviewerPopupv2

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -89,21 +89,12 @@
               {{ T.wordsReportProblem }}
             </button>
           </div>
+          <div v-if="user.reviewer && !nominationStatus.alreadyReviewed">
+            <button class="btn btn-link" @click="onNewPromotionAsReviewer">
+              {{ T.reviewerNomination }}
+            </button>
+          </div>
         </template>
-        <omegaup-quality-nomination-reviewer-popup
-          v-if="user.reviewer && !nominationStatus.alreadyReviewed"
-          :allow-user-add-tags="allowUserAddTags"
-          :level-tags="levelTags"
-          :problem-level="problemLevel"
-          :public-tags="publicTags"
-          :selected-public-tags="selectedPublicTags"
-          :selected-private-tags="selectedPrivateTags"
-          :problem-alias="problem.alias"
-          :problem-title="problem.title"
-          @submit="
-            (tag, qualitySeal) => $emit('submit-reviewer', tag, qualitySeal)
-          "
-        ></omegaup-quality-nomination-reviewer-popup>
         <omegaup-overlay
           v-if="user.loggedIn"
           :show-overlay="popupDisplayed !== PopupDisplayed.None"
@@ -144,6 +135,21 @@
                   $emit('submit-demotion', qualityDemotionComponent)
               "
             ></omegaup-quality-nomination-demotion-popup>
+            <omegaup-quality-nomination-reviewer-popup
+              v-show="popupDisplayed === PopupDisplayed.Reviewer"
+              :allow-user-add-tags="allowUserAddTags"
+              :level-tags="levelTags"
+              :problem-level="problemLevel"
+              :public-tags="publicTags"
+              :selected-public-tags="selectedPublicTags"
+              :selected-private-tags="selectedPrivateTags"
+              :problem-alias="problem.alias"
+              :problem-title="problem.title"
+              @dismiss="popupDisplayed = PopupDisplayed.None"
+              @submit="
+                (tag, qualitySeal) => $emit('submit-reviewer', tag, qualitySeal)
+              "
+            ></omegaup-quality-nomination-reviewer-popup>
           </template>
         </omegaup-overlay>
         <omegaup-arena-runs
@@ -367,6 +373,10 @@ export default class ProblemDetails extends Vue {
       return;
     }
     this.popupDisplayed = PopupDisplayed.Promotion;
+  }
+
+  onNewPromotionAsReviewer(): void {
+    this.popupDisplayed = PopupDisplayed.Reviewer;
   }
 
   onReportInappropriateProblem(): void {

--- a/frontend/www/js/omegaup/components/qualitynomination/PromotionPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/PromotionPopup.vue
@@ -248,3 +248,12 @@ export default class QualityPromotionPopup extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+ul.tag-select {
+  height: 185px;
+  overflow: auto;
+  border: 1px solid #ccc;
+  background: #fff;
+}
+</style>

--- a/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopupv2.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/ReviewerPopupv2.vue
@@ -1,108 +1,109 @@
 <template>
-  <omegaup-popup
-    :reviewer-nomination="true"
-    :possible-tags="PROBLEM_CATEGORIES"
-    @submit="$emit('submit', tag, qualitySeal, selectedPublicTags)"
-  >
-    <template #link-title>
-      {{ T.reviewerNomination }}
-    </template>
-    <template #popup-content="slotProps">
-      <div class="title-text">
-        {{ T.reviewerNominationFormTitle }}
-      </div>
-      <div class="form-group">
-        <label class="control-label">
-          {{ T.reviewerNominationQuality }}
-        </label>
-        <br />
-        <omegaup-radio-switch
-          :value.sync="qualitySeal"
-          :selected-value="qualitySeal"
-        ></omegaup-radio-switch>
-      </div>
-      <div class="form-group">
-        <label class="control-label">
-          {{ T.reviewerNominationCategory }}
-          <ul class="tag-select">
-            <li
-              v-for="problemTopic in slotProps.sortedProblemTags"
-              :key="problemTopic.value"
-              class="tag-select"
-            >
-              <label class="tag-select"
-                ><input
-                  v-model="tag"
-                  type="radio"
-                  :value="problemTopic.value"
-                />
-                {{ problemTopic.text }}</label
-              >
-            </li>
-          </ul></label
-        >
-      </div>
-      <div class="form-group">
-        <vue-typeahead-bootstrap
-          :data="publicTags"
-          :serializer="publicTagsSerializer"
-          :placeholder="T.collecionOtherTags"
-          @hit="addOtherTag"
-        >
-        </vue-typeahead-bootstrap>
-        <br />
-        <div class="card-body table-responsive">
-          <table class="table table-striped">
-            <thead>
-              <th class="text-center" scope="col">
-                {{ T.contestEditTagName }}
-              </th>
-              <th class="text-center" scope="col">
-                {{ T.contestEditTagDelete }}
-              </th>
-            </thead>
-            <tbody>
-              <tr v-for="tag in publicTagsList" :key="tag">
-                <td>{{ getName(tag) }}</td>
-                <td class="text-center">
-                  <button
-                    type="button"
-                    class="btn btn-danger"
-                    :disabled="publicTagsList.length < 2"
-                    @click="removeTag(tag)"
+  <omegaup-overlay-popup @dismiss="onHide">
+    <transition name="fade">
+      <form class="popup h-auto w-auto" @submit.prevent="">
+        <div class="container-fluid d-flex align-items-start flex-column">
+          <template v-if="currentView === AvailableViews.Content">
+            <p class="h4 font-weight-bold pb-4 text-center w-100">
+              {{ T.reviewerNominationFormTitle }}
+            </p>
+            <div class="form-group w-100">
+              <label class="control-label">
+                {{ T.reviewerNominationQuality }}
+              </label>
+              <br />
+              <omegaup-radio-switch
+                :value.sync="qualitySeal"
+                :selected-value="qualitySeal"
+              ></omegaup-radio-switch>
+            </div>
+            <div class="form-group w-100">
+              <label class="control-label w-100">
+                {{ T.reviewerNominationCategory }}
+                <ul class="tag-select">
+                  <li
+                    v-for="problemTopic in sortedProblemTags"
+                    :key="problemTopic.value"
+                    class="tag-select"
                   >
-                    <font-awesome-icon :icon="['fas', 'trash']" />
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                    <label class="tag-select"
+                      ><input
+                        v-model="tag"
+                        type="radio"
+                        :value="problemTopic.value"
+                      />
+                      {{ problemTopic.text }}</label
+                    >
+                  </li>
+                </ul></label
+              >
+            </div>
+            <div class="form-group w-100">
+              <vue-typeahead-bootstrap
+                :data="publicTags"
+                :serializer="publicTagsSerializer"
+                :placeholder="T.collecionOtherTags"
+                @hit="addOtherTag"
+              >
+              </vue-typeahead-bootstrap>
+              <br />
+              <div class="card-body table-responsive w-100">
+                <table class="table table-striped w-100">
+                  <thead>
+                    <th class="text-center" scope="col">
+                      {{ T.contestEditTagName }}
+                    </th>
+                    <th class="text-center" scope="col">
+                      {{ T.contestEditTagDelete }}
+                    </th>
+                  </thead>
+                  <tbody>
+                    <tr v-for="tag in publicTagsList" :key="tag">
+                      <td>{{ getName(tag) }}</td>
+                      <td class="text-center">
+                        <button
+                          type="button"
+                          class="btn btn-danger"
+                          :disabled="publicTagsList.length < 2"
+                          @click="removeTag(tag)"
+                        >
+                          <font-awesome-icon :icon="['fas', 'trash']" />
+                        </button>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div class="text-right">
+              <button
+                class="btn btn-primary mr-3"
+                type="submit"
+                :disabled="qualitySeal && !tag"
+                @click="onSubmit"
+              >
+                {{ T.wordsSend }}
+              </button>
+              <button class="btn btn-secondary" type="button" @click="onHide">
+                {{ T.wordsCancel }}
+              </button>
+            </div>
+          </template>
+          <template v-if="currentView === AvailableViews.Thanks">
+            <div class="w-100 h-100 h3 text-center">
+              {{ T.qualityFormThanksForReview }}
+            </div>
+          </template>
         </div>
-      </div>
-      <div class="button-row text-right">
-        <button
-          class="col-md-4 mr-2 btn btn-primary"
-          type="submit"
-          :disabled="qualitySeal && !tag"
-          @click="slotProps.onSubmit"
-        >
-          {{ T.wordsSend }}
-        </button>
-        <button
-          class="col-md-4 btn btn-secondary"
-          type="button"
-          @click="slotProps.onHide(true)"
-        >
-          {{ T.wordsCancel }}
-        </button>
-      </div>
-    </template>
-  </omegaup-popup>
+      </form>
+    </transition>
+  </omegaup-overlay-popup>
 </template>
 
 <script lang="ts">
 import { Vue, Prop, Component } from 'vue-property-decorator';
-import Popup from './Popup.vue';
+import omegaup_OverlayPopup from '../OverlayPopup.vue';
+import { AvailableViews } from './DemotionPopupv2.vue';
 import omegaup_RadioSwitch from '../RadioSwitch.vue';
 import T from '../../lang';
 import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
@@ -112,9 +113,14 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 library.add(faTrash);
 
+interface ProblemTag {
+  text: string;
+  value: string;
+}
+
 @Component({
   components: {
-    'omegaup-popup': Popup,
+    'omegaup-overlay-popup': omegaup_OverlayPopup,
     'omegaup-radio-switch': omegaup_RadioSwitch,
     'vue-typeahead-bootstrap': VueTypeaheadBootstrap,
     FontAwesomeIcon,
@@ -124,44 +130,85 @@ export default class ReviewerPopup extends Vue {
   @Prop() allowUserAddTags!: boolean;
   @Prop() levelTags!: string[];
   @Prop() problemLevel!: string;
+  @Prop({
+    default: () => [
+      'problemLevelAdvancedCompetitiveProgramming',
+      'problemLevelAdvancedSpecializedTopics',
+      'problemLevelBasicIntroductionToProgramming',
+      'problemLevelBasicKarel',
+      'problemLevelIntermediateAnalysisAndDesignOfAlgorithms',
+      'problemLevelIntermediateDataStructuresAndAlgorithms',
+      'problemLevelIntermediateMathsInProgramming',
+    ],
+  })
+  possibleTags!: string[];
   @Prop() publicTags!: string[];
   @Prop() selectedPublicTags!: string[];
   @Prop() selectedPrivateTags!: string[];
   @Prop() problemAlias!: string;
   @Prop() problemTitle!: string;
 
+  AvailableViews = AvailableViews;
   T = T;
+  currentView: AvailableViews = AvailableViews.Content;
   qualitySeal = true;
   tag = '';
   publicTagsList = this.selectedPublicTags ?? [];
 
-  PROBLEM_CATEGORIES = [
-    'problemLevelAdvancedCompetitiveProgramming',
-    'problemLevelAdvancedSpecializedTopics',
-    'problemLevelBasicIntroductionToProgramming',
-    'problemLevelBasicKarel',
-    'problemLevelIntermediateAnalysisAndDesignOfAlgorithms',
-    'problemLevelIntermediateDataStructuresAndAlgorithms',
-    'problemLevelIntermediateMathsInProgramming',
-  ];
+  get sortedProblemTags(): ProblemTag[] {
+    return this.possibleTags
+      .map(
+        (x: string): ProblemTag => {
+          return {
+            value: x,
+            text: T[x],
+          };
+        },
+      )
+      .sort((a: ProblemTag, b: ProblemTag): number => {
+        return a.text.localeCompare(b.text, T.lang);
+      });
+  }
 
   addOtherTag(tag: string): void {
     if (!this.publicTagsList.includes(tag)) {
       this.publicTagsList.push(tag);
     }
   }
+
   publicTagsSerializer(tagname: string): string {
     if (Object.prototype.hasOwnProperty.call(T, tagname)) {
       return T[tagname];
     }
     return tagname;
   }
+
   getName(alias: string): string {
     return T[alias];
   }
+
   removeTag(name: string) {
     let pos = this.publicTagsList.indexOf(name);
     this.publicTagsList.splice(pos, 1);
   }
+
+  onHide(): void {
+    this.$emit('dismiss');
+  }
+
+  onSubmit(): void {
+    this.$emit('submit', this.tag, this.qualitySeal);
+    this.currentView = AvailableViews.Thanks;
+    setTimeout(() => this.onHide(), 2000);
+  }
 }
 </script>
+
+<style lang="scss" scoped>
+ul.tag-select {
+  height: 225px;
+  overflow: auto;
+  border: 1px solid #ccc;
+  background: #fff;
+}
+</style>


### PR DESCRIPTION
# Descripción

Se agrega el componente de `ReviewerPopupv2` y se reutilizan los componentes
de `overlay` para incluir este nuevo:

![NominationReviewer](https://user-images.githubusercontent.com/3230352/100296333-8b3fc200-2f51-11eb-9fa4-081099097ecb.gif)


Part of: #4493

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
