### PR TITLE
El ranking y coder del mes solo acepta problemas de Calidad

### DIFF
--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -118,7 +118,8 @@ def update_user_rank(cur: MySQLdb.cursors.BaseCursor) -> Sequence[float]:
         ) AS up
         INNER JOIN
             `Problems` AS `p`
-        ON `p`.`problem_id` = up.`problem_id` AND `p`.visibility > 0
+        ON `p`.`problem_id` = up.`problem_id` AND `p`.visibility > 0 AND
+        `p`.quality_seal = 1
         INNER JOIN
             `Identities` AS `i` ON `i`.`identity_id` = up.`identity_id`
         LEFT JOIN


### PR DESCRIPTION
# Descripción

Se modifica la consulta del cronjob para que solo reciba problemas con el distintivo de calidad para contar puntos en el rankingy coder del mes

![Captura de pantalla (2432)](https://user-images.githubusercontent.com/43051192/100384243-51200000-2fe5-11eb-9dd0-3a30745d52fe.png)

![Captura de pantalla (2434)](https://user-images.githubusercontent.com/43051192/100384252-55e4b400-2fe5-11eb-92b8-3f4f7f4127e3.png)

Fixes: #3132

# Comentarios


# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
