### PR TITLE
Migrando la función de initSubmissionTimestamp a la plantilla unificada

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -719,8 +719,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
             // TODO: Replace next lines with: $result['entrypoint'] = 'arena_contest_contestant';
             // when arena contest migration is over
-            $result['template'] = 'arena.contest.contestant.tpl';
-            unset($result['entrypoint']);
+            $result['entrypoint'] = 'arena_contest_contestant';
             return $result;
         }
         $result['smartyProperties']['payload']['needsBasicInformation'] = false;

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -721,7 +721,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
             // TODO: Replace next lines with: $result['entrypoint'] = 'arena_contest_contestant';
             // when arena contest migration is over
-            $result['entrypoint'] = 'arena_contest_contestant';
+            $result['template'] = 'arena.contest.contestant.tpl';
+            unset($result['entrypoint']);
             return $result;
         }
         $result['smartyProperties']['payload']['needsBasicInformation'] = false;

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -25,7 +25,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type Run=array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float|null, time: \OmegaUp\Timestamp, submit_delay: int, type: null|string, username: string, classname: string, alias: string, country: string, contest_alias: null|string}
  * @psalm-type ArenaProblemDetails=array{accepts_submissions: bool, alias: string, commit: string, input_limit: int, languages: list<string>, letter?: string, points: float, problem_id?: int, problemsetter?: ProblemsetterInfo, quality_seal: bool, runs?: list<Run>,  settings?: ProblemSettingsDistrib, source?: string, statement?: ProblemStatement, title: string, visibility: int}
  * @psalm-type BestSolvers=array{classname: string, language: string, memory: float, runtime: float, time: \OmegaUp\Timestamp, username: string}
- * @psalm-type ProblemDetails=array{accepts_submissions: bool, accepted: int, admin?: bool, alias: string, allow_user_add_tags: bool, commit: string, creation_date: \OmegaUp\Timestamp, difficulty: float|null, email_clarifications: bool, input_limit: int, karel_problem: bool, languages: list<string>, letter?: string, limits: SettingLimits, nextSubmissionTimestamp: null|\OmegaUp\Timestamp, order: string, points: float, preferred_language?: string, problem_id: int, problemsetter?: ProblemsetterInfo, quality_seal: bool, runs?: list<Run>, score: float, settings: ProblemSettingsDistrib, show_diff: string, solvers?: list<BestSolvers>, source?: string, statement: ProblemStatement, submissions: int, title: string, version: string, visibility: int, visits: int}
+ * @psalm-type ProblemDetails=array{accepts_submissions: bool, accepted: int, admin?: bool, alias: string, allow_user_add_tags: bool, commit: string, creation_date: \OmegaUp\Timestamp, difficulty: float|null, email_clarifications: bool, input_limit: int, karel_problem: bool, languages: list<string>, letter?: string, limits: SettingLimits, nextSubmissionTimestamp?: \OmegaUp\Timestamp, order: string, points: float, preferred_language?: string, problem_id: int, problemsetter?: ProblemsetterInfo, quality_seal: bool, runs?: list<Run>, score: float, settings: ProblemSettingsDistrib, show_diff: string, solvers?: list<BestSolvers>, source?: string, statement: ProblemStatement, submissions: int, title: string, version: string, visibility: int, visits: int}
  * @psalm-type StatsPayload=array{alias: string, entity_type: string, cases_stats?: array<string, int>, pending_runs: list<string>, total_runs: int, verdict_counts: array<string, int>, max_wait_time?: \OmegaUp\Timestamp|null, max_wait_time_guid?: null|string, distribution?: array<int, int>, size_of_bucket?: float, total_points?: float}
  * @psalm-type SelectedTag=array{public: bool, tagname: string}
  * @psalm-type ProblemAdmin=array{role: string, username: string}
@@ -2543,7 +2543,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         bool $showSolvers,
         bool $preventProblemsetOpen,
         ?string $contestAlias = null
-    ): array {
+    ): ?array {
         $response = [];
 
         // Get the expected commit version.
@@ -2661,31 +2661,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ) : null;
 
         $isPracticeMode = false;
