### PR TITLE
Agregando el botón de clonar curso público desde la vista de detalles

### DIFF
--- a/frontend/www/js/omegaup/components/course/Intro.vue
+++ b/frontend/www/js/omegaup/components/course/Intro.vue
@@ -50,6 +50,46 @@
             </tbody>
           </table>
         </div>
+        <div
+          v-if="course.admission_mode === 'public'"
+          class="accordion"
+          data-accordion-clone
+        >
+          <div class="card">
+            <div class="card-header" data-heading-clone>
+              <h2 class="mb-0">
+                <button
+                  class="btn btn-link btn-block text-right"
+                  type="button"
+                  data-toggle="collapse"
+                  data-target="[data-accordion-collapse]"
+                  aria-expanded="false"
+                  aria-controls="data-accordion-collapse"
+                >
+                  {{ T.wordsCloneThisCourse }}
+                </button>
+              </h2>
+            </div>
+
+            <div
+              data-accordion-collapse
+              class="collapse hide"
+              aria-labelledby="[data-heading-clone]"
+              data-parent="[data-accordion-clone]"
+            >
+              <div class="card-body">
+                <omegaup-course-clone
+                  :initial-alias="aliasWithUsername"
+                  :initial-name="course.name"
+                  @clone="
+                    (alias, name, startTime) =>
+                      $emit('clone', alias, name, startTime)
+                  "
+                ></omegaup-course-clone>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <template
         v-if="userRegistrationRequested === null || userRegistrationAccepted"
@@ -130,6 +170,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import T from '../../lang';
 import { types } from '../../api_types';
 
+import course_Clone from './Clone.vue';
 import omegaup_Markdown from '../Markdown.vue';
 import omegaup_RadioSwitch from '../RadioSwitch.vue';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -154,6 +195,7 @@ interface Statement {
     FontAwesomeIcon,
     'omegaup-markdown': omegaup_Markdown,
     'omegaup-radio-switch': omegaup_RadioSwitch,
+    'omegaup-course-clone': course_Clone,
   },
 })
 export default class CourseIntro extends Vue {
@@ -168,6 +210,7 @@ export default class CourseIntro extends Vue {
   @Prop({ default: null }) userRegistrationAnswered!: boolean;
   @Prop({ default: null }) userRegistrationAccepted!: boolean;
   @Prop() loggedIn!: boolean;
+  @Prop() currentUsername!: string;
 
   T = T;
   shareUserInformation = false;
@@ -180,6 +223,10 @@ export default class CourseIntro extends Vue {
       (this.requestsUserInformation === 'required' &&
         !this.shareUserInformation)
     );
+  }
+
+  get aliasWithUsername(): string {
+    return `${this.course?.alias}_${this.currentUsername}`;
   }
 
   onSubmit(): void {

--- a/frontend/www/js/omegaup/course/intro.ts
+++ b/frontend/www/js/omegaup/course/intro.ts
@@ -2,6 +2,7 @@ import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
+import T from '../lang';
 import Vue from 'vue';
 import course_Intro from '../components/course/Intro.vue';
 
@@ -30,6 +31,7 @@ OmegaUp.on('ready', () => {
           userRegistrationAnswered: payload.userRegistrationAnswered,
           userRegistrationAccepted: payload.userRegistrationAccepted,
           loggedIn: headerPayload.isLoggedIn,
+          currentUsername: headerPayload.currentUsername,
         },
         on: {
           submit: (source: course_Intro) => {
@@ -54,6 +56,23 @@ OmegaUp.on('ready', () => {
                 courseIntro.userRegistrationRequested = true;
               })
               .catch(ui.error);
+          },
+          clone: (alias: string, name: string, startTime: Date) => {
+            api.Course.clone({
+              course_alias: payload.details?.alias,
+              name: name,
+              alias: alias,
+              start_time: startTime.getTime() / 1000,
+            })
+              .then(() => {
+                ui.success(
+                  ui.formatString(T.courseEditCourseClonedSuccessfully, {
+                    course_alias: alias,
+                  }),
+                  /*autoHide=*/ false,
+                );
+              })
+              .catch(ui.apiError);
           },
         },
       });


### PR DESCRIPTION
# Descripción

Se agrega el botón de clonar curso público desde la vista de detalles para que 
un usuario que no se ha registrado al curso tenga la posibilidad de clonarlo.

![ClonePublicCourseFromIntro](https://user-images.githubusercontent.com/3230352/106643040-c14f8280-654e-11eb-8004-b65c5a0dfbcd.gif)

Fixes: #5072 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.