### PR TITLE
Arreglando bug que mostraba 404 en perfil de usuario

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1905,11 +1905,14 @@ class User extends \OmegaUp\Controllers\Controller {
                 );
             }
             // Get identity ranking
-            $scoreboardResponse = \OmegaUp\Controllers\Contest::getScoreboard(
+            $scoreboardResponse = \OmegaUp\Controllers\Contest::getScoreboardForUserProfile(
                 $contestProblemset['contest'],
                 $contestProblemset['problemset'],
                 $identity
             );
+            if (is_null($scoreboardResponse)) {
+                continue;
+            }
             $contest = [
                 'alias' => $contestProblemset['contest']->alias,
                 'title' => $contestProblemset['contest']->title,
@@ -3832,7 +3835,6 @@ class User extends \OmegaUp\Controllers\Controller {
             ];
             return $response;
         }
-
         $response['smartyProperties']['payload'] = [
             'privateProfile' => false,
             'profile' => self::getProfileDetails(

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -42,13 +42,16 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             $contestData
         );
 
-        // Create our contestants and add them explictly to contest
+        // Create our contestants and add them explictly to private contest
         $contestants = [];
         $identities = [];
         for ($i = 0; $i < $nUsers; $i++) {
             [
                 'identity' => $identities[$i],
             ] = \OmegaUp\Test\Factories\User::createUser();
+            if ($admissionMode !== 'private') {
+                continue;
+            }
             \OmegaUp\Test\Factories\Contest::addUser(
                 $contestData,
                 $identities[$i]

--- a/frontend/tests/controllers/UserProfileTest.php
+++ b/frontend/tests/controllers/UserProfileTest.php
@@ -174,11 +174,19 @@ class UserProfileTest extends \OmegaUp\Test\ControllerTestCase {
      * Test the contest which a certain user has participated
      */
     public function testUserContests() {
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $contests = [];
-        $contests[0] = \OmegaUp\Test\Factories\Contest::createContest();
-        $contests[1] = \OmegaUp\Test\Factories\Contest::createContest();
+        $contests[0] = \OmegaUp\Test\Factories\Contest::createContest(
+            new \OmegaUp\Test\Factories\ContestParams(
+                ['admissionMode' => 'private']
+            )
+        );
+        $contests[1] = \OmegaUp\Test\Factories\Contest::createContest(
+            new \OmegaUp\Test\Factories\ContestParams(
+                ['admissionMode' => 'private']
+            )
+        );
 
         \OmegaUp\Test\Factories\Contest::addUser($contests[0], $identity);
         \OmegaUp\Test\Factories\Contest::addUser($contests[1], $identity);
@@ -198,11 +206,11 @@ class UserProfileTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Get ContestStats
         $login = self::login($identity);
-        $response = \OmegaUp\Controllers\User::apiContestStats(new \OmegaUp\Request(
-            [
+        $response = \OmegaUp\Controllers\User::apiContestStats(
+            new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
-            ]
-        ));
+            ])
+        );
 
         // Result should be 1 since user has only actually participated in 1 contest (submitted run)
         $this->assertEquals(1, count($response['contests']));
@@ -223,6 +231,30 @@ class UserProfileTest extends \OmegaUp\Test\ControllerTestCase {
             'scoreboard_url_admin',
             $response['contests'][$alias]['data']
         );
+
+        $login = self::login($contests[0]['director']);
+
+        // When user is removed from the contest, is no longer able to see their
+        // contest stats, but no exception is thrown.
+        \OmegaUp\Controllers\Contest::apiRemoveUser(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'contest_alias' => $alias,
+                'usernameOrEmail' => $identity->username,
+            ])
+        );
+
+        // Get ContestStats
+        $login = self::login($identity);
+        $response = \OmegaUp\Controllers\User::apiContestStats(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ])
+        );
+
+        // Result should be 0 since user was removed from the only contest who
+        // participated (submitted run)
+        $this->assertEquals(0, count($response['contests']));
     }
 
     /*

--- a/frontend/www/js/omegaup/components/user/Profilev2.vue
+++ b/frontend/www/js/omegaup/components/user/Profilev2.vue
@@ -223,11 +223,11 @@ import { Problem, ContestResult } from '../../linkable_resource';
   },
 })
 export default class UserProfile extends Vue {
-  @Prop() data!: types.ExtraProfileDetails | undefined;
+  @Prop() data!: types.ExtraProfileDetails;
   @Prop() profile!: types.UserProfileInfo;
   @Prop() profileBadges!: Set<string>;
   @Prop() visitorBadges!: Set<string>;
-  contests = this.data?.contests
+  contests = this.data.contests
     ? Object.values(this.data.contests)
         .map((contest) => {
           const now = new Date();
@@ -238,22 +238,22 @@ export default class UserProfile extends Vue {
         })
         .filter((contest) => !!contest)
     : [];
-  charts = this.data?.stats ?? null;
+  charts = this.data.stats;
   T = T;
   columns = 3;
   selectedTab = 'badges';
   normalizedRunCounts: Highcharts.PointOptionsObject[] = [];
 
   get createdProblems(): Problem[] {
-    if (!this.data?.createdProblems) return [];
+    if (!this.data.createdProblems) return [];
     return this.data.createdProblems.map((problem) => new Problem(problem));
   }
   get unsolvedProblems(): Problem[] {
-    if (!this.data?.unsolvedProblems) return [];
+    if (!this.data.unsolvedProblems) return [];
     return this.data.unsolvedProblems.map((problem) => new Problem(problem));
   }
   get solvedProblems(): Problem[] {
-    if (!this.data?.solvedProblems) return [];
+    if (!this.data.solvedProblems) return [];
     return this.data.solvedProblems.map((problem) => new Problem(problem));
   }
   get rank(): string {


### PR DESCRIPTION
# Descripción

Después de estar revisando, se encontró que el error 404 estaba apareciendo en
un caso particular: cuando un usuario resolvió problemas en un concurso privado,
pero posteriormente este usuario fue eliminado de dicho concurso. (Quizás hay 
más casos). Ahora para efectos de mostrar información en la página de perfil sólo
se pregunta si el usuario tiene acceso al concurso, en caso de no tener simplemente
se omite dicho concurso y se continúa revisando el resto de concursos.

Fixes: #5181 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
