### PR TITLE
Agregando liga a problema en página de editar curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -31,7 +31,11 @@
                   <font-awesome-icon icon="arrows-alt" />
                 </button>
               </td>
-              <td class="align-middle">{{ problem.alias }}</td>
+              <td class="align-middle">
+                <a :href="`/arena/problem/${problem.alias}/`">{{
+                  problem.alias
+                }}</a>
+              </td>
               <td class="align-middle">{{ problem.points }}</td>
               <td class="button-column">
                 <button

--- a/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
@@ -21,7 +21,11 @@
           </thead>
           <tbody>
             <tr v-for="problem in problems">
-              <td class="align-middle">{{ problem.alias }}</td>
+              <td class="align-middle">
+                <a :href="`/arena/problem/${problem.alias}/`">{{
+                  problem.alias
+                }}</a>
+              </td>
               <td class="align-middle">{{ problem.points }}</td>
               <td class="button-column align-middle">
                 <button


### PR DESCRIPTION
# Descripción

Se añade una liga al problema en la arena en la página de editar curso.

![image](https://user-images.githubusercontent.com/52440153/106676604-39389f80-6585-11eb-8a40-aaddc5b4fa2a.png)

También se añade una liga en la misma página al crear un contenido en vez de editarlo.

![image](https://user-images.githubusercontent.com/52440153/106676752-78ff8700-6585-11eb-86f2-76cc878fb28b.png)

Fixes: #5091

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
