### PR TITLE
Evitando el uso de algunas llamadas al reloj

### DIFF
--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -87,6 +87,7 @@ class Run extends \OmegaUp\Controllers\Controller {
      * runs be created.
      */
     private static function validateWithinSubmissionGap(
+        \OmegaUp\DAO\VO\Submissions $submission,
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Problems $problem,
         ?\OmegaUp\DAO\VO\Contests $contest
@@ -94,6 +95,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         if (is_null($contest)) {
             if (
                 !\OmegaUp\DAO\Submissions::isInsideSubmissionGap(
+                    $submission,
                     null,
                     null,
                     intval($problem->problem_id),
@@ -108,6 +110,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         } else {
             if (
                 !\OmegaUp\DAO\Submissions::isInsideSubmissionGap(
+                    $submission,
                     intval($contest->problemset_id),
                     $contest,
                     intval($problem->problem_id),
@@ -482,7 +485,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             'status' => 'uploading',
             'runtime' => 0,
             'penalty' => $submitDelay,
-            'time' => \OmegaUp\Time::get(),
+            'time' => $submission->time,
             'memory' => 0,
             'score' => 0,
             'contest_score' => !is_null($problemsetId) ? 0 : null,
@@ -495,6 +498,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             // _Now_ that we are in a transaction, we can check whether the run
             // is within the submission gap.
             self::validateWithinSubmissionGap(
+                $submission,
                 $r->identity,
                 $problem,
                 $contest

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -106,6 +106,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
      * submission gap.
      */
     final public static function isInsideSubmissionGap(
+        \OmegaUp\DAO\VO\Submissions $submission,
         ?int $problemsetId,
         ?\OmegaUp\DAO\VO\Contests $contest,
         int $problemId,
@@ -161,7 +162,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
             );
         }
 
-        return \OmegaUp\Time::get() >= ($lastRunTime->time + $submissionGap);
+        return $submission->time->time >= ($lastRunTime->time + $submissionGap);
     }
 
     public static function countAcceptedSubmissions(


### PR DESCRIPTION
Este cambio hace que al momento de crear envíos, se intente evitar
llamadas innecesarias a `\OmegaUp\Time::get()`. Esto es para evitar
condiciones de carrera súper raras (pero teoréticamente factibles).