### PR TITLE
Separando los cambios del controlador para Clarifications

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -3209,7 +3209,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      */
     public static function apiClarifications(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        $offset = $r->ensureOptionalInt('offset') ?? null;
+        $offset = $r->ensureOptionalInt('offset');
         $rowcount = $r->ensureOptionalInt('rowcount') ?? 1000;
 
         $contestAlias = $r->ensureString(

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -7,7 +7,7 @@ namespace OmegaUp\Controllers;
  *
  * @psalm-type PrivacyStatement=array{markdown: string, statementType: string, gitObjectId?: string}
  * @psalm-type Contest=array{acl_id?: int, admission_mode: string, alias: string, contest_id: int, description: string, feedback?: string, finish_time: \OmegaUp\Timestamp, languages?: null|string, last_updated: \OmegaUp\Timestamp, original_finish_time?: \OmegaUp\Timestamp, partial_score: bool, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problemset_id: int, recommended: bool, rerun_id: int, scoreboard?: int, scoreboard_url: string, scoreboard_url_admin: string, show_scoreboard_after?: int, start_time: \OmegaUp\Timestamp, submissions_gap?: int, title: string, urgent?: int, window_length: int|null}
- * @psalm-type NavbarContestProblem=array{acceptsSubmissions: bool, alias: string, bestScore: int, hasRuns: bool, maxScore: float|int, text: string}
+ * @psalm-type NavbarProblemsetProblem=array{acceptsSubmissions: bool, alias: string, bestScore: int, hasRuns: bool, maxScore: float|int, text: string}
  * @psalm-type ContestProblem=array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, order: int, points: float, problem_id: int, submissions: int, title: string, version: string, visibility: int, visits: int}
  * @psalm-type ContestUser=array{access_time: \OmegaUp\Timestamp|null, country_id: null|string, end_time: \OmegaUp\Timestamp|null, is_owner: int|null, username: string}
  * @psalm-type ContestGroup=array{alias: string, name: string}
@@ -25,7 +25,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ContestPublicDetails=array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null}
  * @psalm-type ContestEditPayload=array{details: ContestAdminDetails, problems: list<ContestProblem>, users: list<ContestUser>, groups: list<ContestGroup>, requests: list<ContestRequest>, admins: list<ContestAdmin>, group_admins: list<ContestGroupAdmin>}
  * @psalm-type ContestIntroPayload=array{contest: ContestPublicDetails, needsBasicInformation?: bool, privacyStatement?: PrivacyStatement, problemset?: ContestDetails, requestsUserInformation?: string, shouldShowFirstAssociatedIdentityRunWarning: bool}
- * @psalm-type ContestPracticePayload=array{contest: ContestPublicDetails, problems?: list<NavbarContestProblem>, shouldShowFirstAssociatedIdentityRunWarning: bool}
+ * @psalm-type ContestPracticePayload=array{clarifications: list<Clarification>, contest: ContestPublicDetails, contestAdmin: bool, problems: list<NavbarProblemsetProblem>, shouldShowFirstAssociatedIdentityRunWarning: bool, users: list<ContestUser>|null}
  * @psalm-type ContestListItem=array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, original_finish_time: \OmegaUp\Timestamp, problemset_id: int, recommended: bool, rerun_id: int, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}
  * @psalm-type ContestListPayload=array{contests: array{current: list<ContestListItem>, future: list<ContestListItem>, participating?: list<ContestListItem>, past: list<ContestListItem>, public: list<ContestListItem>, recommended_current: list<ContestListItem>, recommended_past: list<ContestListItem>}, isLogged: bool, query: string}
  * @psalm-type ContestNewPayload=array{languages: array<string, string>}
@@ -638,7 +638,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $contestAdmin,
             $r->identity
         );
