### PR TITLE
Guardando los códigos del evaluador efímero

### DIFF
--- a/frontend/www/js/omegaup/arena/arena.ts
+++ b/frontend/www/js/omegaup/arena/arena.ts
@@ -1905,7 +1905,10 @@ export class Arena {
 
     this.updateAllowedLanguages(this.currentProblem.languages);
 
-    this.ephemeralGrader.send('setSettings', this.currentProblem.settings);
+    this.ephemeralGrader.send('setSettings', {
+      alias: this.currentProblem.alias,
+      settings: this.currentProblem.settings,
+    });
   }
 
   detectShowRun(): void {

--- a/frontend/www/js/omegaup/grader/util.js
+++ b/frontend/www/js/omegaup/grader/util.js
@@ -85,3 +85,47 @@ export const languageExtensionMapping = {
 export function asyncError(err) {
   console.error('Async error', err);
 }
+
+// Wraps a function `f(...args)` into `f(key)(...args)` that is called at most
+// once every `delay` milliseconds. `f(key).flush()` will cause the function to
+// be called immediately.
+export function throttle(f, delay) {
+  let timeouts = {};
+  const throttled = (key) => {
+    let wrapped;
+    if (Object.prototype.hasOwnProperty.call(timeouts, key)) {
+      wrapped = (...args) => {
+        timeouts[key].args = args;
+      };
+    } else {
+      wrapped = (...args) => {
+        f(...args);
+        timeouts[key] = {
+          timeout: setTimeout(() => {
+            const { args } = timeouts[key];
+            delete timeouts[key];
+            if (args !== null) {
+              throttled(key)(...args);
+            }
+          }, delay),
+          args: null,
+        };
+      };
+    }
+    wrapped.flush = () => {
+      if (!Object.prototype.hasOwnProperty.call(timeouts, key)) {
+        return;
+      }
+      const { timeout, args } = timeouts[key];
+      delete timeouts[key];
+      clearTimeout(timeout);
+      if (args !== null) {
+        f(...args);
+      }
+    };
+
+    return wrapped;
+  };
+
+  return throttled;
+}


### PR DESCRIPTION
Este cambio hace que si alguien escribe cositas en el evaluador efímero,
estas cositas se guardan en `localStorage` y se pueden recuperar cuando
se cambia el problema y/o el lenguaje.