### PR TITLE
Arreglando campos de Memoria y Tiempo en la lista de mejores envíos

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Solvers.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Solvers.test.ts
@@ -33,9 +33,15 @@ describe('Solvers.vue', () => {
       },
     });
 
-    expect(wrapper.text()).toContain(T.wordsBestSolvers);
-    expect(wrapper.text()).toContain('py3');
-    expect(wrapper.text()).toContain((10 / 1000.0).toFixed(2));
-    expect(wrapper.text()).toContain((20 / (1024 * 1024)).toFixed(2));
+    expect(wrapper.find('table>caption').text()).toContain(T.wordsBestSolvers);
+    expect(wrapper.find('td[data-submission-language]').text()).toContain(
+      'py3',
+    );
+    expect(wrapper.find('td[data-submission-runtime]').text()).toContain(
+      (10 / 1000.0).toFixed(2),
+    );
+    expect(wrapper.find('td[data-submission-memory]').text()).toContain(
+      (20 / (1024 * 1024)).toFixed(2),
+    );
   });
 });

--- a/frontend/www/js/omegaup/components/arena/Solvers.vue
+++ b/frontend/www/js/omegaup/components/arena/Solvers.vue
@@ -16,17 +16,21 @@
     </thead>
     <tbody>
       <tr v-for="solver in solvers" :key="solver.username">
-        <td>
+        <td data-submission-user>
           <omegaup-username
             :classname="solver.classname"
             :username="solver.username"
             :linkify="true"
           ></omegaup-username>
         </td>
-        <td>{{ solver.language }}</td>
-        <td>{{ (solver.memory / (1024 * 1024)).toFixed(2) }}</td>
-        <td>{{ (solver.runtime / 1000.0).toFixed(2) }}</td>
-        <td>{{ time.formatTimestamp(solver.time) }}</td>
+        <td data-submission-language>{{ solver.language }}</td>
+        <td data-submission-memory>
+          {{ (solver.memory / (1024 * 1024)).toFixed(2) }}
+        </td>
+        <td data-submission-runtime>
+          {{ (solver.runtime / 1000.0).toFixed(2) }}
+        </td>
+        <td data-submission-time>{{ time.formatTimestamp(solver.time) }}</td>
       </tr>
     </tbody>
   </table>

--- a/frontend/www/js/omegaup/components/arena/Solvers.vue
+++ b/frontend/www/js/omegaup/components/arena/Solvers.vue
@@ -24,8 +24,8 @@
           ></omegaup-username>
         </td>
         <td>{{ solver.language }}</td>
-        <td>{{ (solver.runtime / 1000.0).toFixed(2) }}</td>
         <td>{{ (solver.memory / (1024 * 1024)).toFixed(2) }}</td>
+        <td>{{ (solver.runtime / 1000.0).toFixed(2) }}</td>
         <td>{{ time.formatTimestamp(solver.time) }}</td>
       </tr>
     </tbody>


### PR DESCRIPTION
# Descripción

Se arregla la información mostrada en la lista de mejores envíos, ya que los 
campos de `Memoria` y `Tiempo` estaban invertidos.

Fixes: #5033 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
