### PR TITLE
Arreglando parcialmente formularios de creación de problemas y concursos

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5028,7 +5028,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @return array{smartyProperties: array{payload: ProblemFormPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      *
      * @omegaup-request-param bool|null $allow_user_add_tags
-     * @omegaup-request-param null|string $contest_alias
      * @omegaup-request-param bool|null $email_clarifications
      * @omegaup-request-param null|string $extra_wall_time
      * @omegaup-request-param null|string $input_limit

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5093,8 +5093,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
                         /*$assoc=*/true
                     );
                 }
-                $contestAlias = $r->ensureOptionalString(
-                    'contest_alias',
+                $problemAlias = $r->ensureOptionalString(
+                    'problem_alias',
                     /*$required=*/ false,
                     fn (string $alias) => \OmegaUp\Validators::alias($alias)
                 );
@@ -5105,7 +5105,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                                 'title' => $r->ensureOptionalString(
                                     'title'
                                 ) ?? '',
-                                'alias' => $contestAlias ?? '',
+                                'alias' => $problemAlias ?? '',
                                 'emailClarifications' => $r->ensureOptionalBool(
                                     'email_clarifications'
                                 ) ?? false,

--- a/frontend/www/js/omegaup/components/contest/NewForm.test.ts
+++ b/frontend/www/js/omegaup/components/contest/NewForm.test.ts
@@ -31,9 +31,7 @@ describe('NewForm.vue', () => {
       },
     });
 
-    expect(wrapper.find('div.card .card-header .panel-title').text()).toBe(
-      T.contestNew,
-    );
+    expect(wrapper.find('div.card .card-header').text()).toBe(T.contestNew);
 
     const contest = {
       alias: 'contestAlias',

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -1,36 +1,28 @@
 <template>
-  <div class="card panel panel-primary">
+  <div class="card">
     <div v-if="!update" class="card-header bg-primary text-white panel-heading">
-      <h3 class="panel-title">{{ T.contestNew }}</h3>
+      <h3 class="card-title mb-0">{{ T.contestNew }}</h3>
     </div>
-    <div class="card-body panel-body">
-      <div class="btn-group bottom-margin mb-3">
-        <button
-          class="btn btn-default btn-secondary"
-          data-contest-omi
-          @click="fillOmi"
-        >
+    <div class="card-body">
+      <div class="btn-group d-block mb-3 text-center">
+        <button class="btn btn-secondary" data-contest-omi @click="fillOmi">
           {{ T.contestNewFormOmiStyle }}
         </button>
         <button
-          class="btn btn-default btn-secondary"
+          class="btn btn-secondary"
           data-contest-preioi
           @click="fillPreIoi"
         >
           {{ T.contestNewForm }}
         </button>
         <button
-          class="btn btn-default btn-secondary"
+          class="btn btn-secondary"
           data-contest-conacup
           @click="fillConacup"
         >
           {{ T.contestNewFormConacupStyle }}
         </button>
-        <button
-          class="btn btn-default btn-secondary"
-          data-contest-cpc
-          @click="fillIcpc"
-        >
+        <button class="btn btn-secondary" data-contest-cpc @click="fillIcpc">
           {{ T.contestNewFormICPCStyle }}
         </button>
       </div>

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="card problem-form">
     <div v-if="!isUpdate" class="card-header">
-      <h3 class="card-title">
+      <h3 class="card-title mb-0">
         {{ T.problemNew }}
       </h3>
     </div>
-    <div class="page-header text-center top-margin">
-      <p class="no-bottom-margin">
+    <div class="text-center">
+      <p class="mt-3 mb-0">
         {{ T.problemEditFormFirstTimeCreatingAProblem }}
         <strong>
           <a :href="howToWriteProblemLink" target="_blank">
@@ -365,6 +365,7 @@ export default class ProblemForm extends Vue {
   }
 
   onGenerateAlias(): void {
+    console.log('Se llamó a la función');
     if (this.isUpdate) {
       return;
     }

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -365,7 +365,6 @@ export default class ProblemForm extends Vue {
   }
 
   onGenerateAlias(): void {
-    console.log('Se llamó a la función');
     if (this.isUpdate) {
       return;
     }


### PR DESCRIPTION
# Descripción

- Arreglando los estilos de los formularios
- Incluyendo correctamente el alias de un problema

Soluciona parcialmente: #5080 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
