### PR TITLE
Ordenando por fecha de envío los reportes de problemas

### DIFF
--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -366,7 +366,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         }
 
         // TODO(#3696): Change to ASC once duplicates are removed.
-        $sqlOrder = ' ORDER BY p.alias ASC, qn.qualitynomination_id DESC';
+        $sqlOrder = ' ORDER BY qn.time ASC, p.alias ASC, qn.qualitynomination_id DESC';
         $sqlLimit = ' LIMIT ?, ?;';
 
         /** @var int */

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -365,8 +365,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             $sqlFrom .= " AND qn.status = '{$status}'";
         }
 
-        // TODO(#3696): Change to ASC once duplicates are removed.
-        $sqlOrder = ' ORDER BY qn.time ASC, p.alias ASC, qn.qualitynomination_id DESC';
+        $sqlOrder = ' ORDER BY qn.qualitynomination_id ASC';
         $sqlLimit = ' LIMIT ?, ?;';
 
         /** @var int */


### PR DESCRIPTION
# Descripción

Se modificó la consulta para obtener el listado de reportes de problemas de la base de datos para que los ordene por fecha del más antiguo al mas nuevo.

Fixes: #4955 

# Comentarios

![Captura de pantalla (2440)](https://user-images.githubusercontent.com/43051192/100825980-f7716880-341e-11eb-9571-cbf9e728fe9c.png)

![Captura de pantalla (2441)](https://user-images.githubusercontent.com/43051192/100825983-f93b2c00-341e-11eb-9077-27b83f6bba28.png)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
