### PR TITLE
Cambiar cadena de "Público" a "Scoreboard" en los detalles de los cursos

### DIFF
--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -249,6 +249,7 @@ contestUpdateAlreadyHasRuns = "Length of a contest can't be changed once a solut
 contestWillBeginIn = "This contest will begin in "
 contestsCreateNew = "Create a new contest"
 contestsJoinScoreboards = "Merge scoreboards"
+courseActionScoreboard = "Scoreboard"
 courseAddContent = "Add content"
 courseAddProblemsAdd = "Add problems"
 courseAddProblemsAddAssignmentDesc = "Add all the problems that you want to include. These problems will be stored until you press the Add content button. If you do not want to decide which problems to use right now, you can add them later."

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -249,6 +249,7 @@ contestUpdateAlreadyHasRuns = "La duración del concurso no se puede cambiar si 
 contestWillBeginIn = "Este concurso iniciará en "
 contestsCreateNew = "Crear un concurso"
 contestsJoinScoreboards = "Unir scoreboards"
+courseActionScoreboard = "Scoreboard"
 courseAddContent = "Añadir contenido"
 courseAddProblemsAdd = "Agregar problemas"
 courseAddProblemsAddAssignmentDesc = "Agrega los problemas/lecturas que quieras incluir, estos se guardarán hasta que presiones el botón de Añadir contenido. Si aún no decides que problemas utilizarás, puedes agregarlos más tarde."

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -249,6 +249,7 @@ contestUpdateAlreadyHasRuns = "(L3ng7h 0f a c0n7357 can'7 b3 chang3d 0nc3 a 501u
 contestWillBeginIn = "(Thi5 c0n7357 wi11 b3gin in )"
 contestsCreateNew = "(Cr3a73 a n3w c0n7357)"
 contestsJoinScoreboards = "(M3rg3 5c0r3b0ard5)"
+courseActionScoreboard = "(Sc0r3b0ard)"
 courseAddContent = "(Add c0n73n7)"
 courseAddProblemsAdd = "(Add pr0b13m5)"
 courseAddProblemsAddAssignmentDesc = "(Add a11 7h3 pr0b13m5 7ha7 y0u wan7 70 inc1ud3. Th353 pr0b13m5 wi11 b3 570r3d un7i1 y0u pr355 7h3 Add c0n73n7 bu770n. If y0u d0 n07 wan7 70 d3cid3 which pr0b13m5 70 u53 righ7 n0w, y0u can add 7h3m 1a73r.)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -249,6 +249,7 @@ contestUpdateAlreadyHasRuns = "A duração do concurso não pode ser alterada se
 contestWillBeginIn = "Concurso inciará em "
 contestsCreateNew = "Criar um novo concurso"
 contestsJoinScoreboards = "Juntar paineis de avaliação"
+courseActionScoreboard = "Painel de avaliação"
 courseAddContent = "Adicionar conteúdo"
 courseAddProblemsAdd = "Adicionar problemas"
 courseAddProblemsAddAssignmentDesc = "Adicione todos os problemas que deseja incluir. Esses problemas serão armazenados até que você pressione o botão Adicionar conteúdo. Se não quiser decidir quais problemas usar agora, você pode adicioná-los mais tarde."

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -117,7 +117,7 @@ def test_user_ranking_course(driver):
 
         enter_course_assignments_page(driver, course_alias)
         util.check_scoreboard_events(driver, assignment_alias, url,
-                                     num_elements=1, scoreboard='Public')
+                                     num_elements=1, scoreboard='Scoreboard')
 
         enter_course_assignments_page(driver, course_alias)
         with driver.page_transition():

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -157,7 +157,7 @@
                   :href="`/course/${course.alias}/assignment/${assignment.alias}/scoreboard/${assignment.scoreboard_url}/`"
                 >
                   <font-awesome-icon :icon="['fas', 'link']" />{{
-                    T.wordsPublic
+                    T.courseActionScoreboard
                   }}</a
                 >
                 <a

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -250,6 +250,7 @@
 	"contestWillBeginIn": "This contest will begin in ",
 	"contestsCreateNew": "Create a new contest",
 	"contestsJoinScoreboards": "Merge scoreboards",
+	"courseActionScoreboard": "Scoreboard",
 	"courseAddContent": "Add content",
 	"courseAddProblemsAdd": "Add problems",
 	"courseAddProblemsAddAssignmentDesc": "Add all the problems that you want to include. These problems will be stored until you press the Add content button. If you do not want to decide which problems to use right now, you can add them later.",

--- a/frontend/www/js/omegaup/lang.en.ts
+++ b/frontend/www/js/omegaup/lang.en.ts
@@ -251,6 +251,7 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "This contest will begin in ",
   contestsCreateNew: "Create a new contest",
   contestsJoinScoreboards: "Merge scoreboards",
+  courseActionScoreboard: "Scoreboard",
   courseAddContent: "Add content",
   courseAddProblemsAdd: "Add problems",
   courseAddProblemsAddAssignmentDesc: "Add all the problems that you want to include. These problems will be stored until you press the Add content button. If you do not want to decide which problems to use right now, you can add them later.",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -250,6 +250,7 @@
 	"contestWillBeginIn": "Este concurso iniciar\u00e1 en ",
 	"contestsCreateNew": "Crear un concurso",
 	"contestsJoinScoreboards": "Unir scoreboards",
