### PR TITLE
Evitando crear problemas con aliases que se van a truncar

### DIFF
--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -119,6 +119,7 @@ class Tag extends \OmegaUp\Controllers\Controller {
             'problemLevel',
             fn (string $problemAlias) => \OmegaUp\Validators::alias(
                 $problemAlias,
+                /*$length=*/75,
             )
         );
 

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -8,6 +8,9 @@ namespace OmegaUp;
  * @author joemmanuel
  */
 class Validators {
+    // The maximum length for aliases.
+    const ALIAS_MAX_LENGTH = 32;
+
     /**
      * Check if email is valid
      */
@@ -172,20 +175,23 @@ class Validators {
         return (
             preg_match('/^(?:[a-zA-Z0-9_-]+:)?[a-zA-Z0-9_-]+$/', $alias) === 1
             && !self::isRestrictedAlias($alias)
-            && strlen($alias) <= 32
+            && strlen($alias) <= Validators::ALIAS_MAX_LENGTH
         );
     }
 
     /**
      * Returns whether the alias is valid.
      *
-     * @param string $alias
      * @return boolean
      */
-    public static function alias(string $alias): bool {
+    public static function alias(
+        string $alias,
+        int $maxLength = Validators::ALIAS_MAX_LENGTH
+    ): bool {
         return (
             preg_match('/^[a-zA-Z0-9_-]+$/', $alias) === 1
             && !self::isRestrictedAlias($alias)
+            && strlen($alias) <= $maxLength
         );
     }
 

--- a/frontend/tests/Factories/Problem.php
+++ b/frontend/tests/Factories/Problem.php
@@ -148,7 +148,7 @@ class Problem {
                     str_replace(' ', '-', $params->title)
                 ),
                 0,
-                32
+                \OmegaUp\Validators::ALIAS_MAX_LENGTH
             ),
             'author_username' => $params->author->username,
             'validator' => $params->validator,

--- a/frontend/tests/controllers/ProblemCreateTest.php
+++ b/frontend/tests/controllers/ProblemCreateTest.php
@@ -49,7 +49,14 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Verify DB data
         $this->assertEquals($r['title'], $problem->title);
-        $this->assertEquals(substr($r['title'], 0, 32), $problem->alias);
+        $this->assertEquals(
+            substr(
+                $r['title'],
+                0,
+                \OmegaUp\Validators::ALIAS_MAX_LENGTH
+            ),
+            $problem->alias
+        );
         $this->assertEquals($r['order'], $problem->order);
         $this->assertEquals($r['source'], $problem->source);
         $this->assertEqualSets($r['languages'], $problem->languages);
@@ -83,16 +90,33 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEquals(0, $problem->difficulty);
     }
 
-    public function testCreateWithInvlaidAlias() {
+    /**
+     * A PHPUnit data provider for testCreateWithInvalidAlias.
+     *
+     * @return list<list<string>>
+     */
+    public function invalidAliasValueProvider(): array {
+        return [
+            ['this has a space'],
+            ['this-alias-is-way-too-long-and-should-be-rejected'],
+            ['colons:are-disallowed'],
+            ['new'],  // restricted alias
+        ];
+    }
+
+    /**
+     * @dataProvider invalidAliasValueProvider
+     */
+    public function testCreateWithInvalidAlias(string $alias) {
         // Get the problem data
         $problemData = \OmegaUp\Test\Factories\Problem::getRequest();
-        $r = $problemData['request'];
         $problemAuthor = $problemData['author'];
 
         // Login user
         $login = self::login($problemAuthor);
+        $r = $problemData['request'];
         $r['auth_token'] = $login->auth_token;
-        $r['problem_alias'] = 'Invalid alias';
+        $r['problem_alias'] = $alias;
 
         // Call the API
         try {
@@ -307,7 +331,14 @@ class ProblemCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Verify DB data
         $this->assertEquals($r['title'], $problem->title);
-        $this->assertEquals(substr($r['title'], 0, 32), $problem->alias);
+        $this->assertEquals(
+            substr(
+                $r['title'],
+                0,
+                \OmegaUp\Validators::ALIAS_MAX_LENGTH
+            ),
+            $problem->alias
+        );
         $this->assertEquals($r['order'], $problem->order);
         $this->assertEquals($r['source'], $problem->source);
 
@@ -736,7 +767,14 @@ if __name__ == \'__main__\':
 
         // Verify DB data
         $this->assertEquals($r['title'], $problem->title);
-        $this->assertEquals(substr($r['title'], 0, 32), $problem->alias);
+        $this->assertEquals(
+            substr(
+                $r['title'],
+                0,
+                \OmegaUp\Validators::ALIAS_MAX_LENGTH
+            ),
+            $problem->alias
+        );
         $this->assertEquals($r['order'], $problem->order);
         $this->assertEquals($r['source'], $problem->source);
 
@@ -900,7 +938,7 @@ if __name__ == \'__main__\':
                 str_replace(' ', '-', $title)
             ),
             0,
-            32
+            \OmegaUp\Validators::ALIAS_MAX_LENGTH
         );
 
         \OmegaUp\Controllers\Problem::apiCreate(new \OmegaUp\Request([


### PR DESCRIPTION
Este cambio hace que si se intenta crear algo con un alias más largo de
lo que la base de datos puede representar, la petición se va rechaza en
vez de permitirla y truncar silenciosamente.

Fixes: #5402