### PR TITLE
Corrigiendo los tipos de `Clarification::apiCreate()`

### DIFF
--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -28,7 +28,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
      * @return array{clarification_id: int}
      *
      * @omegaup-request-param string $contest_alias
-     * @omegaup-request-param null|string $message
+     * @omegaup-request-param string $message
      * @omegaup-request-param string $problem_alias
      * @omegaup-request-param null|string $username
      */
@@ -45,15 +45,14 @@ class Clarification extends \OmegaUp\Controllers\Controller {
             'problem_alias',
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
-        \OmegaUp\Validators::validateOptionalStringNonEmpty(
-            $r['username'],
-            'username'
-        );
-        \OmegaUp\Validators::validateStringOfLengthInRange(
-            $r['message'],
+        $username = $r->ensureOptionalString('username');
+        $message = $r->ensureString(
             'message',
-            1,
-            200
+            fn (string $message) => \OmegaUp\Validators::stringOfLengthInRange(
+                $message,
+                1,
+                200
+            )
         );
 
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
@@ -66,8 +65,8 @@ class Clarification extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
-        $identity = !is_null($r['username']) ?
-            \OmegaUp\DAO\Identities::findByUsername($r['username']) : null;
+        $identity = !is_null($username) ?
+            \OmegaUp\DAO\Identities::findByUsername($username) : null;
 
         // Is the combination problemset_id and problem_id valid?
         if (
@@ -89,7 +88,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
             'receiver_id' => $receiverId,
             'problemset_id' => $contest->problemset_id,
             'problem_id' => $problem->problem_id,
-            'message' => $r['message'],
+            'message' => $message,
             'time' => \OmegaUp\Time::get(),
             'public' => $receiverId == $r->identity->identity_id,
         ]);

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -376,8 +376,8 @@ Creates a Clarification
 | Name            | Type           | Description |
 | --------------- | -------------- | ----------- |
 | `contest_alias` | `string`       |             |
+| `message`       | `string`       |             |
 | `problem_alias` | `string`       |             |
-| `message`       | `null\|string` |             |
 | `username`      | `null\|string` |             |
 
 ### Returns

--- a/frontend/server/src/Exceptions/InvalidParameterException.php
+++ b/frontend/server/src/Exceptions/InvalidParameterException.php
@@ -4,7 +4,6 @@ namespace OmegaUp\Exceptions;
 
 class InvalidParameterException extends \OmegaUp\Exceptions\ApiException {
     /**
-     * @readonly
      * @var null|string
      */
     public $parameter;

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -223,11 +223,18 @@ class Request extends \ArrayObject {
             strval($mixedVal) :
             ''
         );
-        if (!is_null($validator) && !$validator($val)) {
-            throw new \OmegaUp\Exceptions\InvalidParameterException(
-                'parameterInvalid',
-                $key
-            );
+        if (!is_null($validator)) {
+            try {
+                if (!$validator($val)) {
+                    throw new \OmegaUp\Exceptions\InvalidParameterException(
+                        'parameterInvalid',
+                        $key
+                    );
+                }
+            } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+                $e->parameter = $key;
+                throw $e;
+            }
         }
         $this[$key] = $val;
         return $val;

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -129,6 +129,37 @@ class Validators {
     }
 
     /**
+     * Checks whether the string parameter is of a certain length.
+     *
+     * @param string   $parameter the parameter
+     * @param int|null $minLength the (optional) minimum length
+     * @param int|null $maxLength the (optional) maximum length
+     *
+     * @return true when the parameter's length is within the specified bounds.
+     */
+    public static function stringOfLengthInRange(
+        string $parameter,
+        ?int $minLength,
+        ?int $maxLength
+    ): bool {
+        if (!is_null($minLength) && strlen($parameter) < $minLength) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterStringTooShort',
+                /*$parameter=*/null,
+                ['min_length' => strval($minLength)]
+            );
+        }
+        if (!is_null($maxLength) && strlen($parameter) > $maxLength) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterStringTooLong',
+                /*$parameter=*/null,
+                ['max_length' => strval($maxLength)]
+            );
+        }
+        return true;
+    }
+
+    /**
      * Returns whether the alias is valid.
      * The form of namespaced alias is: "namespace:alias"
      *


### PR DESCRIPTION
Este cambio hace que los tipos de `Clarification::apiCreate()`
concuerden con lo esperado: antes se estaba declarando que `message` era
opcional únicamente porque se estaba accediendo mediante
`$r['message']`!