### PR TITLE
Mostrando correctamente el listado de envíos en concursos modo práctica

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestPractice.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.vue
@@ -35,7 +35,7 @@
               :user="{ loggedIn: true, admin: false, reviewer: false }"
               :problem="problemInfo"
               :active-tab="'problems'"
-              :runs="activeProblem.runs"
+              :runs="problemRuns"
               :popup-displayed="popupDisplayed"
               :guid="guid"
               :problem-alias="problemAlias"
@@ -166,13 +166,17 @@ export default class ArenaContestPractice extends Vue {
     return this.activeProblem?.problem.alias ?? null;
   }
 
+  get problemRuns(): types.Run[] {
+    return this.problem?.runs ?? [];
+  }
+
   onNavigateToProblem(request: ActiveProblem) {
     this.activeProblem = request;
     this.$emit('navigate-to-problem', request);
   }
 
   onRunSubmitted(run: { code: string; language: string }): void {
-    this.$emit('submit-run', Object.assign({}, run, this.activeProblem));
+    this.$emit('submit-run', Object.assign({}, run, this.problem));
   }
 
   onClarificationResponse(response: types.Clarification): void {


### PR DESCRIPTION
# Descripción

Se arregla el bug en el cual dejaban de aparecer los envíos realizados de los
problemas en concursos modo práctica.

Resulta que sólo fue una confusión de nombre de variable, que se tendrá que 
revisar a detalle en un cambio posterior.

Fixes: #5342 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
