### PR TITLE
Agregando más archivos autogenerados a las excepciones de codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -21,8 +21,9 @@ flags:
       - frontend/www/
 
 ignore:
+  - ^frontend/server/lib/third_party/.*
+  - ^frontend/server/src/DAO/Base/.*
+  - ^frontend/server/src/DAO/VO/.*
   - ^frontend/www/js/omegaup/api.ts$
   - ^frontend/www/js/omegaup/api_types.ts$
   - ^frontend/www/third_party/.*
-  - ^frontend/server/src/DAO/Base/.*
-  - ^frontend/server/lib/third_party/.*


### PR DESCRIPTION
Este cambio hace que el coverage sea más preciso, porque no es necesario
agregar pruebas a archivos autogenerados.