### PR TITLE
Bloquear campo en el formulario para crear problema.

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -54,12 +54,11 @@
           :output-limit="outputLimit"
           :input-limit="inputLimit"
           :initial-validator="validator"
-          :initial-language="languages"
           :overall-wall-time-limit="overallWallTimeLimit"
           :validator-time-limit="validatorTimeLimit"
           :valid-languages="data.validLanguages"
           :validator-types="data.validatorTypes"
-          @languages-changed="languagesChanged"
+          :languages.sync="languages"
         ></omegaup-problem-settings>
 
         <div class="row">
@@ -341,10 +340,6 @@ export default class ProblemForm extends Vue {
     return this.selectedTags
       .filter((tag) => tag.public === false)
       .map((tag) => tag.tagname);
-  }
-
-  languagesChanged(newValue: string): void {
-    this.languages = newValue;
   }
 
   addTag(alias: string, tagname: string, isPublic: boolean): void {

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -59,6 +59,7 @@
           :validator-time-limit="validatorTimeLimit"
           :valid-languages="data.validLanguages"
           :validator-types="data.validatorTypes"
+          @languages-changed="languagesChanged"
         ></omegaup-problem-settings>
 
         <div class="row">
@@ -153,6 +154,7 @@
                 name="show_diff"
                 class="form-control"
                 :class="{ 'is-invalid': errors.includes('show_diff') }"
+                :disabled="languages === ''"
               >
                 <option value="none">{{ T.problemVersionDiffModeNone }}</option>
                 <option value="examples">{{ T.wordsOnlyExamples }}</option>
@@ -339,6 +341,10 @@ export default class ProblemForm extends Vue {
     return this.selectedTags
       .filter((tag) => tag.public === false)
       .map((tag) => tag.tagname);
+  }
+
+  languagesChanged(newValue: string): void {
+    this.languages = newValue;
   }
 
   addTag(alias: string, tagname: string, isPublic: boolean): void {

--- a/frontend/www/js/omegaup/components/problem/Settings.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Settings.test.ts
@@ -40,16 +40,32 @@ describe('Settings.vue', () => {
     });
 
     expect(
-      wrapper.find('select[name="languages"]').findAll('option').at(0).text(),
+      wrapper
+        .find('select[name="current_languages"]')
+        .findAll('option')
+        .at(0)
+        .text(),
     ).toContain('C, C++, C++11, C#, Haskell, Java, Pascal, Python, Ruby, Lua');
     expect(
-      wrapper.find('select[name="languages"]').findAll('option').at(1).text(),
+      wrapper
+        .find('select[name="current_languages"]')
+        .findAll('option')
+        .at(1)
+        .text(),
     ).toContain('Karel');
     expect(
-      wrapper.find('select[name="languages"]').findAll('option').at(2).text(),
+      wrapper
+        .find('select[name="current_languages"]')
+        .findAll('option')
+        .at(2)
+        .text(),
     ).toContain(T.wordsJustOutput);
     expect(
-      wrapper.find('select[name="languages"]').findAll('option').at(3).text(),
+      wrapper
+        .find('select[name="current_languages"]')
+        .findAll('option')
+        .at(3)
+        .text(),
     ).toContain(T.wordsNoSubmissions);
   });
 
