### PR TITLE
Arreglando un error en el esquema de la base de datos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.0.23
         ports:
           - 3306:3306
         env:

--- a/frontend/database/32_schema_fixup.sql
+++ b/frontend/database/32_schema_fixup.sql
@@ -16,7 +16,7 @@ ALTER TABLE `User_Roles` DROP KEY `contest_id`;
 --
 -- Corrige la codificación de estas tablas.
 --
-ALTER TABLE `Problemset_User_Request` CONVERT TO CHARACTER SET utf8;
-ALTER TABLE `Problemset_User_Request` DEFAULT CHARACTER SET utf8;
-ALTER TABLE `Problemset_User_Request_History` CONVERT TO CHARACTER SET utf8;
-ALTER TABLE `Problemset_User_Request_History` DEFAULT CHARACTER SET utf8;
+ALTER TABLE `Problemset_User_Request` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `Problemset_User_Request` DEFAULT CHARACTER SET utf8mb4;
+ALTER TABLE `Problemset_User_Request_History` CONVERT TO CHARACTER SET utf8mb4;
+ALTER TABLE `Problemset_User_Request_History` DEFAULT CHARACTER SET utf8mb4;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -689,7 +689,7 @@ CREATE TABLE `Problemset_Identity_Request` (
   KEY `identity_id` (`identity_id`),
   CONSTRAINT `fk_piri_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_purp_problemset_id` FOREIGN KEY (`problemset_id`) REFERENCES `Problemsets` (`problemset_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Used when admission_mode = registration';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Used when admission_mode = registration';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
@@ -705,7 +705,7 @@ CREATE TABLE `Problemset_Identity_Request_History` (
   KEY `identity_problemset_hist` (`identity_id`,`problemset_id`),
   CONSTRAINT `fk_pirhi_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_purhp_problemset_id` FOREIGN KEY (`problemset_id`) REFERENCES `Problemsets` (`problemset_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;

--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -48,6 +48,6 @@ fi
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \
 	--env "MYPYPATH=${OMEGAUP_ROOT}/stuff" \
-	omegaup/hook_tools:20210327 --command-name="./stuff/lint.sh" $ARGS
+	omegaup/hook_tools:20210420 --command-name="./stuff/lint.sh" $ARGS
 
 echo OK


### PR DESCRIPTION
Este cambio hace que cuando hay errores de validación, se muestre el
comando que hay que correr para arreglarlos, en vez de arrojar una
excepción.