### PR TITLE
Una interfaz menos que exportar de omegaup.ts

### DIFF
--- a/frontend/www/js/omegaup/omegaup.ts
+++ b/frontend/www/js/omegaup/omegaup.ts
@@ -273,13 +273,6 @@ export namespace omegaup {
     name: string;
   }
 
-  export interface Group {
-    alias: string;
-    create_time: Date;
-    description: string;
-    name: string;
-  }
-
   export interface IdentityContest {
     username: string;
     end_time?: Date;


### PR DESCRIPTION
# Descripción

Se elimina una interfaz que dejamos de usar en el PR #4990 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) deomegaUp.
- [x] Se corrieron todas las pruebas y pasaron.