### PR TITLE
Validando la integridad del script de codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,14 @@ jobs:
             --show-info=false
 
       - name: Upload code coverage
-        run: bash <(curl -s https://codecov.io/bash) -cF php
+        run: |
+          curl -s https://codecov.io/bash > codecov
+          VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2)
+          for i in 1 256 512
+          do
+            shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM)
+          done
+          bash codecov -cF php
 
       - name: Upload artifacts
         if: ${{ always() }}
@@ -125,7 +132,13 @@ jobs:
 
       - name: Upload code coverage
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF javascript
+          curl -s https://codecov.io/bash > codecov
+          VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2)
+          for i in 1 256 512
+          do
+            shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM)
+          done
+          bash codecov -cF javascript
 
   lint:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Este cambio hace que el script de codecov se valide contra los
hashes publicados como se sugiere en
https://docs.codecov.io/docs/about-the-codecov-bash-uploader . Esto es
para mitigar un incidente que tuvo codecov:
https://about.codecov.io/security-update/