### PR TITLE
Arreglando falla que no permitía agregar identidades a un grupo cuando ya habían sido removidas

### DIFF
--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -397,8 +397,25 @@ class Identity extends \OmegaUp\Controllers\Controller {
         if (!is_null($preexistingIdentity)) {
             $identity->identity_id = $preexistingIdentity->identity_id;
             $identity->user_id = $preexistingIdentity->user_id;
-            // No need to save the object here since it will be updated a bit
-            // later.
+            // No need to save the Identities object here since it will be
+            // updated a bit later.
+
+            $preexistingIdentityInGroup = \OmegaUp\DAO\Identities::findByUsernameAndGroup(
+                $identity->username,
+                intval($group->group_id)
+            );
+
+            if (!is_null($preexistingIdentityInGroup)) {
+                return;
+            }
+            // But, there is a scenario where identity was previously removed
+            // from the group, in this case we need to add it again.
+            \OmegaUp\DAO\GroupsIdentities::create(
+                new \OmegaUp\DAO\VO\GroupsIdentities([
+                    'group_id' => intval($group->group_id),
+                    'identity_id' => $identity->identity_id,
+                ])
+            );
             return;
         }
         \OmegaUp\DAO\Identities::create($identity);

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -394,32 +394,13 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $preexistingIdentity = \OmegaUp\DAO\Identities::findByUsername(
             $identity->username
         );
-        if (!is_null($preexistingIdentity)) {
+        if (is_null($preexistingIdentity)) {
+            \OmegaUp\DAO\Identities::create($identity);
+        } else {
             $identity->identity_id = $preexistingIdentity->identity_id;
             $identity->user_id = $preexistingIdentity->user_id;
-            // No need to save the Identities object here since it will be
-            // updated a bit later.
-
-            $preexistingIdentityInGroup = \OmegaUp\DAO\Identities::findByUsernameAndGroup(
-                $identity->username,
-                intval($group->group_id)
-            );
-
-            if (!is_null($preexistingIdentityInGroup)) {
-                return;
-            }
-            // But, there is a scenario where identity was previously removed
-            // from the group, in this case we need to add it again.
-            \OmegaUp\DAO\GroupsIdentities::create(
-                new \OmegaUp\DAO\VO\GroupsIdentities([
-                    'group_id' => intval($group->group_id),
-                    'identity_id' => $identity->identity_id,
-                ])
-            );
-            return;
         }
-        \OmegaUp\DAO\Identities::create($identity);
-        \OmegaUp\DAO\GroupsIdentities::create(
+        \OmegaUp\DAO\GroupsIdentities::replace(
             new \OmegaUp\DAO\VO\GroupsIdentities([
                 'group_id' => intval($group->group_id),
                 'identity_id' => $identity->identity_id,

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -55,6 +55,36 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
         return new \OmegaUp\DAO\VO\Identities($rs);
     }
 
+    public static function findByUsernameAndGroup(
+        string $username,
+        int $groupId
+    ): ?\OmegaUp\DAO\VO\Identities {
+        $sql = 'SELECT
+                   i.*
+                FROM
+                  `Identities` i
+                INNER JOIN
+                  `Groups_Identities` gi
+                ON
+                  gi.identity_id = i.identity_id
+                INNER JOIN
+                  `Groups_` g
+                ON
+                  g.group_id = gi.group_id
+                WHERE
+                  i.username = ?
+                  AND g.group_id = ?
+                LIMIT
+                  0, 1';
+        $params = [ $username, $groupId ];
+        /** @var array{country_id: null|string, current_identity_school_id: int|null, gender: null|string, identity_id: int, language_id: int|null, name: null|string, password: null|string, state_id: null|string, user_id: int|null, username: string}|null */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($rs)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\Identities($rs);
+    }
+
     /**
      * @return list<\OmegaUp\DAO\VO\Identities>
      */

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -55,36 +55,6 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
         return new \OmegaUp\DAO\VO\Identities($rs);
     }
 
-    public static function findByUsernameAndGroup(
-        string $username,
-        int $groupId
-    ): ?\OmegaUp\DAO\VO\Identities {
-        $sql = 'SELECT
-                   i.*
-                FROM
-                  `Identities` i
-                INNER JOIN
-                  `Groups_Identities` gi
-                ON
-                  gi.identity_id = i.identity_id
-                INNER JOIN
-                  `Groups_` g
-                ON
-                  g.group_id = gi.group_id
-                WHERE
-                  i.username = ?
-                  AND g.group_id = ?
-                LIMIT
-                  0, 1';
-        $params = [ $username, $groupId ];
-        /** @var array{country_id: null|string, current_identity_school_id: int|null, gender: null|string, identity_id: int, language_id: int|null, name: null|string, password: null|string, state_id: null|string, user_id: int|null, username: string}|null */
-        $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
-        if (empty($rs)) {
-            return null;
-        }
-        return new \OmegaUp\DAO\VO\Identities($rs);
-    }
-
     /**
      * @return list<\OmegaUp\DAO\VO\Identities>
      */

--- a/frontend/tests/controllers/IdentityCreateTest.php
+++ b/frontend/tests/controllers/IdentityCreateTest.php
@@ -216,8 +216,8 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testUploadCsvFile() {
         // Identity creator group member will upload csv file
         [
-           'user' => $creator,
-           'identity' => $creatorIdentity,
+            'user' => $creator,
+            'identity' => $creatorIdentity,
         ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
@@ -230,34 +230,34 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call api using identity creator group member
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-           'auth_token' => $creatorLogin->auth_token,
-        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-            'identities.csv',
-            $group['group']->alias
-        ),
-           'group_alias' => $group['group']->alias,
+            'auth_token' => $creatorLogin->auth_token,
+            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                'identities.csv',
+                $group['group']->alias,
+            ),
+            'group_alias' => $group['group']->alias,
         ]));
         $originalResponse = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-               'auth_token' => $creatorLogin->auth_token,
-               'group_alias' => $group['group']->alias,
+                'auth_token' => $creatorLogin->auth_token,
+                'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(5, $originalResponse['identities']);
 
         // Call api again, names should have changed
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-           'auth_token' => $creatorLogin->auth_token,
-        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-            'identities_updated.csv',
-            $group['group']->alias
-        ),
-           'group_alias' => $group['group']->alias,
+            'auth_token' => $creatorLogin->auth_token,
+            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                'identities_updated.csv',
+                $group['group']->alias,
+            ),
+            'group_alias' => $group['group']->alias,
         ]));
         $updatedResponse = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-               'auth_token' => $creatorLogin->auth_token,
