### PR TITLE
Agregando director a los detalles de concurso público

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -20,10 +20,10 @@ namespace OmegaUp\Controllers;
  * @psalm-type ProblemQualityPayload=array{canNominateProblem: bool, dismissed: bool, dismissedBeforeAc: bool, language?: string, nominated: bool, nominatedBeforeAc: bool, problemAlias: string, solved: bool, tried: bool}
  * @psalm-type ProblemsetProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, input_limit: int, languages: string, letter: string, order: int, points: float, problem_id?: int, quality_payload?: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
  * @psalm-type ContestListMinePayload=array{contests: list<Contest>, privateContestsAlert: bool}
- * @psalm-type ContestDetails=array{admin: bool, admission_mode: string, alias: string, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems: list<ProblemsetProblem>, problemset_id: int, requests_user_information: string, rerun_id?: int, scoreboard: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
- * @psalm-type ContestAdminDetails=array{admin: bool, admission_mode: string, alias: string, available_languages: array<string, string>, description: string, director: null|string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems: list<ProblemsetProblem>, problemset_id: int, requests_user_information: string, rerun_id?: int, scoreboard: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
+ * @psalm-type ContestDetails=array{admin: bool, admission_mode: string, alias: string, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems: list<ProblemsetProblem>, problemset_id: int, requests_user_information: string, rerun_id?: int, scoreboard: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
+ * @psalm-type ContestAdminDetails=array{admin: bool, admission_mode: string, alias: string, available_languages: array<string, string>, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems: list<ProblemsetProblem>, problemset_id: int, requests_user_information: string, rerun_id?: int, scoreboard: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
  * @psalm-type StatsPayload=array{alias: string, entity_type: string, cases_stats?: array<string, int>, pending_runs: list<string>, total_runs: int, verdict_counts: array<string, int>, max_wait_time?: \OmegaUp\Timestamp|null, max_wait_time_guid?: null|string, distribution?: array<int, int>, size_of_bucket?: float, total_points?: float}
- * @psalm-type ContestPublicDetails=array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null}
+ * @psalm-type ContestPublicDetails=array{admission_mode: string, alias: string, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null, window_length: int|null}
  * @psalm-type ContestEditPayload=array{details: ContestAdminDetails, problems: list<ContestProblem>, users: list<ContestUser>, groups: list<ContestGroup>, requests: list<ContestRequest>, admins: list<ContestAdmin>, group_admins: list<ContestGroupAdmin>}
  * @psalm-type ContestIntroPayload=array{contest: ContestPublicDetails, needsBasicInformation?: bool, privacyStatement?: PrivacyStatement, problemset?: ContestDetails, requestsUserInformation?: string, shouldShowFirstAssociatedIdentityRunWarning: bool}
  * @psalm-type ContestPracticePayload=array{clarifications: list<Clarification>, contest: ContestPublicDetails, contestAdmin: bool, problems: list<NavbarProblemsetProblem>, shouldShowFirstAssociatedIdentityRunWarning: bool, users: list<ContestUser>}
@@ -477,6 +477,29 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * Validate a contest with contest alias and add its director
+     *
+     * @return array{contest: \OmegaUp\DAO\VO\Contests, contestWithDirector: ContestPublicDetails}
+     * @throws \OmegaUp\Exceptions\NotFoundException
+     */
+    public static function validateContestWithDirector(string $contestAlias) {
+        $contest = \OmegaUp\DAO\Contests::getByAliasWithDirector($contestAlias);
+        if (is_null($contest)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
+        }
+
+        return [
+            'contest' => new \OmegaUp\DAO\VO\Contests(
+                array_intersect_key(
+                    $contest,
+                    \OmegaUp\DAO\VO\Contests::FIELD_NAMES
+                )
+            ),
+            'contestWithDirector' => $contest,
+        ];
+    }
+
+    /**
      * Validate if a contestant has explicit access to a contest.
      */
     private static function isInvitedToContest(
@@ -508,7 +531,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest_alias',
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
-        $contest = self::validateContest($contestAlias);
+        [
+            'contest' => $contest,
+            'contestWithDirector' => $contestWithDirector,
+        ] = self::validateContestWithDirector($contestAlias);
         if (is_null($contest->problemset_id)) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
@@ -534,7 +560,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'smartyProperties' => [
                 'payload' => [
                     'shouldShowFirstAssociatedIdentityRunWarning' => false,
-                    'contest' => self::getPublicDetails($contest, $r->identity),
+                    'contest' => self::getPublicDetails(
+                        $contestWithDirector,
+                        $r->identity
+                    ),
                 ],
                 'title' => new \OmegaUp\TranslationString('enterContest'),
             ],
@@ -629,6 +658,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'contest_admin' => $contestAdmin,
         ] = self::validateDetails($contestAlias, $r->identity);
+        [
+            'contestWithDirector' => $contestWithDirector,
+        ] = self::validateContestWithDirector($contestAlias);
         if (is_null($contest->problemset_id)) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
@@ -665,7 +697,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
                         \OmegaUp\DAO\Problemsets::shouldShowFirstAssociatedIdentityRunWarning(
                             $r->user
                         ),
-                    'contest' => self::getPublicDetails($contest, $r->identity),
+                        'contest' => self::getPublicDetails(
+                            $contestWithDirector,
+                            $r->identity
+                        ),
                     'problems' => $problems,
                     'users' => $contestAdmin ? \OmegaUp\DAO\ProblemsetIdentities::getWithExtraInformation(
                         intval($contest->problemset_id)
@@ -1086,70 +1121,45 @@ class Contest extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
 
+        [
+            'contestWithDirector' => $contestWithDirector,
+        ] = self::validateContestWithDirector($contestAlias);
         $contest = \OmegaUp\Controllers\Contest::validateContest($contestAlias);
 
-        return self::getPublicDetails($contest, $r->identity);
+        return self::getPublicDetails($contestWithDirector, $r->identity);
     }
 
     /**
+     * @param ContestPublicDetails $contest
      * @return ContestPublicDetails
      */
     private static function getPublicDetails(
-        \OmegaUp\DAO\VO\Contests $contest,
+        $contest,
         ?\OmegaUp\DAO\VO\Identities $identity
     ): array {
-        // Initialize response to be the contest information
-        /** @var array{admission_mode: string, alias: string, description: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null} */
-        $result = $contest->asFilteredArray([
-            'admission_mode',
-            'alias',
-            'description',
-            'feedback',
-            'finish_time',
-            'languages',
-            'partial_score',
-            'penalty',
-            'penalty_calc_policy',
-            'penalty_type',
-            'points_decay_factor',
-            'problemset_id',
-            'rerun_id',
-            'scoreboard',
-            'show_scoreboard_after',
-            'start_time',
-            'submissions_gap',
-            'time_start',
-            'title',
-            'window_length',
-        ]);
-
         // Whether the contest is private, verify that our user is invited
         if (
             !is_null($identity) &&
-            $result['admission_mode'] === 'registration'
+            $contest['admission_mode'] === 'registration'
         ) {
             $registration = \OmegaUp\DAO\ProblemsetIdentityRequest::getByPK(
                 $identity->identity_id,
-                $contest->problemset_id
+                $contest['problemset_id']
             );
 
-            $result['user_registration_requested'] = !is_null($registration);
+            $contest['user_registration_requested'] = !is_null($registration);
 
             if (is_null($registration)) {
-                $result['user_registration_answered'] = false;
+                $contest['user_registration_answered'] = false;
             } else {
-                $result['user_registration_answered'] = !is_null(
+                $contest['user_registration_answered'] = !is_null(
                     $registration->accepted
                 );
-                $result['user_registration_accepted'] = $registration->accepted;
+                $contest['user_registration_accepted'] = $registration->accepted;
             }
         }
-        $result['show_penalty'] = (
-            $result['penalty'] !== 0 ||
-            $result['penalty_type'] !== 'none'
-        );
 
-        return $result;
+        return $contest;
     }
 
     /**
@@ -1348,7 +1358,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $director = \OmegaUp\DAO\Identities::findByUserId(
                     $acl->owner_id
                 );
-                if (is_null($director)) {
+                if (is_null($director) || is_null($director->username)) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'userNotExist'
                     );

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -656,7 +656,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         try {
             $r->ensureIdentity();
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
-            if ($contest->admission_mode === 'private') {
+            if ($contestWithDirector['admission_mode'] === 'private') {
                 throw $e;
             }
             $r->identity = null;

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -643,7 +643,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest_alias',
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
-        $contest = \OmegaUp\Controllers\Contest::validateContest($contestAlias);
+        [
+            'contestWithDirector' => $contestWithDirector,
+        ] = self::validateContestWithDirector($contestAlias);
+
+        if ($contestWithDirector['finish_time']->time > \OmegaUp\Time::get()) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException(
+                'originalContestHasNotEnded'
+            );
+        }
 
         try {
             $r->ensureIdentity();
@@ -658,9 +666,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'contest_admin' => $contestAdmin,
         ] = self::validateDetails($contestAlias, $r->identity);
-        [
-            'contestWithDirector' => $contestWithDirector,
-        ] = self::validateContestWithDirector($contestAlias);
         if (is_null($contest->problemset_id)) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -47,6 +47,57 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     }
 
     /**
+     * @return array{admission_mode: string, alias: string, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_penalty: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null}|null
+     */
+    final public static function getByAliasWithDirector(string $alias) {
+        $sql = 'SELECT
+                    i.username AS director,
+                    c.problemset_id,
+                    c.title,
+                    c.description,
+                    c.start_time,
+                    c.finish_time,
+                    c.window_length,
+                    c.rerun_id,
+                    c.admission_mode,
+                    c.alias,
+                    c.scoreboard,
+                    c.points_decay_factor,
+                    c.partial_score,
+                    c.submissions_gap,
+                    c.feedback,
+                    c.penalty,
+                    c.penalty_type,
+                    c.penalty_calc_policy,
+                    c.show_scoreboard_after,
+                    IF(c.penalty <> 0 OR c.penalty_type <> \'none\', 1, 0) AS show_penalty,
+                    c.languages
+                FROM
+                    Contests c
+                INNER JOIN
+                    ACLs acl
+                ON
+                    acl.acl_id = c.acl_id
+                INNER JOIN
+                    Identities i
+                ON
+                    i.user_id = acl.owner_id
+                WHERE
+                    c.alias = ?
+                LIMIT
+                    1;';
+
+        /** @var array{admission_mode: string, alias: string, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: null|string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int, scoreboard: int, show_penalty: int, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, window_length: int|null}|null */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$alias]);
+        if (empty($rs)) {
+            return null;
+        }
+        $rs['show_penalty'] = boolval($rs['show_penalty']);
+        $rs['languages'] = strval($rs['languages']);
+        return $rs;
+    }
+
+    /**
      * @return list<\OmegaUp\DAO\VO\Contests>
      */
     final public static function getByTitle(string $title) {

--- a/frontend/tests/controllers/ContestUsersTest.php
+++ b/frontend/tests/controllers/ContestUsersTest.php
@@ -301,8 +301,6 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
                 'finishTime' => $finishTime,
             ])
         );
-        $identity = [];
-
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         // Add user to our private contest
@@ -332,7 +330,6 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
     public function testContestPracticeWhenOriginalContestHasNotEnded() {
         // Get a contest
         $contestData = \OmegaUp\Test\Factories\Contest::createContest();
-        $identity = [];
 
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 

--- a/frontend/tests/controllers/ContestUsersTest.php
+++ b/frontend/tests/controllers/ContestUsersTest.php
@@ -149,16 +149,16 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $identity = [];
         $numberOfStudents = 3;
-        foreach (range(0, $numberOfStudents - 1) as $studentIterator) {
+        foreach (range(0, $numberOfStudents - 1) as $studentIndex) {
             // Create users
             [
-                'identity' => $identity[$studentIterator],
+                'identity' => $identity[$studentIndex],
             ] = \OmegaUp\Test\Factories\User::createUser();
 
             // Add users to our private contest
             \OmegaUp\Test\Factories\Contest::addUser(
                 $contestData,
-                $identity[$studentIterator]
+                $identity[$studentIndex]
             );
         }
 

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1622,7 +1622,7 @@ export namespace types {
     alias: string;
     available_languages: { [key: string]: string };
     description: string;
-    director?: string;
+    director: string;
     feedback: string;
     finish_time: Date;
     languages: string[];
@@ -1656,7 +1656,7 @@ export namespace types {
     admission_mode: string;
     alias: string;
     description: string;
-    director?: string;
+    director: string;
     feedback: string;
     finish_time: Date;
     languages: string[];
@@ -1791,6 +1791,7 @@ export namespace types {
     admission_mode: string;
     alias: string;
     description: string;
+    director: string;
     feedback: string;
     finish_time: Date;
     languages: string;


### PR DESCRIPTION
# Descripción

Un avance más para la migración de `ArenaContestPractice` a la plantilla unificada.

En este PR se agregan las siguientes funcionalidades:

- Restringir el acceso a este modo de concurso cuando el original aún no concluye.
- Obtener el nombre del organizador del concurso en el payload.

Part of: #3485

# Comentarios

También se crea este PR para separarlo del #5149 donde se había incluido
originalmente, pero como la parte de los popups puede crecer, mejor deben
quedar independientes un cambio del otro.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
