### PR TITLE
Modificando title de insignias obtenidas en perfil para evitar redundancia

### DIFF
--- a/frontend/www/js/omegaup/components/badge/List.vue
+++ b/frontend/www/js/omegaup/components/badge/List.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="card">
-    <div v-if="title" class="card-header">
+    <div v-if="!isProfile" class="card-header">
       <h4 class="card-title">
-        {{ title }}
+        {{ T.omegaupTitleBadges }}
         <span class="badge badge-secondary">{{ badges.length }} </span>
       </h4>
     </div>
@@ -43,6 +43,7 @@ export default class BadgeList extends Vue {
   @Prop() showAllBadgesLink!: boolean;
 
   T = T;
+  isProfile = this.showAllBadgesLink;
 
   get badges(): types.Badge[] {
     return Array.from(this.allBadges)
@@ -62,10 +63,6 @@ export default class BadgeList extends Vue {
         }
         return aName < bName ? -1 : 1;
       });
-  }
-
-  get title(): string {
-    return this.showAllBadgesLink ? '' : T.omegaupTitleBadges;
   }
 
   getBadgeName(alias: string): string {

--- a/frontend/www/js/omegaup/components/badge/List.vue
+++ b/frontend/www/js/omegaup/components/badge/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card">
-    <div class="card-header">
+    <div v-if="title" class="card-header">
       <h4 class="card-title">
         {{ title }}
         <span class="badge badge-secondary">{{ badges.length }} </span>
@@ -65,9 +65,7 @@ export default class BadgeList extends Vue {
   }
 
   get title(): string {
-    return this.showAllBadgesLink
-      ? T.wordsBadgesObtained
-      : T.omegaupTitleBadges;
+    return this.showAllBadgesLink ? '' : T.omegaupTitleBadges;
   }
 
   getBadgeName(alias: string): string {


### PR DESCRIPTION
# Descripción
Se modifica la forma en que se regresa la computed property title para poder hacer render condicional y solo mostrar el card header de la lista de badges cuando se muestran todos.
Fixes: #5139 

![image](https://user-images.githubusercontent.com/12377916/110072725-38458a00-7d4c-11eb-98f1-5f61aadd05f9.png)


# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