+	"courseActionScoreboard": "Scoreboard",
 	"courseAddContent": "A\u00f1adir contenido",
 	"courseAddProblemsAdd": "Agregar problemas",
 	"courseAddProblemsAddAssignmentDesc": "Agrega los problemas/lecturas que quieras incluir, estos se guardar\u00e1n hasta que presiones el bot\u00f3n de A\u00f1adir contenido. Si a\u00fan no decides que problemas utilizar\u00e1s, puedes agregarlos m\u00e1s tarde.",

--- a/frontend/www/js/omegaup/lang.es.ts
+++ b/frontend/www/js/omegaup/lang.es.ts
@@ -251,6 +251,7 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "Este concurso iniciar\u00e1 en ",
   contestsCreateNew: "Crear un concurso",
   contestsJoinScoreboards: "Unir scoreboards",
+  courseActionScoreboard: "Scoreboard",
   courseAddContent: "A\u00f1adir contenido",
   courseAddProblemsAdd: "Agregar problemas",
   courseAddProblemsAddAssignmentDesc: "Agrega los problemas/lecturas que quieras incluir, estos se guardar\u00e1n hasta que presiones el bot\u00f3n de A\u00f1adir contenido. Si a\u00fan no decides que problemas utilizar\u00e1s, puedes agregarlos m\u00e1s tarde.",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -250,6 +250,7 @@
 	"contestWillBeginIn": "(Thi5 c0n7357 wi11 b3gin in )",
 	"contestsCreateNew": "(Cr3a73 a n3w c0n7357)",
 	"contestsJoinScoreboards": "(M3rg3 5c0r3b0ard5)",
+	"courseActionScoreboard": "(Sc0r3b0ard)",
 	"courseAddContent": "(Add c0n73n7)",
 	"courseAddProblemsAdd": "(Add pr0b13m5)",
 	"courseAddProblemsAddAssignmentDesc": "(Add a11 7h3 pr0b13m5 7ha7 y0u wan7 70 inc1ud3. Th353 pr0b13m5 wi11 b3 570r3d un7i1 y0u pr355 7h3 Add c0n73n7 bu770n. If y0u d0 n07 wan7 70 d3cid3 which pr0b13m5 70 u53 righ7 n0w, y0u can add 7h3m 1a73r.)",

--- a/frontend/www/js/omegaup/lang.pseudo.ts
+++ b/frontend/www/js/omegaup/lang.pseudo.ts
@@ -251,6 +251,7 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "(Thi5 c0n7357 wi11 b3gin in )",
   contestsCreateNew: "(Cr3a73 a n3w c0n7357)",
   contestsJoinScoreboards: "(M3rg3 5c0r3b0ard5)",
+  courseActionScoreboard: "(Sc0r3b0ard)",
   courseAddContent: "(Add c0n73n7)",
   courseAddProblemsAdd: "(Add pr0b13m5)",
   courseAddProblemsAddAssignmentDesc: "(Add a11 7h3 pr0b13m5 7ha7 y0u wan7 70 inc1ud3. Th353 pr0b13m5 wi11 b3 570r3d un7i1 y0u pr355 7h3 Add c0n73n7 bu770n. If y0u d0 n07 wan7 70 d3cid3 which pr0b13m5 70 u53 righ7 n0w, y0u can add 7h3m 1a73r.)",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -250,6 +250,7 @@
 	"contestWillBeginIn": "Concurso inciar\u00e1 em ",
 	"contestsCreateNew": "Criar um novo concurso",
 	"contestsJoinScoreboards": "Juntar paineis de avalia\u00e7\u00e3o",
+	"courseActionScoreboard": "Painel de avalia\u00e7\u00e3o",
 	"courseAddContent": "Adicionar conte\u00fado",
 	"courseAddProblemsAdd": "Adicionar problemas",
 	"courseAddProblemsAddAssignmentDesc": "Adicione todos os problemas que deseja incluir. Esses problemas ser\u00e3o armazenados at\u00e9 que voc\u00ea pressione o bot\u00e3o Adicionar conte\u00fado. Se n\u00e3o quiser decidir quais problemas usar agora, voc\u00ea pode adicion\u00e1-los mais tarde.",

--- a/frontend/www/js/omegaup/lang.pt.ts
+++ b/frontend/www/js/omegaup/lang.pt.ts
@@ -251,6 +251,7 @@ const translations: { [key: string]: string; } = {
   contestWillBeginIn: "Concurso inciar\u00e1 em ",
   contestsCreateNew: "Criar um novo concurso",
   contestsJoinScoreboards: "Juntar paineis de avalia\u00e7\u00e3o",
+  courseActionScoreboard: "Painel de avalia\u00e7\u00e3o",
   courseAddContent: "Adicionar conte\u00fado",
   courseAddProblemsAdd: "Adicionar problemas",
   courseAddProblemsAddAssignmentDesc: "Adicione todos os problemas que deseja incluir. Esses problemas ser\u00e3o armazenados at\u00e9 que voc\u00ea pressione o bot\u00e3o Adicionar conte\u00fado. Se n\u00e3o quiser decidir quais problemas usar agora, voc\u00ea pode adicion\u00e1-los mais tarde.",


### PR DESCRIPTION
# Descripción
Se cambia la cadena (string) de "Público" a "Scoreboard" en los detalles de los cursos (Details.vue).

Fixes: #5012
