### PR TITLE
Mostrando el listado de concursos archivados

### DIFF
--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -198,6 +198,7 @@ contestIntroScoreboardTimePercentZero = "The scoreboard will not be shown during
 contestIntroSubmissionsSeparationDesc = "For each incorrect submission you must wait %(window_length) to make a new submission."
 contestJoin = "Join contest"
 contestLengthTooLong = "Contests can't last more than 31 days."
+contestListArchivedContests = "Archived contests"
 contestListEmpty = "No contests in this list"
 contestListShowAdminContests = "Also show contests I manage"
 contestListSubmissions = "Submissions"

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -198,6 +198,7 @@ contestIntroScoreboardTimePercentZero = "El scoreboard no se mostrará durante e
 contestIntroSubmissionsSeparationDesc = "Por cada envío incorrecto se deberá esperar %(window_length) para hacer un nuevo envío."
 contestJoin = "Unirse al concurso"
 contestLengthTooLong = "La duración del concurso no puede ser mayor a 31 días."
+contestListArchivedContests = "Concursos archivados"
 contestListEmpty = "No hay concursos en esta lista"
 contestListShowAdminContests = "También muestra concursos que administro"
 contestListSubmissions = "Envíos"

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -198,6 +198,7 @@ contestIntroScoreboardTimePercentZero = "(Th3 5c0r3b0ard wi11 n07 b3 5h0wn durin
 contestIntroSubmissionsSeparationDesc = "(F0r 3ach inc0rr3c7 5ubmi55i0n y0u mu57 wai7 %(window_length) 70 mak3 a n3w 5ubmi55i0n.)"
 contestJoin = "(J0in c0n7357)"
 contestLengthTooLong = "(C0n73575 can'7 1a57 m0r3 7han 31 day5.)"
+contestListArchivedContests = "(Archiv3d c0n73575)"
 contestListEmpty = "(N0 c0n73575 in 7hi5 1i57)"
 contestListShowAdminContests = "(A150 5h0w c0n73575 I manag3)"
 contestListSubmissions = "(Submi55i0n5)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -198,6 +198,7 @@ contestIntroScoreboardTimePercentZero = "O painel não será mostrado durante o 
 contestIntroSubmissionsSeparationDesc = "Para cada envio incorreto, você deve aguardar %(window_length) para fazer um novo envio."
 contestJoin = "Entrar no concurso"
 contestLengthTooLong = "A duração do concurso não podem ser maior á 31 dias."
+contestListArchivedContests = "Concursos arquivados"
 contestListEmpty = "Não há concursos nesta lista"
 contestListShowAdminContests = "Também mostrar concursos que eu gerencio"
 contestListSubmissions = "Soluções"

--- a/frontend/www/js/omegaup/components/contest/Mine.vue
+++ b/frontend/www/js/omegaup/components/contest/Mine.vue
@@ -19,7 +19,7 @@
       <h5 class="card-header">{{ T.wordsMyContests }}</h5>
       <div class="card-body">
         <div class="row align-items-center justify-content-between">
-          <div class="form-check col-7">
+          <div class="form-check col-md-4">
             <label class="form-check-label">
               <input
                 v-model="shouldShowAllContests"
@@ -32,9 +32,22 @@
               <span>{{ T.contestListShowAdminContests }}</span>
             </label>
           </div>
+          <div class="form-check col-md-3">
+            <label class="form-check-label">
+              <input
+                v-model="shouldShowArchivedContests"
+                class="form-check-input"
+                type="checkbox"
+                @change.prevent="
+                  $emit('show-archived-contests', shouldShowArchivedContests)
+                "
+              />
+              <span>{{ T.contestListArchivedContests }}</span>
+            </label>
+          </div>
           <select
             v-model="allContestsVisibilityOption"
-            class="custom-select col-5"
+            class="custom-select col-md-5"
             @change="onChangeAdmissionMode"
           >
             <option selected value="none">{{ T.forSelectedItems }}</option>
@@ -69,7 +82,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="contest in contests">
+            <tr v-for="contest in contests" :key="contest.alias">
               <td class="d-flex align-items-center">
                 <input
                   v-model="selectedContests"
