### PR TITLE
Agregando componente ToggleSwitch

### DIFF
--- a/frontend/www/js/omegaup/components/ToggleSwitch.test.ts
+++ b/frontend/www/js/omegaup/components/ToggleSwitch.test.ts
@@ -1,0 +1,25 @@
+import { shallowMount } from '@vue/test-utils';
+
+import omegaup_ToggleSwitch, { ToggleSwitchSize } from './ToggleSwitch.vue';
+
+describe('ToggleSwitch.vue', () => {
+  it('Should render a simple toggle switch with default description and size', () => {
+    const wrapper = shallowMount(omegaup_ToggleSwitch, {
+      propsData: {
+        checkedValue: true,
+      },
+    });
+    expect(wrapper.find('label[class*="large"]').text()).toBe('Check');
+  });
+
+  it('Should render a simple toggle switch with custom description and size', () => {
+    const wrapper = shallowMount(omegaup_ToggleSwitch, {
+      propsData: {
+        checkedValue: true,
+        textDescription: 'Are you happy?',
+        size: ToggleSwitchSize.Small,
+      },
+    });
+    expect(wrapper.find('label[class*="small"]').text()).toBe('Are you happy?');
+  });
+});

--- a/frontend/www/js/omegaup/components/ToggleSwitch.vue
+++ b/frontend/www/js/omegaup/components/ToggleSwitch.vue
@@ -41,6 +41,7 @@ export default class ToggleSwitch extends Vue {
 </script>
 
 <style scoped lang="scss">
+@import '../../../sass/main.scss';
 .switch {
   position: relative;
   display: inline-block;
@@ -109,14 +110,14 @@ label[class*='small'] {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: #ccc;
+  background-color: $btn-cancel-color;
   -webkit-transition: 0.4s;
   transition: 0.4s;
   &:before {
     position: absolute;
     content: '';
     bottom: 4px;
-    background-color: white;
+    background-color: $white;
     -webkit-transition: 0.4s;
     transition: 0.4s;
   }
@@ -125,14 +126,14 @@ input {
   &:checked {
     + {
       .slider {
-        background-color: #2196f3;
+        background-color: $header-primary-color;
       }
     }
   }
   &:focus {
     + {
       .slider {
-        box-shadow: 0 0 1px #2196f3;
+        box-shadow: 0 0 1px $header-primary-color;
       }
     }
   }

--- a/frontend/www/js/omegaup/components/ToggleSwitch.vue
+++ b/frontend/www/js/omegaup/components/ToggleSwitch.vue
@@ -1,0 +1,158 @@
+<template>
+  <label class="switch-container font-weight-bold" :class="size">
+    <div class="switch">
+      <input
+        v-model="currentCheckedValue"
+        :value="currentCheckedValue"
+        type="checkbox"
+      />
+      <span class="slider round"></span>
+    </div>
+    <slot name="switch-text">
+      <span class="switch-text">
+        {{ textDescription }}
+      </span>
+    </slot>
+  </label>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
+
+export enum ToggleSwitchSize {
+  Small = 'small',
+  Large = 'large',
+}
+
+@Component
+export default class ToggleSwitch extends Vue {
+  @Prop({ default: 'Check' }) textDescription!: string;
+  @Prop({ default: true }) checkedValue!: boolean;
+  @Prop({ default: ToggleSwitchSize.Large }) size!: ToggleSwitchSize;
+
+  currentCheckedValue = this.checkedValue;
+
+  @Watch('currentCheckedValue')
+  @Emit('update:value')
+  onUpdateInput(newValue: boolean): boolean {
+    return newValue;
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.switch {
+  position: relative;
+  display: inline-block;
+  input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+}
+label[class*='large'] {
+  .switch {
+    width: 60px;
+    height: 34px;
+  }
+  .slider {
+    &:before {
+      height: 26px;
+      width: 26px;
+      left: 4px;
+    }
+  }
+  input {
+    &:checked {
+      + {
+        .slider {
+          &:before {
+            -webkit-transform: translateX(26px);
+            -ms-transform: translateX(26px);
+            transform: translateX(26px);
+          }
+        }
+      }
+    }
+  }
+}
+label[class*='small'] {
+  .switch {
+    width: 40px;
+    height: 26px;
+  }
+  .slider {
+    &:before {
+      height: 18px;
+      width: 18px;
+      left: 3px;
+    }
+  }
+  input {
+    &:checked {
+      + {
+        .slider {
+          &:before {
+            -webkit-transform: translateX(15px);
+            -ms-transform: translateX(15px);
+            transform: translateX(15px);
+          }
+        }
+      }
+    }
+  }
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
+  &:before {
+    position: absolute;
+    content: '';
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: 0.4s;
+    transition: 0.4s;
+  }
+}
+input {
+  &:checked {
+    + {
+      .slider {
+        background-color: #2196f3;
+      }
+    }
+  }
+  &:focus {
+    + {
+      .slider {
+        box-shadow: 0 0 1px #2196f3;
+      }
+    }
+  }
+}
+.slider.round {
+  border-radius: 34px;
+  &:before {
+    border-radius: 50%;
+  }
+}
+.switch-container {
+  width: 100%;
+  position: relative;
+  span.switch-text {
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    margin-left: 5px;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+  }
+}
+</style>

--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -141,15 +141,11 @@
         </div>
       </div>
       <div class="form-group">
-        <label class="switch-container font-weight-bold">
-          <div class="switch">
-            <input v-model="allowTags" type="checkbox" />
-            <span class="slider round"></span>
-          </div>
-          <span class="switch-text">
-            {{ T.problemEditFormAllowUserAddTags }}
-          </span>
-        </label>
+        <omegaup-toggle-switch
+          :value.sync="allowTags"
+          :checked-value="allowTags"
+          :text-description="T.problemEditFormAllowUserAddTags"
+        ></omegaup-toggle-switch>
       </div>
     </div>
     <input
@@ -165,6 +161,7 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
 import VueTypeaheadBootstrap from 'vue-typeahead-bootstrap';
+import omegaup_ToggleSwitch from '../ToggleSwitch.vue';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -175,6 +172,7 @@ library.add(faTrash);
   components: {
     FontAwesomeIcon,
     VueTypeaheadBootstrap,
+    'omegaup-toggle-switch': omegaup_ToggleSwitch,
   },
 })
 export default class ProblemTags extends Vue {
@@ -256,82 +254,3 @@ export default class ProblemTags extends Vue {
   }
 }
 </script>
-
-<style>
-/* The switch - the box around the slider */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 60px;
-  height: 34px;
-}
-
-/* Hide default HTML checkbox */
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-/* The slider */
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
-}
-
-.slider:before {
-  position: absolute;
-  content: '';
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
-}
-
-input:checked + .slider {
-  background-color: #2196f3;
-}
-
-input:focus + .slider {
-  box-shadow: 0 0 1px #2196f3;
-}
-
-input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
-}
-
-/* Rounded sliders */
-.slider.round {
-  border-radius: 34px;
-}
-
-.slider.round:before {
-  border-radius: 50%;
-}
-
-.switch-container {
-  width: 100%;
-  position: relative;
-}
-
-.switch-container span.switch-text {
-  margin: 0;
-  position: absolute;
-  top: 50%;
-  margin-left: 5px;
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-</style>


### PR DESCRIPTION
# Descripción

Se agrega un componente para darle estilos a los checkboxes tradicionales.
Una vez aprobado este cambio, se puede utilizar en cualquier formulario que
se desee.

![ToggleSwitch](https://user-images.githubusercontent.com/3230352/112380100-96f88680-8cae-11eb-994c-de1aa0805299.gif)

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
