### PR TITLE
Cambios para banner de perfil privado

### DIFF
--- a/frontend/www/js/omegaup/components/user/BasicInfov2.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInfov2.vue
@@ -14,7 +14,7 @@
           >/
         </div>
       </div>
-      <div class="form-group row padding-field">
+      <div v-if="profile.email" class="form-group row padding-field">
         <div class="col-sm-3">
           <strong>{{ T.profile }}</strong>
         </div>
@@ -92,7 +92,7 @@
         </div>
       </div>
     </div>
-    <a v-if="!profile.is_private" :href="`/submissions/${profile.username}/`">
+    <a v-if="!profile.email" :href="`/submissions/${profile.username}/`">
       {{ T.wordsSeeLatestSubmissions }}
     </a>
   </div>
@@ -113,6 +113,7 @@ export default class UserBasicInfo extends Vue {
   @Prop() profile!: types.UserProfile;
   @Prop() rank!: string;
   T = T;
+  privateProfile = !this.profile.email && this.profile.is_private;
 }
 </script>
 

--- a/frontend/www/js/omegaup/components/user/Profilev2.vue
+++ b/frontend/www/js/omegaup/components/user/Profilev2.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="container-fluid p-0 mt-0" data-user-profile-root>
+    <h1 v-if="privateProfile">
+      {{ ui.info(T.userProfileIsPrivate) }}
+    </h1>
     <div class="row">
       <div class="col-md-2">
         <div class="card">
@@ -33,7 +36,7 @@
                 </small>
               </p>
             </div>
-            <div class="mb-3">
+            <div v-if="!privateProfile" class="mb-3">
               <h4 class="m-0">
                 {{ Object.keys(solvedProblems).length }}
               </h4>
@@ -41,7 +44,10 @@
                 <small>{{ T.profileSolvedProblems }}</small>
               </p>
             </div>
-            <div v-if="profile.preferred_language" class="mb-3">
+            <div
+              v-if="profile.preferred_language && !privateProfile"
+              class="mb-3"
+            >
               <h5 class="m-0">
                 {{
                   profile.programming_languages[
@@ -66,6 +72,7 @@
           <div class="card-header">
             <nav class="nav nav-tabs" role="tablist">
               <a
+                v-if="!privateProfile"
                 class="nav-item nav-link active"
                 data-toggle="tab"
                 @click="selectedTab = 'badges'"
@@ -76,12 +83,14 @@
                 </span>
               </a>
               <a
+                v-if="!privateProfile"
                 class="nav-item nav-link"
                 data-toggle="tab"
                 @click="selectedTab = 'problems'"
                 >{{ T.wordsProblems }}</a
               >
               <a
+                v-if="!privateProfile"
                 class="nav-item nav-link"
                 data-toggle="tab"
                 @click="selectedTab = 'contests'"
@@ -93,11 +102,13 @@
               </a>
               <a
                 class="nav-item nav-link"
+                :class="[!privateProfile ? '' : 'active']"
                 data-toggle="tab"
                 @click="selectedTab = 'data'"
                 >{{ T.profilePersonalData }}</a
               >
               <a
+                v-if="!privateProfile"
                 class="nav-item nav-link"
                 data-toggle="tab"
                 @click="selectedTab = 'charts'"
@@ -210,6 +221,7 @@ import badge_List from '../badge/List.vue';
 import common_GridPaginator from '../common/GridPaginator.vue';
 import { types } from '../../api_types';
 import * as Highcharts from 'highcharts/highstock';
+import * as ui from '../../ui';
 import { Problem, ContestResult } from '../../linkable_resource';
 
 @Component({
@@ -240,8 +252,10 @@ export default class UserProfile extends Vue {
     : [];
   charts = this.data.stats;
   T = T;
+  ui = ui;
   columns = 3;
-  selectedTab = 'badges';
+  privateProfile = !this.profile.email && this.profile.is_private;
+  selectedTab = this.privateProfile ? 'data' : 'badges';
   normalizedRunCounts: Highcharts.PointOptionsObject[] = [];
 
   get createdProblems(): Problem[] {


### PR DESCRIPTION
# Descripción
Se agrego el render condicional para solo mostrar cierta información de un perfil privado

![image](https://user-images.githubusercontent.com/12377916/109393085-d15c4700-78ed-11eb-8159-910ebb81e280.png)

Fixes: #5122 

# Comentarios
¿Debemos mostrar la foto de perfil ?

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
