### PR TITLE
Arreglando las pruebas flaky de events_socket

### DIFF
--- a/frontend/www/js/omegaup/arena/events_socket.test.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.test.ts
@@ -44,14 +44,12 @@ const options: SocketOptions = {
   currentUsername: 'omegaUp',
   intervalInMilliseconds: 500,
 };
-
 describe('EventsSocket', () => {
   let server: WS | null = null;
-  const now = Date.now();
-  let dateNowSpy: jest.SpyInstance<number, []> | null = null;
+
   beforeEach(() => {
     OmegaUp.ready = true;
-    dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    jest.useFakeTimers();
     server = new WS(`ws://${options.locationHost}/events/`, {
       selectProtocol: () => 'com.omegaup.events',
       jsonProtocol: true,
@@ -102,14 +100,12 @@ describe('EventsSocket', () => {
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
     server = null;
     WS.clean();
-    if (dateNowSpy) {
-      dateNowSpy.mockRestore();
-    }
   });
 
-  jest.useFakeTimers();
   it('can be instantiated', () => {
     const socket = new EventsSocket(options);
     expect(socket.shouldRetry).toEqual(false);
@@ -134,7 +130,6 @@ describe('EventsSocket', () => {
     const socket = new EventsSocket({ ...options, disableSockets: false });
     socket.connect();
     await server?.connected;
-    jest.runAllTimers();
     expect(socket.socketStatus).toEqual(SocketStatus.Connected);
   });
 

--- a/frontend/www/js/omegaup/arena/events_socket.test.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.test.ts
@@ -129,12 +129,12 @@ describe('EventsSocket', () => {
   it('should handle a socket successfully connected', async () => {
     const socket = new EventsSocket({ ...options, disableSockets: false });
     socket.connect();
+    jest.runOnlyPendingTimers();
     await server?.connected;
     expect(socket.socketStatus).toEqual(SocketStatus.Connected);
   });
 
   it('should handle a socket when it is closed', async () => {
-    await server?.connected;
     server?.on('connection', (socket) => {
       socket.close({ wasClean: false, code: 1003, reason: 'any' });
     });
@@ -152,6 +152,7 @@ describe('EventsSocket', () => {
     const socket = new EventsSocket({ ...options, disableSockets: false });
 
     socket.connect();
+    jest.runOnlyPendingTimers();
     await server?.connected;
 
     const localVue = createLocalVue();
@@ -188,6 +189,7 @@ describe('EventsSocket', () => {
     const socket = new EventsSocket({ ...options, disableSockets: false });
 
     socket.connect();
+    jest.runOnlyPendingTimers();
     await server?.connected;
 
     const localVue = createLocalVue();
@@ -223,6 +225,7 @@ describe('EventsSocket', () => {
     const socket = new EventsSocket({ ...options, disableSockets: false });
 
     socket.connect();
+    jest.runOnlyPendingTimers();
     await server?.connected;
 
     server?.send({


### PR DESCRIPTION
# Descripción

Este cambio arregla las pruebas de events_socket, las cuales están fallando
esporádicamente, agregando timers falsos de jest.

Fixes: #5339 

# Comentarios

Al tener llamados a `setTimeout` en el objeto `EventsSocket`, pensé que podría
arreglarse de una forma similar al componente `Countdown`, pero aquí 
comienzan a fallar todas las pruebas donde se intenta conectar al `WebSocket`.

Aún no encuentro el porqué.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
