### PR TITLE
Ordenando los problemas resueltos de un usuario por la fecha de resolución.

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -582,7 +582,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
      */
     final public static function getProblemsSolved(int $identityId): array {
         $sql = '
-            SELECT DISTINCT
+            SELECT
                 p.*
             FROM
                 Problems p
@@ -592,7 +592,10 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 Runs r ON r.run_id = s.current_run_id
             WHERE
                 r.verdict = "AC" AND s.type = "normal" AND s.identity_id = ?
+            GROUP BY
+                p.problem_id
             ORDER BY
+                min(s.time) DESC,
                 p.problem_id DESC;
         ';
         $val = [$identityId];


### PR DESCRIPTION
fecha de resolución.

# Descripción
Este cambio ordena los problemas resueltos de un usuario por la fecha de resolución de forma descendente (del más reciente al más antiguo) y en base al primer AC obtenido en cada problema.


Fixes: #4998