+        $container = null;
         if (!is_null($problemset) && !is_null($loggedIdentity)) {
             $response['admin'] = \OmegaUp\Authorization::isAdmin(
                 $loggedIdentity,
                 $problemset
-            );
-
-            // Get all the available runs done by the current_user
-            $runsArray = \OmegaUp\DAO\Runs::getForProblemDetails(
-                intval($problem->problem_id),
-                $isPracticeMode ? null : $problemsetId,
-                intval($loggedIdentity->identity_id)
-            );
-
-            // Add each filtered run to an array
-            $results = [];
-            foreach ($runsArray as $run) {
-                $run['alias'] = strval($problem->alias);
-                $run['username'] = strval($loggedIdentity->username);
-                $results[] = $run;
-            }
-            $response['runs'] = $results;
-
-            \OmegaUp\DAO\ProblemViewed::MarkProblemViewed(
-                intval($loggedIdentity->identity_id),
-                intval($problem->problem_id)
             );
 
             if (!$response['admin'] || $preventProblemsetOpen !== true) {
@@ -2703,33 +2683,21 @@ class Problem extends \OmegaUp\Controllers\Controller {
                         'problemsetNotFound'
                     );
                 }
-                if ($container instanceof \OmegaUp\DAO\VO\Contests) {
-                    $isPracticeMode = (
-                        $container->admission_mode !== 'private' &&
-                        $container->finish_time->time < \OmegaUp\Time::get()
-                    );
-                    if (!$isPracticeMode) {
-                        // Check and save first time access is not needed for
-                        // contests in practice mode
-                        \OmegaUp\DAO\ProblemsetIdentities::checkAndSaveFirstTimeAccess(
-                            $loggedIdentity,
-                            $container,
-                            \OmegaUp\Authorization::canSubmitToProblemset(
-                                $loggedIdentity,
-                                $problemset
-                            )
-                        );
-                    }
-
-                    $lastRunTime = null;
-
-                    if (($n = count($runsArray)) > 0) {
-                        $lastRun = $runsArray[$n - 1];
-                        $lastRunTime = $lastRun['time'];
-                    }
-                    $response['nextSubmissionTimestamp'] = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(
+                $isPracticeMode = (
+                    $container instanceof \OmegaUp\DAO\VO\Contests &&
+                    $container->admission_mode !== 'private' &&
+                    $container->finish_time->time < \OmegaUp\Time::get()
+                );
+                if (!$isPracticeMode) {
+                    // Check and save first time access is not needed for
+                    // contests in practice mode
+                    \OmegaUp\DAO\ProblemsetIdentities::checkAndSaveFirstTimeAccess(
+                        $loggedIdentity,
                         $container,
-                        $lastRunTime
+                        \OmegaUp\Authorization::canSubmitToProblemset(
+                            $loggedIdentity,
+                            $problemset
+                        )
                     );
                 }
             }
@@ -2754,6 +2722,41 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $response['solvers'] = \OmegaUp\DAO\Runs::getBestSolvingRunsForProblem(
                 intval($problem->problem_id)
             );
+        }
+
+        if (!is_null($loggedIdentity)) {
+            // Get all the available runs done by the current_user
+            $runsArray = \OmegaUp\DAO\Runs::getForProblemDetails(
+                intval($problem->problem_id),
+                $isPracticeMode ? null : $problemsetId,
+                intval($loggedIdentity->identity_id)
+            );
+
+            // Add each filtered run to an array
+            $results = [];
+            foreach ($runsArray as $run) {
+                $run['alias'] = strval($problem->alias);
+                $run['username'] = strval($loggedIdentity->username);
+                $results[] = $run;
+            }
+            $response['runs'] = $results;
+
+            \OmegaUp\DAO\ProblemViewed::MarkProblemViewed(
+                intval($loggedIdentity->identity_id),
+                intval($problem->problem_id)
+            );
+            if ($container instanceof \OmegaUp\DAO\VO\Contests) {
+                $lastRunTime = null;
+
+                if (($n = count($runsArray)) > 0) {
+                    $lastRun = $runsArray[$n - 1];
+                    $lastRunTime = $lastRun['time'];
+                }
+                $response['nextSubmissionTimestamp'] = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(
+                    $container,
+                    $lastRunTime
+                );
+            }
         }
 
         // send the supported languages as a JSON array instead of csv

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -1279,6 +1279,10 @@ export const Problem = {
     messages.ProblemDetailsResponse
   >('/api/problem/details/', (x) => {
     x.creation_date = ((x: number) => new Date(x * 1000))(x.creation_date);
+    if (x.nextSubmissionTimestamp)
+      x.nextSubmissionTimestamp = ((x: number) => new Date(x * 1000))(
+        x.nextSubmissionTimestamp,
+      );
     if (x.problemsetter)
       x.problemsetter = ((x) => {
         if (x.creation_date)

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2511,6 +2511,7 @@ export namespace types {
     languages: string[];
     letter?: string;
     limits: types.SettingLimits;
+    nextSubmissionTimestamp?: Date;
     order: string;
     points: number;
     preferred_language?: string;

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -138,8 +138,14 @@ OmegaUp.on('ready', () => {
             runs,
             code,
             language,
-          }: ActiveProblem & { code: string; language: string }) => {
+            target,
+          }: ActiveProblem & {
+            code: string;
+            language: string;
+            target: Vue & { nextSubmissionTimestamp: Date };
+          }) => {
             api.Run.create({
+              contest_alias: payload.contest.alias,
               problem_alias: problem.alias,
               language: language,
               source: code,
@@ -154,6 +160,8 @@ OmegaUp.on('ready', () => {
                   classname: commonPayload.userClassname,
                   problemAlias: problem.alias,
                 });
+                target.nextSubmissionTimestamp =
+                  response.nextSubmissionTimestamp;
               })
               .catch((run) => {
                 submitRunFailed({


### PR DESCRIPTION
# Descripción

Se migran las acciones de `initSubmissionCountdown` para que esto funcione
desde la plantilla unificada.

![EnableNextSubmissionTimestamp](https://user-images.githubusercontent.com/3230352/117425708-aba07f00-aee8-11eb-82d6-3b00631769f4.gif)

Part of: #3482 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
