### PR TITLE
s/ForSmarty/ForTypeScript/g

### DIFF
--- a/frontend/server/src/Controllers/Badge.php
+++ b/frontend/server/src/Controllers/Badge.php
@@ -150,7 +150,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{smartyProperties: array{payload: BadgeListPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getBadgeListForSmarty(\OmegaUp\Request $r) {
+    public static function getBadgeListForTypeScript(\OmegaUp\Request $r) {
         $r->ensureIdentity();
         $badges = self::apiList($r);
         $ownedBadges = self::apiMyList($r);
@@ -171,7 +171,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $badge_alias
      */
-    public static function getDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getDetailsForTypeScript(\OmegaUp\Request $r) {
         $r->ensureIdentity();
         $badgeAlias = $r->ensureString(
             'badge_alias',

--- a/frontend/server/src/Controllers/Certificate.php
+++ b/frontend/server/src/Controllers/Certificate.php
@@ -13,7 +13,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $uuid
      */
-    public static function getDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getDetailsForTypeScript(\OmegaUp\Request $r) {
         return [
             'smartyProperties' => [
                 'payload' => [

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -501,7 +501,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $auth_token
      * @omegaup-request-param string $contest_alias
      */
-    public static function getContestDetailsForSmarty(
+    public static function getContestDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $contestAlias = $r->ensureString(
@@ -607,7 +607,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $contest_alias
      */
-    public static function getContestPracticeDetailsForSmarty(
+    public static function getContestPracticeDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $contestAlias = $r->ensureString(
@@ -693,7 +693,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page_size
      * @omegaup-request-param string $query
      */
-    public static function getContestListDetailsForSmarty(
+    public static function getContestListDetailsForTypeScript(
         \OmegaUp\Request $r
     ) {
         try {
@@ -798,7 +798,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page_size
      * @omegaup-request-param string $query
      */
-    public static function getContestListMineForSmarty(
+    public static function getContestListMineForTypeScript(
         \OmegaUp\Request $r
     ): array {
         // Authenticate user
@@ -849,7 +849,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{smartyProperties: array{payload: ContestNewPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getContestNewForSmarty(
+    public static function getContestNewForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -873,7 +873,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $contest_alias
      */
-    public static function getContestEditForSmarty(
+    public static function getContestEditForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -1628,7 +1628,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getActivityFeedDetailsForSmarty(
+    public static function getActivityFeedDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -4326,7 +4326,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param null|string $contest_alias
      */
-    public static function getStatsDataForSmarty(\OmegaUp\Request $r) {
+    public static function getStatsDataForTypeScript(\OmegaUp\Request $r) {
         // Get user
         $r->ensureIdentity();
         $contestAlias = $r->ensureString(
@@ -4497,7 +4497,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $contest_alias
      * @omegaup-request-param null|string $filterBy
      */
-    public static function getContestReportDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getContestReportDetailsForTypeScript(\OmegaUp\Request $r) {
         $contestReport = self::getContestReportDetails($r)['ranking'];
         foreach ($contestReport as &$user) {
             if (!isset($user['problems'])) {

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2779,14 +2779,14 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $assignment_alias
      * @omegaup-request-param string $course_alias
      */
-    public static function getCourseDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getCourseDetailsForTypeScript(\OmegaUp\Request $r): array {
         return self::getIntroDetails($r);
     }
 
     /**
      * @return array{entrypoint: string, smartyProperties: array{title: string}}
      */
-    public static function getCoursesHomepageForSmarty(\OmegaUp\Request $r): array {
+    public static function getCoursesHomepageForTypeScript(\OmegaUp\Request $r): array {
         return [
             'smartyProperties' => [
                 'title' => new \OmegaUp\TranslationString(
@@ -2803,7 +2803,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $course_alias
      * @omegaup-request-param string $token
      */
-    public static function getCourseCloneDetailsForSmarty(
+    public static function getCourseCloneDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -2847,7 +2847,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $course_alias
      * @omegaup-request-param bool|null $is_practice
      */
-    public static function getCourseAdminDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getCourseAdminDetailsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
 
         $isPractice = $r->ensureOptionalBool('is_practice') ?? false;
@@ -2895,7 +2895,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @return array{entrypoint: string, smartyProperties: array{payload: CourseNewPayload, title:\OmegaUp\TranslationString}}
      */
-    public static function getCourseNewDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getCourseNewDetailsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
 
         return [
@@ -2920,7 +2920,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $course
      */
-    public static function getCourseEditDetailsForSmarty(
+    public static function getCourseEditDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -2999,7 +2999,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $course
      */
-    public static function getCourseSubmissionsListForSmarty(\OmegaUp\Request $r) {
+    public static function getCourseSubmissionsListForTypeScript(\OmegaUp\Request $r) {
         $r->ensureMainUserIdentity();
         $courseAlias = $r->ensureString(
             'course',
@@ -3047,7 +3047,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page
      * @omegaup-request-param string $course
      */
-    public static function getStudentsProgressForSmarty(
+    public static function getStudentsProgressForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureIdentity();
@@ -3119,7 +3119,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $course
      * @omegaup-request-param string $student
      */
-    public static function getStudentProgressForSmarty(
+    public static function getStudentProgressForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureIdentity();
@@ -3179,7 +3179,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @return array{entrypoint: string, smartyProperties: array{payload: CourseListMinePayload, title: \OmegaUp\TranslationString}}
      */
-    public static function getCourseMineDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getCourseMineDetailsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
         $page = $r->ensureOptionalInt('page') ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
@@ -3252,7 +3252,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @return array{entrypoint: string, smartyProperties: array{payload: CourseListPayload, title: \OmegaUp\TranslationString}}
      */
-    public static function getCourseListDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getCourseListDetailsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
         $r->ensureOptionalInt('page');
         $r->ensureOptionalInt('page_size');
@@ -3292,7 +3292,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @return array{entrypoint: string, smartyProperties: array{payload: CourseListPayload, title: \OmegaUp\TranslationString}}
      */
-    public static function getCourseSummaryListDetailsForSmarty(
+    public static function getCourseSummaryListDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $coursesTypes = ['student', 'public'];
@@ -3375,7 +3375,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $course
      */
-    public static function getCourseStatisticsForSmarty(
+    public static function getCourseStatisticsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureIdentity();
@@ -3425,7 +3425,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getActivityFeedDetailsForSmarty(
+    public static function getActivityFeedDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();

--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -428,7 +428,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $group
      */
-    public static function getGroupEditDetailsForSmarty(
+    public static function getGroupEditDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         // Authenticate user
@@ -499,7 +499,7 @@ class Group extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{smartyProperties: array{payload: GroupListPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getGroupListForSmarty(\OmegaUp\Request $r): array {
+    public static function getGroupListForTypeScript(\OmegaUp\Request $r): array {
         // Authenticate user
         $r->ensureMainUserIdentity();
 
@@ -525,7 +525,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      *
      * @return array{smartyProperties: array{payload: GroupScoreboardContestsPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getGroupScoreboardEditForSmarty(
+    public static function getGroupScoreboardEditForTypeScript(
         \OmegaUp\Request $r
     ): array {
         // Authenticate user

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3445,7 +3445,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $problem_alias
      */
-    public static function getStatsDataForSmarty(\OmegaUp\Request $r) {
+    public static function getStatsDataForTypeScript(\OmegaUp\Request $r) {
         // Get user
         $r->ensureIdentity();
 
@@ -4279,7 +4279,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{smartyProperties: array{payload: ProblemsMineInfoPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getProblemsMineInfoForSmarty(\OmegaUp\Request $r): array {
+    public static function getProblemsMineInfoForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();
 
         $privateProblemsAlert = false;
@@ -4330,7 +4330,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $problemset_id
      * @omegaup-request-param null|string $statement_type
      */
-    public static function getProblemDetailsForSmarty(
+    public static function getProblemDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         try {
@@ -4589,7 +4589,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
      */
-    public static function getProblemListForSmarty(
+    public static function getProblemListForTypeScript(
         \OmegaUp\Request $r
     ): array {
         // Authenticate request
@@ -4670,7 +4670,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{smartyProperties: array{payload: ProblemListCollectionPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getProblemCollectionDetailsForSmarty(
+    public static function getProblemCollectionDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $tags = [];
@@ -4712,7 +4712,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{validLanguages: array<string, string>, validatorTypes: array<string, null|string>, visibilityStatuses: array<string, int>}
      */
-    public static function getCommonPayloadForSmarty(): array {
+    public static function getCommonPayloadForTypeScript(): array {
         $validatorTypes = [
             \OmegaUp\ProblemParams::VALIDATOR_TOKEN_CASELESS => \OmegaUp\Translations::getInstance()->get(
                 'problemEditFormTokenCaseless'
@@ -4792,7 +4792,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $validator_time_limit
      * @omegaup-request-param null|string $visibility
      */
-    public static function getProblemEditDetailsForSmarty(
+    public static function getProblemEditDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -4863,7 +4863,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'smartyProperties' => [
                 'payload' => array_merge(
                     $details,
-                    self::getCommonPayloadForSmarty(),
+                    self::getCommonPayloadForTypeScript(),
                     $extraInfo
                 ),
                 'title' => new \OmegaUp\TranslationString(
@@ -4897,7 +4897,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $details = self::getProblemEditDetails($problem, $r->identity);
                 $result['smartyProperties']['payload'] = array_merge(
                     $details,
-                    self::getCommonPayloadForSmarty()
+                    self::getCommonPayloadForTypeScript()
                 );
                 $result['smartyProperties']['payload'] = array_merge(
                     $extraInfo,
@@ -5048,7 +5048,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $validator_time_limit
      * @omegaup-request-param null|string $visibility
      */
-    public static function getProblemNewForSmarty(
+    public static function getProblemNewForTypeScript(
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
@@ -5155,7 +5155,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                                 'publicTags' => \OmegaUp\Controllers\Tag::getPublicTags(),
                                 'levelTags' => \OmegaUp\Controllers\Tag::getLevelTags(),
                             ],
-                            self::getCommonPayloadForSmarty()
+                            self::getCommonPayloadForTypeScript()
                         ),
                         'title' => new \OmegaUp\TranslationString(
                             'omegaupTitleProblemNew'
@@ -5199,7 +5199,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                         'publicTags' => \OmegaUp\Controllers\Tag::getPublicTags(),
                         'levelTags' => \OmegaUp\Controllers\Tag::getLevelTags(),
                     ],
-                    self::getCommonPayloadForSmarty()
+                    self::getCommonPayloadForTypeScript()
                 ),
                 'title' => new \OmegaUp\TranslationString(
                     'omegaupTitleProblemNew'
@@ -5567,7 +5567,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $name
      * @omegaup-request-param mixed $os
      */
-    public static function getLibinteractiveGenForSmarty(\OmegaUp\Request $r): array {
+    public static function getLibinteractiveGenForTypeScript(\OmegaUp\Request $r): array {
         if (count($r) === 0) {
             // \OmegaUp\Request does not support empty().
             return [
@@ -5733,7 +5733,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
      */
-    public static function getCollectionsDetailsByLevelForSmarty(\OmegaUp\Request $r): array {
+    public static function getCollectionsDetailsByLevelForTypeScript(\OmegaUp\Request $r): array {
         $collectionLevel = $r->ensureString('level');
 
         $frequentTags = [];
@@ -5960,7 +5960,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $some_tags
      * @omegaup-request-param mixed $sort_order
      */
-    public static function getCollectionsDetailsByAuthorForSmarty(\OmegaUp\Request $r): array {
+    public static function getCollectionsDetailsByAuthorForTypeScript(\OmegaUp\Request $r): array {
         $problems = [];
         $authorsRanking = [];
 

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -1252,7 +1252,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param int $qualitynomination_id
      */
-    public static function getDetailsForSmarty(
+    public static function getDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
@@ -1285,7 +1285,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $length
      * @omegaup-request-param int $page
      */
-    public static function getListForSmarty(\OmegaUp\Request $r): array {
+    public static function getListForTypeScript(\OmegaUp\Request $r): array {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
 
         $r->ensureMainUserIdentity();
@@ -1324,7 +1324,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $length
      * @omegaup-request-param int $page
      */
-    public static function getMyListForSmarty(\OmegaUp\Request $r): array {
+    public static function getMyListForTypeScript(\OmegaUp\Request $r): array {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
 
         $r->ensureMainUserIdentity();

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -61,7 +61,7 @@ class School extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param int $school_id
      */
-    public static function getSchoolProfileDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getSchoolProfileDetailsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureInt('school_id');
         $school = \OmegaUp\DAO\Schools::getByPK(intval($r['school_id']));
 
@@ -273,7 +273,7 @@ class School extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $length
      * @omegaup-request-param int $page
      */
-    public static function getRankForSmarty(\OmegaUp\Request $r): array {
+    public static function getRankForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureOptionalInt('page');
         $r->ensureOptionalInt('length');
 
@@ -317,7 +317,7 @@ class School extends \OmegaUp\Controllers\Controller {
      * of School of the Month
      * @return array{smartyProperties: array{payload: SchoolOfTheMonthPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getSchoolOfTheMonthDetailsForSmarty(\OmegaUp\Request $r): array {
+    public static function getSchoolOfTheMonthDetailsForTypeScript(\OmegaUp\Request $r): array {
         try {
             $r->ensureIdentity();
             $identity = $r->identity;

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -22,7 +22,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $length
      * @omegaup-request-param int $page
      */
-    public static function getLatestSubmissionsForSmarty(\OmegaUp\Request $r): array {
+    public static function getLatestSubmissionsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureOptionalInt('page');
         $r->ensureOptionalInt('length');
 
@@ -69,7 +69,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page
      * @omegaup-request-param mixed $username
      */
-    public static function getLatestUserSubmissionsForSmarty(\OmegaUp\Request $r): array {
+    public static function getLatestUserSubmissionsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureOptionalInt('page');
         $r->ensureOptionalInt('length');
 

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2570,7 +2570,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getAuthorRankForSmarty(\OmegaUp\Request $r) {
+    public static function getAuthorRankForTypeScript(\OmegaUp\Request $r) {
         $page = $r->ensureOptionalInt('page') ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
 
@@ -3425,7 +3425,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $length
      * @omegaup-request-param int $page
      */
-    public static function getRankForSmarty(\OmegaUp\Request $r) {
+    public static function getRankForTypeScript(\OmegaUp\Request $r) {
         $r->ensureOptionalInt('page');
         $r->ensureOptionalInt('length');
         \OmegaUp\Validators::validateOptionalInEnum(
@@ -3524,7 +3524,7 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * @return array{entrypoint: string, smartyProperties: array{fullWidth: bool, payload: IndexPayload, title: \OmegaUp\TranslationString}}
      */
-    public static function getIndexDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getIndexDetailsForTypeScript(\OmegaUp\Request $r) {
         try {
             $r->ensureIdentity();
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
@@ -3594,7 +3594,7 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * @return array{smartyProperties: array{payload: CoderOfTheMonthPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
      */
-    public static function getCoderOfTheMonthDetailsForSmarty(
+    public static function getCoderOfTheMonthDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
         try {
@@ -3707,7 +3707,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $token
      * @omegaup-request-param mixed $username
      */
-    public static function getProfileDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getProfileDetailsForTypeScript(\OmegaUp\Request $r) {
         self::authenticateOrAllowUnauthenticatedRequest($r);
         $identity = self::resolveTargetIdentity($r);
         if (is_null($identity)) {
@@ -3769,7 +3769,7 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * @return array{smartyProperties: array{STATUS_ERROR: string}|array{COUNTRIES: list<\OmegaUp\DAO\VO\Countries>, PROGRAMMING_LANGUAGES: array<string, string>, profile: UserProfileInfo}, template: string}
      */
-    public static function getProfileEditDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getProfileEditDetailsForTypeScript(\OmegaUp\Request $r) {
         try {
             self::authenticateOrAllowUnauthenticatedRequest($r);
 
@@ -3811,7 +3811,7 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * @return array{smartyProperties: array{STATUS_ERROR?: string, payload?: array{email: null|string}, profile?: UserProfileInfo}, template: string}
      */
-    public static function getEmailEditDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getEmailEditDetailsForTypeScript(\OmegaUp\Request $r) {
         $currentSession = \OmegaUp\Controllers\Session::getCurrentSession();
 
         try {
@@ -3850,7 +3850,7 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * @return array{smartyProperties: array{STATUS_ERROR?: string, admin?: true, practice?: false, profile?: UserProfileInfo}, template: string}
      */
-    public static function getInterviewResultsDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getInterviewResultsDetailsForTypeScript(\OmegaUp\Request $r) {
         try {
             self::authenticateOrAllowUnauthenticatedRequest($r);
 
@@ -3951,7 +3951,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $state
      * @omegaup-request-param string $third_party_login
      */
-    public static function getLoginDetailsForSmarty(\OmegaUp\Request $r) {
+    public static function getLoginDetailsForTypeScript(\OmegaUp\Request $r) {
         $thirdPartyLogin = $r->ensureOptionalString('third_party_login');
         if ($r->offsetExists('linkedin')) {
             $thirdPartyLogin = 'linkedin';

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -342,7 +342,7 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
             )
         );
 
-        $smartyResult = \OmegaUp\Controllers\Badge::getDetailsForSmarty(new \OmegaUp\Request([
+        $smartyResult = \OmegaUp\Controllers\Badge::getDetailsForTypeScript(new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
             'badge_alias' => 'problemSetter'
         ]));

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -451,9 +451,9 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * @dataProvider coderOfTheMonthCategoryProvider
      */
-    public function testCoderOfTheMonthDetailsForSmarty(string $category) {
+    public function testCoderOfTheMonthDetailsForTypeScript(string $category) {
         // Test coder of the month details when user is not logged
-        $response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForSmarty(
+        $response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForTypeScript(
             new \OmegaUp\Request(['category' => $category])
         )['smartyProperties'];
         $this->assertArrayHasKey('payload', $response);
@@ -469,7 +469,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             'identity' => $identity,
         ] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
-        $response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForSmarty(
+        $response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'category' => $category,
@@ -487,7 +487,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             'identity' => $mentorIdentity,
         ] = \OmegaUp\Test\Factories\User::createMentorIdentity();
         $login = self::login($mentorIdentity);
-        $response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForSmarty(
+        $response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'category' => $category,

--- a/frontend/tests/controllers/CollectionListTest.php
+++ b/frontend/tests/controllers/CollectionListTest.php
@@ -185,8 +185,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
 
-        // Call getCollectionsDetailsByLevelForSmarty with a level tag collection type
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with a level tag collection type
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -207,8 +207,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with an author collection type
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript with an author collection type
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
             ])
@@ -291,8 +291,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
 
-        // Call getCollectionsDetailsByLevelForSmarty with easy difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with easy difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -302,8 +302,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(2, $result);
 
-        // Call getCollectionsDetailsByLevelForSmarty with medium difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with medium difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -313,8 +313,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(1, $result);
 
-        // Call getCollectionsDetailsByLevelForSmarty with hard difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with hard difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -324,8 +324,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(1, $result);
 
-        // Call getCollectionsDetailsByLevelForSmarty with all difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with all difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -335,8 +335,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(4, $result);
 
-        // Call getCollectionsDetailsByLevelForSmarty without difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript without difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming'
@@ -345,8 +345,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(4, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with easy difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript with easy difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'difficulty' => 'easy'
@@ -355,8 +355,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(2, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with medium difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript with medium difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'difficulty' => 'medium'
@@ -365,8 +365,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(1, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with hard difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript with hard difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'difficulty' => 'hard'
@@ -375,8 +375,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(1, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with all difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript with all difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'difficulty' => 'all'
@@ -385,8 +385,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(4, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty without difficulty parameter
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript without difficulty parameter
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token
             ])
@@ -444,8 +444,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
 
-        // Call getCollectionsDetailsByLevelForSmarty
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -459,8 +459,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals('problem_2', $result[2]['alias']);
         $this->assertEquals('problem_3', $result[3]['alias']);
 
-        // Call getCollectionsDetailsByLevelForSmarty with 2 as rowcount and 1 as page
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with 2 as rowcount and 1 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -474,8 +474,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals('problem_0', $result[0]['alias']);
         $this->assertEquals('problem_1', $result[1]['alias']);
 
-        // Call getCollectionsDetailsByLevelForSmarty with 2 as rowcount and 2 as page
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        // Call getCollectionsDetailsByLevelForTypeScript with 2 as rowcount and 2 as page
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -500,8 +500,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
 
-        // Call getCollectionsDetailsByAuthorForSmarty
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
             ])
@@ -509,8 +509,8 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(8, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with a username of an author
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        // Call getCollectionsDetailsByAuthorForTypeScript with a username of an author
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'author' => 'author_0'
@@ -519,9 +519,9 @@ class CollectionListTest extends \OmegaUp\Test\ControllerTestCase {
 
         $this->assertCount(2, $result);
 
-        // Call getCollectionsDetailsByAuthorForSmarty with a username of an author, 1 as rowcount
+        // Call getCollectionsDetailsByAuthorForTypeScript with a username of an author, 1 as rowcount
         // and 2 as page
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'author' => 'author_0',

--- a/frontend/tests/controllers/ContestUsersTest.php
+++ b/frontend/tests/controllers/ContestUsersTest.php
@@ -127,7 +127,7 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
                 $contestData['contest']
             )
         );
-        $contestDetails = \OmegaUp\Controllers\Contest::getContestDetailsForSmarty(
+        $contestDetails = \OmegaUp\Controllers\Contest::getContestDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $userLogin->auth_token,
                 'contest_alias' => $contestData['request']['alias'],
@@ -165,7 +165,7 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
                 $contestData['contest']
             )
         );
-        $contestDetails = \OmegaUp\Controllers\Contest::getContestDetailsForSmarty(
+        $contestDetails = \OmegaUp\Controllers\Contest::getContestDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $userLogin->auth_token,
                 'contest_alias' => $contestData['request']['alias'],
@@ -273,7 +273,7 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Contest needs basic information for the user
-        $contestDetails = \OmegaUp\Controllers\Contest::getContestDetailsForSmarty(
+        $contestDetails = \OmegaUp\Controllers\Contest::getContestDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $userLogin->auth_token,
                 'contest_alias' => $contestData['request']['alias'],

--- a/frontend/tests/controllers/CourseAssignmentsTest.php
+++ b/frontend/tests/controllers/CourseAssignmentsTest.php
@@ -137,7 +137,7 @@ class CourseAssignmentsTest extends \OmegaUp\Test\ControllerTestCase {
             ])
         );
 
-        $details = \OmegaUp\Controllers\Course::getCourseAdminDetailsForSmarty(
+        $details = \OmegaUp\Controllers\Course::getCourseAdminDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $adminLogin->auth_token,
                 'course_alias' => $courseData['course_alias'],
@@ -164,7 +164,7 @@ class CourseAssignmentsTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Student tries to access into the course in admin mode
         try {
-            \OmegaUp\Controllers\Course::getCourseAdminDetailsForSmarty(
+            \OmegaUp\Controllers\Course::getCourseAdminDetailsForTypeScript(
                 new \OmegaUp\Request([
                     'auth_token' => $userLogin->auth_token,
                     'course_alias' => $courseData['course_alias'],
@@ -190,7 +190,7 @@ class CourseAssignmentsTest extends \OmegaUp\Test\ControllerTestCase {
         $addedAdminLogin = self::login($identity);
 
         // Now, user is able to access into a course in admin mode
-        $details = \OmegaUp\Controllers\Course::getCourseAdminDetailsForSmarty(
+        $details = \OmegaUp\Controllers\Course::getCourseAdminDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $addedAdminLogin->auth_token,
                 'course_alias' => $courseData['course_alias'],

--- a/frontend/tests/controllers/CourseListTest.php
+++ b/frontend/tests/controllers/CourseListTest.php
@@ -98,7 +98,7 @@ class CourseListTest extends \OmegaUp\Test\ControllerTestCase {
     public function testListCoursesMine() {
         $adminLogin = self::login($this->adminUser);
 
-        $archivedCourses = \OmegaUp\Controllers\Course::getCourseMineDetailsForSmarty(
+        $archivedCourses = \OmegaUp\Controllers\Course::getCourseMineDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $adminLogin->auth_token,
             ])
@@ -133,7 +133,7 @@ class CourseListTest extends \OmegaUp\Test\ControllerTestCase {
         );
     }
 
-    public function testGetCourseListForSmarty() {
+    public function testGetCourseListForTypeScript() {
         $userLogin = self::login($this->identity);
 
         // Public courses are visible in student courses list when users were
@@ -163,7 +163,7 @@ class CourseListTest extends \OmegaUp\Test\ControllerTestCase {
         int $numberOfStudentCourses,
         int $numberOfPublicCourses
     ) {
-        $response = \OmegaUp\Controllers\Course::getCourseSummaryListDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Course::getCourseSummaryListDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $userLogin->auth_token,
             ])

--- a/frontend/tests/controllers/CourseRegistrationTest.php
+++ b/frontend/tests/controllers/CourseRegistrationTest.php
@@ -362,7 +362,7 @@ class CourseRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         // Invited users can join the course , they don't need to requset access
         $invitedLogin = self::login($invited);
 
-        $response = \OmegaUp\Controllers\Course::getCourseDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $invitedLogin->auth_token,
                 'course_alias' => $courseData['course_alias'],
@@ -386,7 +386,7 @@ class CourseRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         // The second one needs request access to join the course
         $uninvitedLogin = self::login($uninvited);
 
-        $response = \OmegaUp\Controllers\Course::getCourseDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $invitedLogin->auth_token,
                 'course_alias' => $courseData['course_alias'],

--- a/frontend/tests/controllers/CourseUsersTest.php
+++ b/frontend/tests/controllers/CourseUsersTest.php
@@ -61,7 +61,7 @@ class CourseUsersTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($identity);
 
         try {
-            \OmegaUp\Controllers\Course::getCourseDetailsForSmarty(
+            \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
                 new \OmegaUp\Request([
                     'auth_token' => $login->auth_token,
                     'course_alias' => $courseData['course_alias'],
@@ -91,7 +91,7 @@ class CourseUsersTest extends \OmegaUp\Test\ControllerTestCase {
         // User login
         $login = self::login($identity);
 
-        $response = \OmegaUp\Controllers\Course::getCourseDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'course_alias' => $courseData['course_alias'],
@@ -123,7 +123,7 @@ class CourseUsersTest extends \OmegaUp\Test\ControllerTestCase {
         // User login
         $login = self::login($identity);
 
-        $response = \OmegaUp\Controllers\Course::getCourseDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'course_alias' => $courseData['course_alias'],

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -606,7 +606,7 @@ if __name__ == \'__main__\':
 
         $problemsCount = [];
         $total = 0;
-        $response = \OmegaUp\Controllers\Problem::getProblemCollectionDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Problem::getProblemCollectionDetailsForTypeScript(
             new \OmegaUp\Request([])
         )['smartyProperties']['payload'];
         foreach ($response['problemCount'] as $levelTag) {

--- a/frontend/tests/controllers/ProblemExtraInformationTest.php
+++ b/frontend/tests/controllers/ProblemExtraInformationTest.php
@@ -21,7 +21,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
         $r = new \OmegaUp\Request([
             'problem_alias' => $problemData['request']['problem_alias'],
         ]);
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             $r
         )['smartyProperties'];
 
@@ -36,7 +36,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
         ] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
         $r['auth_token'] = $login->auth_token;
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             $r
         )['smartyProperties'];
 
@@ -54,7 +54,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
 
         $login = self::login($identity);
 
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -75,7 +75,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
         );
         \OmegaUp\Test\Factories\Run::gradeRun($runData, 0, 'WA', 60);
         $login = self::login($identity);
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -98,7 +98,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
                 'contents' => json_encode(['before_ac' => true]),
             ])
         );
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -128,7 +128,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
                 'contents' => json_encode([]),
             ])
         );
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -151,7 +151,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
                 ]),
             ])
         );
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -176,7 +176,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Problem author should get the problem as unlocked
         $login = self::login($problemData['author']);
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -193,7 +193,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
             'identity' => $identity,
         ] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,
@@ -210,7 +210,7 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
                 'zipName' => OMEGAUP_TEST_RESOURCES_ROOT . 'imagetest.zip',
             ])
         );
-        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
             new \OmegaUp\Request([
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'auth_token' => $login->auth_token,

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1188,7 +1188,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         $problems = [];
         $requestParams = [];
         for ($i = 1; $i <= $pages; $i++) {
-            $response = \OmegaUp\Controllers\Problem::getProblemListForSmarty(
+            $response = \OmegaUp\Controllers\Problem::getProblemListForTypeScript(
                 new \OmegaUp\Request([
                     'auth_token' => $login->auth_token,
                     'rowcount' => 1000,
@@ -1294,7 +1294,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertTrue($response['results'][1]['quality_seal']);
         $this->assertTrue($response['results'][2]['quality_seal']);
 
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicIntroductionToProgramming',
@@ -1308,7 +1308,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
             );
         }
 
-        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+        $result = \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'level' => 'problemLevelBasicKarel',

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -2087,7 +2087,7 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
         // Login API
         $login = self::login($problemData['author']);
 
-        $response = \OmegaUp\Controllers\Problem::getProblemEditDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Problem::getProblemEditDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'problem' => $problemData['request']['problem_alias'],
@@ -2109,7 +2109,7 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
         ]);
 
         // Updating more than one statement at the same time
-        $response = \OmegaUp\Controllers\Problem::getProblemEditDetailsForSmarty(
+        $response = \OmegaUp\Controllers\Problem::getProblemEditDetailsForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
                 'problem' => $problemData['request']['problem_alias'],

--- a/frontend/tests/controllers/UserRankTest.php
+++ b/frontend/tests/controllers/UserRankTest.php
@@ -191,7 +191,7 @@ class UserRankTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\Test\Factories\Run::gradeRun($runDataContestantWithNoCountry);
 
         // User should not have filters
-        $availableFilters = \OmegaUp\Controllers\User::getRankForSmarty(
+        $availableFilters = \OmegaUp\Controllers\User::getRankForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
             ])
@@ -226,7 +226,7 @@ class UserRankTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\Test\Utils::runUpdateRanks();
 
         // Getting available filters from identities
-        $availableFilters = \OmegaUp\Controllers\User::getRankForSmarty(
+        $availableFilters = \OmegaUp\Controllers\User::getRankForTypeScript(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
             ])

--- a/frontend/www/arena/contest.php
+++ b/frontend/www/arena/contest.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/arena/courseadmin.php
+++ b/frontend/www/arena/courseadmin.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseAdminDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseAdminDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/arena/index.php
+++ b/frontend/www/arena/index.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestListDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestListDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/arena/problem.php
+++ b/frontend/www/arena/problem.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/badge.php
+++ b/frontend/www/badge.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Badge::getDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Badge::getDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/badge/list.php
+++ b/frontend/www/badge/list.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Badge::getBadgeListForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Badge::getBadgeListForTypeScript(
         $r
     )
 );

--- a/frontend/www/certificate/details.php
+++ b/frontend/www/certificate/details.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Certificate::getDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Certificate::getDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/coderofthemonth.php
+++ b/frontend/www/coderofthemonth.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 1) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/contests/activity.php
+++ b/frontend/www/contests/activity.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getActivityFeedDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getActivityFeedDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/contests/edit.php
+++ b/frontend/www/contests/edit.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestEditForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestEditForTypeScript(
         $r
     )
 );

--- a/frontend/www/contests/mine.php
+++ b/frontend/www/contests/mine.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestListMineForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestListMineForTypeScript(
         $r
     )
 );

--- a/frontend/www/contests/new.php
+++ b/frontend/www/contests/new.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestNewForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getContestNewForTypeScript(
         $r
     )
 );

--- a/frontend/www/contests/report.php
+++ b/frontend/www/contests/report.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 try {
-    $result = \OmegaUp\Controllers\Contest::getContestReportDetailsForSmarty(
+    $result = \OmegaUp\Controllers\Contest::getContestReportDetailsForTypeScript(
         new \OmegaUp\Request($_REQUEST)
     );
 } catch (\Exception $e) {

--- a/frontend/www/contests/stats.php
+++ b/frontend/www/contests/stats.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getStatsDataForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Contest::getStatsDataForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/activity.php
+++ b/frontend/www/course/activity.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getActivityFeedDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getActivityFeedDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/assignment.php
+++ b/frontend/www/course/assignment.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/clone.php
+++ b/frontend/www/course/clone.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseCloneDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseCloneDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/edit.php
+++ b/frontend/www/course/edit.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseEditDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseEditDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/home.php
+++ b/frontend/www/course/home.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCoursesHomepageForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCoursesHomepageForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/list.php
+++ b/frontend/www/course/list.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseSummaryListDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseSummaryListDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/mine.php
+++ b/frontend/www/course/mine.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseMineDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseMineDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/new.php
+++ b/frontend/www/course/new.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseNewDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseNewDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/singlelist.php
+++ b/frontend/www/course/singlelist.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseListDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseListDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/statistics.php
+++ b/frontend/www/course/statistics.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
     function (\OmegaUp\Request $r): array {
-        return \OmegaUp\Controllers\Course::getCourseStatisticsForSmarty(
+        return \OmegaUp\Controllers\Course::getCourseStatisticsForTypeScript(
             $r
         );
     }

--- a/frontend/www/course/student.php
+++ b/frontend/www/course/student.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getStudentProgressForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getStudentProgressForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/students.php
+++ b/frontend/www/course/students.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getStudentsProgressForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getStudentsProgressForTypeScript(
         $r
     )
 );

--- a/frontend/www/course/submissionslist.php
+++ b/frontend/www/course/submissionslist.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseSubmissionsListForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Course::getCourseSubmissionsListForTypeScript(
         $r
     )
 );

--- a/frontend/www/group/edit.php
+++ b/frontend/www/group/edit.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Group::getGroupEditDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Group::getGroupEditDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/group/list.php
+++ b/frontend/www/group/list.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Group::getGroupListForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Group::getGroupListForTypeScript(
         $r
     )
 );

--- a/frontend/www/group/scoreboardedit.php
+++ b/frontend/www/group/scoreboardedit.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Group::getGroupScoreboardEditForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Group::getGroupScoreboardEditForTypeScript(
         $r
     )
 );

--- a/frontend/www/index.php
+++ b/frontend/www/index.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getIndexDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getIndexDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/interviews/results.php
+++ b/frontend/www/interviews/results.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getInterviewResultsDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getInterviewResultsDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/libinteractive/gen/index.php
+++ b/frontend/www/libinteractive/gen/index.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getLibinteractiveGenForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getLibinteractiveGenForTypeScript(
         $r
     )
 );

--- a/frontend/www/login.php
+++ b/frontend/www/login.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 1) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getLoginDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getLoginDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/collection.php
+++ b/frontend/www/problems/collection.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemCollectionDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemCollectionDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/collection_details_by_author.php
+++ b/frontend/www/problems/collection_details_by_author.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getCollectionsDetailsByAuthorForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/collection_details_by_level.php
+++ b/frontend/www/problems/collection_details_by_level.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getCollectionsDetailsByLevelForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/edit.php
+++ b/frontend/www/problems/edit.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemEditDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemEditDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/list.php
+++ b/frontend/www/problems/list.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemListForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemListForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/mine.php
+++ b/frontend/www/problems/mine.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemsMineInfoForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemsMineInfoForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/new.php
+++ b/frontend/www/problems/new.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemNewForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getProblemNewForTypeScript(
         $r
     )
 );

--- a/frontend/www/problems/stats.php
+++ b/frontend/www/problems/stats.php
@@ -7,7 +7,7 @@ if (OMEGAUP_LOCKDOWN) {
 }
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getStatsDataForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getStatsDataForTypeScript(
         $r
     )
 );

--- a/frontend/www/profile/edit.php
+++ b/frontend/www/profile/edit.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getProfileEditDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getProfileEditDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/profile/index.php
+++ b/frontend/www/profile/index.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getProfileDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getProfileDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/qualitynomination/details.php
+++ b/frontend/www/qualitynomination/details.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\QualityNomination::getDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\QualityNomination::getDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/qualitynomination/list.php
+++ b/frontend/www/qualitynomination/list.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\QualityNomination::getListForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\QualityNomination::getListForTypeScript(
         $r
     )
 );

--- a/frontend/www/qualitynomination/my_list.php
+++ b/frontend/www/qualitynomination/my_list.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\QualityNomination::getMyListForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\QualityNomination::getMyListForTypeScript(
         $r
     )
 );

--- a/frontend/www/rank/authors.php
+++ b/frontend/www/rank/authors.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getAuthorRankForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getAuthorRankForTypeScript(
         $r
     )
 );

--- a/frontend/www/rank/schools.php
+++ b/frontend/www/rank/schools.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\School::getRankForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\School::getRankForTypeScript(
         $r
     )
 );

--- a/frontend/www/rank/users.php
+++ b/frontend/www/rank/users.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getRankForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getRankForTypeScript(
         $r
     )
 );

--- a/frontend/www/schools/profile.php
+++ b/frontend/www/schools/profile.php
@@ -2,7 +2,7 @@
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\School::getSchoolProfileDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\School::getSchoolProfileDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/schools/schoolofthemonth.php
+++ b/frontend/www/schools/schoolofthemonth.php
@@ -2,7 +2,7 @@
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\School::getSchoolOfTheMonthDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\School::getSchoolOfTheMonthDetailsForTypeScript(
         $r
     )
 );

--- a/frontend/www/submissions/list.php
+++ b/frontend/www/submissions/list.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Submission::getLatestSubmissionsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Submission::getLatestSubmissionsForTypeScript(
         $r
     )
 );

--- a/frontend/www/submissions/user_list.php
+++ b/frontend/www/submissions/user_list.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Submission::getLatestUserSubmissionsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Submission::getLatestUserSubmissionsForTypeScript(
         $r
     )
 );

--- a/frontend/www/users/emailedit.php
+++ b/frontend/www/users/emailedit.php
@@ -4,7 +4,7 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 \OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 \OmegaUp\UITools::render(
-    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getEmailEditDetailsForSmarty(
+    fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\User::getEmailEditDetailsForTypeScript(
         $r
     )
 );


### PR DESCRIPTION
Este cambio renombra todas las funciones ForSmarty para que ahora digan
ForTypeScript, según discutido en Slack.