### PR TITLE
Usando `update:value` en Typeahead.vue

### DIFF
--- a/frontend/www/js/omegaup/components/common/Typeahead.test.ts
+++ b/frontend/www/js/omegaup/components/common/Typeahead.test.ts
@@ -1,14 +1,64 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import common_Typeahead from './Typeahead.vue';
+import VoerroTagsInput from '@voerro/vue-tagsinput';
+import Vue from 'vue';
 
 describe('Typeahead.vue', () => {
-  it('Should handle empty existing options list', async () => {
-    const wrapper = shallowMount(common_Typeahead, {
+  it('Should not call update-existing-options with a short query', async () => {
+    const wrapper = mount(common_Typeahead, {
       propsData: {
         existingOptions: [],
       },
     });
 
-    expect(wrapper.vm.$data.selectedOptions).toStrictEqual([]);
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('change', 'qu');
+    expect(wrapper.emitted()).toEqual({});
+  });
+
+  it('Should call update-existing-options with a longer query', async () => {
+    const wrapper = mount(common_Typeahead, {
+      propsData: {
+        existingOptions: [],
+      },
+    });
+
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('change', 'query');
+    expect(wrapper.emitted()).toEqual({
+      'update-existing-options': [['query']],
+    });
+  });
+
+  it('Should call update:value with a non-empty tag', async () => {
+    const wrapper = mount(common_Typeahead, {
+      propsData: {
+        existingOptions: [],
+      },
+    });
+
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('input', [{ key: 'key', value: 'value' }]);
+    tagsInput.vm.$emit('tag-added');
+    await Vue.nextTick();
+    expect(wrapper.emitted()).toEqual({
+      'update:value': [['key'], ['key']],
+    });
+  });
+
+  it('Should call update:value with an empty tag', async () => {
+    const wrapper = mount(common_Typeahead, {
+      propsData: {
+        existingOptions: [{ key: 'key', value: 'value' }],
+      },
+    });
+
+    const tagsInput = wrapper.findComponent(VoerroTagsInput);
+    tagsInput.vm.$emit('input', []);
+    tagsInput.vm.$emit('tag-removed');
+    await Vue.nextTick();
+    expect(wrapper.emitted()).toEqual({
+      'update:value': [[null]],
+    });
   });
 });

--- a/frontend/www/js/omegaup/components/common/Typeahead.vue
+++ b/frontend/www/js/omegaup/components/common/Typeahead.vue
@@ -44,11 +44,11 @@ export default class Typeahead extends Vue {
 
   onTagAdded(): void {
     if (this.selectedOptions.length < 1) return;
-    this.$emit('update-selected-option', this.selectedOptions[0].key);
+    this.$emit('update:value', this.selectedOptions[0].key);
   }
 
   onTagRemoved(): void {
-    this.$emit('update-selected-option', null);
+    this.$emit('update:value', null);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/contest/AddProblem.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblem.vue
@@ -8,10 +8,10 @@
             <omegaup-common-typeahead
               :existing-options="existingProblems"
               :type="'problem'"
+              :value.sync="alias"
               @update-existing-options="
                 (query) => $emit('update-existing-problems', query)
               "
-              @update-selected-option="onSelectProblem"
             >
             </omegaup-common-typeahead>
           </div>
@@ -228,10 +228,6 @@ export default class AddProblem extends Vue {
       return;
     }
     this.$emit('runs-diff', this.alias, versions, selectedCommit);
-  }
-
-  onSelectProblem(alias: string) {
-    this.alias = alias;
   }
 
   get addProblemButtonLabel(): string {


### PR DESCRIPTION
Este cambio hace que Typeahead use un evento de nombre `update:value`
para poder usar `:value.sync` en el componente padre.