### PR TITLE
Cambiando administrar problema por editar problema

### DIFF
--- a/frontend/templates/arena.contest.tpl
+++ b/frontend/templates/arena.contest.tpl
@@ -49,7 +49,7 @@
 				<div id="problem" class="main">
 					<div id="problem-settings-summary"></div>
 {if $admin}
-					<a id="edit-problem-link"></a>
+					<a id="edit-problem-link">{#omegaupTitleProblemEdit#}</a>
 {/if}
 					<div class="karel-js-link hide">
 						<a href="/karel.js/" target="_blank">{#openInKarelJs#} <span class="glyphicon glyphicon-new-window"></span></a>

--- a/frontend/templates/arena.contest.tpl
+++ b/frontend/templates/arena.contest.tpl
@@ -49,14 +49,7 @@
 				<div id="problem" class="main">
 					<div id="problem-settings-summary"></div>
 {if $admin}
-					<form enctype="multipart/form-data" action="/api/problem/update" method="post" id="update-problem">
-						<fieldset>
-							<legend>Administrar problema</legend>
-							<input name="problem_alias" type="hidden" />
-							<input name="problem_contents" type="file" />
-							<button type="submit">Actualizar casos/redacci&oacute;n</button>
-						</fieldset>
-					</form>
+					<a id="edit-problem-link"></a>
 {/if}
 					<div class="karel-js-link hide">
 						<a href="/karel.js/" target="_blank">{#openInKarelJs#} <span class="glyphicon glyphicon-new-window"></span></a>

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1604,8 +1604,9 @@ export class Arena {
       const problem = (this.currentProblem = this.problems[problemMatch[1]]);
 
       // Set link to edit problem
-      $('#edit-problem-link').text('Editar este problema');
-      $('#edit-problem-link').attr('href', `/problem/${problem.alias}/edit/`);
+      document
+        .querySelector('#edit-problem-link')
+        ?.setAttribute('href', `/problem/${problem.alias}/edit/`);
 
       // Set as active the selected problem
       if (this.navbarProblems) {

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1602,6 +1602,11 @@ export class Arena {
     if (problemMatch && this.problems[problemMatch[1]]) {
       const newRun = problemMatch[2];
       const problem = (this.currentProblem = this.problems[problemMatch[1]]);
+
+      // Set link to edit problem
+      $('#edit-problem-link').text('Editar este problema');
+      $('#edit-problem-link').attr('href', `/problem/${problem.alias}/edit/`);
+
       // Set as active the selected problem
       if (this.navbarProblems) {
         this.navbarProblems.activeProblem = this.currentProblem.alias;


### PR DESCRIPTION
# Descripción

Se reemplaza el formulario de administrar problema por una liga a `https://omegaup.com/problem/problem_alias/edit/`

![image](https://user-images.githubusercontent.com/52440153/105566329-974dc300-5cf9-11eb-814f-3999b6895320.png)

Fixes: #4316

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
