### PR TITLE
Normalizando el estilo de los type assertions en TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,9 @@ module.exports = {
     // functions from being defined.
     '@typescript-eslint/no-empty-function': 'off',
 
+    // Avoid using bracket type assertions, since those are the old syntax.
+    '@typescript-eslint/consistent-type-assertions': 'error',
+
     // TODO: Remove when we migrate to Vue 3, since this syntax doesn't _quite_
     // work all the time in Vue 2.
     'vue/no-deprecated-v-bind-sync': 'off',
@@ -34,7 +37,7 @@ module.exports = {
     // TODO(#4778): Add key to ALL v-for.
     'vue/require-v-for-key': 'off',
 
-    // TODO: Remove when we migrate to Vue 3, beacuse of 
+    // TODO: Remove when we migrate to Vue 3, beacause of
     // https://v3.vuejs.org/guide/migration/key-attribute.html#with-template-v-for
     'vue/no-v-for-template-key-on-child': 'off',
 

--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -705,11 +705,11 @@ class APIGenerator {
                 echo "   export function {$typeName}(elementId: string = 'payload'): types.{$typeName} {\n";
                 if (is_null($conversionResult->conversionFunction)) {
                     echo "     return JSON.parse(\n";
-                    echo "       (<HTMLElement>document.getElementById(elementId)).innerText,\n";
+                    echo "       (document.getElementById(elementId) as HTMLElement).innerText,\n";
                     echo "     );\n\n";
                 } else {
                     echo "     return ({$conversionResult->conversionFunction})(\n";
-                    echo "       JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),\n";
+                    echo "       JSON.parse((document.getElementById(elementId) as HTMLElement).innerText),\n";
                     echo "     );\n\n";
                 }
                 echo "   }\n\n";

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -57,7 +57,9 @@ export namespace types {
         })(x.events);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -65,7 +67,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.AuthorRankTablePayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -86,7 +88,9 @@ export namespace types {
         })(x.badge);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -112,7 +116,9 @@ export namespace types {
         })(x.ownedBadges);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -120,7 +126,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CertificateDetailsPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -128,7 +134,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CoderOfTheMonthPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -136,7 +142,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CollectionDetailsByAuthorPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -144,7 +150,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CollectionDetailsByLevelPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -152,7 +158,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CommonPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -200,7 +206,9 @@ export namespace types {
         })(x.users);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -225,7 +233,9 @@ export namespace types {
           })(x.problemset);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -252,7 +262,9 @@ export namespace types {
         })(x.contests);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -394,7 +406,9 @@ export namespace types {
         })(x.contests);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -402,7 +416,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ContestNewPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -417,7 +431,9 @@ export namespace types {
         })(x.contest);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -449,7 +465,9 @@ export namespace types {
         })(x.details);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -481,7 +499,9 @@ export namespace types {
         })(x.details);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -537,7 +557,9 @@ export namespace types {
           })(x.selectedAssignment);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -622,7 +644,9 @@ export namespace types {
         })(x.courses);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -708,7 +732,9 @@ export namespace types {
         })(x.courses);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -716,7 +742,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CourseNewPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -748,7 +774,9 @@ export namespace types {
         })(x.course);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -756,7 +784,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CourseSubmissionsListPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -764,7 +792,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.GroupEditPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -783,7 +811,9 @@ export namespace types {
         })(x.groups);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -819,7 +849,9 @@ export namespace types {
         })(x.contests);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -856,7 +888,9 @@ export namespace types {
         })(x.coderOfTheMonthData);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -891,7 +925,9 @@ export namespace types {
           })(x.details);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -899,7 +935,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.LoginDetailsPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -959,7 +995,9 @@ export namespace types {
         })(x.solvers);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1005,7 +1043,9 @@ export namespace types {
           })(x.publishedRevision);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1013,7 +1053,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ProblemFormPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1021,7 +1061,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ProblemListCollectionPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1029,7 +1069,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ProblemListPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1037,7 +1077,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ProblemQualityPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1045,7 +1085,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ProblemsMineInfoPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1053,7 +1093,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.SchoolOfTheMonthPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1061,7 +1101,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.SchoolProfileDetailsPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1069,7 +1109,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.SchoolRankPayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
 
@@ -1083,7 +1123,9 @@ export namespace types {
           );
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1115,7 +1157,9 @@ export namespace types {
         })(x.course);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1147,7 +1191,9 @@ export namespace types {
         })(x.course);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1166,7 +1212,9 @@ export namespace types {
         })(x.submissions);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1224,7 +1272,9 @@ export namespace types {
         })(x.profile);
         return x;
       })(
-        JSON.parse((<HTMLElement>document.getElementById(elementId)).innerText),
+        JSON.parse(
+          (document.getElementById(elementId) as HTMLElement).innerText,
+        ),
       );
     }
 
@@ -1232,7 +1282,7 @@ export namespace types {
       elementId: string = 'payload',
     ): types.UserRankTablePayload {
       return JSON.parse(
-        (<HTMLElement>document.getElementById(elementId)).innerText,
+        (document.getElementById(elementId) as HTMLElement).innerText,
       );
     }
   }

