### PR TITLE
Agregando componente MultiTypeahead

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -16,6 +16,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type Problem=array{title: string, alias: string, submissions: int, accepted: int, difficulty: float}
  * @psalm-type UserProfile=array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: string, country_id: null|string, email: null|string, gender: null|string, graduation_date: \OmegaUp\Timestamp|null, gravatar_92: string, hide_problem_tags: bool, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool}
  * @psalm-type UserListItem=array{label: string, value: string}
+ * @psalm-type ListItem=array{key: string, value: string}
  * @psalm-type UserRankTablePayload=array{availableFilters: array{country?: null|string, school?: null|string, state?: null|string}, filter: string, isIndex: false, isLogged: bool, length: int, page: int, ranking: UserRank, pagerItems: list<PageItem>}
  * @psalm-type CoderOfTheMonth=array{category: string, classname: string, coder_of_the_month_id: int, country_id: string, description: null|string, interview_url: null|string, problems_solved: int, ranking: int, school_id: int|null, score: float, selected_by: int|null, time: string, user_id: int, username: string}
  * @psalm-type CoderOfTheMonthList=list<array{username: string, country_id: string, gravatar_32: string, date: string, classname: string}>

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2256,6 +2256,11 @@ export namespace types {
     TimeLimit: string;
   }
 
+  export interface ListItem {
+    key: string;
+    value: string;
+  }
+
   export interface LoginDetailsPayload {
     facebookUrl: string;
     linkedinUrl: string;

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.test.ts
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.test.ts
@@ -1,0 +1,14 @@
+import { shallowMount } from '@vue/test-utils';
+import common_MultiTypeahead from './MultiTypeahead.vue';
+
+describe('MultiTypeahead.vue', () => {
+  it('Should handle empty existing options list', async () => {
+    const wrapper = shallowMount(common_MultiTypeahead, {
+      propsData: {
+        existingOptions: [],
+      },
+    });
+
+    expect(wrapper.vm.$data.selectedOptions).toStrictEqual([]);
+  });
+});

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.test.ts
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.test.ts
@@ -1,14 +1,67 @@
-import { shallowMount } from '@vue/test-utils';
+import VoerroTagsInput from '@voerro/vue-tagsinput';
+import { mount } from '@vue/test-utils';
+import Vue from 'vue';
 import common_MultiTypeahead from './MultiTypeahead.vue';
 
 describe('MultiTypeahead.vue', () => {
-  it('Should handle empty existing options list', async () => {
-    const wrapper = shallowMount(common_MultiTypeahead, {
+  it('Should not call update-existing-options with a short query', async () => {
+    const wrapper = mount(common_MultiTypeahead, {
       propsData: {
         existingOptions: [],
       },
     });
 
-    expect(wrapper.vm.$data.selectedOptions).toStrictEqual([]);
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('change', 'qu');
+    expect(wrapper.emitted()).toEqual({});
+  });
+
+  it('Should call update-existing-options with a longer query', async () => {
+    const wrapper = mount(common_MultiTypeahead, {
+      propsData: {
+        existingOptions: [],
+      },
+    });
+
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('change', 'query');
+    expect(wrapper.emitted()).toEqual({
+      'update-existing-options': [['query']],
+    });
+  });
+
+  it('Should call update:value with a non-empty tag', async () => {
+    const wrapper = mount(common_MultiTypeahead, {
+      propsData: {
+        existingOptions: [],
+      },
+    });
+
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('input', [{ key: 'key', value: 'value' }]);
+    tagsInput.vm.$emit('tag-added');
+    await Vue.nextTick();
+    expect(wrapper.emitted()).toEqual({
+      'update:value': [
+        [[{ key: 'key', value: 'value' }]],
+        [[{ key: 'key', value: 'value' }]],
+      ],
+    });
+  });
+
+  it('Should call update:value with an empty tag', async () => {
+    const wrapper = mount(common_MultiTypeahead, {
+      propsData: {
+        existingOptions: [{ key: 'key', value: 'value' }],
+      },
+    });
+
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('input', []);
+    tagsInput.vm.$emit('tag-removed');
+    await Vue.nextTick();
+    expect(wrapper.emitted()).toEqual({
+      'update:value': [[[]]],
+    });
   });
 });

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
@@ -12,8 +12,8 @@
     :only-existing-tags="true"
     :typeahead-hide-discard="true"
     @change="updateExistingOptions"
-    @tag-added="onTagAdded"
-    @tag-removed="onTagRemoved"
+    @tag-added="$emit('update:value', selectedOptions)"
+    @tag-removed="$emit('update:value', selectedOptions)"
   >
   </tags-input>
 </template>
@@ -41,14 +41,6 @@ export default class Typeahead extends Vue {
   updateExistingOptions(query: string): void {
     if (query.length < this.activationThreshold) return;
     this.$emit('update-existing-options', query);
-  }
-
-  onTagAdded(): void {
-    this.$emit('update-selected-option', this.selectedOptions);
-  }
-
-  onTagRemoved(): void {
-    this.$emit('update-selected-option', this.selectedOptions);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
@@ -1,0 +1,64 @@
+<template>
+  <tags-input
+    v-model="selectedOptions"
+    :existing-tags="existingOptions"
+    :typeahead="true"
+    :typeahead-style="'dropdown'"
+    :typeahead-max-results="maxResults"
+    :typeahead-activation-threshold="activationThreshold"
+    :placeholder="T.typeaheadSearchPlaceholder"
+    :limit="0"
+    :hide-input-on-limit="true"
+    :only-existing-tags="true"
+    :typeahead-hide-discard="true"
+    @change="updateExistingOptions"
+    @tag-added="onTagAdded"
+    @tag-removed="onTagRemoved"
+  >
+  </tags-input>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import VoerroTagsInput from '@voerro/vue-tagsinput';
+import '@voerro/vue-tagsinput/dist/style.css';
+import T from '../../lang';
+import { types } from '../../api_types';
+
+@Component({
+  components: {
+    'tags-input': VoerroTagsInput,
+  },
+})
+export default class Typeahead extends Vue {
+  @Prop() existingOptions!: types.ListItem[];
+  @Prop({ default: 3 }) activationThreshold!: number;
+  @Prop({ default: 10 }) maxResults!: number;
+
+  T = T;
+  selectedOptions: types.ListItem[] = [];
+
+  updateExistingOptions(query: string): void {
+    if (query.length < this.activationThreshold) return;
+    this.$emit('update-existing-options', query);
+  }
+
+  onTagAdded(): void {
+    this.$emit('update-selected-option', this.selectedOptions);
+  }
+
+  onTagRemoved(): void {
+    this.$emit('update-selected-option', this.selectedOptions);
+  }
+}
+</script>
+
+<style lang="scss">
+@import '../../../../sass/main.scss';
+
+.tags-input-remove:before,
+.tags-input-remove:after,
+.tags-input-typeahead-item-highlighted-default {
+  background-color: $omegaup-primary--darker;
+}
+</style>


### PR DESCRIPTION
# Descripción

Se separa el nuevo componente de `Typeahead` en `MultiTypeahead` para poder
diferenciar los casos en los que sólo se puede elegir una opción a la que te 
permita elegir una o mas opciones.

Part of: #5220 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
