### PR TITLE
Arreglando el deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           tar --xz --create --file "${TARBALL}" -C frontend/www js/dist css/dist media/dist
           AWS_ACCESS_KEY_ID=${{ secrets.AWS_BUILD_ARTIFACTS_ACCESS_KEY_ID }} \
           AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_BUILD_ARTIFACTS_SECRET_ACCESS_KEY }} \
+          AWS_REGION=us-east-1 \
             aws s3 cp \
             "${TARBALL}" \
             "s3://omegaup-build-artifacts/webpack-artifacts/${{ github.sha }}.tar.xz"


### PR DESCRIPTION
Desde que se actualizó el `aws` cli a la versión 2 , ahora intenta
contactar al servicio
[IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
para obtener la región del bucket al que se intentan subir los
artefactos del build. En local, esto no es ningún problema porque IMDS
existe en una IP no-ruteable dentro de los data centers de Amazon, así
que ese intento falla y `aws`continúa asumiendo la región `us-east-1`
(la default) y todo funciona bien. El problema es que Azure _también_
ofrece el mismo servicio de IMDS en el mismo lugar, así que `aws` lo
intenta contactar, esto falla con 400 porque no se están administrando
los parámetros correctos y todo el proceso se aborta.

Para prevenir que `aws` intente contactar a IMDS, se está pasando la
variable de entorno `AWS_REGION=us-east-1` explícitamente para que `aws`
no tenga que andar adivinando.