-        /** @var list<NavbarContestProblem> */
+        /** @var list<NavbarProblemsetProblem> */
         $problems = [];
         foreach ($problemset['problems'] as $problem) {
             array_push($problems, [
@@ -666,6 +666,17 @@ class Contest extends \OmegaUp\Controllers\Controller {
                         ),
                     'contest' => self::getPublicDetails($contest, $r->identity),
                     'problems' => $problems,
+                    'users' => $contestAdmin ? \OmegaUp\DAO\ProblemsetIdentities::getWithExtraInformation(
+                        intval($contest->problemset_id)
+                    ) : null,
+                    'contestAdmin' => $contestAdmin,
+                    'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
+                        intval($contest->problemset_id),
+                        $contestAdmin,
+                        $r->identity->identity_id,
+                        /*$offset=*/ null,
+                        /*$rowcount=*/ 100
+                    ),
                 ],
                 'fullWidth' => true,
                 'title' => new \OmegaUp\TranslationString('enterContest'),
@@ -3188,31 +3199,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * Validate the Clarifications request
-     *
-     * @omegaup-request-param string $contest_alias
-     * @omegaup-request-param int $offset
-     * @omegaup-request-param int $rowcount
-     */
-    private static function validateClarifications(\OmegaUp\Request $r): \OmegaUp\DAO\VO\Contests {
-        // Check contest_alias
-        $contestAlias = $r->ensureString(
-            'contest_alias',
-            fn (string $alias) => \OmegaUp\Validators::alias($alias)
-        );
-
-        $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
-        }
-
-        $r->ensureOptionalInt('offset' /* optional */);
-        $r->ensureOptionalInt('rowcount' /* optional */);
-
-        return $contest;
-    }
-
-    /**
      * Get clarifications of a contest
      *
      * @return array{clarifications: list<Clarification>}
@@ -3223,9 +3209,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
      */
     public static function apiClarifications(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        $r->ensureOptionalInt('offset' /* optional */);
-        $r->ensureOptionalInt('rowcount' /* optional */);
-        $contest = self::validateClarifications($r);
+        $offset = $r->ensureOptionalInt('offset') ?? null;
+        $rowcount = $r->ensureOptionalInt('rowcount') ?? 1000;
+
+        $contestAlias = $r->ensureString(
+            'contest_alias',
+            fn (string $alias) => \OmegaUp\Validators::alias($alias)
+        );
+        $contest = self::validateContest($contestAlias);
 
         $isContestDirector = \OmegaUp\Authorization::isContestAdmin(
             $r->identity,
@@ -3233,12 +3224,12 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         return [
-            'clarifications' => \OmegaUp\DAO\Clarifications::GetProblemsetClarifications(
+            'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
                 intval($contest->problemset_id),
                 $isContestDirector,
                 $r->identity->identity_id,
-                empty($r['offset']) ? null : intval($r['offset']),
-                empty($r['rowcount']) ? 1000 : intval($r['rowcount'])
+                $offset,
+                $rowcount
             ),
         ];
     }

--- a/frontend/server/src/DAO/Clarifications.php
+++ b/frontend/server/src/DAO/Clarifications.php
@@ -15,7 +15,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
     /**
      * @return list<Clarification>
      */
-    final public static function GetProblemsetClarifications(
+    final public static function getProblemsetClarifications(
         int $problemset_id,
         bool $admin,
         int $identityId,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -424,11 +424,35 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ContestPracticePayload {
       return ((x) => {
+        x.clarifications = ((x) => {
+          if (!Array.isArray(x)) {
+            return x;
+          }
+          return x.map((x) => {
+            x.time = ((x: number) => new Date(x * 1000))(x.time);
+            return x;
+          });
+        })(x.clarifications);
         x.contest = ((x) => {
           x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
           x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
           return x;
         })(x.contest);
+        if (x.users)
+          x.users = ((x) => {
+            if (!Array.isArray(x)) {
+              return x;
+            }
+            return x.map((x) => {
+              if (x.access_time)
+                x.access_time = ((x: number) => new Date(x * 1000))(
+                  x.access_time,
+                );
+              if (x.end_time)
+                x.end_time = ((x: number) => new Date(x * 1000))(x.end_time);
+              return x;
+            });
+          })(x.users);
         return x;
       })(
         JSON.parse(
@@ -1725,9 +1749,12 @@ export namespace types {
   }
 
   export interface ContestPracticePayload {
+    clarifications: types.Clarification[];
     contest: types.ContestPublicDetails;
-    problems?: types.NavbarContestProblem[];
+    contestAdmin: boolean;
+    problems: types.NavbarProblemsetProblem[];
     shouldShowFirstAssociatedIdentityRunWarning: boolean;
+    users?: types.ContestUser[];
   }
 
   export interface ContestProblem {
@@ -2170,7 +2197,7 @@ export namespace types {
     validateRecaptcha: boolean;
   }
 
-  export interface NavbarContestProblem {
+  export interface NavbarProblemsetProblem {
     acceptsSubmissions: boolean;
     alias: string;
     bestScore: number;

--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -228,7 +228,7 @@ export class Arena {
 
   navbarProblems:
     | (Vue & {
-        problems: types.NavbarContestProblem[];
+        problems: types.NavbarProblemsetProblem[];
         activeProblem: string | null;
       })
     | null = null;

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -19,7 +19,7 @@ OmegaUp.on('ready', () => {
     components: { 'omegaup-arena-contest-practice': arena_ContestPractice },
     data: () => ({
       problemInfo: null as types.ProblemInfo | null,
-      problems: payload.problems as types.NavbarContestProblem[],
+      problems: payload.problems as types.NavbarProblemsetProblem[],
       problem: null as ActiveProblem | null,
     }),
     render: function (createElement) {

--- a/frontend/www/js/omegaup/components/arena/ContestPractice.test.ts
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.test.ts
@@ -143,7 +143,7 @@ describe('ContestPractice.vue', () => {
             maxScore: 100,
             text: 'B. hello other problem omegaUp',
           },
-        ] as types.NavbarContestProblem[],
+        ] as types.NavbarProblemsetProblem[],
         problemInfo: sampleProblem,
       },
     });

--- a/frontend/www/js/omegaup/components/arena/ContestPractice.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.vue
@@ -92,7 +92,7 @@ export interface ActiveProblem {
 })
 export default class ArenaContestPractice extends Vue {
   @Prop() contest!: types.ContestPublicDetails;
-  @Prop() problems!: types.NavbarContestProblem[];
+  @Prop() problems!: types.NavbarProblemsetProblem[];
   @Prop({ default: null }) problem!: ActiveProblem | null;
   @Prop() problemInfo!: types.ProblemInfo;
   @Prop({ default: () => [] }) clarifications!: types.Clarification[];

--- a/frontend/www/js/omegaup/components/arena/NavbarProblems.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarProblems.vue
@@ -91,7 +91,7 @@ library.add(fas);
   },
 })
 export default class ArenaNavbarProblems extends Vue {
-  @Prop() problems!: types.NavbarContestProblem[];
+  @Prop() problems!: types.NavbarProblemsetProblem[];
   @Prop() activeProblem!: string | null;
   @Prop() courseAlias!: string | null;
   @Prop() courseName!: string | null;


### PR DESCRIPTION
# Descripción

Separando los cambios del servidor con todo lo referente a Clarifications en 
`ArenaContestPractice`

Part of: #5126

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
