### PR TITLE
Agregando pruebas en vue para agregar código embebido en markdown

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Details.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Details.test.ts
@@ -9,7 +9,7 @@ import problem_Details from './Details.vue';
 
 describe('Details.vue', () => {
   const date = new Date();
-  const sampleProblem: types.ProblemInfo = {
+  const problem: types.ProblemInfo = {
     alias: 'triangulos',
     accepts_submissions: true,
     karel_problem: false,
@@ -55,8 +55,18 @@ describe('Details.vue', () => {
     statement: {
       images: {},
       sources: {},
-      language: 'es',
-      markdown: '# test',
+      language: 'en',
+      markdown: `# test with embed code
+Here we can add code.
+<details>
+  <summary>
+    Example:
+  </summary>
+
+  {{sample.cpp}}
+
+  </details>
+      `,
     },
     title: 'Triangulos',
     visibility: 2,
@@ -146,23 +156,23 @@ describe('Details.vue', () => {
     const wrapper = mount(problem_Details, {
       propsData: {
         initialTab: 'problems',
-        problem: sampleProblem,
+        problem,
         runDetailsData,
-        user: user,
-        nominationStatus: nominationStatus,
+        user,
+        nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
         runs: [] as types.Run[],
         allRuns: [] as types.Run[],
         clarifications: [] as types.Clarification[],
         solutionStatus: 'not_found',
-        histogram: histogram,
+        histogram,
         showNewRunWindow: false,
         publicTags: [],
       },
     });
 
-    expect(wrapper.text()).toContain(sampleProblem.points);
+    expect(wrapper.text()).toContain(problem.points);
     expect(wrapper.text()).toContain(time.formatDate(date));
   });
 
@@ -170,17 +180,17 @@ describe('Details.vue', () => {
     const wrapper = mount(problem_Details, {
       propsData: {
         initialTab: 'problems',
-        problem: sampleProblem,
+        problem,
         runDetailsData,
-        user: user,
-        nominationStatus: nominationStatus,
+        user,
+        nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
-        runs: runs,
+        runs,
         allRuns: runs,
         clarifications: [] as types.Clarification[],
         solutionStatus: 'not_found',
-        histogram: histogram,
+        histogram,
         showNewRunWindow: false,
         publicTags: [],
         shouldShowTabs: true,
@@ -203,17 +213,17 @@ describe('Details.vue', () => {
     const wrapper = mount(problem_Details, {
       propsData: {
         initialTab: 'problems',
-        problem: sampleProblem,
+        problem,
         runDetailsData,
-        user: user,
-        nominationStatus: nominationStatus,
+        user,
+        nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
-        runs: runs,
+        runs,
         allRuns: runs,
         clarifications: [] as types.Clarification[],
         solutionStatus: 'not_found',
-        histogram: histogram,
+        histogram,
         showNewRunWindow: false,
         publicTags: [],
         shouldShowTabs: true,
@@ -266,17 +276,17 @@ describe('Details.vue', () => {
     const wrapper = mount(problem_Details, {
       propsData: {
         initialTab: 'problems',
-        problem: sampleProblem,
+        problem,
         runDetailsData,
-        user: user,
-        nominationStatus: nominationStatus,
+        user,
+        nominationStatus,
         initialClarifications: [],
         activeTab: 'problems',
-        runs: runs,
+        runs,
         allRuns: runs,
         clarifications: clarifications as types.Clarification[],
         solutionStatus: 'not_found',
-        histogram: histogram,
+        histogram,
         showNewRunWindow: false,
         publicTags: [],
         shouldShowTabs: true,
@@ -285,6 +295,72 @@ describe('Details.vue', () => {
     await wrapper.find('a[href="#clarifications"]').trigger('click');
     expect(wrapper.find('.tab-content .show table thead tr th').text()).toBe(
       T.wordsContest,
+    );
+  });
+
+  it('Should handle unrecognized source filename error', () => {
+    const wrapper = mount(problem_Details, {
+      propsData: {
+        initialTab: 'problems',
+        problem,
+        runDetailsData,
+        user,
+        nominationStatus,
+        initialClarifications: [],
+        activeTab: 'problems',
+        runs,
+        allRuns: runs,
+        clarifications: [] as types.Clarification[],
+        solutionStatus: 'not_found',
+        histogram,
+        showNewRunWindow: false,
+        publicTags: [],
+        shouldShowTabs: true,
+      },
+    });
+
+    expect(wrapper.find('div[data-markdown-statement]').text()).toContain(
+      'Unrecognized source filename: sample.cpp',
+    );
+  });
+
+  it('Should handle a valid source filename with content', async () => {
+    problem.statement.sources = {
+      'sample.cpp': `#include <iostream>
+
+int main() {
+  std::cout << "This is only an example";
+  return 0;
+}`,
+    };
+    const wrapper = mount(problem_Details, {
+      propsData: {
+        initialTab: 'problems',
+        problem,
+        runDetailsData,
+        user,
+        nominationStatus,
+        initialClarifications: [],
+        activeTab: 'problems',
+        runs,
+        allRuns: runs,
+        clarifications: [] as types.Clarification[],
+        solutionStatus: 'not_found',
+        histogram,
+        showNewRunWindow: false,
+        publicTags: [],
+        shouldShowTabs: true,
+      },
+    });
+
+    expect(wrapper.find('details').attributes()).toMatchObject({});
+    await wrapper.find('details > summary').trigger('click');
+    expect(wrapper.find('details').attributes()).toMatchObject({ open: '' });
+    expect(wrapper.find('div[data-markdown-statement]').text()).toContain(
+      '#include <iostream>',
+    );
+    expect(wrapper.find('div[data-markdown-statement]').text()).toContain(
+      'This is only an example',
     );
   });
 });

--- a/frontend/www/js/omegaup/components/problem/StatementEdit.test.ts
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.test.ts
@@ -1,58 +1,15 @@
 import { mount } from '@vue/test-utils';
 
 import type { types } from '../../api_types';
-import T from '../../lang';
 
-import problem_Solution from './Solution.vue';
+import problem_StatementEdit from './StatementEdit.vue';
 
-describe('Solution.vue', () => {
-  it('Should handle an empty/locked solution', () => {
-    const wrapper = mount(problem_Solution, {
-      propsData: {
-        solution: null as types.ProblemStatement | null,
-        status: 'locked',
-        availableTokens: 0,
-        allTokens: 0,
-      },
-    });
-
-    expect(wrapper.text()).toContain(T.solutionLocked.split('\n')[0]);
-  });
-
-  it('Should handle an empty/unlocked solution', () => {
-    const wrapper = mount(problem_Solution, {
-      propsData: {
-        solution: null as types.ProblemStatement | null,
-        status: 'unlocked',
-        availableTokens: 0,
-        allTokens: 0,
-      },
-    });
-
-    expect(wrapper.text()).toContain(T.solutionConfirm);
-  });
-
-  it('Should handle a non-empty, unlocked solution', () => {
-    const wrapper = mount(problem_Solution, {
-      propsData: {
-        solution: {
-          markdown: 'Hello, World!',
-          images: {},
-        } as types.ProblemStatement | null,
-        status: 'unlocked',
-        availableTokens: 0,
-        allTokens: 0,
-      },
-    });
-
-    expect(wrapper.text()).toContain('Hello, World!');
-  });
-
+describe('StatementEdit.vue', () => {
   it('Should handle unrecognized source filename error', () => {
-    const wrapper = mount(problem_Solution, {
+    const wrapper = mount(problem_StatementEdit, {
       propsData: {
-        solution: {
-          markdown: `# test with embed code in solution
+        statement: {
+          markdown: `# test with embed code in statement
 Here we can add code.
 <details>
   <summary>
@@ -76,10 +33,10 @@ Here we can add code.
   });
 
   it('Should handle a valid source filename with content', async () => {
-    const wrapper = mount(problem_Solution, {
+    const wrapper = mount(problem_StatementEdit, {
       propsData: {
-        solution: {
-          markdown: `# test with embed code in solution
+        statement: {
+          markdown: `# test with embed code in statement
 Here we can add code.
 <details>
   <summary>
@@ -91,7 +48,7 @@ Here we can add code.
   </details>`,
           sources: {
             'sample.cpp': `#include <iostream>
-
+      
       int main() {
         std::cout << "This is only an example";
         return 0;


### PR DESCRIPTION
# Descripción

Se agregan las pruebas que quedaron pendientes en el PR #5315 para poder
embeber código en el markdown.

Fixes: #5316 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
