### PR TITLE
Eliminando el campo `domain` de las cookies

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -5,7 +5,6 @@ require_once dirname(__DIR__) . '/server/try_define.php';
 # GLOBAL CONFIG
 # ###################################
 try_define('OMEGAUP_LOCKDOWN_DOMAIN', 'localhost-lockdown');
-try_define('OMEGAUP_COOKIE_DOMAIN', '');
 try_define('OMEGAUP_AUTH_TOKEN_COOKIE_NAME', 'ouat');
 try_define('OMEGAUP_MD5_SALT', 'omegaup');
 try_define('OMEGAUP_URL', 'http://localhost');

--- a/frontend/server/src/SessionManager.php
+++ b/frontend/server/src/SessionManager.php
@@ -52,48 +52,19 @@ class SessionManager {
         }
 
         // Set the new one
-        $domain = OMEGAUP_COOKIE_DOMAIN;
         $secure = !empty(\OmegaUp\Request::getServerVar('HTTPS'));
         $_COOKIE[$name] = $value;
-        if (PHP_VERSION_ID < 70300) {
-            setcookie(
-                $name,
-                $value,
-                $expire,
-                "{$path}; SameSite=Lax",  // This hack only works for PHP < 7.3.
-                $domain,
-                /*secure=*/$secure,
-                /*httponly=*/true
-            );
-        } elseif (PHP_VERSION_ID < 70400) {
-            /**
-             * @psalm-suppress TooManyArguments this is needed to support
-             *                                  Same-Site cookies.
-             */
-            setcookie(
-                $name,
-                $value,
-                $expire,
-                $path,
-                $domain,
-                /*secure=*/$secure,
-                /*httponly=*/true,
-                /*samesite=*/'Lax'
-            );
-        } else {
-            setcookie(
-                $name,
-                $value,
-                [
-                    'expires' => $expire,
-                    'path' => $path,
-                    'domain' => $domain,
-                    'secure' => $secure,
-                    'httponly' => true,
-                    'samesite' => 'Lax',
-                ]
-            );
-        }
+        setcookie(
+            $name,
+            $value,
+            [
+                'expires' => $expire,
+                'path' => $path,
+                'secure' => $secure,
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ]
+        );
     }
 
     public function getCookie(string $name): ?string {


### PR DESCRIPTION
Este cambio deja de mandar el dominio en las cookies. Resulta que la
intención de esto era evitar que se compartieran las cookies entre el
dominio principal y los demás, pero según RFC 6265, si se especifica
explícitamente un valor para `domain`, ese dominio _y cualquier
subdominio_ serán destinos para el cookie recién establecido.