### PR TITLE
Habilitando el autoscaling del cluster de runners

### DIFF
--- a/stuff/runner/deploy-template.sh
+++ b/stuff/runner/deploy-template.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PWD="$(dirname "$(realpath "${0}")")"
+
 if [[ -z "$1" ]]; then
   echo "Usage: $0 <location>"
   exit 1
@@ -29,6 +31,6 @@ fi
 echo "deploying resource group..."
 az deployment group create \
   --resource-group "${resource_group}" \
-  --template-file omegaup-runner-template.json \
-  --parameter "customData=$(base64 --wrap=0 cloud-init.yml)" \
+  --template-file "${PWD}/omegaup-runner-template.json" \
+  --parameter "customData=$(base64 --wrap=0 "${PWD}/cloud-init.yml")" \
   --subscription "${subscription}"

--- a/stuff/runner/omegaup-runner-template.json
+++ b/stuff/runner/omegaup-runner-template.json
@@ -14,19 +14,19 @@
         },
         "instanceCount": {
             "type": "string",
-            "defaultValue": "1"
+            "defaultValue": "2"
         },
         "autoScaleDefault": {
             "type": "string",
-            "defaultValue": "1"
+            "defaultValue": "2"
         },
         "autoScaleMin": {
             "type": "string",
-            "defaultValue": "1"
+            "defaultValue": "2"
         },
         "autoScaleMax": {
             "type": "string",
-            "defaultValue": "1"
+            "defaultValue": "8"
         }
     },
     "variables": {
@@ -124,7 +124,7 @@
                                     "metricResourceUri": "[variables('vmssId')]",
                                     "timeGrain": "PT1M",
                                     "statistic": "Average",
-                                    "timeWindow": "PT5M",
+                                    "timeWindow": "PT1M",
                                     "timeAggregation": "Average",
                                     "operator": "GreaterThan",
                                     "threshold": "75"
@@ -132,8 +132,8 @@
                                 "scaleAction": {
                                     "direction": "Increase",
                                     "type": "ChangeCount",
-                                    "value": "1",
-                                    "cooldown": "PT1M"
+                                    "value": "3",
+                                    "cooldown": "PT5M"
                                 }
                             },
                             {
@@ -146,13 +146,13 @@
                                     "timeWindow": "PT5M",
                                     "timeAggregation": "Average",
                                     "operator": "LessThan",
-                                    "threshold": "10"
+                                    "threshold": "20"
                                 },
                                 "scaleAction": {
                                     "direction": "Decrease",
                                     "type": "ChangeCount",
                                     "value": "1",
-                                    "cooldown": "PT1M"
+                                    "cooldown": "PT2M"
                                 }
                             }
                         ]


### PR DESCRIPTION
Este cambio hace que la cantidad de runners fluctúe entre 2 y 8,
dependiendo de la carga de CPU.