### PR TITLE
Arreglando estilos del Scoreboard

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -178,35 +178,38 @@ export default class ArenaScoreboard extends Vue {
     padding: 0.2em;
     .points {
       font-weight: bold;
-      width: 3.5em;
-      border-right-style: dotted;
     }
     .penalty {
       font-size: 70%;
+    }
+    div[class$='points'] {
+      border-right-style: dotted;
+    }
+    div[class$='penalty'] {
       border-left-width: 0;
     }
-    .accepted {
-      background: #dfd;
-    }
-    .pending {
-      background: #ddf;
-    }
-    .wrong {
-      background: #fdd;
-    }
-    .position.recent-event {
-      font-weight: bold;
-      background: #dfd;
-    }
-    .accepted.recent-event {
-      background: #8f8;
-    }
-    .position {
-      width: 3.5em;
-    }
-    .legend {
-      width: 0.5em;
-    }
+  }
+  .accepted {
+    background: #dfd;
+  }
+  .pending {
+    background: #ddf;
+  }
+  .wrong {
+    background: #fdd;
+  }
+  .position.recent-event {
+    font-weight: bold;
+    background: #dfd;
+  }
+  .accepted.recent-event {
+    background: #8f8;
+  }
+  .position {
+    width: 3.5em;
+  }
+  .legend {
+    width: 0.5em;
   }
 }
 </style>

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -182,12 +182,6 @@ export default class ArenaScoreboard extends Vue {
     .penalty {
       font-size: 70%;
     }
-    div[class$='points'] {
-      border-right-style: dotted;
-    }
-    div[class$='penalty'] {
-      border-left-width: 0;
-    }
   }
   .accepted {
     background: #dfd;


### PR DESCRIPTION
# Descripción

Se arreglan algunos estilos en el componente de `Scoreboard.vue` que se 
cambiaron en el PR #5045.

Había un estilo que le estaba dando un ancho de `3.5em` al campo de 
`points`, pero esto deformaba la tabla. Anteriormente no se estaban 
aplicando estos estilos porque el selector era incorrecto. 

Antes se mostraba así:

![image](https://user-images.githubusercontent.com/3230352/105771288-f55eee00-5f25-11eb-9e9c-836a0e237c82.png)


Ahora se mostrará así:

![image](https://user-images.githubusercontent.com/3230352/105771222-d5c7c580-5f25-11eb-8674-f16235c3e69b.png)


# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.