### PR TITLE
Cambiando el componente de DateTimePicker por uno de vue

### DIFF
--- a/frontend/www/js/omegaup/time.test.ts
+++ b/frontend/www/js/omegaup/time.test.ts
@@ -18,7 +18,7 @@ describe('time', () => {
   });
 
   describe('formatDateTimeLocal', () => {
-    const expectedValue = '2010-01-01T11:22';
+    const expectedValue = '2010-01-01T11:22:33.0000Z';
 
     it('Should format dates correctly', () => {
       expect(time.formatDateTimeLocal(new Date('2010-01-01 11:22:33'))).toEqual(

--- a/frontend/www/js/omegaup/time.ts
+++ b/frontend/www/js/omegaup/time.ts
@@ -107,7 +107,11 @@ export function parseDateTimeLocal(dateString: string): Date {
   // Date.parse() will use UTC if given a timestamp with that format, instead
   // of the local timezone.
   const result = new Date();
-  const matches = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(dateString);
+  console.log(dateString);
+  const matches = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})Z$/.exec(
+    dateString,
+  );
+  console.log(matches);
   if (matches !== null) {
     result.setFullYear(Number.parseInt(matches[1], 10));
     // Months in JavaScript start at 0.

--- a/package.json
+++ b/package.json
@@ -104,21 +104,26 @@
     "@types/gapi": "^0.0.39",
     "@types/gapi.auth2": "0.0.52",
     "@types/latinize": "^0.2.15",
+    "@types/luxon": "^1.26.2",
     "@types/sortablejs": "^1.10.4",
+    "@types/vue-datetime": "^1.0.1",
     "codemirror": "^5.38.0",
     "jszip": "^3.1.5",
     "latinize": "^0.4.1",
+    "luxon": "^1.26.0",
     "monaco-editor": "^0.21",
     "pako": "^1.0.7",
     "typescript-optional": "^2.0.1",
     "v-clipboard": "^2.2.3",
     "v-tooltip": "^3.0.0-alpha.7",
     "vue": "^2.5.22",
+    "vue-datetime": "^1.0.0-beta.14",
     "vue-gapi": "^0.3.1",
     "vue-google-oauth2": "^1.5.5",
     "vue-multiselect": "^2.1.6",
     "vue-recaptcha": "^1.3.0",
     "vue-slider-component": "^3.0.25",
-    "vue-typeahead-bootstrap": "^2.1.2"
+    "vue-typeahead-bootstrap": "^2.1.2",
+    "weekstart": "^1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,6 +1882,11 @@
   resolved "https://registry.yarnpkg.com/@types/latinize/-/latinize-0.2.15.tgz#a1718e53c5d6a37a554cbe4209e4ab15adc975f9"
   integrity sha1-oXGOU8XWo3pVTL5CCeSrFa3Jdfk=
 
+"@types/luxon@^1.26.2":
+  version "1.26.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-1.26.2.tgz#656c24c1af3d41b8854700dc94ed556b9b6ce2f8"
+  integrity sha512-2pvzy4LuxBMBBLAbml6PDcJPiIeZQ0Hqj3PE31IxkNI250qeoRMDovTrHXeDkIL4auvtarSdpTkLHs+st43EYQ==
+
 "@types/mdast@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
@@ -1984,6 +1989,13 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/vue-datetime@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/vue-datetime/-/vue-datetime-1.0.1.tgz#fedfbea8792eae48c6b9b9cafa133363a689674b"
+  integrity sha512-MbuhT/JbOLvLIrMGwvq0KxghgM5Ud65sHRi+zNHcx6iWhkIv221KJzSXaEFufbWlkZSrSCNa+utaiqjNjBahVQ==
+  dependencies:
+    vue "^2.0.0"
 
 "@types/webpack-sources@*":
   version "0.1.5"
@@ -6283,6 +6295,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
+  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -9328,6 +9345,11 @@ vue-codemirror-lite@^1.0.4:
   dependencies:
     codemirror "^5.22.0"
 
+vue-datetime@^1.0.0-beta.14:
+  version "1.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/vue-datetime/-/vue-datetime-1.0.0-beta.14.tgz#791e724500929cdfeb31395154d9a26fd27ffb46"
+  integrity sha512-n25LqldE1xryeoweohiqlxy8iUsi+UwZnKLaN4gXjk7xxGL6rUl1y/GGvkoMwJUzRKttw+QnQV4oFAYupUQdug==
+
 vue-eslint-parser@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz#9cdbcc823e656b087507a1911732b867ac101e83"
@@ -9451,15 +9473,15 @@ vue-typeahead-bootstrap@^2.1.2:
     resize-observer-polyfill "^1.5.0"
     vue "^2.5.17"
 
+vue@^2.0.0, vue@^2.5.22:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
+  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+
 vue@^2.5.17:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
-
-vue@^2.5.22:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
-  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
 
 vuex@^3.0.1:
   version "3.1.2"
@@ -9597,6 +9619,11 @@ webpack@^5.8:
     terser-webpack-plugin "^5.0.3"
     watchpack "^2.0.0"
     webpack-sources "^2.1.1"
+
+weekstart@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/weekstart/-/weekstart-1.1.0.tgz#af642eb10dc24b1af9d4dcc0415056edc087b897"
+  integrity sha512-ZO3I7c7J9nwGN1PZKZeBYAsuwWEsCOZi5T68cQoVNYrzrpp5Br0Bgi0OF4l8kH/Ez7nKfxa5mSsXjsgris3+qg==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
# Descripción

Intentando reparar el bug donde describen que no se puede publicar un 
concurso  con fecha de abril y algunos otros meses, se decide cambiar el
componente de `DateTimePicker` por uno nativo de vue. 

El problema es que aún cuando se cambió, el error persiste sin poder 
identificar a que se debe la falla, ya se permite elegir una fecha de abril,
pero al guardar los cambios y actualizar la página lo muestra como si fuera 
de mayo:

![DateTimePickerFailed](https://user-images.githubusercontent.com/3230352/113236190-a9039780-9261-11eb-9eec-9e5cfa62b554.gif)


Part of: #5298

# Comentarios

Como no funciona correctamente lo dejaré como draft en lo que encuentro
como solucionarlo.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