@@ -205,6 +218,7 @@ export default class List extends Vue {
   ui = ui;
   time = time;
   shouldShowAllContests = false;
+  shouldShowArchivedContests = false;
   allContestsVisibilityOption = 'none';
   selectedContests: string[] = [];
 

--- a/frontend/www/js/omegaup/components/contest/Mine.vue
+++ b/frontend/www/js/omegaup/components/contest/Mine.vue
@@ -39,7 +39,10 @@
                 class="form-check-input"
                 type="checkbox"
                 @change.prevent="
-                  $emit('show-archived-contests', shouldShowArchivedContests)
+                  $emit(
+                    'change-show-archived-contests',
+                    shouldShowArchivedContests,
+                  )
                 "
               />
               <span>{{ T.contestListArchivedContests }}</span>

--- a/frontend/www/js/omegaup/contest/mine.ts
+++ b/frontend/www/js/omegaup/contest/mine.ts
@@ -26,13 +26,15 @@ OmegaUp.on('ready', () => {
           privateContestsAlert: payload.privateContestsAlert,
         },
         on: {
-          'show-archived-contests': (shouldShowArchivedContests: boolean) => {
+          'change-show-archived-contests': (
+            shouldShowArchivedContests: boolean,
+          ) => {
             showArchivedContests = shouldShowArchivedContests;
-            fillContestsTable(showAllContests, showArchivedContests);
+            fillContestsTable({ showAllContests, showArchivedContests });
           },
           'change-show-all-contests': (shouldShowAll: boolean) => {
             showAllContests = shouldShowAll;
-            fillContestsTable(showAllContests, showArchivedContests);
+            fillContestsTable({ showAllContests, showArchivedContests });
           },
           'change-admission-mode': (
             selectedContests: string[],
@@ -53,7 +55,7 @@ OmegaUp.on('ready', () => {
                 ui.error(ui.formatString(T.bulkOperationError, error));
               })
               .finally(() => {
-                fillContestsTable(showAllContests, showArchivedContests);
+                fillContestsTable({ showAllContests, showArchivedContests });
               });
           },
           'download-csv-users': (contestAlias: string) => {
@@ -105,10 +107,13 @@ OmegaUp.on('ready', () => {
     },
   });
 
-  function fillContestsTable(
-    showAllContests: boolean,
-    showArchivedContests: boolean,
-  ): void {
+  function fillContestsTable({
+    showAllContests,
+    showArchivedContests,
+  }: {
+    showAllContests: boolean;
+    showArchivedContests: boolean;
+  }): void {
     const param = { show_archived: showArchivedContests };
     (showAllContests ? api.Contest.adminList(param) : api.Contest.myList(param))
       .then((result) => {

--- a/frontend/www/js/omegaup/contest/mine.ts
+++ b/frontend/www/js/omegaup/contest/mine.ts
@@ -10,6 +10,7 @@ import contest_Mine from '../components/contest/Mine.vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ContestListMinePayload();
   let showAllContests = false;
+  let showArchivedContests = false;
   const contestMine = new Vue({
     el: '#main-container',
     components: {
@@ -25,9 +26,13 @@ OmegaUp.on('ready', () => {
           privateContestsAlert: payload.privateContestsAlert,
         },
         on: {
+          'show-archived-contests': (shouldShowArchivedContests: boolean) => {
+            showArchivedContests = shouldShowArchivedContests;
+            fillContestsTable(showAllContests, showArchivedContests);
+          },
           'change-show-all-contests': (shouldShowAll: boolean) => {
             showAllContests = shouldShowAll;
-            fillContestsTable(shouldShowAll);
+            fillContestsTable(showAllContests, showArchivedContests);
           },
           'change-admission-mode': (
             selectedContests: string[],
@@ -48,7 +53,7 @@ OmegaUp.on('ready', () => {
                 ui.error(ui.formatString(T.bulkOperationError, error));
               })
               .finally(() => {
-                fillContestsTable(showAllContests);
+                fillContestsTable(showAllContests, showArchivedContests);
               });
           },
           'download-csv-users': (contestAlias: string) => {
@@ -100,8 +105,12 @@ OmegaUp.on('ready', () => {
     },
   });
 
-  function fillContestsTable(showAllContests: boolean): void {
-    (showAllContests ? api.Contest.adminList() : api.Contest.myList())
+  function fillContestsTable(
+    showAllContests: boolean,
+    showArchivedContests: boolean,
+  ): void {
+    const param = { show_archived: showArchivedContests };
+    (showAllContests ? api.Contest.adminList(param) : api.Contest.myList(param))
       .then((result) => {
         contestMine.contests = result.contests;
       })

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -199,6 +199,7 @@
 	"contestIntroSubmissionsSeparationDesc": "For each incorrect submission you must wait %(window_length) to make a new submission.",
 	"contestJoin": "Join contest",
 	"contestLengthTooLong": "Contests can't last more than 31 days.",
+	"contestListArchivedContests": "Archived contests",
 	"contestListEmpty": "No contests in this list",
 	"contestListShowAdminContests": "Also show contests I manage",
 	"contestListSubmissions": "Submissions",

--- a/frontend/www/js/omegaup/lang.en.ts
+++ b/frontend/www/js/omegaup/lang.en.ts
@@ -200,6 +200,7 @@ const translations: { [key: string]: string; } = {
   contestIntroSubmissionsSeparationDesc: "For each incorrect submission you must wait %(window_length) to make a new submission.",
   contestJoin: "Join contest",
   contestLengthTooLong: "Contests can't last more than 31 days.",
+  contestListArchivedContests: "Archived contests",
   contestListEmpty: "No contests in this list",
   contestListShowAdminContests: "Also show contests I manage",
   contestListSubmissions: "Submissions",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -199,6 +199,7 @@
 	"contestIntroSubmissionsSeparationDesc": "Por cada env\u00edo incorrecto se deber\u00e1 esperar %(window_length) para hacer un nuevo env\u00edo.",
 	"contestJoin": "Unirse al concurso",
 	"contestLengthTooLong": "La duraci\u00f3n del concurso no puede ser mayor a 31 d\u00edas.",
+	"contestListArchivedContests": "Concursos archivados",
 	"contestListEmpty": "No hay concursos en esta lista",
 	"contestListShowAdminContests": "Tambi\u00e9n muestra concursos que administro",
 	"contestListSubmissions": "Env\u00edos",

--- a/frontend/www/js/omegaup/lang.es.ts
+++ b/frontend/www/js/omegaup/lang.es.ts
@@ -200,6 +200,7 @@ const translations: { [key: string]: string; } = {
   contestIntroSubmissionsSeparationDesc: "Por cada env\u00edo incorrecto se deber\u00e1 esperar %(window_length) para hacer un nuevo env\u00edo.",
   contestJoin: "Unirse al concurso",
   contestLengthTooLong: "La duraci\u00f3n del concurso no puede ser mayor a 31 d\u00edas.",
+  contestListArchivedContests: "Concursos archivados",
   contestListEmpty: "No hay concursos en esta lista",
   contestListShowAdminContests: "Tambi\u00e9n muestra concursos que administro",
   contestListSubmissions: "Env\u00edos",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -199,6 +199,7 @@
 	"contestIntroSubmissionsSeparationDesc": "(F0r 3ach inc0rr3c7 5ubmi55i0n y0u mu57 wai7 %(window_length) 70 mak3 a n3w 5ubmi55i0n.)",
 	"contestJoin": "(J0in c0n7357)",
 	"contestLengthTooLong": "(C0n73575 can'7 1a57 m0r3 7han 31 day5.)",
+	"contestListArchivedContests": "(Archiv3d c0n73575)",
 	"contestListEmpty": "(N0 c0n73575 in 7hi5 1i57)",
 	"contestListShowAdminContests": "(A150 5h0w c0n73575 I manag3)",
 	"contestListSubmissions": "(Submi55i0n5)",

--- a/frontend/www/js/omegaup/lang.pseudo.ts
+++ b/frontend/www/js/omegaup/lang.pseudo.ts
@@ -200,6 +200,7 @@ const translations: { [key: string]: string; } = {
   contestIntroSubmissionsSeparationDesc: "(F0r 3ach inc0rr3c7 5ubmi55i0n y0u mu57 wai7 %(window_length) 70 mak3 a n3w 5ubmi55i0n.)",
   contestJoin: "(J0in c0n7357)",
   contestLengthTooLong: "(C0n73575 can'7 1a57 m0r3 7han 31 day5.)",
+  contestListArchivedContests: "(Archiv3d c0n73575)",
   contestListEmpty: "(N0 c0n73575 in 7hi5 1i57)",
   contestListShowAdminContests: "(A150 5h0w c0n73575 I manag3)",
   contestListSubmissions: "(Submi55i0n5)",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -199,6 +199,7 @@
 	"contestIntroSubmissionsSeparationDesc": "Para cada envio incorreto, voc\u00ea deve aguardar %(window_length) para fazer um novo envio.",
 	"contestJoin": "Entrar no concurso",
 	"contestLengthTooLong": "A dura\u00e7\u00e3o do concurso n\u00e3o podem ser maior \u00e1 31 dias.",
+	"contestListArchivedContests": "Concursos arquivados",
 	"contestListEmpty": "N\u00e3o h\u00e1 concursos nesta lista",
 	"contestListShowAdminContests": "Tamb\u00e9m mostrar concursos que eu gerencio",
 	"contestListSubmissions": "Solu\u00e7\u00f5es",

--- a/frontend/www/js/omegaup/lang.pt.ts
+++ b/frontend/www/js/omegaup/lang.pt.ts
@@ -200,6 +200,7 @@ const translations: { [key: string]: string; } = {
   contestIntroSubmissionsSeparationDesc: "Para cada envio incorreto, voc\u00ea deve aguardar %(window_length) para fazer um novo envio.",
   contestJoin: "Entrar no concurso",
   contestLengthTooLong: "A dura\u00e7\u00e3o do concurso n\u00e3o podem ser maior \u00e1 31 dias.",
+  contestListArchivedContests: "Concursos arquivados",
   contestListEmpty: "N\u00e3o h\u00e1 concursos nesta lista",
   contestListShowAdminContests: "Tamb\u00e9m mostrar concursos que eu gerencio",
   contestListSubmissions: "Solu\u00e7\u00f5es",


### PR DESCRIPTION
# Descripción

Último cambio referente a poder archivar concursos. En este se agrega el listado
de concursos en la vista de "Mis concursos".

![ArchivedContestsList](https://user-images.githubusercontent.com/3230352/110255836-651bbc00-7f5b-11eb-8c24-26a30a2d10d6.gif)

Fixes: #5164

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
