### PR TITLE
Limpiando los timers falsos al terminar las pruebas

### DIFF
--- a/frontend/www/js/omegaup/components/Countdown.test.ts
+++ b/frontend/www/js/omegaup/components/Countdown.test.ts
@@ -5,17 +5,19 @@ describe('Countdown.vue', () => {
   let now = Date.now();
   let dateNowSpy: jest.SpyInstance<number, []> | null = null;
 
-  beforeAll(() => {
+  beforeEach(() => {
     dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    jest.useFakeTimers();
   });
 
-  afterAll(() => {
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
     if (dateNowSpy) {
       dateNowSpy.mockRestore();
     }
   });
 
-  jest.useFakeTimers();
   it('Should handle a countdown with 5 seconds left to finish', async () => {
     const wrapper = shallowMount(omegaup_Countdown, {
       propsData: {


### PR DESCRIPTION
Este cambio hace que después de que corren las pruebas que usan timers
falsos, estos se regresen a su estado original.