### PR TITLE
Creando grupo de generadores de diplomas

### DIFF
--- a/frontend/database/175_acl_certificate_generators.sql
+++ b/frontend/database/175_acl_certificate_generators.sql
@@ -1,0 +1,18 @@
+-- omegaup:certificate-generator
+INSERT INTO
+  `Roles` (`role_id`,`name`,`description`)
+VALUES
+  (8,'CertificateGenerator','Miembro del grupo que tiene privilegios para generar diplomas');
+
+INSERT INTO `ACLs` (`acl_id`, `owner_id`) VALUES (8, 1);
+
+INSERT INTO `Groups_` (`acl_id`, `alias`, `name`, `description`) VALUES (
+  8,
+  'omegaup:certificate-generator',
+  'omegaup:certificate-generator',
+  'Equipo de usuarios con privilegios para generar diplomas'
+);
+
+SET @certificate_generator_group_id = LAST_INSERT_ID();
+
+INSERT INTO `Group_Roles` VALUES(@certificate_generator_group_id, 8, 8);

--- a/frontend/database/ACLs.md
+++ b/frontend/database/ACLs.md
@@ -9,3 +9,4 @@ ID    | Descripción
 5     | `omegaup:mentor`. Los miembros de este grupo pueden ver los correos de los coders del mes.
 6     | `omegaup:support`. Los miembros de este grupo pueden realizar tareas administrativas dentro del sitio.
 7     | `omegaup:group-identity-creator`. Los miembros de este grupo tienen privilegios para crear identidades a partir de un grupo.
+8     | `omegaup:certificate-generator`. Los miembros de este grupo tienen privilegios para generar diplomas.

--- a/frontend/server/src/Authorization.php
+++ b/frontend/server/src/Authorization.php
@@ -43,6 +43,12 @@ class Authorization {
      */
     private static $_groupIdentityCreator = null;
 
+    /**
+     * Cache for system group for certificate generators
+     * @var null|\OmegaUp\DAO\VO\Groups
+     */
+    private static $_certificateGeneratorGroup = null;
+
     // Administrator for an ACL.
     const ADMIN_ROLE = 1;
 
@@ -61,6 +67,9 @@ class Authorization {
     // Identity creator.
     const IDENTITY_CREATOR_ROLE = 7;
 
+    // Certificate generator.
+    const CERTIFICATE_GENERATOR_ROLE = 8;
+
     // System-level ACL.
     const SYSTEM_ACL = 1;
 
@@ -78,6 +87,9 @@ class Authorization {
 
     // Group identities creators.
     const IDENTITY_CREATOR_GROUP_ALIAS = 'omegaup:group-identity-creator';
+
+    // Group for certificate generators.
+    const CERTIFICATE_GENERATOR_GROUP_ALIAS = 'omegaup:group-certificate-generator';
 
     public static function canViewSubmission(
         \OmegaUp\DAO\VO\Identities $identity,
@@ -239,6 +251,10 @@ class Authorization {
         return self::isGroupIdentityCreator($identity);
     }
 
+    public static function canGenerateCertificates(\OmegaUp\DAO\VO\Identities $identity): bool {
+        return self::isCertificateGenerator($identity);
+    }
+
     public static function canViewCourse(
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Courses $course,
@@ -382,6 +398,21 @@ class Authorization {
         return in_array($today, $availableDateToChooseCoder);
     }
 
+    public static function isCertificateGenerator(\OmegaUp\DAO\VO\Identities $identity): bool {
+        if (is_null(self::$_certificateGeneratorGroup)) {
+            self::$_certificateGeneratorGroup = \OmegaUp\DAO\Groups::findByAlias(
+                self::CERTIFICATE_GENERATOR_GROUP_ALIAS
+            );
+            if (is_null(self::$_certificateGeneratorGroup)) {
+                return false;
+            }
+        }
+        return self::isGroupMember(
+            $identity,
+            self::$_certificateGeneratorGroup
+        );
+    }
+
     public static function isGroupIdentityCreator(\OmegaUp\DAO\VO\Identities $identity): bool {
         if (is_null(self::$_groupIdentityCreator)) {
             self::$_groupIdentityCreator = \OmegaUp\DAO\Groups::findByAlias(
@@ -481,6 +512,7 @@ class Authorization {
         self::$_mentorGroup = null;
         self::$_supportGroup = null;
         self::$_groupIdentityCreator = null;
+        self::$_certificateGeneratorGroup = null;
     }
 
     public static function canSubmitToProblemset(


### PR DESCRIPTION
# Descripción

Se agrega el grupo de generadores de diplomas como parte del proyecto de Generación y Validación Automática de Diplomas.

Fixes: #5246

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
