### PR TITLE
Haciendo menos flaky la prueba de RunSubmit

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunSubmit.test.ts
+++ b/frontend/www/js/omegaup/components/arena/RunSubmit.test.ts
@@ -7,9 +7,11 @@ import * as ui from '../../ui';
 import arena_RunSubmit from './RunSubmit.vue';
 
 describe('RunSubmit.vue', () => {
+  const currentDate = new Date();
+  const now = currentDate.getTime();
+
   it('Should handle disabled button', () => {
-    const now = new Date();
-    const future = now.getTime() + 10 * 1000;
+    const future = now + 10 * 1000;
     const nextSubmission = new Date(future);
     const wrapper = mount(arena_RunSubmit, {
       propsData: {
@@ -34,6 +36,8 @@ describe('RunSubmit.vue', () => {
   });
 
   it('Should handle enable button', () => {
+    const past = now - 1 * 1000;
+    const nextSubmission = new Date(past);
     const wrapper = shallowMount(arena_RunSubmit, {
       propsData: {
         languages: [
@@ -41,7 +45,7 @@ describe('RunSubmit.vue', () => {
           { py3: 'Python 3.6' },
           { java: 'Java' },
         ],
-        nextSubmissionTimestamp: new Date(),
+        nextSubmissionTimestamp: nextSubmission,
         preferredLanguage: 'es',
       },
     });


### PR DESCRIPTION
# Descripción

Actualmente la prueba de RunSubmit está presentando inconsistencias debido
a que se calculan los tiempos para habilitar/deshabilitar el botón de _Enviar_. 
Así que se agregan fechas estáticas para evitar dichas inconsistencias.

Part of: #4957 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
