### PR TITLE
Almacenando problemas de un concurso modo práctica y evitar llamados innecesarios vía API

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -8,6 +8,7 @@ import arena_ContestPractice, {
   ActiveProblem,
 } from '../components/arena/ContestPractice.vue';
 import arena_NewClarification from '../components/arena/NewClarificationPopup.vue';
+import problemsStore from './problemStore';
 
 OmegaUp.on('ready', () => {
   time.setSugarLocale();
@@ -37,6 +38,13 @@ OmegaUp.on('ready', () => {
         },
         on: {
           'navigate-to-problem': (source: ActiveProblem) => {
+            const problemIndex = problemsStore.state.index[source.alias];
+            if (typeof problemIndex !== 'undefined') {
+              contestPractice.problemInfo =
+                problemsStore.state.problems[problemIndex];
+              window.location.hash = `#problems/${source.alias}`;
+              return;
+            }
             api.Problem.details({
               contest_alias: payload.contest.alias,
               problem_alias: source.alias,
@@ -50,6 +58,7 @@ OmegaUp.on('ready', () => {
                 contestPractice.problemInfo = problemInfo;
                 source.alias = problemInfo.alias;
                 source.runs = problemInfo.runs ?? [];
+                problemsStore.commit('addProblem', problemInfo);
                 window.location.hash = `#problems/${source.alias}`;
               })
               .catch(() => {

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -61,12 +61,14 @@ OmegaUp.on('ready', () => {
         },
         on: {
           'navigate-to-problem': (request: ActiveProblem) => {
-            const problemAliasStored = problemsStore.state.sortedAliases.find(
-              (alias: string) => alias === request.problem.alias,
-            );
-            if (typeof problemAliasStored !== 'undefined') {
+            if (
+              Object.prototype.hasOwnProperty.call(
+                problemsStore.state.problems,
+                request.problem.alias,
+              )
+            ) {
               contestPractice.problemInfo =
-                problemsStore.state.problems[problemAliasStored];
+                problemsStore.state.problems[request.problem.alias];
               window.location.hash = `#problems/${request.problem.alias}`;
               return;
             }

--- a/frontend/www/js/omegaup/arena/problemStore.ts
+++ b/frontend/www/js/omegaup/arena/problemStore.ts
@@ -1,19 +1,44 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import { types } from '../api_types';
 
 Vue.use(Vuex);
 
-interface ProblemState {
-  showOverlay: boolean;
+export interface ProblemState {
+  // The maping of problem alias to indices on the problems array
+  problems: types.ProblemInfo[];
+
+  index: Record<string, number>;
 }
 
-const problemStore = new Vuex.Store<ProblemState>({
-  state: { showOverlay: false },
+const problemsStore = new Vuex.Store<ProblemState>({
+  state: {
+    problems: [],
+    index: {},
+  },
   mutations: {
-    toggleOverlay(state, showOverlay: boolean) {
-      state.showOverlay = !showOverlay;
+    addProblem(state, problem: types.ProblemInfo) {
+      if (Object.prototype.hasOwnProperty.call(state.index, problem.alias)) {
+        Vue.set(
+          state.problems,
+          state.index[problem.alias],
+          Object.assign(
+            {},
+            state.problems[state.index[problem.alias]],
+            problem,
+          ),
+        );
+        return;
+      }
+      Vue.set(state.index, problem.alias, state.problems.length);
+      state.problems.push(problem);
+    },
+    // Just in case be necessary delete the list of problems
+    clear(state) {
+      state.problems.splice(0);
+      state.index = {};
     },
   },
 });
 
-export default problemStore;
+export default problemsStore;

--- a/frontend/www/js/omegaup/arena/problemStore.ts
+++ b/frontend/www/js/omegaup/arena/problemStore.ts
@@ -7,14 +7,11 @@ Vue.use(Vuex);
 export interface ProblemState {
   // The mapping of problem alias to indices on the problems array
   problems: Record<string, types.ProblemInfo>;
-
-  sortedAliases: string[];
 }
 
 const problemsStore = new Vuex.Store<ProblemState>({
   state: {
     problems: {},
-    sortedAliases: [],
   },
   mutations: {
     addProblem(state, problem: types.ProblemInfo) {
@@ -22,8 +19,6 @@ const problemsStore = new Vuex.Store<ProblemState>({
         return;
       }
       Vue.set(state.problems, problem.alias, problem);
-      state.sortedAliases.push(problem.alias);
-      state.sortedAliases = state.sortedAliases.sort();
     },
   },
 });

--- a/frontend/www/js/omegaup/arena/problemStore.ts
+++ b/frontend/www/js/omegaup/arena/problemStore.ts
@@ -5,7 +5,7 @@ import { types } from '../api_types';
 Vue.use(Vuex);
 
 export interface ProblemState {
-  // The maping of problem alias to indices on the problems array
+  // The mapping of problem alias to indices on the problems array
   problems: types.ProblemInfo[];
 
   index: Record<string, number>;

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -105,12 +105,12 @@
         </template>
         <omegaup-overlay
           v-if="user.loggedIn"
-          :show-overlay="popupDisplayed !== PopupDisplayed.None"
+          :show-overlay="currentPopupDisplayed !== PopupDisplayed.None"
           @hide-overlay="onPopupDismissed"
         >
           <template #popup>
             <omegaup-arena-runsubmit-popup
-              v-show="popupDisplayed === PopupDisplayed.RunSubmit"
+              v-show="currentPopupDisplayed === PopupDisplayed.RunSubmit"
               :preferred-language="problem.preferred_language"
               :languages="problem.languages"
               @dismiss="onPopupDismissed"
@@ -120,12 +120,12 @@
               "
             ></omegaup-arena-runsubmit-popup>
             <omegaup-arena-rundetails-popup
-              v-show="popupDisplayed === PopupDisplayed.RunDetails"
+              v-show="currentPopupDisplayed === PopupDisplayed.RunDetails"
               :data="currentRunDetailsData"
               @dismiss="onPopupDismissed"
             ></omegaup-arena-rundetails-popup>
             <omegaup-quality-nomination-promotion-popup
-              v-show="popupDisplayed === PopupDisplayed.Promotion"
+              v-show="currentPopupDisplayed === PopupDisplayed.Promotion"
               :solved="nominationStatus && nominationStatus.solved"
               :tried="nominationStatus && nominationStatus.tried"
               @submit="
@@ -141,15 +141,15 @@
               "
             ></omegaup-quality-nomination-promotion-popup>
             <omegaup-quality-nomination-demotion-popup
-              v-show="popupDisplayed === PopupDisplayed.Demotion"
-              @dismiss="popupDisplayed = PopupDisplayed.None"
+              v-show="currentPopupDisplayed === PopupDisplayed.Demotion"
+              @dismiss="currentPopupDisplayed = PopupDisplayed.None"
               @submit="
                 (qualityDemotionComponent) =>
                   $emit('submit-demotion', qualityDemotionComponent)
               "
             ></omegaup-quality-nomination-demotion-popup>
             <omegaup-quality-nomination-reviewer-popup
-              v-show="popupDisplayed === PopupDisplayed.Reviewer"
+              v-show="currentPopupDisplayed === PopupDisplayed.Reviewer"
               :allow-user-add-tags="allowUserAddTags"
               :level-tags="levelTags"
               :problem-level="problemLevel"
@@ -158,7 +158,7 @@
               :selected-private-tags="selectedPrivateTags"
               :problem-alias="problem.alias"
               :problem-title="problem.title"
-              @dismiss="popupDisplayed = PopupDisplayed.None"
+              @dismiss="currentPopupDisplayed = PopupDisplayed.None"
               @submit="
                 (tag, qualitySeal) => $emit('submit-reviewer', tag, qualitySeal)
               "
@@ -219,12 +219,12 @@
         ></omegaup-arena-runs>
         <omegaup-overlay
           v-if="user.loggedIn"
-          :show-overlay="popupDisplayed !== PopupDisplayed.None"
+          :show-overlay="currentPopupDisplayed !== PopupDisplayed.None"
           @hide-overlay="onPopupDismissed"
         >
           <template #popup>
             <omegaup-arena-rundetails-popup
-              v-show="popupDisplayed === PopupDisplayed.RunDetails"
+              v-show="currentPopupDisplayed === PopupDisplayed.RunDetails"
               :data="currentRunDetailsData"
               @dismiss="onPopupDismissed"
             ></omegaup-arena-rundetails-popup>
@@ -370,8 +370,7 @@ export default class ProblemDetails extends Vue {
   @Prop({ default: 0 }) availableTokens!: number;
   @Prop({ default: 0 }) allTokens!: number;
   @Prop() histogram!: types.Histogram;
-  @Prop({ default: PopupDisplayed.None })
-  initialPopupDisplayed!: PopupDisplayed;
+  @Prop({ default: PopupDisplayed.None }) popupDisplayed!: PopupDisplayed;
   @Prop() activeTab!: string;
   @Prop() allowUserAddTags!: boolean;
   @Prop() levelTags!: string[];
@@ -394,7 +393,7 @@ export default class ProblemDetails extends Vue {
   time = time;
   selectedTab = this.activeTab;
   clarifications = this.initialClarifications || [];
-  popupDisplayed = this.initialPopupDisplayed;
+  currentPopupDisplayed = this.popupDisplayed;
   hasUnreadClarifications =
     this.initialClarifications?.length > 0 &&
     this.activeTab !== 'clarifications';
@@ -468,12 +467,12 @@ export default class ProblemDetails extends Vue {
       this.$emit('redirect-login-page');
       return;
     }
-    this.popupDisplayed = PopupDisplayed.RunSubmit;
+    this.currentPopupDisplayed = PopupDisplayed.RunSubmit;
   }
 
   onRunDetails(guid: string): void {
     this.$emit('show-run', this, guid);
-    this.popupDisplayed = PopupDisplayed.RunDetails;
+    this.currentPopupDisplayed = PopupDisplayed.RunDetails;
   }
 
   onNewPromotion(): void {
@@ -481,19 +480,19 @@ export default class ProblemDetails extends Vue {
       this.$emit('redirect-login-page');
       return;
     }
-    this.popupDisplayed = PopupDisplayed.Promotion;
+    this.currentPopupDisplayed = PopupDisplayed.Promotion;
   }
 
   onNewPromotionAsReviewer(): void {
-    this.popupDisplayed = PopupDisplayed.Reviewer;
+    this.currentPopupDisplayed = PopupDisplayed.Reviewer;
   }
 
   onReportInappropriateProblem(): void {
-    this.popupDisplayed = PopupDisplayed.Demotion;
+    this.currentPopupDisplayed = PopupDisplayed.Demotion;
   }
 
   onPopupDismissed(): void {
-    this.popupDisplayed = PopupDisplayed.None;
+    this.currentPopupDisplayed = PopupDisplayed.None;
     this.$emit('update:activeTab', this.selectedTab);
   }
 
@@ -654,9 +653,9 @@ export default class ProblemDetails extends Vue {
     this.clarifications = newValue;
   }
 
-  @Watch('initialPopupDisplayed')
+  @Watch('popupDisplayed')
   onPopupDisplayedChanged(newValue: PopupDisplayed): void {
-    this.popupDisplayed = newValue;
+    this.currentPopupDisplayed = newValue;
     if (newValue === PopupDisplayed.None) return;
     if (newValue === PopupDisplayed.RunSubmit) {
       this.onNewSubmission();

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -26,7 +26,7 @@ OmegaUp.on('ready', () => {
     },
     data: () => ({
       initialClarifications: payload.clarifications,
-      initialPopupDisplayed: PopupDisplayed.None,
+      popupDisplayed: PopupDisplayed.None,
       runDetailsData: null as types.RunDetails | null,
       solutionStatus: payload.solutionStatus,
       solution: null as types.ProblemStatement | null,
@@ -56,7 +56,7 @@ OmegaUp.on('ready', () => {
           solution: this.solution,
           availableTokens: this.availableTokens,
           allTokens: this.allTokens,
-          initialPopupDisplayed: this.initialPopupDisplayed,
+          popupDisplayed: this.popupDisplayed,
           runDetailsData: this.runDetailsData,
           allowUserAddTags: payload.allowUserAddTags,
           levelTags: payload.levelTags,
@@ -129,7 +129,7 @@ OmegaUp.on('ready', () => {
               })
               .catch((error) => {
                 ui.apiError(error);
-                source.popupDisplayed = PopupDisplayed.None;
+                source.currentPopupDisplayed = PopupDisplayed.None;
               });
           },
           'apply-filter': (
@@ -466,12 +466,12 @@ OmegaUp.on('ready', () => {
     }, 5 * 60 * 1000);
   }
   if (locationHash.includes('new-run')) {
-    problemDetailsView.initialPopupDisplayed = PopupDisplayed.RunSubmit;
+    problemDetailsView.popupDisplayed = PopupDisplayed.RunSubmit;
   } else if (locationHash[1] && locationHash[1].includes('show-run:')) {
     const showRunRegex = /.*\/show-run:([a-fA-F0-9]+)/;
     const showRunMatch = window.location.hash.match(showRunRegex);
     problemDetailsView.guid = showRunMatch ? showRunMatch[1] : null;
-    problemDetailsView.initialPopupDisplayed = PopupDisplayed.RunDetails;
+    problemDetailsView.popupDisplayed = PopupDisplayed.RunDetails;
   } else if (
     (payload.nominationStatus?.solved || payload.nominationStatus?.tried) &&
     !(
@@ -486,6 +486,6 @@ OmegaUp.on('ready', () => {
     ) &&
     payload.nominationStatus?.canNominateProblem
   ) {
-    problemDetailsView.initialPopupDisplayed = PopupDisplayed.Promotion;
+    problemDetailsView.popupDisplayed = PopupDisplayed.Promotion;
   }
 });


### PR DESCRIPTION
# Descripción

Se agrega `problemsStore` en `vuex` para almacenar los detalles de los problemas
que ya se abrieron previamente en un concurso de práctica para que estos no 
vuelvan a mandar llamar la API de `problemDetails`.

![ProblemsStore](https://user-images.githubusercontent.com/3230352/108774908-e9b31700-7525-11eb-848b-f5325e58025e.gif)

Part of: #3485

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
