### PR TITLE
Haciendo refactor para obtener los detalles comunes de un concurso

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -517,7 +517,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{clarifications: list<Clarification>, contestAdmin: bool, problems: list<NavbarProblemsetProblem>, users: list<ContestUser>}
+     * @return array{clarifications: list<Clarification>, problems: list<NavbarProblemsetProblem>, users: list<ContestUser>}
      */
     public static function getCommonDetails(
         \OmegaUp\DAO\VO\Contests $contest,
@@ -554,7 +554,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'users' => \OmegaUp\DAO\ProblemsetIdentities::getWithExtraInformation(
                 intval($contest->problemset_id)
             ),
-            'contestAdmin' => $contestAdmin,
             'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
                 intval($contest->problemset_id),
                 $contestAdmin,
@@ -650,6 +649,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $result['smartyProperties']['payload'],
                 [
                     'shouldShowFirstAssociatedIdentityRunWarning' => $shouldShowFirstAssociatedIdentityRunWarning,
+                    'contestAdmin' => $contestAdmin,
                 ],
                 self::getCommonDetails($contest, $contestAdmin, $r->identity)
             );
@@ -719,7 +719,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     public static function getContestPracticeDetailsForTypeScript(
         \OmegaUp\Request $r
     ): array {
-        // Only logged users can access to practice mode
+        // Only logged users can access practice mode
         $r->ensureIdentity();
 
         $contestAlias = $r->ensureString(
@@ -762,6 +762,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                             $contestWithDirector,
                             $r->identity
                         ),
+                        'contestAdmin' => $contestAdmin,
                     ],
                     self::getCommonDetails(
                         $contest,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -481,46 +481,6 @@ export namespace types {
       );
     }
 
-    export function ContestPracticePayload(
-      elementId: string = 'payload',
-    ): types.ContestPracticePayload {
-      return ((x) => {
-        x.clarifications = ((x) => {
-          if (!Array.isArray(x)) {
-            return x;
-          }
-          return x.map((x) => {
-            x.time = ((x: number) => new Date(x * 1000))(x.time);
-            return x;
-          });
-        })(x.clarifications);
-        x.contest = ((x) => {
-          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
-          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
-          return x;
-        })(x.contest);
-        x.users = ((x) => {
-          if (!Array.isArray(x)) {
-            return x;
-          }
-          return x.map((x) => {
-            if (x.access_time)
-              x.access_time = ((x: number) => new Date(x * 1000))(
-                x.access_time,
-              );
-            if (x.end_time)
-              x.end_time = ((x: number) => new Date(x * 1000))(x.end_time);
-            return x;
-          });
-        })(x.users);
-        return x;
-      })(
-        JSON.parse(
-          (document.getElementById(elementId) as HTMLElement).innerText,
-        ),
-      );
-    }
-
     export function CourseCloneDetailsPayload(
       elementId: string = 'payload',
     ): types.CourseCloneDetailsPayload {
@@ -1835,15 +1795,6 @@ export namespace types {
     last_updated: Date;
     start_time: Date;
     title: string;
-  }
-
-  export interface ContestPracticePayload {
-    clarifications: types.Clarification[];
-    contest: types.ContestPublicDetails;
-    contestAdmin: boolean;
-    problems: types.NavbarProblemsetProblem[];
-    shouldShowFirstAssociatedIdentityRunWarning: boolean;
-    users: types.ContestUser[];
   }
 
   export interface ContestProblem {

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -17,7 +17,7 @@ import JSZip from 'jszip';
 
 OmegaUp.on('ready', () => {
   time.setSugarLocale();
-  const payload = types.payloadParsers.ContestPracticePayload();
+  const payload = types.payloadParsers.ContestDetailsPayload();
   const commonPayload = types.payloadParsers.CommonPayload();
   const activeTab = window.location.hash
     ? window.location.hash.substr(1).split('/')[0]


### PR DESCRIPTION
# Descripción

Se aplica refactor con los detalles que comparten el payload de concursos
normal con el modo práctica.

Fixes: #5161 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
