### PR TITLE
Reordenando el dropdown en la página de estadísticas del curso

### DIFF
--- a/frontend/www/js/omegaup/components/course/Statistics.vue
+++ b/frontend/www/js/omegaup/components/course/Statistics.vue
@@ -50,9 +50,8 @@ export default class Statistics extends Vue {
   @Prop() verdicts!: types.CourseProblemVerdict[];
   T = T;
   // chart options
-  selected = this.verdictChartOptions;
+  selected = this.averageChartOptions;
   options = [
-    { value: this.varianceChartOptions, text: T.courseStatisticsVariance },
     { value: this.averageChartOptions, text: T.courseStatisticsAverageScore },
     {
       value: this.highScoreChartOptions,
@@ -62,10 +61,11 @@ export default class Statistics extends Vue {
       value: this.lowScoreChartOptions,
       text: T.courseStatisticsStudentsScored,
     },
-    { value: this.minimumChartOptions, text: T.courseStatisticsMinimumScore },
-    { value: this.maximumChartOptions, text: T.courseStatisticsMaximumScore },
     { value: this.runsChartOptions, text: T.courseStatisticsAverageRuns },
     { value: this.verdictChartOptions, text: T.courseStatisticsVerdicts },
+    { value: this.varianceChartOptions, text: T.courseStatisticsVariance },
+    { value: this.minimumChartOptions, text: T.courseStatisticsMinimumScore },
+    { value: this.maximumChartOptions, text: T.courseStatisticsMaximumScore },
   ];
   // get chart options
   get varianceChartOptions() {


### PR DESCRIPTION
# Descripción

Se reordena el dropdown y la opción escogida por defecto se cambia a average.

![image](https://user-images.githubusercontent.com/52440153/106678451-bf0a1a00-6588-11eb-9543-a2617dd826d8.png)

Fixes: #4653

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
