### PR TITLE
Agregando casi-finales para la migración de contest edit

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -34,7 +34,7 @@ rewrite ^/contest/mine/?$ /contests/mine.php last;
 rewrite ^/contest/new/?$ /contests/new.php last;
 rewrite ^/contest/([a-zA-Z0-9_+-]+)/?$ /arena/$1/ permanent;
 rewrite ^/contest/([a-zA-Z0-9_+-]+)/activity/?$ /contests/activity.php?contest=$1 last;
-rewrite ^/contest/([a-zA-Z0-9_+-]+)/edit/?$ /contests/edit.php?contest=$1 last;
+rewrite ^/contest/([a-zA-Z0-9_+-]+)/edit/?$ /contests/edit.php?contest_alias=$1 last;
 rewrite ^/contest/([a-zA-Z0-9_+-]+)/report/?$ /contests/report.php?contest_alias=$1 last;
 rewrite ^/contest/([a-zA-Z0-9_+-]+)/stats/?$ /contests/stats.php?contest_alias=$1 last;
 rewrite ^/course/?$ /course/list.php last;

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -861,7 +861,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $contest_alias
      */
-    public static function getContestEditv2ForSmarty(
+    public static function getContestEditForSmarty(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -947,24 +947,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 )
             ],
             'entrypoint' => 'contest_edit',
-        ];
-    }
-
-    /**
-     * @return array{smartyProperties: array{LANGUAGES: list<string>, IS_UPDATE: bool}, template: string}
-     */
-    public static function getContestEditForSmarty(
-        \OmegaUp\Request $r
-    ): array {
-        $r->ensureMainUserIdentity();
-        return [
-            'smartyProperties' => [
-                'LANGUAGES' => array_keys(
-                    \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
-                ),
-                'IS_UPDATE' => true,
-            ],
-            'template' => 'contest.edit.tpl',
         ];
     }
 

--- a/frontend/templates/contest.edit.tpl
+++ b/frontend/templates/contest.edit.tpl
@@ -1,8 +1,0 @@
-{include file='redirect.tpl' inline}
-{include file='head.tpl' htmlTitle="{#omegaupTitleContestEdit#}" inline}
-
-<div id="contest-edit"></div>
-
-{js_include entrypoint="contest_edit"}
-{include file='footer.tpl' inline}
-

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -466,9 +466,16 @@ def create_contest(driver, alias, scoreboard_time_percent=100):
 def add_students_contest(driver, users):
     '''Add students to a recently contest.'''
 
+    driver.wait.until(
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR,
+             'a[data-nav-contest-edit]'))).click()
+    driver.wait.until(
+        EC.visibility_of_element_located(
+            (By.XPATH, '//a[@data-nav-contestant]')))
     util.add_students(
         driver, users,
-        tab_xpath='//li[contains(@class, "contestants")]//a',
+        tab_xpath='//a[@data-nav-contestant]',
         container_xpath='//div[contains(@class, "contestants-input-area")]',
         parent_xpath='div[contains(@class, "contestants")]',
         submit_locator=(By.CLASS_NAME, 'user-add-single'))
@@ -481,7 +488,11 @@ def add_students_bulk(driver, users):
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR,
-             ('li.contestants > a')))).click()
+             'a[data-nav-contest-edit]'))).click()
+    driver.wait.until(
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR,
+             ('a.contestants')))).click()
     driver.wait.until(
         EC.visibility_of_element_located(
             (By.CSS_SELECTOR, 'div.contestants')))
@@ -510,7 +521,11 @@ def add_problem_to_contest(driver, problem):
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR,
-             'li.problems > a'))).click()
+             'a[data-nav-contest-edit]'))).click()
+    driver.wait.until(
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR,
+             'a.problems'))).click()
 
     driver.typeahead_helper('*[contains(@class, "problems-container")]',
                             problem)