@@ -62,7 +78,7 @@ describe('Settings.vue', () => {
       wrapper.find('input[name="validator_time_limit"]').attributes('disabled'),
     ).toBe('disabled');
 
-    const languages = wrapper.find('select[name="languages"]')
+    const languages = wrapper.find('select[name="current_languages"]')
       .element as HTMLInputElement;
     languages.value = 'cat';
     await languages.dispatchEvent(new Event('change'));
@@ -76,8 +92,8 @@ describe('Settings.vue', () => {
       wrapper.find('input[name="validator_time_limit"]').attributes('disabled'),
     ).toBeFalsy();
     expect(
-      (wrapper.find('select[name="languages"]').element as HTMLInputElement)
-        .value,
+      (wrapper.find('select[name="current_languages"]')
+        .element as HTMLInputElement).value,
     ).toBe('cat');
     expect(
       (wrapper.find('select[name="validator"]').element as HTMLInputElement)

--- a/frontend/www/js/omegaup/components/problem/Settings.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Settings.test.ts
@@ -40,32 +40,16 @@ describe('Settings.vue', () => {
     });
 
     expect(
-      wrapper
-        .find('select[name="current_languages"]')
-        .findAll('option')
-        .at(0)
-        .text(),
+      wrapper.find('select[name="languages"]').findAll('option').at(0).text(),
     ).toContain('C, C++, C++11, C#, Haskell, Java, Pascal, Python, Ruby, Lua');
     expect(
-      wrapper
-        .find('select[name="current_languages"]')
-        .findAll('option')
-        .at(1)
-        .text(),
+      wrapper.find('select[name="languages"]').findAll('option').at(1).text(),
     ).toContain('Karel');
     expect(
-      wrapper
-        .find('select[name="current_languages"]')
-        .findAll('option')
-        .at(2)
-        .text(),
+      wrapper.find('select[name="languages"]').findAll('option').at(2).text(),
     ).toContain(T.wordsJustOutput);
     expect(
-      wrapper
-        .find('select[name="current_languages"]')
-        .findAll('option')
-        .at(3)
-        .text(),
+      wrapper.find('select[name="languages"]').findAll('option').at(3).text(),
     ).toContain(T.wordsNoSubmissions);
   });
 
@@ -78,7 +62,7 @@ describe('Settings.vue', () => {
       wrapper.find('input[name="validator_time_limit"]').attributes('disabled'),
     ).toBe('disabled');
 
-    const languages = wrapper.find('select[name="current_languages"]')
+    const languages = wrapper.find('select[name="languages"]')
       .element as HTMLInputElement;
     languages.value = 'cat';
     await languages.dispatchEvent(new Event('change'));
@@ -92,8 +76,8 @@ describe('Settings.vue', () => {
       wrapper.find('input[name="validator_time_limit"]').attributes('disabled'),
     ).toBeFalsy();
     expect(
-      (wrapper.find('select[name="current_languages"]')
-        .element as HTMLInputElement).value,
+      (wrapper.find('select[name="languages"]').element as HTMLInputElement)
+        .value,
     ).toBe('cat');
     expect(
       (wrapper.find('select[name="validator"]').element as HTMLInputElement)

--- a/frontend/www/js/omegaup/components/problem/Settings.vue
+++ b/frontend/www/js/omegaup/components/problem/Settings.vue
@@ -9,6 +9,7 @@
           class="form-control"
           :class="{ 'is-invalid': errors.includes('languages') }"
           required
+          @change="onLanguagesChange($event)"
         >
           <option
             v-for="(languageText, languageIndex) in validLanguages"
@@ -146,7 +147,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
 import T from '../../lang';
 
 @Component
@@ -177,6 +178,12 @@ export default class Settings extends Vue {
   @Watch('initialLanguage')
   onInitialLanguageChange(newInitial: string): void {
     this.languages = newInitial;
+  }
+
+  @Emit('languages-changed')
+  onLanguagesChange(event: Event): string {
+    const newValue = (event.target as HTMLInputElement).value;
+    return newValue;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/Settings.vue
+++ b/frontend/www/js/omegaup/components/problem/Settings.vue
@@ -5,9 +5,9 @@
         <label>{{ T.problemEditFormLanguages }}</label>
         <select
           v-model="currentLanguages"
-          name="current_languages"
+          name="languages"
           class="form-control"
-          :class="{ 'is-invalid': errors.includes('current_languages') }"
+          :class="{ 'is-invalid': errors.includes('languages') }"
           required
         >
           <option

--- a/frontend/www/js/omegaup/components/problem/Settings.vue
+++ b/frontend/www/js/omegaup/components/problem/Settings.vue
@@ -4,12 +4,11 @@
       <div class="form-group col-md-6">
         <label>{{ T.problemEditFormLanguages }}</label>
         <select
-          v-model="languages"
-          name="languages"
+          v-model="currentLanguages"
+          name="current_languages"
           class="form-control"
-          :class="{ 'is-invalid': errors.includes('languages') }"
+          :class="{ 'is-invalid': errors.includes('current_languages') }"
           required
-          @change="onLanguagesChange($event)"
         >
           <option
             v-for="(languageText, languageIndex) in validLanguages"
@@ -27,7 +26,7 @@
           name="validator"
           class="form-control"
           :class="{ 'is-invalid': errors.includes('validator') }"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           required
         >
           <option
@@ -48,7 +47,7 @@
         <input
           name="validator_time_limit"
           :value="validatorTimeLimit"
-          :disabled="languages === '' || validator !== 'custom'"
+          :disabled="currentLanguages === '' || validator !== 'custom'"
           type="text"
           class="form-control"
           :class="{
@@ -63,7 +62,7 @@
         <input
           name="time_limit"
           :value="timeLimit"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           type="text"
           class="form-control"
           :class="{ 'is-invalid': errors.includes('time_limit') }"
@@ -83,7 +82,7 @@
             'is-invalid': errors.includes('overall_wall_time_limit'),
           }"
           :value="overallWallTimeLimit"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           type="text"
           class="form-control"
           required
@@ -95,7 +94,7 @@
         <input
           name="extra_wall_time"
           :value="extraWallTime"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           type="text"
           class="form-control"
           :class="{ 'is-invalid': errors.includes('extra_wall_time') }"
@@ -110,7 +109,7 @@
         <input
           name="memory_limit"
           :value="memoryLimit"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           type="text"
           class="form-control"
           :class="{ 'is-invalid': errors.includes('memory_limit') }"
@@ -123,7 +122,7 @@
         <input
           name="output_limit"
           :value="outputLimit"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           type="text"
           class="form-control"
           :class="{ 'is-invalid': errors.includes('output_limit') }"
@@ -135,7 +134,7 @@
         <input
           name="input_limit"
           :value="inputLimit"
-          :disabled="languages === ''"
+          :disabled="currentLanguages === ''"
           type="text"
           class="form-control"
           :class="{ 'is-invalid': errors.includes('input_limit') }"
@@ -159,7 +158,7 @@ export default class Settings extends Vue {
   @Prop() inputLimit!: number;
   @Prop() overallWallTimeLimit!: number;
   @Prop() validatorTimeLimit!: number;
-  @Prop() initialLanguage!: string;
+  @Prop() languages!: string;
   @Prop() validLanguages!: Array<string>;
   @Prop() initialValidator!: string;
   @Prop() validatorTypes!: Array<string>;
@@ -168,21 +167,16 @@ export default class Settings extends Vue {
   T = T;
 
   validator = this.initialValidator;
-  languages = this.initialLanguage;
+  currentLanguages = this.languages;
 
   @Watch('initialValidator')
   onInitialValidatorChange(newInitial: string): void {
     this.validator = newInitial;
   }
 
-  @Watch('initialLanguage')
-  onInitialLanguageChange(newInitial: string): void {
-    this.languages = newInitial;
-  }
-
-  @Emit('languages-changed')
-  onLanguagesChange(event: Event): string {
-    const newValue = (event.target as HTMLInputElement).value;
+  @Emit('update:languages')
+  @Watch('currentLanguages')
+  onCurrentLanguagesChange(newValue: string): string {
     return newValue;
   }
 }


### PR DESCRIPTION
# Descripción

Este cambio soluciona el issue de bloquear el campo 'Mostrar diferencias en los casos' al seleccionar 
la opción 'Tipo de Problema' = 'Lectura (Sin envíos)' en el formulario de 'Crear Problema'.

Fixes: #4851