### PR TITLE
Corrigiendo algunos estilos en Arena y ContestPractice

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Arena.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Arena.test.ts
@@ -13,6 +13,8 @@ describe('Arena.vue', () => {
 
     expect(wrapper.find('.clock').text()).toBe('∞');
     expect(wrapper.find('.socket-status').text()).toBe('✗');
-    expect(wrapper.find('.title>h1>span').text()).toBe('Hello omegaUp');
+    expect(wrapper.find('div[data-arena-wrapper]>div>h2>span').text()).toBe(
+      'Hello omegaUp',
+    );
   });
 });

--- a/frontend/www/js/omegaup/components/arena/Arena.vue
+++ b/frontend/www/js/omegaup/components/arena/Arena.vue
@@ -1,13 +1,13 @@
 <template>
   <div data-arena-wrapper :class="backgroundClass">
-    <div class="title">
-      <h1>
+    <div class="text-center mt-4 pt-2">
+      <h2>
         <span>{{ contestTitle }}</span>
         <sup class="socket-status" title="WebSocket">✗</sup>
-      </h1>
+      </h2>
       <div class="clock">∞</div>
     </div>
-    <ul class="nav justify-content-center nav-tabs">
+    <ul class="nav justify-content-center nav-tabs mt-4">
       <li
         v-for="tab in availableTabs"
         :key="tab.name"
@@ -119,28 +119,13 @@ export default class Arena extends Vue {
   overflow-y: auto;
 }
 
-.title {
-  min-height: 80px;
-  h1 {
-    text-align: center;
-    font-size: 2em;
-    margin: 0.5em;
-  }
-}
-
 .socket-status {
   color: #800;
 }
 
-.title,
 .clock {
-  text-align: center;
-}
-
-.clock {
-  font-size: 6em;
+  font-size: 3em;
   line-height: 0.4em;
-  margin-bottom: 0.2em;
 }
 
 .navleft {

--- a/frontend/www/js/omegaup/components/arena/ContestPractice.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.vue
@@ -147,9 +147,14 @@ export default class ArenaContestPractice extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .navleft {
   overflow: hidden;
+}
+
+.nav-tabs .nav-link {
+  background-color: #ddd;
+  border-top-color: #ddd;
 }
 
 .navleft .navbar {


### PR DESCRIPTION
# Descripción

Antes:
![image](https://user-images.githubusercontent.com/20785082/108523762-4a2f2380-729c-11eb-8aeb-4a6c679cc039.png)


Ahora: 
![image](https://user-images.githubusercontent.com/20785082/108523704-3b487100-729c-11eb-8cbe-593c0760ad06.png)


# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