@@ -574,7 +589,11 @@ def change_contest_admission_mode(driver, contest_admission_mode):
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR,
-             'li.admission-mode > a'))).click()
+             'a[data-nav-contest-edit]'))).click()
+    driver.wait.until(
+        EC.element_to_be_clickable(
+            (By.CSS_SELECTOR,
+             'a.admission-mode'))).click()
     Select(driver.wait.until(
         EC.element_to_be_clickable(
             (By.XPATH,

--- a/frontend/www/js/omegaup/components/contest/AddContestant.vue
+++ b/frontend/www/js/omegaup/components/contest/AddContestant.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="card contestants-input-area">
+    <div class="card contestants">
       <div class="card-body">
         <form class="form" @submit.prevent="onSubmit">
           <div class="form-group">

--- a/frontend/www/js/omegaup/components/contest/AddContestant.vue
+++ b/frontend/www/js/omegaup/components/contest/AddContestant.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="card">
+    <div class="card contestants-input-area">
       <div class="card-body">
         <form class="form" @submit.prevent="onSubmit">
           <div class="form-group">
@@ -10,7 +10,7 @@
               :init="(el) => typeahead.userTypeahead(el)"
             ></omegaup-autocomplete>
           </div>
-          <button class="btn btn-primary" type="submit">
+          <button class="btn btn-primary user-add-single" type="submit">
             {{ T.contestAdduserAddUser }}
           </button>
           <hr />
@@ -22,12 +22,12 @@
               rows="4"
             ></textarea>
           </div>
-          <button class="btn btn-primary" type="submit">
+          <button class="btn btn-primary user-add-bulk" type="submit">
             {{ T.contestAdduserAddUsers }}
           </button>
         </form>
       </div>
-      <table class="table table-striped mb-0">
+      <table class="table table-striped mb-0 participants">
         <thead>
           <tr>
             <th class="text-center">{{ T.wordsUser }}</th>
@@ -126,7 +126,7 @@ export default class AddContestant extends Vue {
     if (this.contestant !== '') {
       users.push(this.contestant);
     }
-    if (this.users.length) {
+    if (users.length) {
       this.$emit(
         'emit-add-user',
         users.map((user) => user.trim()),

--- a/frontend/www/js/omegaup/components/contest/AddContestant.vue
+++ b/frontend/www/js/omegaup/components/contest/AddContestant.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="card contestants">
+    <div class="card contestants-input-area">
       <div class="card-body">
         <form class="form" @submit.prevent="onSubmit">
           <div class="form-group">

--- a/frontend/www/js/omegaup/components/contest/AddProblemv2.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblemv2.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card">
+  <div class="card problems-container">
     <div class="card-body">
       <form class="form" @submit.prevent="onSubmit">
         <div class="row">

--- a/frontend/www/js/omegaup/components/contest/Editv2.vue
+++ b/frontend/www/js/omegaup/components/contest/Editv2.vue
@@ -150,7 +150,7 @@
           "
         ></omegaup-common-publish>
       </div>
-      <div v-if="showTab === 'contestants'" class="tab-pane active">
+      <div v-if="showTab === 'contestants'" class="tab-pane active contestants">
         <omegaup-contest-add-contestant
           :contest="details"
           :initial-users="users"

--- a/frontend/www/js/omegaup/components/contest/Editv2.vue
+++ b/frontend/www/js/omegaup/components/contest/Editv2.vue
@@ -22,6 +22,7 @@
           href="#"
           data-toggle="dropdown"
           role="button"
+          data-nav-contest-edit
           class="nav-link active dropdown-toggle"
           aria-haspopup="true"
           aria-expanded="false"
@@ -41,7 +42,7 @@
             v-if="!virtual"
             href="#"
             data-toggle="tab"
-            class="dropdown-item"
+            class="dropdown-item problems"
             :class="{ active: showTab === 'problems' }"
             @click="showTab = 'problems'"
             >{{ T.wordsAddProblem }}</a
@@ -50,7 +51,7 @@
             v-if="!virtual"
             href="#"
             data-toggle="tab"
-            class="dropdown-item"
+            class="dropdown-item admission-mode"
             :class="{ active: showTab === 'publish' }"
             @click="showTab = 'publish'"
             >{{ T.contestNewFormAdmissionMode }}</a
@@ -58,8 +59,8 @@
           <a
             href="#"
             data-toggle="tab"
-            class="dropdown-item"
-            :class="{ active: virtual && showTab === 'contestants' }"
+            class="dropdown-item contestants"
+            :class="{ active: showTab === 'contestants' }"
             @click="showTab = 'contestants'"
             >{{ T.contestAdduserAddContestant }}</a
           >

--- a/frontend/www/js/omegaup/components/contest/Editv2.vue
+++ b/frontend/www/js/omegaup/components/contest/Editv2.vue
@@ -59,6 +59,7 @@
           <a
             href="#"
             data-toggle="tab"
+            data-nav-contestant
             class="dropdown-item contestants"
             :class="{ active: showTab === 'contestants' }"
             @click="showTab = 'contestants'"

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -3,7 +3,6 @@ import { types } from '../api_types';
 import Vue from 'vue';
 import T from '../lang';
 import contest_Edit from '../components/contest/Editv2.vue';
-import contest_AddProblem from '../components/contest/AddProblemv2.vue';
 import * as ui from '../ui';
 import * as api from '../api';
 
@@ -41,7 +40,7 @@ OmegaUp.on('ready', () => {
       },
       refreshDetails: (): void => {
         api.Contest.adminDetails({
-          contest: payload.details.alias,
+          contest_alias: payload.details.alias,
         })
           .then((response) => {
             contestEdit.details = response;
@@ -131,7 +130,12 @@ OmegaUp.on('ready', () => {
           },
           'get-versions': (
             problemAlias: string,
-            addProblemComponent: contest_AddProblem,
+            addProblemComponent: {
+              versionLog: types.ProblemVersion[];
+              problems: types.ContestProblem[];
+              selectedRevision: types.ProblemVersion;
+              publishedRevision: types.ProblemVersion;
+            },
           ) => {
             api.Problem.versions({
               problem_alias: problemAlias,

--- a/webpack.config-frontend.js
+++ b/webpack.config-frontend.js
@@ -41,7 +41,7 @@ module.exports = {
     common_navbar: './frontend/www/js/omegaup/common/navbar.ts',
     common_navbar_v2: './frontend/www/js/omegaup/common/navbar_v2.ts',
     common_stats: './frontend/www/js/omegaup/common/stats.ts',
-    contest_edit: './frontend/www/js/omegaup/contest/edit.js',
+    contest_edit: './frontend/www/js/omegaup/contest/edit.ts',
     contest_intro: './frontend/www/js/omegaup/contest/intro.ts',
     contest_list: './frontend/www/js/omegaup/contest/list.js',
     contest_list_participant:


### PR DESCRIPTION
# Descripción

Aquí ya se despliega el nuevo componente + ts.

Avance parcial de #3921 


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
