### PR TITLE
Agregando función createCharts en el archivo ranking.ts

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -48,14 +48,23 @@ OmegaUp.on('ready', () => {
     users = rankingInfo.users;
 
     const startTimestamp = payload.contest.start_time.getTime();
-    const finishTimestamp =  Math.min(payload.contest.finish_time?.getTime() || Infinity, Date.now());
+    const finishTimestamp = Math.min(
+      payload.contest.finish_time?.getTime() || Infinity,
+      Date.now(),
+    );
     const { series, navigatorData } = onRankingEvents({
       events: payload.scoreboardEvents,
       currentRanking: rankingInfo.currentRanking,
       startTimestamp,
       finishTimestamp,
     });
-    rankingChartOptions = createChart({ series, navigatorData, startTimestamp, finishTimestamp, maxPoints: rankingInfo.maxPoints });
+    rankingChartOptions = createChart({
+      series,
+      navigatorData,
+      startTimestamp,
+      finishTimestamp,
+      maxPoints: rankingInfo.maxPoints,
+    });
   }
 
   const contestContestant = new Vue({

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -37,7 +37,7 @@ OmegaUp.on('ready', () => {
 
   let ranking: types.ScoreboardRankingEntry[];
   let users: omegaup.UserRank[];
-  let rankingChartOptions: Highcharts.Options | null;
+  let rankingChartOptions: Highcharts.Options | null = null;
   if (payload.scoreboard && payload.scoreboardEvents) {
     const rankingInfo = onRankingChanged({
       scoreboard: payload.scoreboard,
@@ -58,13 +58,15 @@ OmegaUp.on('ready', () => {
       startTimestamp,
       finishTimestamp,
     });
-    rankingChartOptions = createChart({
-      series,
-      navigatorData,
-      startTimestamp,
-      finishTimestamp,
-      maxPoints: rankingInfo.maxPoints,
-    });
+    if (series.length) {
+      rankingChartOptions = createChart({
+        series,
+        navigatorData,
+        startTimestamp,
+        finishTimestamp,
+        maxPoints: rankingInfo.maxPoints,
+      });
+    }
   }
 
   const contestContestant = new Vue({

--- a/frontend/www/js/omegaup/arena/events_socket.test.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.test.ts
@@ -234,6 +234,7 @@ describe('EventsSocket', () => {
       users: [],
       ranking: [],
       currentRanking: { omegaUp: 0 },
+      maxPoints: 300,
     });
     server?.send({
       message: '/scoreboard/update/',

--- a/frontend/www/js/omegaup/arena/ranking.test.ts
+++ b/frontend/www/js/omegaup/arena/ranking.test.ts
@@ -5,6 +5,8 @@ import {
   onRankingChanged,
   onRankingEvents,
   updateProblemScore,
+  createChart,
+  scoreboardColors,
 } from './ranking';
 
 describe('ranking', () => {
@@ -181,6 +183,112 @@ describe('ranking', () => {
           type: 'line',
         }),
       ]);
+    });
+
+    it('Should get ranking chart options object', () => {
+      const startTimestamp = Date.now() - 10000;
+      const finishTimestamp = Date.now() + 10000;
+      const { currentRanking, maxPoints } = onRankingChanged({
+        currentUsername: 'omegaUp',
+        scoreboard: scoreboard,
+        navbarProblems: navbarProblems,
+      });
+      const params = {
+        events: scoreboardEvents,
+        currentRanking,
+        maxPoints,
+        startTimestamp,
+        finishTimestamp,
+      };
+
+      const { series, navigatorData } = onRankingEvents(params);
+      expect(navigatorData).toEqual([
+        [expect.any(Number), 0],
+        [expect.any(Number), 100],
+        [expect.any(Number), 100],
+      ]);
+      expect(series).toEqual([
+        expect.objectContaining({
+          name: 'omegaUp',
+          rank: 0,
+          step: 'right',
+          type: 'line',
+        }),
+      ]);
+
+      const rankingChartOptions = createChart({
+        series,
+        navigatorData,
+        startTimestamp,
+        finishTimestamp,
+        maxPoints,
+      });
+      expect(rankingChartOptions).toEqual(
+        expect.objectContaining({
+          chart: {
+            height: 300,
+            spacingTop: 20,
+          },
+          colors: scoreboardColors,
+          navigator: {
+            series: {
+              data: [
+                [expect.any(Number), 0],
+                [expect.any(Number), 100],
+                [expect.any(Number), 100],
+              ],
+              lineColor: '#333',
+              lineWidth: 3,
+              step: 'left',
+              type: 'line',
+            },
+          },
+          plotOptions: {
+            series: {
+              animation: false,
+              lineWidth: 3,
+              marker: {
+                lineWidth: 1,
+                radius: 5,
+                symbol: 'circle',
+              },
+              states: {
+                hover: {
+                  lineWidth: 3,
+                },
+              },
+            },
+          },
+          rangeSelector: {
+            enabled: false,
+          },
+          series: [
+            {
+              data: [
+                [expect.any(Number), 0],
+                [expect.any(Number), 100],
+                [expect.any(Number), 100],
+                [expect.any(Number), 100],
+              ],
+              name: 'omegaUp',
+              rank: 0,
+              step: 'right',
+              type: 'line',
+            },
+          ],
+          xAxis: {
+            max: expect.any(Number),
+            min: expect.any(Number),
+            ordinal: false,
+          },
+          yAxis: {
+            max: 200,
+            min: 0,
+            showFirstLabel: false,
+            showLastLabel: true,
+          },
+        }),
+      );
     });
   });
 });

--- a/frontend/www/js/omegaup/arena/ranking.test.ts
+++ b/frontend/www/js/omegaup/arena/ranking.test.ts
@@ -155,7 +155,7 @@ describe('ranking', () => {
     });
 
     it('Should get ranking events for charts', () => {
-      const { currentRanking } = onRankingChanged({
+      const { currentRanking, maxPoints } = onRankingChanged({
         currentUsername: 'omegaUp',
         scoreboard: scoreboard,
         navbarProblems: navbarProblems,
@@ -163,6 +163,7 @@ describe('ranking', () => {
       const params = {
         events: scoreboardEvents,
         currentRanking,
+        maxPoints
         startTimestamp: Date.now() - 10000,
         finishTimestamp: Date.now() + 10000,
       };

--- a/frontend/www/js/omegaup/arena/ranking.test.ts
+++ b/frontend/www/js/omegaup/arena/ranking.test.ts
@@ -163,7 +163,7 @@ describe('ranking', () => {
       const params = {
         events: scoreboardEvents,
         currentRanking,
-        maxPoints
+        maxPoints,
         startTimestamp: Date.now() - 10000,
         finishTimestamp: Date.now() + 10000,
       };

--- a/frontend/www/js/omegaup/arena/ranking.ts
+++ b/frontend/www/js/omegaup/arena/ranking.ts
@@ -81,7 +81,7 @@ export function onRankingEvents({
     finishTimestamp,
     navigatorData[navigatorData.length - 1][1],
   ]);
-  
+
   return { series, navigatorData };
 }
 
@@ -95,8 +95,8 @@ export function createChart({
   series: (Highcharts.SeriesLineOptions & { rank: number })[];
   navigatorData: number[][];
   maxPoints: number;
-  startTimestamp: number,
-  finishTimestamp: number,
+  startTimestamp: number;
+  finishTimestamp: number;
 }): Highcharts.Options | null {
   if (!series.length) return null;
 
@@ -114,46 +114,46 @@ export function createChart({
   ];
 
   return {
-      chart: { height: 300, spacingTop: 20 },
+    chart: { height: 300, spacingTop: 20 },
 
-      colors: scoreboardColors,
+    colors: scoreboardColors,
 
-      xAxis: {
-        ordinal: false,
-        min: startTimestamp,
-        max: finishTimestamp,
+    xAxis: {
+      ordinal: false,
+      min: startTimestamp,
+      max: finishTimestamp,
+    },
+
+    yAxis: {
+      showLastLabel: true,
+      showFirstLabel: false,
+      min: 0,
+      max: maxPoints,
+    },
+
+    plotOptions: {
+      series: {
+        animation: false,
+        lineWidth: 3,
+        states: { hover: { lineWidth: 3 } },
+        marker: { radius: 5, symbol: 'circle', lineWidth: 1 },
       },
+    },
 
-      yAxis: {
-        showLastLabel: true,
-        showFirstLabel: false,
-        min: 0,
-        max: maxPoints,
+    navigator: {
+      series: {
+        type: 'line',
+        step: true,
+        lineWidth: 3,
+        lineColor: '#333',
+        data: navigatorData,
       },
+    },
 
-      plotOptions: {
-        series: {
-          animation: false,
-          lineWidth: 3,
-          states: { hover: { lineWidth: 3 } },
-          marker: { radius: 5, symbol: 'circle', lineWidth: 1 },
-        },
-      },
+    rangeSelector: { enabled: false },
 
-      navigator: {
-        series: {
-          type: 'line',
-          step: true,
-          lineWidth: 3,
-          lineColor: '#333',
-          data: navigatorData,
-        },
-      },
-
-      rangeSelector: { enabled: false },
-
-      series: series,
-    } as Highcharts.Options;
+    series: series,
+  } as Highcharts.Options;
 }
 
 export function updateProblemScore({
@@ -203,7 +203,7 @@ export function onRankingChanged({
   ranking: types.ScoreboardRankingEntry[];
   users: omegaup.UserRank[];
   currentRanking: { [username: string]: number };
-  maxPoints: number
+  maxPoints: number;
 } {
   const users: omegaup.UserRank[] = [];
   const problems: { [alias: string]: types.NavbarProblemsetProblem } = {};

--- a/frontend/www/js/omegaup/arena/ranking.ts
+++ b/frontend/www/js/omegaup/arena/ranking.ts
@@ -4,6 +4,19 @@ import { myRunsStore } from './runsStore';
 import { omegaup } from '../omegaup';
 import { getMaxScore } from './navigation';
 
+export const scoreboardColors = [
+  '#FB3F51',
+  '#FF5D40',
+  '#FFA240',
+  '#FFC740',
+  '#59EA3A',
+  '#37DD6F',
+  '#34D0BA',
+  '#3AAACF',
+  '#8144D6',
+  '#CD35D3',
+];
+
 export interface RankingRequest {
   problemsetId: number;
   scoreboardToken: string;
@@ -97,22 +110,7 @@ export function createChart({
   maxPoints: number;
   startTimestamp: number;
   finishTimestamp: number;
-}): Highcharts.Options | null {
-  if (!series.length) return null;
-
-  const scoreboardColors = [
-    '#FB3F51',
-    '#FF5D40',
-    '#FFA240',
-    '#FFC740',
-    '#59EA3A',
-    '#37DD6F',
-    '#34D0BA',
-    '#3AAACF',
-    '#8144D6',
-    '#CD35D3',
-  ];
-
+}): Highcharts.Options {
   return {
     chart: { height: 300, spacingTop: 20 },
 
@@ -143,7 +141,7 @@ export function createChart({
     navigator: {
       series: {
         type: 'line',
-        step: true,
+        step: 'left',
         lineWidth: 3,
         lineColor: '#333',
         data: navigatorData,
@@ -153,7 +151,7 @@ export function createChart({
     rangeSelector: { enabled: false },
 
     series: series,
-  } as Highcharts.Options;
+  };
 }
 
 export function updateProblemScore({

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -79,6 +79,7 @@
       <omegaup-arena-scoreboard
         :problems="problems"
         :ranking="ranking"
+        :ranking-chart-options="rankingChartOptions"
         :last-updated="lastUpdated"
         :digits-after-decimal-point="digitsAfterDecimalPoint"
         :show-penalty="showPenalty"
@@ -124,6 +125,7 @@
 </template>
 
 <script lang="ts">
+import * as Highcharts from 'highcharts/highstock';
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import * as ui from '../../ui';
@@ -179,6 +181,7 @@ export default class ArenaContest extends Vue {
   @Prop({ default: null }) guid!: null | string;
   @Prop() minirankingUsers!: omegaup.UserRank[];
   @Prop() ranking!: types.ScoreboardRankingEntry[];
+  @Prop() rankingChartOptions!: Highcharts.Options;
   @Prop() lastUpdated!: Date;
   @Prop() submissionDeadline!: Date;
   @Prop({ default: 2 }) digitsAfterDecimalPoint!: number;

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -3,6 +3,7 @@
     <!-- id-lint off -->
     <div id="ranking-chart"></div>
     <!-- id-lint on -->
+    <highcharts v-if="rankingChartOptions" :options="rankingChartOptions"></highcharts>
     <label v-if="showInvitedUsersFilter">
       <input
         v-model="onlyShowExplicitlyInvited"
@@ -84,16 +85,23 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
+import * as Highcharts from 'highcharts/highstock';
+import { Chart } from 'highcharts-vue';
 import { types } from '../../api_types';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
 
-@Component
+@Component({
+  components: {
+    highcharts: Chart,
+  },
+})
 export default class ArenaScoreboard extends Vue {
   @Prop({ default: 10 }) numberOfPositions!: number;
   @Prop() problems!: omegaup.Problem[];
   @Prop() ranking!: types.ScoreboardRankingEntry[];
+  @Prop() rankingChartOptions!: Highcharts.Options | null;
   @Prop() lastUpdated!: Date;
   @Prop({ default: true }) showInvitedUsersFilter!: boolean;
   @Prop({ default: true }) showPenalty!: boolean;

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -3,7 +3,10 @@
     <!-- id-lint off -->
     <div id="ranking-chart"></div>
     <!-- id-lint on -->
-    <highcharts v-if="rankingChartOptions" :options="rankingChartOptions"></highcharts>
+    <highcharts
+      v-if="rankingChartOptions"
+      :options="rankingChartOptions"
+    ></highcharts>
     <label v-if="showInvitedUsersFilter">
       <input
         v-model="onlyShowExplicitlyInvited"


### PR DESCRIPTION
# Descripción

Se agregan la función `createCharts` al archivo `ranking.ts` y se aprovecha para 
agregar el componente highcharts-vue en el componente de scoreboard.

No debería afectar a los lugares donde se manda llamar sin haberse realizado
la migración a la plantilla unificada, porque se agregó la condición para que 
sólo se pintara cuando se mande el objeto con las opciones de la gráfica.

![image](https://user-images.githubusercontent.com/3230352/117091375-a85a9700-ad20-11eb-8f95-3cf913e16cd3.png)

Fixes: #5347 
Fixes: #5346 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