-               'group_alias' => $group['group']->alias,
+                'auth_token' => $creatorLogin->auth_token,
+                'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(6, $updatedResponse['identities']);
@@ -284,34 +284,34 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call api using identity creator group member
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-           'auth_token' => $creatorLogin->auth_token,
-        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-            'identities.csv',
-            $group['group']->alias
-        ),
-           'group_alias' => $group['group']->alias,
+            'auth_token' => $creatorLogin->auth_token,
+            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                'identities.csv',
+                $group['group']->alias
+            ),
+            'group_alias' => $group['group']->alias,
         ]));
         $originalResponse = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-               'auth_token' => $creatorLogin->auth_token,
-               'group_alias' => $group['group']->alias,
+                'auth_token' => $creatorLogin->auth_token,
+                'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(5, $originalResponse['identities']);
 
         // Call api again, names should have changed
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-           'auth_token' => $creatorLogin->auth_token,
-        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-            'identities_updated.csv',
-            $group['group']->alias
-        ),
-           'group_alias' => $group['group']->alias,
+            'auth_token' => $creatorLogin->auth_token,
+            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                'identities_updated.csv',
+                $group['group']->alias
+            ),
+            'group_alias' => $group['group']->alias,
         ]));
         $updatedResponse = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-               'auth_token' => $creatorLogin->auth_token,
-               'group_alias' => $group['group']->alias,
+                'auth_token' => $creatorLogin->auth_token,
+                'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(6, $updatedResponse['identities']);
@@ -330,25 +330,25 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
         }
         $removedMembers = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-               'auth_token' => $creatorLogin->auth_token,
-               'group_alias' => $group['group']->alias,
+                'auth_token' => $creatorLogin->auth_token,
+                'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertEmpty($removedMembers['identities']);
 
         // Call api again, identities should appear in the group again
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-           'auth_token' => $creatorLogin->auth_token,
-        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-            'identities.csv',
-            $group['group']->alias
-        ),
-           'group_alias' => $group['group']->alias,
-        ]));
+            'auth_token' => $creatorLogin->auth_token,
+            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                'identities.csv',
+                $group['group']->alias
+            ),
+            'group_alias' => $group['group']->alias,
+       ]));
         $updatedMembers = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-               'auth_token' => $creatorLogin->auth_token,
-               'group_alias' => $group['group']->alias,
+                'auth_token' => $creatorLogin->auth_token,
+                'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(5, $updatedMembers['identities']);

--- a/frontend/tests/controllers/IdentityCreateTest.php
+++ b/frontend/tests/controllers/IdentityCreateTest.php
@@ -344,7 +344,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
                 $group['group']->alias
             ),
             'group_alias' => $group['group']->alias,
-       ]));
+        ]));
         $updatedMembers = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,

--- a/frontend/tests/controllers/IdentityCreateTest.php
+++ b/frontend/tests/controllers/IdentityCreateTest.php
@@ -216,8 +216,8 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testUploadCsvFile() {
         // Identity creator group member will upload csv file
         [
-            'user' => $creator,
-            'identity' => $creatorIdentity,
+           'user' => $creator,
+           'identity' => $creatorIdentity,
         ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
@@ -230,34 +230,34 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Call api using identity creator group member
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-            'auth_token' => $creatorLogin->auth_token,
-            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-                'identities.csv',
-                $group['group']->alias
-            ),
-            'group_alias' => $group['group']->alias,
+           'auth_token' => $creatorLogin->auth_token,
+        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+            'identities.csv',
+            $group['group']->alias
+        ),
+           'group_alias' => $group['group']->alias,
         ]));
         $originalResponse = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-                'auth_token' => $creatorLogin->auth_token,