--- a/frontend/www/js/omegaup/arena/admin.ts
+++ b/frontend/www/js/omegaup/arena/admin.ts
@@ -52,7 +52,7 @@ OmegaUp.on('ready', () => {
         }
 
         $('#title .contest-title').text(ui.contestTitle(contest));
-        arenaInstance.updateSummary(<omegaup.Contest>contest);
+        arenaInstance.updateSummary(contest as omegaup.Contest);
 
         arenaInstance.submissionGap = contest.submissions_gap;
         if (!(arenaInstance.submissionGap > 0)) arenaInstance.submissionGap = 0;

--- a/frontend/www/js/omegaup/arena/admin_arena.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.ts
@@ -112,15 +112,15 @@ export default class ArenaAdmin {
         .forEach((input) => input.setAttribute('disabled', 'disabled'));
       api.Clarification.create({
         contest_alias: this.arena.options.contestAlias,
-        problem_alias: (<HTMLInputElement>(
-          clarificationElement.querySelector('select[name="problem"]')
-        )).value,
-        username: (<HTMLInputElement>(
-          clarificationElement.querySelector('select[name="user"]')
-        )).value,
-        message: (<HTMLInputElement>(
-          clarificationElement.querySelector('textarea[name="message"]')
-        )).value,
+        problem_alias: (clarificationElement.querySelector(
+          'select[name="problem"]',
+        ) as HTMLInputElement).value,
+        username: (clarificationElement.querySelector(
+          'select[name="user"]',
+        ) as HTMLInputElement).value,
+        message: (clarificationElement.querySelector(
+          'textarea[name="message"]',
+        ) as HTMLInputElement).value,
       })
         .then(() => {
           this.arena.hideOverlay();
@@ -140,19 +140,19 @@ export default class ArenaAdmin {
   }
 
   refreshRuns(): void {
-    const runsListComponent = <arena_Runs>this.runsList.$children[0];
+    const runsListComponent = this.runsList.$children[0] as arena_Runs;
 
     const options = {
-      assignment_alias: <string | undefined>undefined,
-      contest_alias: <string | undefined>undefined,
-      course_alias: <string | undefined>undefined,
+      assignment_alias: undefined as string | undefined,
+      contest_alias: undefined as string | undefined,
+      course_alias: undefined as string | undefined,
       problem_alias: runsListComponent.filterProblem || undefined,
       offset: runsListComponent.filterOffset * runsListComponent.rowCount,
       rowcount: runsListComponent.rowCount,
       verdict: runsListComponent.filterVerdict || undefined,
       language: runsListComponent.filterLanguage || undefined,
       username: runsListComponent.filterUsername || undefined,
-      show_all: <boolean | undefined>undefined,
+      show_all: undefined as boolean | undefined,
       status: runsListComponent.filterStatus || undefined,
     };
 

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -589,9 +589,9 @@ export class Arena {
       },
       data: () => ({
         markdown: '',
-        imageMapping: <markdown.ImageMapping>{},
-        sourceMapping: <markdown.SourceMapping>{},
-        problemSettings: <types.ProblemSettingsDistrib | undefined>undefined,
+        imageMapping: {} as markdown.ImageMapping,
+        sourceMapping: {} as markdown.SourceMapping,
+        problemSettings: undefined as types.ProblemSettingsDistrib | undefined,
       }),
       render: function (createElement) {
         return createElement('omegaup-markdown', {
@@ -623,11 +623,12 @@ export class Arena {
     $('.libinteractive-download form').on('submit', (e: Event) => {
       e.preventDefault();
 
-      const form = <HTMLElement>e.target;
+      const form = e.target as HTMLElement;
       const alias = this.currentProblem.alias;
       const commit = this.currentProblem.commit;
-      const os = (<HTMLInputElement>form.querySelector('.download-os'))?.value;
-      const lang = (<HTMLInputElement>form.querySelector('.download-lang'))
+      const os = (form.querySelector('.download-os') as HTMLInputElement)
+        ?.value;
+      const lang = (form.querySelector('.download-lang') as HTMLInputElement)
         ?.value;
       const extension = os == 'unix' ? '.tar.bz2' : '.zip';
 
@@ -637,7 +638,7 @@ export class Arena {
     });
 
     $('.libinteractive-download .download-lang').on('change', (e: Event) => {
-      let form = <HTMLElement>e.target;
+      let form = e.target as HTMLElement;
       while (!form.classList.contains('libinteractive-download')) {
         if (!form.parentElement) {
           return;
@@ -646,7 +647,7 @@ export class Arena {
       }
       $(form)
         .find('.libinteractive-extension')
-        .html(<string>$(<HTMLElement>e.target).val());
+        .html($(e.target as HTMLElement).val() as string);
     });
 
     $('.output-only-download a').attr(
@@ -812,20 +813,18 @@ export class Arena {
     $('#title .contest-title').text(problemset.title ?? problemset.name ?? '');
     this.updateSummary({
       ...problemset,
-      alias: <string>problemset.alias,
-      title: <string>problemset.title,
-      start_time: <Date>problemset.start_time,
-      admission_mode: <omegaup.AdmissionMode | undefined>(
-        problemset.admission_mode
-      ),
-      requests_user_information: <omegaup.RequestsUserInformation | undefined>(
-        problemset.requests_user_information
-      ),
+      alias: problemset.alias as string,
+      title: problemset.title as string,
+      start_time: problemset.start_time as Date,
+      admission_mode: problemset.admission_mode as
+        | omegaup.AdmissionMode
+        | undefined,
+      requests_user_information: problemset.requests_user_information,
     });
     this.submissionGap = Math.max(0, problemset.submissions_gap ?? 60);
 
     this.initClock(
-      <Date>problemset.start_time,
+      problemset.start_time as Date,
       problemset.finish_time ?? null,
       problemset.submission_deadline ?? null,
     );
@@ -850,7 +849,7 @@ export class Arena {
         $('<option>')
           .val(problem.alias)
           .text(problemName)
-          .appendTo(<Element>problemSelect);
+          .appendTo(problemSelect as Element);
       }
     }
 
@@ -1006,12 +1005,12 @@ export class Arena {
   onVirtualRankingChange(virtualContestData: types.Scoreboard): void {
     // This clones virtualContestData to data so that virtualContestData values
     // won't be overriden by processes below
-    const data = <types.Scoreboard>(
-      JSON.parse(JSON.stringify(virtualContestData.ranking))
-    );
-    const dataRanking = <
-      (types.ScoreboardRankingEntry & { virtual?: boolean })[]
-    >data.ranking;
+    const data = JSON.parse(
+      JSON.stringify(virtualContestData.ranking),
+    ) as types.Scoreboard;
+    const dataRanking: (types.ScoreboardRankingEntry & {
+      virtual?: boolean;
+    })[] = data.ranking;
     const events = this.originalContestScoreboardEvents ?? [];
     const currentDelta =
       (new Date().getTime() - (this.startTime?.getTime() ?? 0)) / (1000 * 60);
@@ -1311,8 +1310,8 @@ export class Arena {
     if (series.length == 0 || !this.elements.ranking) return;
 
     this.rankingChart = Highcharts.stockChart(
-      <HTMLElement>document.getElementById('ranking-chart'),
-      <Highcharts.Options>{
+      document.getElementById('ranking-chart') as HTMLElement,
+      {
         chart: { height: 300, spacingTop: 20 },
 
         colors: scoreboardColors,
@@ -1358,7 +1357,7 @@ export class Arena {
         rangeSelector: { enabled: false },
 
         series: series,
-      },
+      } as Highcharts.Options,
     );
   }
 
@@ -1392,11 +1391,9 @@ export class Arena {
         clarifications.push(clarification);
       }
     } else {
-      r = <HTMLElement | null>(
-        document
-          .querySelector('.clarifications tbody.clarification-list tr.template')
-          ?.cloneNode(true)
-      );
+      r = document
+        .querySelector('.clarifications tbody.clarification-list tr.template')
+        ?.cloneNode(true) as HTMLElement | null;
       if (r) {
         r.classList.remove('template');
         r.classList.add('inserted');
@@ -1452,9 +1449,10 @@ export class Arena {
             api.Clarification.update({
               clarification_id: id,
               answer: responseText,
-              public: (<HTMLInputElement>(
-                $('.create-response-is-public', responseFormNode)[0]
-              )).checked,
+              public: ($(
+                '.create-response-is-public',
+                responseFormNode,
+              )[0] as HTMLInputElement).checked,
             })
               .then(() => {
                 $('pre', answerNode).html(responseText);
@@ -1862,9 +1860,9 @@ export class Arena {
       this.markdownView.sourceMapping = problem.statement.sources;
       this.markdownView.problemSettings = problem.settings;
     }
-    const creationDateElement = <HTMLElement>(
-      document.querySelector('#problem .problem-creation-date')
-    );
+    const creationDateElement = document.querySelector(
+      '#problem .problem-creation-date',
+    ) as HTMLElement;
     if (problem.problemsetter?.creation_date && creationDateElement) {
       creationDateElement.innerText = ui.formatString(T.wordsUploadedOn, {
         date: time.formatDate(problem.problemsetter.creation_date),
@@ -1873,9 +1871,9 @@ export class Arena {
   }
 
   onProblemRendered(): void {
-    const libinteractiveInterfaceNameElement = <HTMLElement>(
-      this.markdownView.$el.querySelector('span.libinteractive-interface-name')
-    );
+    const libinteractiveInterfaceNameElement = this.markdownView.$el.querySelector(
+      'span.libinteractive-interface-name',
+    ) as HTMLElement;
     if (
       libinteractiveInterfaceNameElement &&
       this.currentProblem.settings?.interactive?.module_name
@@ -1976,8 +1974,8 @@ export class Arena {
 
   onCloseSubmit(e: Event): void {
     if (
-      (<HTMLElement>e.target).id !== 'overlay' &&
-      (<HTMLElement>e.target).closest('button.close') === null
+      (e.target as HTMLElement).id !== 'overlay' &&
+      (e.target as HTMLElement).closest('button.close') === null
     ) {
       return;
     }
@@ -2057,7 +2055,8 @@ export class Arena {
         };
         this.updateRun(run);
         if (this.runSubmitView) {
-          const component = <arena_RunSubmit>this.runSubmitView.$refs.component;
+          const component = this.runSubmitView.$refs
+            .component as arena_RunSubmit;
           component.clearForm();
           // Wait until the code view has been cleared before hiding the
           // overlay. Not doing so will sometimes cause the contents of the
@@ -2149,13 +2148,12 @@ export class Arena {
           !this.options.contestAlias || this.options.contestAlias === 'admin'
             ? data.show_diff
             : 'none',
-        feedback: <omegaup.SubmissionFeedback>(
-          ((this.options.contestAlias && this.currentProblemset?.feedback) ||
-            'detailed')
-        ),
+        feedback: ((this.options.contestAlias &&
+          this.currentProblemset?.feedback) ||
+          'detailed') as omegaup.SubmissionFeedback,
       });
-      const runDetailsView = <HTMLElement | null>(
-        document.querySelector('[data-run-details-view]')
+      const runDetailsView: HTMLElement | null = document.querySelector(
+        '[data-run-details-view]',
       );
       if (runDetailsView) runDetailsView.style.display = 'block';
     }
@@ -2308,13 +2306,11 @@ export function GetOptionsFromLocation(
     options.disableSockets = true;
   }
   if (document.getElementById('payload')) {
-    const payload = <
-      types.CommonPayload & {
-        shouldShowFirstAssociatedIdentityRunWarning?: boolean;
-        contest?: omegaup.Contest;
-        preferred_language?: string;
-      }
-    >types.payloadParsers.CommonPayload();
+    const payload = types.payloadParsers.CommonPayload() as types.CommonPayload & {
+      shouldShowFirstAssociatedIdentityRunWarning?: boolean;
+      contest?: omegaup.Contest;
+      preferred_language?: string;
+    };
     if (payload !== null) {
       options.shouldShowFirstAssociatedIdentityRunWarning =
         payload.shouldShowFirstAssociatedIdentityRunWarning || false;
@@ -2416,9 +2412,9 @@ export class EphemeralGrader {
   loaded: boolean;
 
   constructor() {
-    this.ephemeralEmbeddedGraderElement = <null | HTMLIFrameElement>(
-      document.getElementById('ephemeral-embedded-grader')
-    );
+    this.ephemeralEmbeddedGraderElement = document.getElementById(
+      'ephemeral-embedded-grader',
+    ) as null | HTMLIFrameElement;
     this.messageQueue = [];
     this.loaded = false;
 
@@ -2449,7 +2445,7 @@ export class EphemeralGrader {
     if (!this.ephemeralEmbeddedGraderElement) {
       return;
     }
-    (<Window>this.ephemeralEmbeddedGraderElement.contentWindow).postMessage(
+    (this.ephemeralEmbeddedGraderElement.contentWindow as Window).postMessage(
       message,
       `${window.location.origin}/grader/ephemeral/embedded/`,
     );

--- a/frontend/www/js/omegaup/arena/contest.ts
+++ b/frontend/www/js/omegaup/arena/contest.ts
@@ -3,9 +3,9 @@ import { Arena, GetOptionsFromLocation } from './arena';
 import { OmegaUp } from '../omegaup';
 
 function getInputValue(itemSelector: string): string | undefined {
-  const element = document.querySelector(itemSelector);
+  const element: HTMLInputElement | null = document.querySelector(itemSelector);
   if (element) {
-    return (<HTMLInputElement>element).value;
+    return element.value;
   }
 }
 

--- a/frontend/www/js/omegaup/badge/list.ts
+++ b/frontend/www/js/omegaup/badge/list.ts
@@ -14,10 +14,10 @@ OmegaUp.on('ready', function () {
     render: function (createElement) {
       return createElement('omegaup-badge-list', {
         props: {
-          allBadges: <Set<string>>new Set(payload.badges),
-          visitorBadges: <Set<string>>(
-            new Set(payload.ownedBadges.map((badge) => badge.badge_alias))
-          ),
+          allBadges: new Set(payload.badges) as Set<string>,
+          visitorBadges: new Set(
+            payload.ownedBadges.map((badge) => badge.badge_alias),
+          ) as Set<string>,
           showAllBadgesLink: false,
         },
       });

--- a/frontend/www/js/omegaup/common/navbar.ts
+++ b/frontend/www/js/omegaup/common/navbar.ts
@@ -25,10 +25,10 @@ OmegaUp.on('ready', () => {
       isMainUserIdentity: payload.isMainUserIdentity,
       lockDownImage: payload.lockDownImage,
       navbarSection: payload.navbarSection,
-      notifications: <types.Notification[]>[],
-      graderInfo: <types.GraderStatus | null>null,
+      notifications: [] as types.Notification[],
+      graderInfo: null as types.GraderStatus | null,
       graderQueueLength: -1,
-      errorMessage: <string | null>null,
+      errorMessage: null as string | null,
       initialClarifications: [],
     }),
     render: function (createElement) {

--- a/frontend/www/js/omegaup/common/navbar_v2.ts
+++ b/frontend/www/js/omegaup/common/navbar_v2.ts
@@ -13,10 +13,10 @@ OmegaUp.on('ready', () => {
       'omegaup-common-navbar': common_NavbarV2,
     },
     data: () => ({
-      notifications: <types.Notification[]>[],
-      graderInfo: <types.GraderStatus | null>null,
+      notifications: [] as types.Notification[],
+      graderInfo: null as types.GraderStatus | null,
       graderQueueLength: -1,
-      errorMessage: <string | null>null,
+      errorMessage: null as string | null,
     }),
     render: function (createElement) {
       return createElement('omegaup-common-navbar', {

--- a/frontend/www/js/omegaup/common/stats.ts
+++ b/frontend/www/js/omegaup/common/stats.ts
@@ -145,7 +145,7 @@ OmegaUp.on('ready', () => {
           events: {
             load: (ev: Event): void => {
               // set up the updating of the chart each second
-              const series = (<Highcharts.Chart>(ev.target as unknown))
+              const series = ((ev.target as unknown) as Highcharts.Chart)
                 .series[0];
               setInterval(() => {
                 const x = new Date().getTime(), // current time

--- a/frontend/www/js/omegaup/components/Autocomplete.vue
+++ b/frontend/www/js/omegaup/components/Autocomplete.vue
@@ -23,7 +23,7 @@ export default class Autocomplete extends Vue {
   @Prop() init!: (el: JQuery<HTMLElement>) => void;
 
   mounted() {
-    this.init($(<HTMLElement>this.$refs.input));
+    this.init($(this.$refs.input as HTMLElement));
   }
 
   @Emit('input')

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -71,7 +71,7 @@ export default class Markdown extends Vue {
         if (!preElement.firstChild) {
           return;
         }
-        const inputValue = (<HTMLPreElement>preElement).innerText;
+        const inputValue = (preElement as HTMLElement).innerText;
 
         const clipboardButton = document.createElement('button');
         clipboardButton.appendChild(document.createTextNode('📋'));
@@ -84,7 +84,7 @@ export default class Markdown extends Vue {
           ui.copyToClipboard(inputValue);
         });
 
-        (<HTMLElement>preElement.parentElement).insertBefore(
+        (preElement.parentElement as HTMLElement).insertBefore(
           clipboardButton,
           preElement,
         );
@@ -128,9 +128,9 @@ export default class Markdown extends Vue {
       // Now that the global MathJax config is set, we can lazily load the
       // library. The element to be rendered will be queued up in
       // MathJax.startup.elements.
-      let scriptElement: HTMLScriptElement | null = <HTMLScriptElement | null>(
-        document.getElementById('MathJax-script')
-      );
+      let scriptElement = document.getElementById(
+        'MathJax-script',
+      ) as HTMLScriptElement | null;
       if (!scriptElement) {
         scriptElement = document.createElement('script');
         scriptElement.src = '/third_party/js/mathjax/es5/tex-svg.js';

--- a/frontend/www/js/omegaup/components/admin/Roles.vue
+++ b/frontend/www/js/omegaup/components/admin/Roles.vue
@@ -62,7 +62,7 @@ export default class AdminRoles extends Vue {
   ): omegaup.Selectable<omegaup.Role> {
     return {
       value: role,
-      selected: (<HTMLInputElement>ev.target).checked,
+      selected: (ev.target as HTMLInputElement).checked,
     };
   }
 
@@ -73,7 +73,7 @@ export default class AdminRoles extends Vue {
   ): omegaup.Selectable<types.Group> {
     return {
       value: group,
-      selected: (<HTMLInputElement>ev.target).checked,
+      selected: (ev.target as HTMLInputElement).checked,
     };
   }
 }

--- a/frontend/www/js/omegaup/components/admin/Support.vue
+++ b/frontend/www/js/omegaup/components/admin/Support.vue
@@ -157,9 +157,9 @@ export default class AdminSupport extends Vue {
   }
 
   onCopyToken(): void {
-    let copyText: HTMLInputElement = <HTMLInputElement>(
-      this.$el.querySelector('input[name=link]')
-    );
+    const copyText = this.$el.querySelector(
+      'input[name=link]',
+    ) as HTMLInputElement;
     copyText.select();
     document.execCommand('copy');
     this.$emit('copy-token');

--- a/frontend/www/js/omegaup/components/admin/User.vue
+++ b/frontend/www/js/omegaup/components/admin/User.vue
@@ -98,7 +98,7 @@ export default class User extends Vue {
   ): omegaup.Selectable<omegaup.Experiment> {
     return {
       value: experiment,
-      selected: (<HTMLInputElement>ev.target).checked,
+      selected: (ev.target as HTMLInputElement).checked,
     };
   }
 
@@ -109,7 +109,7 @@ export default class User extends Vue {
   ): omegaup.Selectable<omegaup.Role> {
     return {
       value: role,
-      selected: (<HTMLInputElement>ev.target).checked,
+      selected: (ev.target as HTMLInputElement).checked,
     };
   }
 

--- a/frontend/www/js/omegaup/components/arena/ContestPractice.test.ts
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.test.ts
@@ -2,7 +2,7 @@ jest.mock('../../../../third_party/js/diff_match_patch.js');
 
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import * as time from '../../time';
 
 import arena_ContestPractice from './ContestPractice.vue';
@@ -85,7 +85,7 @@ describe('Details.vue', () => {
     visibility: 2,
     input_limit: 1000,
     guid: '80bbe93bc01c1d47ff9fb396dfaff741',
-    runDetailsData: <types.RunDetails>{
+    runDetailsData: {
       admin: false,
       alias: 'sumas',
       cases: {},
@@ -120,7 +120,7 @@ describe('Details.vue', () => {
       source_link: false,
       source_name: 'Main.py3',
       source_url: 'blob:http://localhost:8001/url',
-    },
+    } as types.RunDetails,
   } as types.ProblemInfo;
 
   it('Should handle details for a problem in a contest, practice mode', () => {

--- a/frontend/www/js/omegaup/components/arena/RunDetails.test.ts
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.test.ts
@@ -4,7 +4,7 @@ import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import arena_RunDetails from './RunDetails.vue';
 
@@ -12,7 +12,7 @@ describe('RunDetails.vue', () => {
   it('Should handle run details', () => {
     const wrapper = shallowMount(arena_RunDetails, {
       propsData: {
-        data: <types.RunDetails>{
+        data: {
           admin: false,
           alias: 'sumas',
           cases: {},
@@ -47,7 +47,7 @@ describe('RunDetails.vue', () => {
           source_link: false,
           source_name: 'Main.py3',
           source_url: 'blob:http://localhost:8001/url',
-        },
+        } as types.RunDetails,
       },
     });
 

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -521,7 +521,7 @@ export default class Runs extends Vue {
   }
 
   showVerdictHelp(ev: Event): void {
-    $(<HTMLElement>ev.target).popover('show');
+    $(ev.target as HTMLElement).popover('show');
   }
 
   statusColor(run: types.Run): string {

--- a/frontend/www/js/omegaup/components/arena/Runsv2.vue
+++ b/frontend/www/js/omegaup/components/arena/Runsv2.vue
@@ -524,7 +524,7 @@ export default class Runsv2 extends Vue {
   }
 
   showVerdictHelp(ev: Event): void {
-    $(<HTMLElement>ev.target).popover('show');
+    $(ev.target as HTMLElement).popover('show');
   }
 
   statusColor(run: types.Run): string {

--- a/frontend/www/js/omegaup/components/arena/Solvers.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Solvers.test.ts
@@ -4,13 +4,13 @@ import expect from 'expect';
 import T from '../../lang';
 
 import arena_Solvers from './Solvers.vue';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 describe('Solvers.vue', () => {
   it('Should handle empty solvers list', () => {
     const wrapper = shallowMount(arena_Solvers, {
       propsData: {
-        solvers: <types.BestSolvers[]>[],
+        solvers: [] as types.BestSolvers[],
       },
     });
 
@@ -20,7 +20,7 @@ describe('Solvers.vue', () => {
   it('Should handle solvers list', async () => {
     const wrapper = shallowMount(arena_Solvers, {
       propsData: {
-        solvers: <types.BestSolvers[]>[
+        solvers: [
           {
             classname: 'user-rank-unranked',
             language: 'py3',
@@ -29,7 +29,7 @@ describe('Solvers.vue', () => {
             time: new Date(),
             username: 'username',
           },
-        ],
+        ] as types.BestSolvers[],
       },
     });
 

--- a/frontend/www/js/omegaup/components/badge/List.test.ts
+++ b/frontend/www/js/omegaup/components/badge/List.test.ts
@@ -10,8 +10,8 @@ describe('List.vue', () => {
     const wrapper = shallowMount(badge_List, {
       propsData: {
         showAllBadgesLink: true,
-        allBadges: <Set<string>>new Set([badgeAlias]),
-        visitorBadges: <Set<string>>new Set([badgeAlias]),
+        allBadges: new Set([badgeAlias]) as Set<string>,
+        visitorBadges: new Set([badgeAlias]) as Set<string>,
       },
     });
     expect(wrapper.find('.badges-link').text()).toBe(T.wordsBadgesSeeAll);

--- a/frontend/www/js/omegaup/components/course/AddStudents.test.ts
+++ b/frontend/www/js/omegaup/components/course/AddStudents.test.ts
@@ -11,8 +11,8 @@ describe('AddStudents.vue', () => {
     const wrapper = shallowMount(course_AddStudents, {
       propsData: {
         courseAlias: 'course_alias',
-        students: <types.CourseStudent[]>[],
-        identityRequests: <types.IdentityRequest[]>[],
+        students: [] as types.CourseStudent[],
+        identityRequests: [] as types.IdentityRequest[],
       },
     });
 
@@ -23,13 +23,13 @@ describe('AddStudents.vue', () => {
     const wrapper = shallowMount(course_AddStudents, {
       propsData: {
         courseAlias: 'course_alias',
-        students: <types.CourseStudent[]>[
+        students: [
           {
             name: 'omegaUp user',
             username: 'user',
           },
-        ],
-        identityRequests: <types.IdentityRequest[]>[
+        ] as types.CourseStudent[],
+        identityRequests: [
           {
             accepted: false,
             country: 'mx',
@@ -37,7 +37,7 @@ describe('AddStudents.vue', () => {
             request_time: new Date(),
             username: 'user_1',
           },
-        ],
+        ] as types.IdentityRequest[],
       },
     });
 

--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.test.ts
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.test.ts
@@ -10,7 +10,7 @@ describe('AssignmentDetails.vue', () => {
   it('Should handle empty assignments and progress as admin', () => {
     const wrapper = shallowMount(course_AssignmentDetails, {
       propsData: {
-        assignment: <omegaup.Assignment>{},
+        assignment: {} as omegaup.Assignment,
         assignmentFormMode: omegaup.AssignmentFormMode.New,
         finishTimeCourse: new Date(),
         startTimeCourse: new Date(),

--- a/frontend/www/js/omegaup/components/course/AssignmentList.test.ts
+++ b/frontend/www/js/omegaup/components/course/AssignmentList.test.ts
@@ -4,7 +4,7 @@ import Sortable from 'sortablejs';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_AssignmentList from './AssignmentList.vue';
 
@@ -12,7 +12,7 @@ describe('AssignmentList.vue', () => {
   it('Should handle empty content list', () => {
     const wrapper = shallowMount(course_AssignmentList, {
       propsData: {
-        content: <types.CourseAssignment[]>[],
+        content: [] as types.CourseAssignment[],
         courseAlias: 'course_alias',
       },
     });
@@ -31,7 +31,7 @@ describe('AssignmentList.vue', () => {
     const wrapper = shallowMount(course_AssignmentList, {
       localVue,
       propsData: {
-        content: <omegaup.Assignment[]>[
+        content: [
           {
             alias: 'CA',
             assignment_type: 'test',
@@ -46,7 +46,7 @@ describe('AssignmentList.vue', () => {
             scoreboard_url_admin: 'sb02',
             start_time: new Date(),
           },
-        ],
+        ] as omegaup.Assignment[],
         courseAlias: 'course_alias',
         assignmentFormMode: omegaup.AssignmentFormMode.Default,
       },

--- a/frontend/www/js/omegaup/components/course/CardsList.test.ts
+++ b/frontend/www/js/omegaup/components/course/CardsList.test.ts
@@ -2,12 +2,12 @@ import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_CardsList from './CardsList.vue';
 
 const coursesListProps = {
-  courses: <types.StudentCourses>{
+  courses: {
     admin: {
       accessMode: 'admin',
       activeTab: '',
@@ -50,7 +50,7 @@ const coursesListProps = {
         },
       },
     },
-  },
+  } as types.StudentCourses,
 };
 
 describe('CardsList.vue', () => {

--- a/frontend/www/js/omegaup/components/course/CloneWithToken.test.ts
+++ b/frontend/www/js/omegaup/components/course/CloneWithToken.test.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_CloneWithToken from './CloneWithToken.vue';
 
@@ -10,7 +10,7 @@ describe('CloneWithToken.vue', () => {
     const courseName = 'Test course';
     const wrapper = shallowMount(course_CloneWithToken, {
       propsData: {
-        course: <types.CourseDetails>{
+        course: {
           admission_mode: 'private',
           alias: 'test-course',
           assignments: [],
@@ -27,7 +27,7 @@ describe('CloneWithToken.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: false,
-        },
+        } as types.CourseDetails,
         username: 'omegaup',
         classname: 'user-rank-unranked',
         token: 'fak3T0k3n',

--- a/frontend/www/js/omegaup/components/course/CourseCard.test.ts
+++ b/frontend/www/js/omegaup/components/course/CourseCard.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_CourseCard from './CourseCard.vue';
 
@@ -15,7 +15,7 @@ describe('CourseCard.vue', () => {
         schoolName: 'omegaUp',
         finishTime: null,
         progress: 0,
-        content: <types.CourseAssignment[]>[
+        content: [
           {
             alias: 't1',
             assignment_type: 'homework',
@@ -44,7 +44,7 @@ describe('CourseCard.vue', () => {
             scoreboard_url_admin: 'admin_url',
             start_time: new Date(),
           },
-        ],
+        ] as types.CourseAssignment[],
         loggedIn: true,
         isOpen: false,
         showTopics: true,

--- a/frontend/www/js/omegaup/components/course/Details.test.ts
+++ b/frontend/www/js/omegaup/components/course/Details.test.ts
@@ -2,7 +2,7 @@ import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_Details from './Details.vue';
 
@@ -11,7 +11,7 @@ describe('Details.vue', () => {
     const courseName = 'Test course';
     const wrapper = shallowMount(course_Details, {
       propsData: {
-        course: <types.CourseDetails>{
+        course: {
           admission_mode: 'registration',
           alias: 'test-course',
           assignments: [],
@@ -28,8 +28,8 @@ describe('Details.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: false,
-        },
-        progress: <types.AssignmentProgress>{},
+        } as types.CourseDetails,
+        progress: {} as types.AssignmentProgress,
       },
     });
 
@@ -46,7 +46,7 @@ describe('Details.vue', () => {
     const courseName = 'Test course';
     const wrapper = shallowMount(course_Details, {
       propsData: {
-        course: <types.CourseDetails>{
+        course: {
           admission_mode: 'registration',
           alias: 'test-course',
           assignments: [],
@@ -63,8 +63,8 @@ describe('Details.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: false,
-        },
-        progress: <types.AssignmentProgress>{},
+        } as types.CourseDetails,
+        progress: {} as types.AssignmentProgress,
       },
     });
 
@@ -79,7 +79,7 @@ describe('Details.vue', () => {
     const courseName = 'Test course';
     const wrapper = shallowMount(course_Details, {
       propsData: {
-        course: <types.CourseDetails>{
+        course: {
           admission_mode: 'public',
           alias: 'test-course',
           assignments: [
@@ -111,13 +111,13 @@ describe('Details.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: true,
-        },
-        progress: <types.AssignmentProgress>{
-          'test-assignment': <types.Progress>{
+        } as types.CourseDetails,
+        progress: {
+          'test-assignment': {
             score: 0,
             max_score: 1,
-          },
-        },
+          } as types.Progress,
+        } as types.AssignmentProgress,
       },
     });
 

--- a/frontend/www/js/omegaup/components/course/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/course/Edit.test.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_Edit from './Edit.vue';
 
@@ -13,7 +13,7 @@ describe('Edit.vue', () => {
     const courseName = 'Test course';
     const wrapper = shallowMount(course_Edit, {
       propsData: {
-        data: <types.CourseEditPayload>{
+        data: {
           course: {
             admission_mode: 'registration',
             alias: 'test-course',
@@ -54,7 +54,7 @@ describe('Edit.vue', () => {
           admins: [],
           groupsAdmins: [],
           tags: [],
-        },
+        } as types.CourseEditPayload,
         initialTab: 'course',
       },
     });

--- a/frontend/www/js/omegaup/components/course/Edit.vue
+++ b/frontend/www/js/omegaup/components/course/Edit.vue
@@ -262,7 +262,7 @@ import common_GroupAdmins from '../common/GroupAdmins.vue';
 import course_Clone from './Clone.vue';
 import course_GenerateLinkClone from './GenerateLinkClone.vue';
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import { omegaup } from '../../omegaup';
 
 const now = new Date();
@@ -334,7 +334,7 @@ export default class CourseEdit extends Vue {
     this.assignmentProblems = [];
     this.$nextTick(() => {
       this.assignmentDetails.$el.scrollIntoView();
-      (<HTMLElement>this.assignmentDetails.$refs.name).focus();
+      (this.assignmentDetails.$refs.name as HTMLElement).focus();
     });
   }
 
@@ -344,7 +344,7 @@ export default class CourseEdit extends Vue {
     this.$emit('select-assignment', this.assignment);
     this.$nextTick(() => {
       this.assignmentDetails.$el.scrollIntoView();
-      (<HTMLElement>this.assignmentDetails.$refs.name).focus();
+      (this.assignmentDetails.$refs.name as HTMLElement).focus();
     });
   }
 

--- a/frontend/www/js/omegaup/components/course/FilteredList.test.ts
+++ b/frontend/www/js/omegaup/components/course/FilteredList.test.ts
@@ -2,14 +2,14 @@ import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_FilteredList from './FilteredList.vue';
 
 const noop = () => {};
 const baseFilteredCoursesListProps = {
   activeTab: 'past',
-  courses: <types.CoursesByAccessMode>{
+  courses: {
     accessMode: 'public',
     activeTab: 'current',
     filteredCourses: {
@@ -47,7 +47,7 @@ const baseFilteredCoursesListProps = {
         timeType: 'past',
       },
     },
-  },
+  } as types.CoursesByAccessMode,
 };
 Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });
 

--- a/frontend/www/js/omegaup/components/course/Form.test.ts
+++ b/frontend/www/js/omegaup/components/course/Form.test.ts
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import expect from 'expect';
 
 import T from '../../lang';
@@ -7,7 +7,7 @@ import T from '../../lang';
 import course_Form from './Form.vue';
 
 const baseCourseFormProps = {
-  course: <types.CourseDetails>{
+  course: {
     admission_mode: 'registration',
     alias: 'Newx',
     assignments: [],
@@ -24,7 +24,7 @@ const baseCourseFormProps = {
     start_time: new Date(),
     student_count: 3,
     unlimited_duration: false,
-  },
+  } as types.CourseDetails,
   update: true,
 };
 const selector = '.omegaup-course-details button.btn-primary';

--- a/frontend/www/js/omegaup/components/course/List.test.ts
+++ b/frontend/www/js/omegaup/components/course/List.test.ts
@@ -2,12 +2,12 @@ import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_List from './List.vue';
 
 const coursesListProps = {
-  courses: <types.StudentCourses>{
+  courses: {
     public: {
       accessMode: 'public',
       activeTab: 'current',
@@ -51,7 +51,7 @@ const coursesListProps = {
         },
       },
     },
-  },
+  } as types.StudentCourses,
 };
 
 describe('List.vue', () => {

--- a/frontend/www/js/omegaup/components/course/Mine.test.ts
+++ b/frontend/www/js/omegaup/components/course/Mine.test.ts
@@ -2,13 +2,13 @@ import { mount } from '@vue/test-utils';
 import expect from 'expect';
 import T from '../../lang';
 import course_Mine from './Mine.vue';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 describe('Mine.vue', () => {
   it('Should display course admin list', () => {
     const wrapper = mount(course_Mine, {
       propsData: {
-        courses: <types.AdminCourses>{
+        courses: {
           admin: {
             accessMode: 'admin',
             activeTab: 'current',
@@ -17,7 +17,7 @@ describe('Mine.vue', () => {
               past: {},
             },
           },
-        },
+        } as types.AdminCourses,
         isMainUserIdentity: true,
       },
     });

--- a/frontend/www/js/omegaup/components/course/ProblemList.test.ts
+++ b/frontend/www/js/omegaup/components/course/ProblemList.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_ProblemLists from './ProblemList.vue';
 
@@ -11,10 +11,10 @@ describe('ProblemLists.vue', () => {
   it('Should handle empty assignments and problems', () => {
     const wrapper = shallowMount(course_ProblemLists, {
       propsData: {
-        assignmentProblems: <types.ProblemsetProblem[]>[],
-        assignments: <omegaup.Assignment[]>[],
-        selectedAssignment: <omegaup.Assignment>{},
-        taggedProblems: <omegaup.Problem[]>[],
+        assignmentProblems: [] as types.ProblemsetProblem[],
+        assignments: [] as omegaup.Assignment[],
+        selectedAssignment: {} as omegaup.Assignment,
+        taggedProblems: [] as omegaup.Problem[],
         assignmentFormMode: omegaup.AssignmentFormMode.New,
       },
     });

--- a/frontend/www/js/omegaup/components/course/ScheduledProblemList.test.ts
+++ b/frontend/www/js/omegaup/components/course/ScheduledProblemList.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_ScheduledProblemLists from './ScheduledProblemList.vue';
 
@@ -11,9 +11,9 @@ describe('ScheduledProblemLists.vue', () => {
   it('Should handle empty assignments and problems', () => {
     const wrapper = shallowMount(course_ScheduledProblemLists, {
       propsData: {
-        assignments: <types.CourseAssignment[]>[],
-        assignmentProblems: <types.ProblemsetProblem[]>[],
-        selectedAssignment: <types.CourseAssignment>{
+        assignments: [] as types.CourseAssignment[],
+        assignmentProblems: [] as types.ProblemsetProblem[],
+        selectedAssignment: {
           problemset_id: 0,
           alias: '',
           description: '',
@@ -27,8 +27,8 @@ describe('ScheduledProblemLists.vue', () => {
           scoreboard_url: '',
           scoreboard_url_admin: '',
           assignment_type: 'homework',
-        },
-        taggedProblems: <omegaup.Problem[]>[],
+        } as types.CourseAssignment,
+        taggedProblems: [] as omegaup.Problem[],
       },
     });
 

--- a/frontend/www/js/omegaup/components/course/StudentProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { omegaup } from '../../omegaup';
 
 import course_StudentProgress from './StudentProgress.vue';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 describe('StudentProgress.vue', () => {
   it('Should handle scores', async () => {
@@ -12,7 +12,7 @@ describe('StudentProgress.vue', () => {
         course: {
           alias: 'hello',
         },
-        assignments: <omegaup.Assignment[]>[
+        assignments: [
           {
             alias: 'assignment',
             assignment_type: 'homework',
@@ -25,8 +25,8 @@ describe('StudentProgress.vue', () => {
             scoreboard_url_admin: '',
             max_points: 200,
           } as omegaup.Assignment,
-        ],
-        student: <types.StudentProgress>{
+        ] as omegaup.Assignment[],
+        student: {
           name: 'student',
           points: {
             ['assignment']: {
@@ -47,7 +47,7 @@ describe('StudentProgress.vue', () => {
             },
           },
           username: 'student',
-        },
+        } as types.StudentProgress,
         problemTitles: {
           problem1: 'Problem 1',
           problem2: 'Problem 2',

--- a/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
@@ -9,7 +9,7 @@ import course_ViewProgress, {
   toOds,
   toCsv,
 } from './ViewProgress.vue';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 describe('ViewProgress.vue', () => {
   if (typeof window.URL.createObjectURL === 'undefined') {
@@ -20,11 +20,11 @@ describe('ViewProgress.vue', () => {
     });
   }
   const baseViewProgressProps = {
-    course: <types.CourseDetails>{
+    course: {
       alias: 'hello',
       name: 'Hello course',
-    },
-    assignments: <omegaup.Assignment[]>[
+    } as types.CourseDetails,
+    assignments: [
       {
         alias: 'assignment',
         assignment_type: 'homework',
@@ -37,8 +37,8 @@ describe('ViewProgress.vue', () => {
         scoreboard_url_admin: '',
         max_points: 200,
       } as omegaup.Assignment,
-    ],
-    students: <types.StudentProgress[]>[
+    ] as omegaup.Assignment[],
+    students: [
       {
         name: 'student',
         points: {
@@ -52,7 +52,7 @@ describe('ViewProgress.vue', () => {
         },
         username: 'student',
       } as types.StudentProgress,
-    ],
+    ] as types.StudentProgress[],
   };
   const student = baseViewProgressProps.students[0];
   const assignment = baseViewProgressProps.assignments[0];

--- a/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 
 import T from '../../lang';
 import { omegaup } from '../../omegaup';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import course_ViewStudent from './ViewStudent.vue';
 
@@ -82,9 +82,8 @@ describe('ViewStudent.vue', () => {
       },
     });
 
-    const assignments = <HTMLInputElement>(
-      wrapper.find('select[data-assignment]').element
-    );
+    const assignments = wrapper.find('select[data-assignment]')
+      .element as HTMLInputElement;
     assignments.value = 'assignment';
     await assignments.dispatchEvent(new Event('change'));
     expect(wrapper.find('div[data-markdown-statement]').text()).toBe(

--- a/frontend/www/js/omegaup/components/identity/Edit.vue
+++ b/frontend/www/js/omegaup/components/identity/Edit.vue
@@ -100,7 +100,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import T from '../../lang';
 import * as iso3166 from '@/third_party/js/iso-3166-2.js/iso3166.min.js';
 import * as typeahead from '../../typeahead';
@@ -118,7 +118,7 @@ export default class IdentityEdit extends Vue {
   T = T;
   typeahead = typeahead;
   selectedIdentity = Object.assign(
-    <types.Identity>{
+    {
       username: '',
       classname: '',
       name: '',
@@ -127,7 +127,7 @@ export default class IdentityEdit extends Vue {
       school_id: 0,
       country_id: 'MX',
       state_id: '',
-    },
+    } as types.Identity,
     this.identity,
   );
 

--- a/frontend/www/js/omegaup/components/notification/Clarifications.vue
+++ b/frontend/www/js/omegaup/components/notification/Clarifications.vue
@@ -63,7 +63,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import T from '../../lang';
 
 @Component
@@ -78,7 +78,7 @@ export default class Clarifications extends Vue {
   @Watch('initialClarifications')
   onPropertyChanged(newValue: types.Clarification[]): void {
     this.clarifications = newValue;
-    const audio = <HTMLMediaElement>this.$refs.notificationAudio;
+    const audio = this.$refs.notificationAudio as HTMLMediaElement;
     if (audio !== null) {
       audio.play();
     }

--- a/frontend/www/js/omegaup/components/problem/CollectionList.test.ts
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import problem_CollectionList from './CollectionList.vue';
 
@@ -12,19 +12,16 @@ describe('CollectionList.vue', () => {
       propsData: {
         data: {
           level: 'problemLevelBasicIntroductionToProgramming',
-          frequentTags: <types.TagWithProblemCount[]>[
+          frequentTags: [
             { name: 'problemTagMatrices', problemCount: 1 },
             { name: 'problemTagDiophantineEquations', problemCount: 1 },
             { name: 'problemTagInputAndOutput', problemCount: 1 },
             { name: 'problemTagArrays', problemCount: 1 },
-          ],
-          publicTags: <string[]>['problemTagConditionals', 'problemTagLoops'],
+          ] as types.TagWithProblemCount[],
+          publicTags: ['problemTagConditionals', 'problemTagLoops'],
         },
         difficulty: 'easy',
-        selectedTags: <string[]>[
-          'problemTagMatrices',
-          'problemTagDiophantineEquations',
-        ],
+        selectedTags: ['problemTagMatrices', 'problemTagDiophantineEquations'],
         problems: [
           {
             alias: 'Problem-1',
@@ -74,24 +71,20 @@ describe('CollectionList.vue', () => {
     );
     expect(wrapper.find('input[value="problemTagLoops"]').exists()).toBe(false);
 
-    const checkboxInput1 = <HTMLInputElement>(
-      wrapper.find('input[value="problemTagMatrices"]').element
-    );
-    const checkboxInput2 = <HTMLInputElement>(
-      wrapper.find('input[value="problemTagDiophantineEquations"]').element
-    );
-    const checkboxInput3 = <HTMLInputElement>(
-      wrapper.find('input[value="problemTagInputAndOutput"]').element
-    );
-    const checkboxInput4 = <HTMLInputElement>(
-      wrapper.find('input[value="problemTagArrays"]').element
-    );
-    const radioInput1 = <HTMLInputElement>(
-      wrapper.find('input[value="all"]').element
-    );
-    const radioInput2 = <HTMLInputElement>(
-      wrapper.find('input[value="easy"]').element
-    );
+    const checkboxInput1 = wrapper.find('input[value="problemTagMatrices"]')
+      .element as HTMLInputElement;
+    const checkboxInput2 = wrapper.find(
+      'input[value="problemTagDiophantineEquations"]',
+    ).element as HTMLInputElement;
+    const checkboxInput3 = wrapper.find(
+      'input[value="problemTagInputAndOutput"]',
+    ).element as HTMLInputElement;
+    const checkboxInput4 = wrapper.find('input[value="problemTagArrays"]')
+      .element as HTMLInputElement;
+    const radioInput1 = wrapper.find('input[value="all"]')
+      .element as HTMLInputElement;
+    const radioInput2 = wrapper.find('input[value="easy"]')
+      .element as HTMLInputElement;
 
     expect(checkboxInput1.checked).toBeTruthy();
     expect(checkboxInput2.checked).toBeTruthy();
@@ -120,7 +113,7 @@ describe('CollectionList.vue', () => {
         data: {
           level: 'problemLevelBasicIntroductionToProgramming',
           frequentTags: [{ alias: 'problemTagMatrices' }],
-          publicTags: <string[]>['problemTagConditionals'],
+          publicTags: ['problemTagConditionals'],
         },
         difficulty: 'all',
       },

--- a/frontend/www/js/omegaup/components/problem/CollectionListAuthor.test.ts
+++ b/frontend/www/js/omegaup/components/problem/CollectionListAuthor.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import T from '../../lang';
 
 import problem_CollectionListAuthor from './CollectionListAuthor.vue';
@@ -36,7 +36,7 @@ describe('CollectionListAuthor.vue', () => {
           } as types.AuthorsRank,
         } as types.CollectionDetailsByAuthorPayload,
         difficulty: 'easy',
-        selectedAuthors: <string[]>['user3'],
+        selectedAuthors: ['user3'],
         problems: [
           {
             alias: 'Problem-1',
@@ -72,21 +72,16 @@ describe('CollectionListAuthor.vue', () => {
     expect(wrapper.find('input[value="user2"]').exists()).toBe(true);
     expect(wrapper.find('input[value="user3"]').exists()).toBe(true);
 
-    const checkboxInput1 = <HTMLInputElement>(
-      wrapper.find('input[value="user1"]').element
-    );
-    const checkboxInput2 = <HTMLInputElement>(
-      wrapper.find('input[value="user2"]').element
-    );
-    const checkboxInput3 = <HTMLInputElement>(
-      wrapper.find('input[value="user3"]').element
-    );
-    const radioInput1 = <HTMLInputElement>(
-      wrapper.find('input[value="all"]').element
-    );
-    const radioInput2 = <HTMLInputElement>(
-      wrapper.find('input[value="easy"]').element
-    );
+    const checkboxInput1 = wrapper.find('input[value="user1"]')
+      .element as HTMLInputElement;
+    const checkboxInput2 = wrapper.find('input[value="user2"]')
+      .element as HTMLInputElement;
+    const checkboxInput3 = wrapper.find('input[value="user3"]')
+      .element as HTMLInputElement;
+    const radioInput1 = wrapper.find('input[value="all"]')
+      .element as HTMLInputElement;
+    const radioInput2 = wrapper.find('input[value="easy"]')
+      .element as HTMLInputElement;
 
     expect(checkboxInput1.checked).toBeFalsy();
     expect(checkboxInput2.checked).toBeFalsy();

--- a/frontend/www/js/omegaup/components/problem/Details.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Details.test.ts
@@ -2,14 +2,14 @@ jest.mock('../../../../third_party/js/diff_match_patch.js');
 
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import * as time from '../../time';
 
 import problem_Details from './Details.vue';
 
 describe('Details.vue', () => {
   const date = new Date();
-  const sampleProblem = <types.ProblemInfo>{
+  const sampleProblem: types.ProblemInfo = {
     alias: 'triangulos',
     accepts_submissions: true,
     karel_problem: false,
@@ -61,53 +61,54 @@ describe('Details.vue', () => {
     title: 'Triangulos',
     visibility: 2,
     input_limit: 1000,
-    guid: '80bbe93bc01c1d47ff9fb396dfaff741',
-    runDetailsData: <types.RunDetails>{
-      admin: false,
-      alias: 'sumas',
-      cases: {},
-      details: {
-        compile_meta: {
-          Main: {
-            memory: 12091392,
-            sys_time: 0.029124,
-            time: 0.174746,
-            verdict: 'OK',
-            wall_time: 0.51659,
-          },
-        },
-        contest_score: 5,
-        groups: [],
-        judged_by: 'localhost',
-        max_score: 100,
-        memory: 10407936,
-        score: 0.05,
-        time: 0.31891,
-        verdict: 'PA',
-        wall_time: 0.699709,
-      },
-      feedback: 'none',
-      groups: [],
-      guid: '80bbe93bc01c1d47ff9fb396dfaff741',
-      judged_by: '',
-      language: 'py3',
-      logs: '',
-      show_diff: 'none',
-      source: 'print(3)',
-      source_link: false,
-      source_name: 'Main.py3',
-      source_url: 'blob:http://localhost:8001/url',
-    },
   };
 
-  const user = <types.UserInfoForProblem>{
+  const runDetailsData: types.RunDetails = {
+    admin: false,
+    alias: 'sumas',
+    cases: {},
+    details: {
+      compile_meta: {
+        Main: {
+          memory: 12091392,
+          sys_time: 0.029124,
+          time: 0.174746,
+          verdict: 'OK',
+          wall_time: 0.51659,
+        },
+      },
+      contest_score: 5,
+      groups: [],
+      judged_by: 'localhost',
+      max_score: 100,
+      memory: 10407936,
+      score: 0.05,
+      time: 0.31891,
+      verdict: 'PA',
+      wall_time: 0.699709,
+    },
+    feedback: 'none',
+    guid: '80bbe93bc01c1d47ff9fb396dfaff741',
+    judged_by: '',
+    language: 'py3',
+    logs: '',
+    show_diff: 'none',
+    source: 'print(3)',
+    source_link: false,
+    source_name: 'Main.py3',
+    source_url: 'blob:http://localhost:8001/url',
+  };
+
+  const user: types.UserInfoForProblem = {
     admin: true,
     loggedIn: true,
     reviewer: true,
   };
 
-  const nominationStatus = <types.NominationStatus>{
+  const nominationStatus: types.NominationStatus = {
     alreadyReviewed: false,
+    canNominateProblem: false,
+    language: 'en',
     dismissed: false,
     dismissedBeforeAc: false,
     nominated: false,
@@ -116,14 +117,14 @@ describe('Details.vue', () => {
     tried: false,
   };
 
-  const histogram = <types.Histogram>{
+  const histogram: types.Histogram = {
     difficulty: 0.0,
     difficultyHistogram: '[0,1,2,3,4]',
     quality: 0.0,
     qualityHistogram: '[0,1,2,3,4]',
   };
 
-  const runs = <types.Run[]>[
+  const runs: types.Run[] = [
     {
       alias: 'Hello',
       classname: 'user-rank-unranked',
@@ -147,13 +148,14 @@ describe('Details.vue', () => {
       propsData: {
         initialTab: 'problems',
         problem: sampleProblem,
+        runDetailsData,
         user: user,
         nominationStatus: nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
-        runs: <types.Run[]>[],
-        allRuns: <types.Run[]>[],
-        clarifications: <types.Clarification[]>[],
+        runs: [] as types.Run[],
+        allRuns: [] as types.Run[],
+        clarifications: [] as types.Clarification[],
         solutionStatus: 'not_found',
         histogram: histogram,
         showNewRunWindow: false,
@@ -170,13 +172,14 @@ describe('Details.vue', () => {
       propsData: {
         initialTab: 'problems',
         problem: sampleProblem,
+        runDetailsData,
         user: user,
         nominationStatus: nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
         runs: runs,
         allRuns: runs,
-        clarifications: <types.Clarification[]>[],
+        clarifications: [] as types.Clarification[],
         solutionStatus: 'not_found',
         histogram: histogram,
         showNewRunWindow: false,
@@ -201,13 +204,14 @@ describe('Details.vue', () => {
       propsData: {
         initialTab: 'problems',
         problem: sampleProblem,
+        runDetailsData,
         user: user,
         nominationStatus: nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
         runs: runs,
         allRuns: runs,
-        clarifications: <types.Clarification[]>[],
+        clarifications: [] as types.Clarification[],
         solutionStatus: 'not_found',
         histogram: histogram,
         showNewRunWindow: false,

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -540,7 +540,7 @@ export default class ProblemDetails extends Vue {
         source_name: `Main.${data.language}`,
         groups: groups,
         show_diff: this.isAdmin ? data.show_diff : 'none',
-        feedback: <omegaup.SubmissionFeedback>omegaup.SubmissionFeedback.None,
+        feedback: omegaup.SubmissionFeedback.None as omegaup.SubmissionFeedback,
       }),
     );
 

--- a/frontend/www/js/omegaup/components/problem/FilterAuthors.test.ts
+++ b/frontend/www/js/omegaup/components/problem/FilterAuthors.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import T from '../../lang';
 
 import problem_FilterAuthors from './FilterAuthors.vue';
@@ -35,12 +35,10 @@ describe('FilterAuthors.vue', () => {
     expect(wrapper.find('input[value="user1"]').exists()).toBe(true);
     expect(wrapper.find('input[value="user2"]').exists()).toBe(true);
 
-    const checkboxInput1 = <HTMLInputElement>(
-      wrapper.find('input[value="user1"]').element
-    );
-    const checkboxInput2 = <HTMLInputElement>(
-      wrapper.find('input[value="user2"]').element
-    );
+    const checkboxInput1 = wrapper.find('input[value="user1"]')
+      .element as HTMLInputElement;
+    const checkboxInput2 = wrapper.find('input[value="user2"]')
+      .element as HTMLInputElement;
 
     checkboxInput1.click();
     expect(checkboxInput1.checked).toBeTruthy();

--- a/frontend/www/js/omegaup/components/problem/FilterTags.test.ts
+++ b/frontend/www/js/omegaup/components/problem/FilterTags.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
 import T from '../../lang';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import problem_FilterTags from './FilterTags.vue';
 
@@ -10,20 +10,20 @@ describe('Filter.vue', () => {
   it('Should handle list of tags', async () => {
     const wrapper = mount(problem_FilterTags, {
       propsData: {
-        tags: <types.TagWithProblemCount[]>[
+        tags: [
           { name: 'problemTagMatrices', problemCount: 5 },
           { name: 'problemTagDiophantineEquations', problemCount: 4 },
           { name: 'problemTagInputAndOutput', problemCount: 3 },
           { name: 'problemTagArrays', problemCount: 2 },
-        ],
-        publicQualityTags: <types.TagWithProblemCount[]>[
+        ] as types.TagWithProblemCount[],
+        publicQualityTags: [
           { name: 'problemTagConditionals', problemCount: 1 },
           { name: 'problemTagLoops', problemCount: 1 },
           { name: 'problemTagFunctions', problemCount: 1 },
           { name: 'problemTagCharsAndStrings', problemCount: 1 },
           { name: 'problemTagSimulation', problemCount: 1 },
           { name: 'problemTagAnalyticGeometry', problemCount: 1 },
-        ],
+        ] as types.TagWithProblemCount[],
       },
     });
 

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -360,7 +360,7 @@ export default class ProblemForm extends Vue {
   }
 
   onUploadFile(ev: InputEvent): void {
-    const uploadedFile = <HTMLInputElement>ev.target;
+    const uploadedFile = ev.target as HTMLInputElement;
     this.hasFile = uploadedFile.files !== null;
   }
 

--- a/frontend/www/js/omegaup/components/problem/Mine.vue
+++ b/frontend/www/js/omegaup/components/problem/Mine.vue
@@ -195,7 +195,7 @@ export default class ProblemMine extends Vue {
 
   T = T;
   shouldShowAllProblems = false;
-  selectedProblems = <types.ProblemListItem[]>[];
+  selectedProblems: types.ProblemListItem[] = [];
   allProblemsVisibilityOption = -1;
 
   get statementShowAllProblems(): string {

--- a/frontend/www/js/omegaup/components/problem/Settings.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Settings.test.ts
@@ -62,15 +62,13 @@ describe('Settings.vue', () => {
       wrapper.find('input[name="validator_time_limit"]').attributes('disabled'),
     ).toBe('disabled');
 
-    const languages = <HTMLInputElement>(
-      wrapper.find('select[name="languages"]').element
-    );
+    const languages = wrapper.find('select[name="languages"]')
+      .element as HTMLInputElement;
     languages.value = 'cat';
     await languages.dispatchEvent(new Event('change'));
 
-    const validator = <HTMLInputElement>(
-      wrapper.find('select[name="validator"]').element
-    );
+    const validator = wrapper.find('select[name="validator"]')
+      .element as HTMLInputElement;
     validator.value = 'custom';
     await validator.dispatchEvent(new Event('change'));
 
@@ -78,11 +76,11 @@ describe('Settings.vue', () => {
       wrapper.find('input[name="validator_time_limit"]').attributes('disabled'),
     ).toBeFalsy();
     expect(
-      (<HTMLInputElement>wrapper.find('select[name="languages"]').element)
+      (wrapper.find('select[name="languages"]').element as HTMLInputElement)
         .value,
     ).toBe('cat');
     expect(
-      (<HTMLInputElement>wrapper.find('select[name="validator"]').element)
+      (wrapper.find('select[name="validator"]').element as HTMLInputElement)
         .value,
     ).toBe('custom');
   });

--- a/frontend/www/js/omegaup/components/problem/Solution.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Solution.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import expect from 'expect';
 
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 import T from '../../lang';
 
 import problem_Solution from './Solution.vue';
@@ -10,7 +10,7 @@ describe('Solution.vue', () => {
   it('Should handle an empty/locked solution', () => {
     const wrapper = mount(problem_Solution, {
       propsData: {
-        solution: <types.ProblemStatement | null>null,
+        solution: null as types.ProblemStatement | null,
         status: 'locked',
         availableTokens: 0,
         allTokens: 0,
@@ -23,7 +23,7 @@ describe('Solution.vue', () => {
   it('Should handle an empty/unlocked solution', () => {
     const wrapper = mount(problem_Solution, {
       propsData: {
-        solution: <types.ProblemStatement | null>null,
+        solution: null as types.ProblemStatement | null,
         status: 'unlocked',
         availableTokens: 0,
         allTokens: 0,
@@ -36,10 +36,10 @@ describe('Solution.vue', () => {
   it('Should handle a non-empty, unlocked solution', () => {
     const wrapper = mount(problem_Solution, {
       propsData: {
-        solution: <types.ProblemStatement | null>{
+        solution: {
           markdown: 'Hello, World!',
           images: {},
-        },
+        } as types.ProblemStatement | null,
         status: 'unlocked',
         availableTokens: 0,
         allTokens: 0,

--- a/frontend/www/js/omegaup/components/problem/Tags.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Tags.test.ts
@@ -10,7 +10,7 @@ const baseProblemTagsPropsData = {
   canAddNewTags: true,
   initialAllowTags: true,
   isCreate: true,
-  levelTags: <string[]>[
+  levelTags: [
     'problemLevelAdvancedCompetitiveProgramming',
     'problemLevelAdvancedSpecializedTopics',
     'problemLevelBasicIntroductionToProgramming',
@@ -19,9 +19,9 @@ const baseProblemTagsPropsData = {
     'problemLevelIntermediateDataStructuresAndAlgorithms',
     'problemLevelIntermediateMathsInProgramming',
   ],
-  publicTags: <string[]>['some', 'public', 'tags'],
-  selectedPrivateTags: <string[]>[],
-  selectedPublicTags: <string[]>[],
+  publicTags: ['some', 'public', 'tags'],
+  selectedPrivateTags: [] as string[],
+  selectedPublicTags: [] as string[],
   title: '',
 };
 

--- a/frontend/www/js/omegaup/components/qualitynomination/List.test.ts
+++ b/frontend/www/js/omegaup/components/qualitynomination/List.test.ts
@@ -2,14 +2,14 @@ import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
 import T from '../../lang';
 import qualitynomination_List from './List.vue';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 describe('List.vue', () => {
   it('Should handle list of nominations', async () => {
     const wrapper = shallowMount(qualitynomination_List, {
       propsData: {
-        nominations: <types.NominationListItem[]>[
-          <types.NominationListItem>{
+        nominations: [
+          {
             author: {
               name: 'nombre',
               username: 'user',
@@ -32,8 +32,8 @@ describe('List.vue', () => {
             status: 'open',
             time: new Date('2020-06-03 23:46:10'),
             votes: [],
-          },
-        ],
+          } as types.NominationListItem,
+        ] as types.NominationListItem[],
         pagerItems: [
           {
             class: 'disabled',

--- a/frontend/www/js/omegaup/components/user/BasicInfov2.test.ts
+++ b/frontend/www/js/omegaup/components/user/BasicInfov2.test.ts
@@ -1,6 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import expect from 'expect';
-import { types } from '../../api_types';
+import type { types } from '../../api_types';
 
 import user_BasicInfo from './BasicInfov2.vue';
 
@@ -9,7 +9,7 @@ describe('BasicInfov2.vue', () => {
     const email = 'test@omegaup.com';
     const wrapper = shallowMount(user_BasicInfo, {
       propsData: {
-        profile: <types.UserProfile>{ email: email },
+        profile: { email: email } as types.UserProfile,
         rank: 'Ω',
       },
     });

--- a/frontend/www/js/omegaup/components/user/Chartsv2.vue
+++ b/frontend/www/js/omegaup/components/user/Chartsv2.vue
@@ -322,11 +322,11 @@ export default class UserCharts extends Vue {
       },
       series: this.runsForPeriod.map(
         (x) =>
-          <Highcharts.SeriesColumnOptions>{
+          ({
             data: x.data,
             name: x.name,
             type: 'column',
-          },
+          } as Highcharts.SeriesColumnOptions),
       ),
     };
   }

--- a/frontend/www/js/omegaup/components/user/Profile.test.ts
+++ b/frontend/www/js/omegaup/components/user/Profile.test.ts
@@ -9,7 +9,7 @@ describe('Profilev2.vue', () => {
     const badges = ['100SolvedProblems'];
     const wrapper = shallowMount(user_Profile, {
       propsData: {
-        data: <types.UserProfileDetailsPayload>{
+        data: {
           profile: {
             country: 'Mexico',
             country_id: 'MX',
@@ -57,9 +57,9 @@ describe('Profilev2.vue', () => {
           ownedBadges: [],
           programmingLanguages: {},
           userClassname: 'user-rank-unranked',
-        },
-        profileBadges: <Set<string>>new Set(badge_alias),
-        visitorBadges: <Set<string>>new Set(badge_alias),
+        } as types.UserProfileDetailsPayload,
+        profileBadges: new Set(badge_alias) as Set<string>,
+        visitorBadges: new Set(badge_alias) as Set<string>,
       },
     });
     expect(wrapper.find('a[href="/profile/edit/"]').exists()).toBe(true);

--- a/frontend/www/js/omegaup/contest/new.ts
+++ b/frontend/www/js/omegaup/contest/new.ts
@@ -15,7 +15,7 @@ OmegaUp.on('ready', () => {
       'omegaup-contest-new': contest_NewForm,
     },
     data: () => ({
-      invalidParameterName: <null | string>null,
+      invalidParameterName: null as null | string,
     }),
     render: function (createElement) {
       return createElement('omegaup-contest-new', {

--- a/frontend/www/js/omegaup/contest/print.ts
+++ b/frontend/www/js/omegaup/contest/print.ts
@@ -1,19 +1,17 @@
 import Vue from 'vue';
 
-import { types } from '../api_types';
+import type { types } from '../api_types';
 
 import omegaup_Markdown from '../components/Markdown.vue';
 
 (() => {
   document.querySelectorAll('div.problem').forEach((problem) => {
-    const problemDetails = <types.ProblemDetails>(
-      JSON.parse(
-        (<HTMLElement>problem.querySelector('script.payload')).innerText,
-      )
-    );
+    const problemDetails = JSON.parse(
+      (problem.querySelector('script.payload') as HTMLElement).innerText,
+    ) as types.ProblemDetails;
 
     new Vue({
-      el: <HTMLElement>problem.querySelector('div.statement'),
+      el: problem.querySelector('div.statement') as HTMLElement,
       components: {
         'omegaup-markdown': omegaup_Markdown,
       },

--- a/frontend/www/js/omegaup/course/edit.ts
+++ b/frontend/www/js/omegaup/course/edit.ts
@@ -476,5 +476,5 @@ OmegaUp.on('ready', () => {
       });
     },
   });
-  const component = <course_Edit>courseEdit.$refs.component;
+  const component = courseEdit.$refs.component as course_Edit;
 });

--- a/frontend/www/js/omegaup/course/student.ts
+++ b/frontend/www/js/omegaup/course/student.ts
@@ -25,7 +25,7 @@ OmegaUp.on('ready', () => {
       'omegaup-course-viewstudent': course_ViewStudent,
     },
     data: () => ({
-      problems: <types.CourseProblem[]>[],
+      problems: [] as types.CourseProblem[],
     }),
     render: function (createElement) {
       return createElement('omegaup-course-viewstudent', {

--- a/frontend/www/js/omegaup/login/reset.ts
+++ b/frontend/www/js/omegaup/login/reset.ts
@@ -6,7 +6,7 @@ import login_PasswordReset from '../components/login/PasswordReset.vue';
 
 OmegaUp.on('ready', () => {
   const payload = JSON.parse(
-    (<HTMLElement>document.getElementById('payload')).innerText,
+    (document.getElementById('payload') as HTMLElement).innerText,
   );
 
   new Vue({

--- a/frontend/www/js/omegaup/problem/collection.ts
+++ b/frontend/www/js/omegaup/problem/collection.ts
@@ -24,7 +24,7 @@ OmegaUp.on('ready', () => {
           ): void => {
             window.location.replace(
               `/problem/?${ui.buildURLQuery(
-                <{ [key: string]: any }>queryParameters,
+                queryParameters as { [key: string]: any },
               )}`,
             );
           },

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -27,9 +27,9 @@ OmegaUp.on('ready', () => {
     data: () => ({
       initialClarifications: payload.clarifications,
       initialPopupDisplayed: PopupDisplayed.None,
-      runDetailsData: <types.RunDetails | null>null,
+      runDetailsData: null as types.RunDetails | null,
       solutionStatus: payload.solutionStatus,
-      solution: <types.ProblemStatement | null>null,
+      solution: null as types.ProblemStatement | null,
       availableTokens: 0,
       allTokens: 0,
       activeTab: window.location.hash ? locationHash[0] : 'problems',
@@ -38,7 +38,7 @@ OmegaUp.on('ready', () => {
         payload.nominationStatus?.nominated ||
         (payload.nominationStatus?.nominatedBeforeAc &&
           !payload.nominationStatus?.solved),
-      guid: <null | string>null,
+      guid: null as null | string,
     }),
     render: function (createElement) {
       return createElement('omegaup-problem-details', {

--- a/frontend/www/js/omegaup/problem/mine.ts
+++ b/frontend/www/js/omegaup/problem/mine.ts
@@ -15,8 +15,8 @@ OmegaUp.on('ready', () => {
       'omegaup-problem-mine': problem_Mine,
     },
     data: () => ({
-      problems: <types.ProblemListItem[]>[],
-      pagerItems: <types.PageItem[]>[],
+      problems: [] as types.ProblemListItem[],
+      pagerItems: [] as types.PageItem[],
     }),
     render: function (createElement) {
       return createElement('omegaup-problem-mine', {

--- a/frontend/www/js/omegaup/problem/print.ts
+++ b/frontend/www/js/omegaup/problem/print.ts
@@ -1,16 +1,16 @@
 import Vue from 'vue';
 
-import { types } from '../api_types';
+import type { types } from '../api_types';
 
 import omegaup_Markdown from '../components/Markdown.vue';
 
 (() => {
-  const problemDetails = <types.ProblemDetails>(
-    JSON.parse((<HTMLElement>document.getElementById('payload')).innerText)
-  );
+  const problemDetails = JSON.parse(
+    (document.getElementById('payload') as HTMLElement).innerText,
+  ) as types.ProblemDetails;
 
   new Vue({
-    el: <HTMLElement>document.querySelector('div.statement'),
+    el: document.querySelector('div.statement') as HTMLElement,
     components: {
       'omegaup-markdown': omegaup_Markdown,
     },

--- a/frontend/www/js/omegaup/problem/statement.ts
+++ b/frontend/www/js/omegaup/problem/statement.ts
@@ -57,16 +57,16 @@ OmegaUp.on('ready', () => {
           alias: 'problema',
           title: 'Tu problema',
           source: 'fuente',
-          problemsetter: <types.ProblemsetterInfo>{
+          problemsetter: {
             classname: 'user-rank-unranked',
             name: 'tu-usuario',
             username: 'tu_usuario',
-          },
-          statement: <types.ProblemStatement>{
+          } as types.ProblemsetterInfo,
+          statement: {
             markdown: markdownStatement,
             language: 'es',
             images: {},
-          },
+          } as types.ProblemStatement,
           markdownType: 'statements',
           showEditControls: false,
         },

--- a/frontend/www/js/omegaup/qualitynomination/list.ts
+++ b/frontend/www/js/omegaup/qualitynomination/list.ts
@@ -7,10 +7,10 @@ import { types, messages } from '../api_types';
 
 OmegaUp.on('ready', function () {
   const payload = JSON.parse(
-    (<HTMLElement>document.getElementById('payload')).innerText,
+    (document.getElementById('payload') as HTMLElement).innerText,
   );
   const headerPayload = JSON.parse(
-    (<HTMLElement>document.getElementById('header-payload')).innerText,
+    (document.getElementById('header-payload') as HTMLElement).innerText,
   );
 
   const nominationsList = new Vue({
@@ -19,8 +19,8 @@ OmegaUp.on('ready', function () {
       'omegaup-qualitynomination-list': qualitynomination_List,
     },
     data: () => ({
-      nominations: <types.NominationListItem[]>[],
-      pagerItems: <types.PageItem[]>[],
+      nominations: [] as types.NominationListItem[],
+      pagerItems: [] as types.PageItem[],
       pages: 1,
     }),
     render: function (createElement) {

--- a/frontend/www/js/omegaup/time.ts
+++ b/frontend/www/js/omegaup/time.ts
@@ -221,7 +221,7 @@ export function remoteDate(date: Date): Date {
  */
 export function remoteTimeAdapter<T>(value: T): T {
   if (value instanceof Date) {
-    return <T>(remoteDate(value) as unknown);
+    return (remoteDate(value) as unknown) as T;
   }
 
   if (Array.isArray(value)) {
@@ -234,7 +234,7 @@ export function remoteTimeAdapter<T>(value: T): T {
   } else if (typeof value === 'object') {
     for (const p in value) {
       if (
-        !Object.prototype.hasOwnProperty.call(<any>value, p) ||
+        !Object.prototype.hasOwnProperty.call(value as any, p) ||
         typeof value[p] !== 'object'
       ) {
         continue;

--- a/frontend/www/js/omegaup/typeahead.ts
+++ b/frontend/www/js/omegaup/typeahead.ts
@@ -43,9 +43,9 @@ function typeaheadWrapper<T>(
     contest_alias?: string;
   }) => Promise<T[]>,
 ) {
-  let lastRequest = <
-    [string, (results: T[]) => void, (results: T[]) => void] | null
-  >null;
+  let lastRequest:
+    | [string, (results: T[]) => void, (results: T[]) => void]
+    | null = null;
   let pendingRequest = false;
   function wrappedCall(
     query: string,
@@ -106,7 +106,7 @@ export function problemTypeahead(
 ) {
   if (!cb) {
     cb = (event: Event, val: types.ProblemListItem) =>
-      $(<EventTarget>event.target).val(val.alias);
+      $(event.target as EventTarget).val(val.alias);
   }
   elem
     .typeahead<types.ProblemListItem>(
@@ -160,7 +160,7 @@ export function problemsetProblemTypeahead(
 
   if (!cb) {
     cb = (event: Event, problem) =>
-      $(<EventTarget>event.target).val(problem.alias);
+      $(event.target as EventTarget).val(problem.alias);
   }
 
   elem
@@ -189,7 +189,7 @@ export function schoolTypeahead(
 ) {
   if (!cb) {
     cb = (event: Event, val: { id: number; label: string; value: string }) =>
-      $(<EventTarget>event.target).val(val.value);
+      $(event.target as EventTarget).val(val.value);
   }
   elem
     .typeahead<{ id: number; label: string; value: string }>(
@@ -219,7 +219,7 @@ export function tagTypeahead(
 ) {
   if (!cb) {
     cb = (event: Event, val: { name: string }) =>
-      $(<EventTarget>event.target).val(val.name);
+      $(event.target as EventTarget).val(val.name);
   }
   elem
     .typeahead<{ name: string }>(
@@ -243,7 +243,7 @@ export function userContestTypeahead(
   contestAlias: string,
 ): void {
   const cb = (event: Event, val: { label: string; value: string }) =>
-    $(<EventTarget>event.target)
+    $(event.target as EventTarget)
       .attr('data-value', val.value)
       .val(val.label);
   elem
@@ -287,7 +287,7 @@ export function userTypeahead(
 ): void {
   if (!cb) {
     cb = (event: Event, val: types.UserListItem) =>
-      $(<EventTarget>event.target).val(val.label);
+      $(event.target as EventTarget).val(val.label);
   }
   typeahead<types.UserListItem>(elem, api.User.list, cb);
 }
@@ -298,7 +298,7 @@ export function groupTypeahead(
 ): void {
   if (!cb) {
     cb = (event: Event, val: { label: string; value: string }) =>
-      $(<EventTarget>event.target)
+      $(event.target as EventTarget)
         .attr('data-value', val.value)
         .val(val.label);
   }


### PR DESCRIPTION
Este cambio hace que ya no sea posible introducir nuevos type assertions
del tipo `<Type>expression` y en vez ahora se debe usar `expression as
Type` siempre.