### PR TITLE
Arreglando los tipos de Highcharts

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -297,7 +297,7 @@ export class Arena {
 
   summaryView: Vue & { contest: omegaup.Contest };
 
-  rankingChart: Highcharts.Chart | null = null;
+  rankingChart: Highcharts.StockChart | null = null;
 
   constructor(options: ArenaOptions) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -1350,7 +1350,7 @@ export class Arena {
         navigator: {
           series: {
             type: 'line',
-            step: true,
+            step: 'right',
             lineWidth: 3,
             lineColor: '#333',
             data: navigatorSeries,
@@ -1360,7 +1360,7 @@ export class Arena {
         rangeSelector: { enabled: false },
 
         series: series,
-      } as Highcharts.Options,
+      },
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint_d": "^10.0.4",
     "file-loader": "^6.2",
     "fork-ts-checker-webpack-plugin": "^6.1",
-    "highcharts": "9",
+    "highcharts": "^9.1.0",
     "highcharts-vue": "^1.3.5",
     "html-webpack-plugin": "^4.5",
     "jest": "^26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4962,10 +4962,10 @@ highcharts-vue@^1.3.5:
   resolved "https://registry.yarnpkg.com/highcharts-vue/-/highcharts-vue-1.3.5.tgz#9a3e5f6050bf0227c19238433abfb17ab7262db3"
   integrity sha512-By1kc3m8XoI20pMshs/ue69j4rH6eQioDPoIrtC20RTti4QyvNAx8DisGSO3GAWe9sn50hPk8NsyxcwZIGaz3Q==
 
-highcharts@9:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.0.0.tgz#2e5d382481f71c50ac7f086e7bdead394fab71d4"
-  integrity sha512-MJCtidFytGSQvsV3OEM+vFTLpjUcp7jmFpLn8h3oL4WKp0gxUOQg6Nw00sqMWGdiadst0gOZO4804zynTcYjZQ==
+highcharts@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.1.0.tgz#2cdb38e2e03530b4fde022bb05fbce5b34651e39"
+  integrity sha512-K7HUuKhEylZ1pMdzGR35kPgUmpp0MDNpaWhEMkGiC5Jfzg/endtTLHJN2lsFqEO+xoN7AykBK98XaJPEpsrLyA==
 
 hosted-git-info@^2.1.4:
   version "2.8.5"


### PR DESCRIPTION
La actualización a Highcharts 9 rompió la compilación. Lo bueno es que
gracias a los tipos, saber qué cambiar fue fácil.