### PR TITLE
Arreglando la funcionalidad de clonar concursos

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1716,8 +1716,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $r['description'],
             'description'
         );
-        \OmegaUp\Validators::validateNumber($r['start_time'], 'start_time');
-        $startTime = $r['start_time'];
+        $startTime = $r->ensureTimestamp('start_time');
 
         $length = (
             $originalContest->finish_time->time -
@@ -1735,8 +1734,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'title' => $r['title'],
             'description' => $r['description'],
             'alias' => $alias,
-            'start_time' => $startTime,
-            'finish_time' => $startTime + $length,
+            'start_time' => $startTime->time,
+            'finish_time' => $startTime->time + $length,
             'scoreboard' => $originalContest->scoreboard,
             'points_decay_factor' => $originalContest->points_decay_factor,
             'submissions_gap' => $originalContest->submissions_gap,

--- a/frontend/tests/controllers/ContestCloneTest.php
+++ b/frontend/tests/controllers/ContestCloneTest.php
@@ -2,9 +2,23 @@
 
 class ContestCloneTest extends \OmegaUp\Test\ControllerTestCase {
     /**
-     * Create clone of a contest
+     * A PHPUnit data provider for the test with different valid format dates.
+     *
+     * @return list<list<int|float>>
      */
-    public function testCreateContestClone() {
+    public function dateValueProvider(): array {
+        return [
+            [\OmegaUp\Time::get()],
+            [\OmegaUp\Time::get() + 0.047],
+        ];
+    }
+
+    /**
+     * @dataProvider dateValueProvider
+     * Create clone of a contest
+     * @param int|float $date
+     */
+    public function testCreateContestClone($date) {
         // Get a contest
         $contestData = \OmegaUp\Test\Factories\Contest::createContest();
 
@@ -23,15 +37,17 @@ class ContestCloneTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Clone the contest
         $login = self::login($contestData['director']);
-        $contestClonedData = \OmegaUp\Controllers\Contest::apiClone(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'contest_alias' => $contestData['request']['alias'],
-            'title' => \OmegaUp\Test\Utils::createRandomString(),
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => $contestAlias,
-            'contest' => $contestData['contest'],
-            'start_time' => \OmegaUp\Time::get()
-        ]));
+        $contestClonedData = \OmegaUp\Controllers\Contest::apiClone(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'contest_alias' => $contestData['request']['alias'],
+                'title' => \OmegaUp\Test\Utils::createRandomString(),
+                'description' => \OmegaUp\Test\Utils::createRandomString(),
+                'alias' => $contestAlias,
+                'contest' => $contestData['contest'],
+                'start_time' => $date,
+            ])
+        );
 
         $this->assertEquals($contestAlias, $contestClonedData['alias']);
 


### PR DESCRIPTION
# Descripción

Se arregla un bug donde no se podía clonar concursos debido a que la hora de
inicio del concurso clonado no se estaba mandando con el formato correcto.

![ContestCloneFixed](https://user-images.githubusercontent.com/3230352/105270641-c0d0e800-5b5b-11eb-8499-a7b441823a2e.gif)

Fixes: #5029 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.