### PR TITLE
Arreglando falla al mostrar detalles de envío en curso como Administrador

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunDetails.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetails.vue
@@ -31,7 +31,7 @@
             ></textarea>
             <button
               class="btn btn-sm btn-primary"
-              :disabled="feedback.length === 0"
+              :disabled="!feedback"
               @click.prevent="
                 $emit('send-feedback', {
                   guid: data.guid,


### PR DESCRIPTION
# Descripción

Se arregla bug que no permitía ver los detalles de un envío como administrador
de un curso.

Esto se debía a que se intentaba conocer la longitud de caracteres de un campo 
que podía contener un valor nulo.

Fixes: #5309 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
