### PR TITLE
Agregando archivo codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+flags:
+  php:
+    paths:
+      - ^frontend/server/.*
+  javascript:
+    paths:
+      - ^frontend/www/.*
+ignore:
+  - frontend/www/js/omegaup/api.ts
+  - frontend/www/js/omegaup/api_types.ts
+  - ^frontend/www/third_party/.*
+  - ^frontend/server/src/DAO/Base/.*
+  - ^frontend/server/lib/third_party/.*
+codecov:
+  require_ci_to_pass: true
+  strict_yaml_branch: master
+coverage:
+  status:
+    project:
+      php:
+        flags:
+          - php
+      javascript:
+        flags:
+          - javascript


### PR DESCRIPTION
Este cambio hace que codecov deje de reconocer los archivos
autogenerados y se queje por falta de pruebas.