### PR TITLE
Arreglando curso clonado cuando una tarea no tiene problemas

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -719,6 +719,11 @@ class Course extends \OmegaUp\Controllers\Controller {
                 }
 
                 foreach ($assignmentProblems['problems'] as $problem) {
+                    if (is_null($problem['problem_alias'])) {
+                        // When assignment does not have problems, there is
+                        // nothing to do here
+                        continue;
+                    }
                     // Create and assign problems to new course
                     self::addProblemToAssignment(
                         $problem['problem_alias'],

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -719,11 +719,6 @@ class Course extends \OmegaUp\Controllers\Controller {
                 }
 
                 foreach ($assignmentProblems['problems'] as $problem) {
-                    if (is_null($problem['problem_alias'])) {
-                        // When assignment does not have problems, there is
-                        // nothing to do here
-                        continue;
-                    }
                     // Create and assign problems to new course
                     self::addProblemToAssignment(
                         $problem['problem_alias'],

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -34,16 +34,17 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                 p.problem_id,
                 pp.order as problem_order
             FROM
-                Problems p
-            INNER JOIN
-                Problemset_Problems pp ON pp.problem_id = p.problem_id
-            INNER JOIN
-                Assignments a ON pp.problemset_id = a.problemset_id
+                Assignments a
+            LEFT JOIN
+                Problemset_Problems pp ON pp.problemset_id = a.problemset_id
+            LEFT JOIN
+                Problems p ON pp.problem_id = p.problem_id
             INNER JOIN
                 Courses c ON a.course_id = c.course_id
             WHERE
                 c.alias = ?
             ORDER BY
+                a.`order` ASC,
                 a.`assignment_id` ASC,
                 pp.`order` ASC,
                 `pp`.`problem_id` ASC;

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -13,7 +13,7 @@ namespace OmegaUp\DAO;
  */
 class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
     /**
-     * @return array<string, array{name: string, description: string, start_time: \OmegaUp\Timestamp, finish_time: \OmegaUp\Timestamp|null, order: int, max_points: float, assignment_alias: string, assignment_type: string, publish_time_delay: int|null, problems: array{problem_alias: string, problem_id: int, order: int}[]}>
+     * @return array<string, array{assignment_alias: string, assignment_type: string, description: string, finish_time: \OmegaUp\Timestamp|null, max_points: float, name: string, order: int, problems: list<array{order: int, problem_alias: string, problem_id: int}>, publish_time_delay: int|null, start_time: \OmegaUp\Timestamp}>
      */
     final public static function getProblemsAssignmentByCourseAlias(
         \OmegaUp\DAO\VO\Courses $course
@@ -50,7 +50,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                 `pp`.`problem_id` ASC;
         ';
         $val = [$course->alias];
-        /** @var list<array{assignment_alias: string, assignment_type: string, description: string, finish_time: \OmegaUp\Timestamp|null, max_points: float, name: string, order: int, problem_alias: string, problem_id: int, problem_order: int, publish_time_delay: int|null, start_time: \OmegaUp\Timestamp}> $problemsAssignments */
+        /** @var list<array{assignment_alias: string, assignment_type: string, description: string, finish_time: \OmegaUp\Timestamp|null, max_points: float, name: string, order: int, problem_alias: null|string, problem_id: int|null, problem_order: int|null, publish_time_delay: int|null, start_time: \OmegaUp\Timestamp}> $problemsAssignments */
         $problemsAssignments = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             $val
@@ -74,10 +74,13 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                     'problems' => [],
                 ];
             }
+            if (is_null($assignment['problem_alias'])) {
+                continue;
+            }
             $result[$assignmentAlias]['problems'][] = [
                 'problem_alias' => $assignment['problem_alias'],
-                'problem_id' => $assignment['problem_id'],
-                'order' => $assignment['problem_order'],
+                'problem_id' => intval($assignment['problem_id']),
+                'order' => intval($assignment['problem_order']),
             ];
         }
 


### PR DESCRIPTION
# Descripción

Se arregla un bug donde no se clonaban los contenidos que aún no contienen 
problemas.

Resulta que la consulta que obtenía los `problemsets` estaba obteniendo sólo los
`assignments` en los que había al menos un problema y esto ocasionaba que estos
no se clonaran en el nuevo curso.

![CourseCloneWithEmptyContentFixed](https://user-images.githubusercontent.com/3230352/117187930-12ffe700-ada2-11eb-84a0-b218a52cc49b.gif)


Fixes: #5356 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
