### PR TITLE
Arreglando paginador de las páginas de problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4790,7 +4790,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         // Defaults for offset and pageSize
-        $offset = $r->ensureOptionalInt('offset') ?? 0;
+        $offset = $r->ensureOptionalInt('offset') ?? null;
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
@@ -5928,7 +5928,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $frequentTags = [];
 
-        $offset = $r->ensureOptionalInt('offset') ?? 0;
+        $offset = $r->ensureOptionalInt('offset') ?? null;
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
@@ -6149,7 +6149,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problems = [];
         $authorsRanking = [];
 
-        $offset = $r->ensureOptionalInt('offset') ?? 0;
+        $offset = $r->ensureOptionalInt('offset') ?? null;
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4790,7 +4790,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         // Defaults for offset and pageSize
-        $offset = $r->ensureOptionalInt('offset') ?? null;
+        $offset = $r->ensureOptionalInt('offset');
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
@@ -5928,7 +5928,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $frequentTags = [];
 
-        $offset = $r->ensureOptionalInt('offset') ?? null;
+        $offset = $r->ensureOptionalInt('offset');
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
@@ -6149,7 +6149,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problems = [];
         $authorsRanking = [];
 
-        $offset = $r->ensureOptionalInt('offset') ?? null;
+        $offset = $r->ensureOptionalInt('offset');
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -113,7 +113,7 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Test for the authors rank with a by a request
+     * Test for the authors rank with quality problems by a request
      */
     public function testCollectionAuthors() {
         $identities = [];
@@ -213,6 +213,9 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertCount(4, $result);
     }
 
+    /**
+     * Test for the difficulty of quality problems
+     */
     public function testDifficultyOfQualityProblems() {
         $identities = [];
         $problems = [];
@@ -379,5 +382,196 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         )['smartyProperties']['payload']['problems'];
 
         $this->assertCount(4, $result);
+    }
+
+    /**
+     * Test for the problem paginator
+     */
+    public function testProblemPaginator() {
+        $problems = [
+            [
+                'title' => 'problem_',
+                'alias' => 'problem_',
+                'level' => 'problemLevelBasicIntroductionToProgramming',
+                'tags' => [
+                    'problemTagMatrices',
+                    'problemTagInputAndOutput',
+                    'problemTagDiophantineEquations',
+                ],
+            ],
+        ];
+
+        // Reviewer user
+        $reviewerLogin = self::login(
+            \OmegaUp\Test\Factories\QualityNomination::$reviewers[0]
+        );
+
+        for ($i = 0; $i < 8; $i++) {
+            // Get the problem data
+            $problemData = \OmegaUp\Test\Factories\Problem::getRequest(
+                new \OmegaUp\Test\Factories\ProblemParams([
+                    'problem_level' => $problems['0']['level'],
+                ])
+            );
+
+            // Assign data to the request
+            $r = $problemData['request'];
+            $r['title'] = $problems['0']['title'] . $i;
+            $r['problem_alias'] = $problems['0']['alias'] . $i;
+            $problemAuthor = $problemData['author'];
+
+            // Login user
+            $login = self::login($problemAuthor);
+            $r['auth_token'] = $login->auth_token;
+            $tags = [];
+            foreach ($problems['0']['tags'] as $tag) {
+                $tags[] = ['tagname' => $tag, 'public' => true];
+            }
+            $r['selected_tags'] = json_encode($tags);
+
+            // Call the API
+            \OmegaUp\Controllers\Problem::apiCreate($r);
+
+            // Review problem as quality problem
+            \OmegaUp\Controllers\QualityNomination::apiCreate(new \OmegaUp\Request([
+                'auth_token' => $reviewerLogin->auth_token,
+                'problem_alias' => $problems['0']['alias'] . $i,
+                'nomination' => 'quality_tag',
+                'contents' => json_encode([
+                    'quality_seal' => true,
+                    'tag' => $problems['0']['level'],
+                ]),
+            ]));
+        }
+
+        \OmegaUp\Test\Utils::runAggregateFeedback();
+
+        // Create user
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = self::login($identity);
+
+        // Call getCollectionsDetailsByLevelForSmarty with 2 as rowcount and 1 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'level' => 'problemLevelBasicIntroductionToProgramming',
+                'rowcount' => '2',
+                'page' => '1',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('problem_0', $result['0']['alias']);
+        $this->assertEquals('problem_1', $result['1']['alias']);
+
+        // Call getCollectionsDetailsByLevelForSmarty with 2 as rowcount and 2 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'level' => 'problemLevelBasicIntroductionToProgramming',
+                'rowcount' => '2',
+                'page' => '2',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('problem_2', $result['0']['alias']);
+        $this->assertEquals('problem_3', $result['1']['alias']);
+
+        // Call getCollectionsDetailsByLevelForSmarty with 2 as rowcount and 3 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'level' => 'problemLevelBasicIntroductionToProgramming',
+                'rowcount' => '2',
+                'page' => '3',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('problem_4', $result['0']['alias']);
+        $this->assertEquals('problem_5', $result['1']['alias']);
+
+        // Call getCollectionsDetailsByLevelForSmarty with 2 as rowcount and 4 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'level' => 'problemLevelBasicIntroductionToProgramming',
+                'rowcount' => '2',
+                'page' => '4',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('problem_6', $result['0']['alias']);
+        $this->assertEquals('problem_7', $result['1']['alias']);
+
+        // Call getProblemListForSmarty with 4 as rowcount and 1 as page
+        $result = \OmegaUp\Controllers\Problem::getProblemListForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'rowcount' => '4',
+                'page' => '1',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(4, $result);
+        $this->assertEquals('problem_0', $result['0']['alias']);
+        $this->assertEquals('problem_1', $result['1']['alias']);
+        $this->assertEquals('problem_2', $result['2']['alias']);
+        $this->assertEquals('problem_3', $result['3']['alias']);
+
+        // Call getProblemListForSmarty with 4 as rowcount and 2 as page
+        $result = \OmegaUp\Controllers\Problem::getProblemListForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'rowcount' => '4',
+                'page' => '2',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(4, $result);
+        $this->assertEquals('problem_4', $result['0']['alias']);
+        $this->assertEquals('problem_5', $result['1']['alias']);
+        $this->assertEquals('problem_6', $result['2']['alias']);
+        $this->assertEquals('problem_7', $result['3']['alias']);
+
+        // Call getCollectionsDetailsByAuthorForSmarty with 6 as rowcount and 1 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'rowcount' => '6',
+                'page' => '1',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(6, $result);
+        $this->assertEquals('problem_0', $result['0']['alias']);
+        $this->assertEquals('problem_1', $result['1']['alias']);
+        $this->assertEquals('problem_2', $result['2']['alias']);
+        $this->assertEquals('problem_3', $result['3']['alias']);
+        $this->assertEquals('problem_4', $result['4']['alias']);
+        $this->assertEquals('problem_5', $result['5']['alias']);
+
+        // Call getCollectionsDetailsByAuthorForSmarty with 6 as rowcount and 2 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'rowcount' => '6',
+                'page' => '2',
+                'sort_order' => 'asc'
+            ])
+        )['smartyProperties']['payload']['problems'];
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('problem_6', $result['0']['alias']);
+        $this->assertEquals('problem_7', $result['1']['alias']);
     }
 }


### PR DESCRIPTION
# Descripción

Arreglado un error en el paginador de las listas de problemas que provocaba que se mostraran siempre los mismos 100 problemas a pesar de cambiar de página.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
