### PR TITLE
Aplicando un refactor a Contest::apiScoreboard

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -3339,28 +3339,25 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'problemset' => $problemset
         ] = self::validateBasicDetails($contestAlias);
-        \OmegaUp\Validators::validateOptionalStringNonEmpty(
-            $r['token'],
-            'token'
+
+        $token = $r->ensureOptionalString(
+            'token',
+            /*$required=*/ false,
         );
+        $identity = null;
         try {
             $r->ensureIdentity();
+            $identity = $r->identity;
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
             // Do nothing.
-            $r->identity = null;
         }
-        return self::getScoreboard(
-            $contest,
-            $problemset,
-            $r->identity,
-            $r['token']
-        );
+        return self::getScoreboard($contest, $problemset, $identity, $token);
     }
 
     /**
      * @return Scoreboard
      */
-    private static function getScoreboard(
+    public static function getScoreboard(
         \OmegaUp\DAO\VO\Contests $contest,
         \OmegaUp\DAO\VO\Problemsets $problemset,
         ?\OmegaUp\DAO\VO\Identities $identity,
@@ -3369,7 +3366,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // If true, will override Scoreboard Pertentage to 100%
         $showAllRuns = false;
 
-        if (is_null($token)) {
+        if (empty($token)) {
             // User should be logged
             if (is_null($identity)) {
                 throw new \OmegaUp\Exceptions\UnauthorizedException();

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3966,7 +3966,6 @@ Get Contests which a certain user has participated in
 
 | Name       | Type           | Description |
 | ---------- | -------------- | ----------- |
-| `token`    | `null\|string` |             |
 | `username` | `null\|string` |             |
 
 ### Returns

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3964,16 +3964,16 @@ Get Contests which a certain user has participated in
 
 ### Parameters
 
-| Name         | Type           | Description |
-| ------------ | -------------- | ----------- |
-| `auth_token` | `null\|string` |             |
-| `username`   | `null\|string` |             |
+| Name       | Type           | Description |
+| ---------- | -------------- | ----------- |
+| `token`    | `null\|string` |             |
+| `username` | `null\|string` |             |
 
 ### Returns
 
-| Name       | Type                                                                                                                                        |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contests` | `{ [key: string]: { data: { alias: string; finish_time: Date; last_updated: Date; start_time: Date; title: string; }; place?: number; }; }` |
+| Name       | Type                                                                       |
+| ---------- | -------------------------------------------------------------------------- |
+| `contests` | `{ [key: string]: { data: types.ContestParticipated; place?: number; }; }` |
 
 ## `/api/user/create/`
 

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -22,10 +22,16 @@ namespace OmegaUp\Controllers;
  * @psalm-type IndexPayload=array{coderOfTheMonthData: array{all: UserProfile|null, female: UserProfile|null}, currentUserInfo: array{username?: string}, userRank: list<CoderOfTheMonth>, schoolOfTheMonthData: array{country_id: null|string, country: null|string, name: string, school_id: int, state: null|string}|null, schoolRank: list<array{name: string, ranking: int, school_id: int, school_of_the_month_id: int, score: float}>}
  * @psalm-type CoderOfTheMonthPayload=array{codersOfCurrentMonth: CoderOfTheMonthList, codersOfPreviousMonth: CoderOfTheMonthList, candidatesToCoderOfTheMonth: list<array{category: string, classname: string, coder_of_the_month_id: int, country_id: string, description: null|string, interview_url: null|string, problems_solved: int, ranking: int, school_id: int|null, score: float, selected_by: int|null, time: string, username: string}>, isMentor: bool, category: string, options?: array{canChooseCoder: bool, coderIsSelected: bool}}
  * @psalm-type UserProfileInfo=array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender: null|string, graduation_date: \OmegaUp\Timestamp|null|string, gravatar_92: null|string, hide_problem_tags: bool, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{author_ranking: int|null, name: null|string, problems_solved: int|null, rank: int|null}, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null, programming_languages: array<string,string>}
- * @psalm-type UserProfileContests=array<string, array{data: array{alias: string, title: string, start_time: \OmegaUp\Timestamp, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp}, place: int}>
+ * @psalm-type ContestParticipated=array{alias: string, title: string, start_time: \OmegaUp\Timestamp, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp}
+ * @psalm-type UserProfileContests=array<string, array{data: ContestParticipated, place: int}>
  * @psalm-type UserProfileStats=array{date: null|string, runs: int, verdict: string}
+ * @psalm-type RunMetadata=array{verdict: string, time: float, sys_time: int, wall_time: float, memory: int}
+ * @psalm-type CaseResult=array{contest_score: float, max_score: float, meta: RunMetadata, name: string, out_diff?: string, score: float, verdict: string}
  * @psalm-type ExtraProfileDetails=array{contests: UserProfileContests, solvedProblems: list<Problem>, unsolvedProblems: list<Problem>, createdProblems: list<Problem>, stats: list<UserProfileStats>, badges: list<string>, ownedBadges: list<Badge>}
  * @psalm-type UserProfileDetailsPayload=array{statusError?: string, profile: UserProfileInfo, extraProfileDetails?: ExtraProfileDetails}
+ * @psalm-type ScoreboardRankingProblem=array{alias: string, penalty: float, percent: float, pending?: int, place?: int, points: float, run_details?: array{cases?: list<CaseResult>, details: array{groups: list<array{cases: list<array{meta: RunMetadata}>}>}}, runs: int}
+ * @psalm-type ScoreboardRankingEntry=array{classname: string, country: string, is_invited: bool, name: null|string, place?: int, problems: list<ScoreboardRankingProblem>, total: array{penalty: float, points: float}, username: string}
+ * @psalm-type Scoreboard=array{finish_time: \OmegaUp\Timestamp|null, problems: list<array{alias: string, order: int}>, ranking: list<ScoreboardRankingEntry>, start_time: \OmegaUp\Timestamp, time: \OmegaUp\Timestamp, title: string}
  * @psalm-type LoginDetailsPayload=array{facebookUrl: string, linkedinUrl: string, statusError?: string, validateRecaptcha: bool}
  */
 class User extends \OmegaUp\Controllers\Controller {
@@ -1831,9 +1837,9 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Get Contests which a certain user has participated in
      *
-     * @return array{contests: array<string, array{data: array{alias: string, title: string, start_time: \OmegaUp\Timestamp, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp}, place?: int}>}
+     * @return array{contests: array<string, array{data: ContestParticipated, place?: int}>}
      *
-     * @omegaup-request-param null|string $auth_token
+     * @omegaup-request-param null|string $token
      * @omegaup-request-param null|string $username
      */
     public static function apiContestStats(\OmegaUp\Request $r): array {
@@ -1848,17 +1854,14 @@ class User extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
-        $authToken = $r->ensureOptionalString(
-            'auth_token',
-            /*$required=*/false
+        $token = $r->ensureOptionalString(
+            'token',
+            /*$required=*/ false,
+            fn (string $token) => \OmegaUp\Validators::stringNonEmpty($token)
         );
 
         return [
-            'contests' => self::getContestStats(
-                $identity->identity_id,
-                $identity->username,
-                $authToken
-            ),
+            'contests' => self::getContestStats($identity, $token),
         ];
     }
 
@@ -1866,30 +1869,40 @@ class User extends \OmegaUp\Controllers\Controller {
      * @return UserProfileContests
      */
     private static function getContestStats(
-        int $identityId,
-        string $identityUsername,
-        ?string $authToken = null
+        \OmegaUp\DAO\VO\Identities $identity,
+        ?string $token
     ): array {
         // Get contests where identity had at least 1 run
         $contestsParticipated = \OmegaUp\DAO\Contests::getContestsParticipated(
-            $identityId
+            intval($identity->identity_id)
         );
 
         /** @var UserProfileContests */
         $contests = [];
 
-        foreach ($contestsParticipated as &$contest) {
+        foreach ($contestsParticipated as $contestProblemset) {
+            if (
+                is_null($contestProblemset['contest']->alias)
+                || is_null($contestProblemset['contest']->title)
+            ) {
+                throw new \OmegaUp\Exceptions\NotFoundException(
+                    'contestNotFound'
+                );
+            }
             // Get identity ranking
-            $scoreboardResponse = \OmegaUp\Controllers\Contest::apiScoreboard(
-                new \OmegaUp\Request([
-                    'auth_token' => $authToken,
-                    'contest_alias' => $contest['alias'],
-                    'token' => $contest['scoreboard_url_admin'],
-                ])
+            $scoreboardResponse = \OmegaUp\Controllers\Contest::getScoreboard(
+                $contestProblemset['contest'],
+                $contestProblemset['problemset'],
+                $identity,
+                $token
             );
-
-            // Avoid divulging the scoreboard URL unnecessarily.
-            unset($contest['scoreboard_url_admin']);
+            $contest = [
+                'alias' => $contestProblemset['contest']->alias,
+                'title' => $contestProblemset['contest']->title,
+                'start_time' => $contestProblemset['contest']->start_time,
+                'finish_time' => $contestProblemset['contest']->finish_time,
+                'last_updated' => $contestProblemset['contest']->last_updated,
+            ];
 
             $contests[$contest['alias']] = [
                 'data' => $contest,
@@ -1899,7 +1912,7 @@ class User extends \OmegaUp\Controllers\Controller {
             // Grab the place of the current identity in the given contest
             foreach ($scoreboardResponse['ranking'] as $identityData) {
                 if (
-                    $identityData['username'] == $identityUsername &&
+                    $identityData['username'] == strval($identity->username) &&
                     isset($identityData['place'])
                 ) {
                     $contests[$contest['alias']]['place'] = $identityData['place'];
@@ -3777,8 +3790,8 @@ class User extends \OmegaUp\Controllers\Controller {
                         ),
                         'extraProfileDetails' => [
                             'contests' => self::getContestStats(
-                                $identity->identity_id,
-                                $identity->username
+                                $identity,
+                                /*$token=*/ null
                             ),
                             'solvedProblems' => self::getSolvedProblems(
                                 $identity->identity_id

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1839,7 +1839,6 @@ class User extends \OmegaUp\Controllers\Controller {
      *
      * @return array{contests: array<string, array{data: ContestParticipated, place?: int}>}
      *
-     * @omegaup-request-param null|string $token
      * @omegaup-request-param null|string $username
      */
     public static function apiContestStats(\OmegaUp\Request $r): array {
@@ -1854,14 +1853,8 @@ class User extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
-        $token = $r->ensureOptionalString(
-            'token',
-            /*$required=*/ false,
-            fn (string $token) => \OmegaUp\Validators::stringNonEmpty($token)
-        );
-
         return [
-            'contests' => self::getContestStats($identity, $token),
+            'contests' => self::getContestStats($identity),
         ];
     }
 
@@ -1869,8 +1862,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @return UserProfileContests
      */
     private static function getContestStats(
-        \OmegaUp\DAO\VO\Identities $identity,
-        ?string $token
+        \OmegaUp\DAO\VO\Identities $identity
     ): array {
         // Get contests where identity had at least 1 run
         $contestsParticipated = \OmegaUp\DAO\Contests::getContestsParticipated(
@@ -1893,8 +1885,7 @@ class User extends \OmegaUp\Controllers\Controller {
             $scoreboardResponse = \OmegaUp\Controllers\Contest::getScoreboard(
                 $contestProblemset['contest'],
                 $contestProblemset['problemset'],
-                $identity,
-                $token
+                $identity
             );
             $contest = [
                 'alias' => $contestProblemset['contest']->alias,
@@ -3789,10 +3780,7 @@ class User extends \OmegaUp\Controllers\Controller {
                             $identity
                         ),
                         'extraProfileDetails' => [
-                            'contests' => self::getContestStats(
-                                $identity,
-                                /*$token=*/ null
-                            ),
+                            'contests' => self::getContestStats($identity),
                             'solvedProblems' => self::getSolvedProblems(
                                 $identity->identity_id
                             ),

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1754,6 +1754,14 @@ export namespace types {
     languages: { [key: string]: string };
   }
 
+  export interface ContestParticipated {
+    alias: string;
+    finish_time: Date;
+    last_updated: Date;
+    start_time: Date;
+    title: string;
+  }
+
   export interface ContestPracticePayload {
     clarifications: types.Clarification[];
     contest: types.ContestPublicDetails;
@@ -3003,16 +3011,7 @@ export namespace types {
   }
 
   export interface UserProfileContests {
-    [key: string]: {
-      data: {
-        alias: string;
-        finish_time: Date;
-        last_updated: Date;
-        start_time: Date;
-        title: string;
-      };
-      place: number;
-    };
+    [key: string]: { data: types.ContestParticipated; place: number };
   }
 
   export interface UserProfileDetailsPayload {
@@ -3946,16 +3945,7 @@ export namespace messages {
   export type _UserContestStatsServerResponse = any;
   export type UserContestStatsResponse = {
     contests: {
-      [key: string]: {
-        data: {
-          alias: string;
-          finish_time: Date;
-          last_updated: Date;
-          start_time: Date;
-          title: string;
-        };
-        place?: number;
-      };
+      [key: string]: { data: types.ContestParticipated; place?: number };
     };
   };
   export type UserCreateRequest = { [key: string]: any };


### PR DESCRIPTION
# Descripción

Se agrega el refactor de `Contest::apiScoreboard` para despupes comenzar a
solucionar el bug de que no se muestra correctamente la página de Perfil 
cuando se intenta ingresar a uno privado.

Part of: #5122

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
