### PR TITLE
Arreglando bug que no permitía mostrar código en las soluciones de un problema

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -56,6 +56,7 @@
           <omegaup-markdown
             ref="statement-markdown"
             :markdown="problem.statement.markdown"
+            :source-mapping="problem.statement.sources"
             :image-mapping="problem.statement.images"
             :problem-settings="problem.settings"
             @rendered="onProblemRendered"

--- a/frontend/www/js/omegaup/components/problem/Solution.vue
+++ b/frontend/www/js/omegaup/components/problem/Solution.vue
@@ -3,6 +3,7 @@
     <omegaup-markdown
       v-if="showSolution"
       :markdown="solution.markdown"
+      :source-mapping="solution.sources"
       :image-mapping="solution.images"
     ></omegaup-markdown>
     <div v-else class="interstitial">

--- a/frontend/www/js/omegaup/components/problem/StatementEdit.vue
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.vue
@@ -36,6 +36,7 @@
           <h1 class="title text-center">{{ title }}</h1>
           <omegaup-markdown
             :markdown="currentMarkdown"
+            :source-mapping="statement.sources"
             :image-mapping="statement.images"
             preview="true"
           ></omegaup-markdown>


### PR DESCRIPTION
# Descripción

Resulta que no se estaba mandando el `sourceMapping` al componente de
`Markdown.vue`, el cual contiene todo el mapeo de los recursos que pertenecen
al problema, tanto en el statement, como en la solución del mismo. Y esto 
ocasionaba que nunca encontrara recursos (código) para mostrar.

![SourceMappingProblems](https://user-images.githubusercontent.com/3230352/113973374-d623ed00-9801-11eb-84e8-f0b89633c40c.gif)


Part of: #5314 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