-                'group_alias' => $group['group']->alias,
+               'auth_token' => $creatorLogin->auth_token,
+               'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(5, $originalResponse['identities']);
 
         // Call api again, names should have changed
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
-            'auth_token' => $creatorLogin->auth_token,
-            'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-                'identities_updated.csv',
-                $group['group']->alias
-            ),
-            'group_alias' => $group['group']->alias,
+           'auth_token' => $creatorLogin->auth_token,
+        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+            'identities_updated.csv',
+            $group['group']->alias
+        ),
+           'group_alias' => $group['group']->alias,
         ]));
         $updatedResponse = \OmegaUp\Controllers\Group::apiMembers(
             new \OmegaUp\Request([
-                'auth_token' => $creatorLogin->auth_token,
-                'group_alias' => $group['group']->alias,
+               'auth_token' => $creatorLogin->auth_token,
+               'group_alias' => $group['group']->alias,
             ])
         );
         $this->assertCount(6, $updatedResponse['identities']);
@@ -265,6 +265,93 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $originalResponse['identities'],
             $updatedResponse['identities']
         );
+    }
+
+    public function testRemoveIdentitiesFromGroupAndAddThemAgain() {
+        // Identity creator group member will upload csv file
+        [
+           'user' => $creator,
+           'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        $creatorLogin = self::login($creatorIdentity);
+        $group = \OmegaUp\Test\Factories\Groups::createGroup(
+            $creatorIdentity,
+            null,
+            null,
+            null,
+            $creatorLogin
+        );
+
+        // Call api using identity creator group member
+        \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
+           'auth_token' => $creatorLogin->auth_token,
+        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+            'identities.csv',
+            $group['group']->alias
+        ),
+           'group_alias' => $group['group']->alias,
+        ]));
+        $originalResponse = \OmegaUp\Controllers\Group::apiMembers(
+            new \OmegaUp\Request([
+               'auth_token' => $creatorLogin->auth_token,
+               'group_alias' => $group['group']->alias,
+            ])
+        );
+        $this->assertCount(5, $originalResponse['identities']);
+
+        // Call api again, names should have changed
+        \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
+           'auth_token' => $creatorLogin->auth_token,
+        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+            'identities_updated.csv',
+            $group['group']->alias
+        ),
+           'group_alias' => $group['group']->alias,
+        ]));
+        $updatedResponse = \OmegaUp\Controllers\Group::apiMembers(
+            new \OmegaUp\Request([
+               'auth_token' => $creatorLogin->auth_token,
+               'group_alias' => $group['group']->alias,
+            ])
+        );
+        $this->assertCount(6, $updatedResponse['identities']);
+        $this->assertNotEquals(
+            $originalResponse['identities'],
+            $updatedResponse['identities']
+        );
+
+        // Now, we are going to remove all identities from the group
+        foreach ($updatedResponse['identities'] as $identity) {
+            \OmegaUp\Controllers\Group::apiRemoveUser(new \OmegaUp\Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'usernameOrEmail' => $identity['username'],
+                'group_alias' => $group['group']->alias
+            ]));
+        }
+        $removedMembers = \OmegaUp\Controllers\Group::apiMembers(
+            new \OmegaUp\Request([
+               'auth_token' => $creatorLogin->auth_token,
+               'group_alias' => $group['group']->alias,
+            ])
+        );
+        $this->assertEmpty($removedMembers['identities']);
+
+        // Call api again, identities should appear in the group again
+        \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
+           'auth_token' => $creatorLogin->auth_token,
+        'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+            'identities.csv',
+            $group['group']->alias
+        ),
+           'group_alias' => $group['group']->alias,
+        ]));
+        $updatedMembers = \OmegaUp\Controllers\Group::apiMembers(
+            new \OmegaUp\Request([
+               'auth_token' => $creatorLogin->auth_token,
+               'group_alias' => $group['group']->alias,
+            ])
+        );
+        $this->assertCount(5, $updatedMembers['identities']);
     }
 
     /**


### PR DESCRIPTION
# Descripción

Se arregla el bug que no permitía volver a agregar identidades cargadas vía CSV
que habían sido borradas con anterioridad.

Resulta que se agregó una condición en `Identities:apiBulkCreate` indicando que
si una identidad ya existía, se saltara el paso de agregarla y además de ligarla al 
grupo. En este caso estaba afectando, ya que aunque si existe la identidad, esta 
ya no pertenecía al grupo, cosa que ocasionaba que nunca los pudiera agregar
nuevamente.

![ApiBulkCreateFixed](https://user-images.githubusercontent.com/3230352/117102788-abfd1680-ad3e-11eb-96fc-d7612bc0bd65.gif)

Fixes: #5361 

# Comentarios

Desde un PR anterior, siento que el linter se está comportando raro, en el anterior
no estaba arreglando una fala simple donde me faltaba una coma.

Ahora modificó líneas en el archivo de pruebas que yo no moví y se nota que 
están mal indentadas algunas líneas

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.