### PR TITLE
Separando los cambios del cliente para arreglar roles de usuario

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -34,6 +34,9 @@ namespace OmegaUp\Controllers;
  * @psalm-type ScoreboardRankingEntry=array{classname: string, country: string, is_invited: bool, name: null|string, place?: int, problems: list<ScoreboardRankingProblem>, total: array{penalty: float, points: float}, username: string}
  * @psalm-type Scoreboard=array{finish_time: \OmegaUp\Timestamp|null, problems: list<array{alias: string, order: int}>, ranking: list<ScoreboardRankingEntry>, start_time: \OmegaUp\Timestamp, time: \OmegaUp\Timestamp, title: string}
  * @psalm-type LoginDetailsPayload=array{facebookUrl: string, linkedinUrl: string, statusError?: string, validateRecaptcha: bool}
+ * @psalm-type Experiment=array{config: bool, hash: string, name: string}
+ * @psalm-type UserRole=array{name: string}
+ * @psalm-type UserDetailsPayload=array{emails: list<string>, experiments: list<string>, roleNames: list<UserRole>, systemExperiments: list<Experiment>, systemRoles: list<string>, username: string, verified: bool}
  */
 class User extends \OmegaUp\Controllers\Controller {
     /** @var bool */

--- a/frontend/server/src/DAO/Emails.php
+++ b/frontend/server/src/DAO/Emails.php
@@ -13,7 +13,7 @@ namespace OmegaUp\DAO;
  */
 class Emails extends \OmegaUp\DAO\Base\Emails {
     /**
-     * @return \OmegaUp\DAO\VO\Emails[]
+     * @return list<\OmegaUp\DAO\VO\Emails>
      */
     final public static function getByUserId(int $userId): array {
         $sql = 'SELECT
@@ -23,6 +23,7 @@ class Emails extends \OmegaUp\DAO\Base\Emails {
                 WHERE
                     user_id = ?';
 
+        /** @var list<array{email: null|string, email_id: int, user_id: int|null}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [$userId]);
 
         $emails = [];

--- a/frontend/www/js/omegaup/admin/user.ts
+++ b/frontend/www/js/omegaup/admin/user.ts
@@ -1,0 +1,93 @@
+import admin_User from '../components/admin/User.vue';
+import { OmegaUp } from '../omegaup';
+import * as api from '../api';
+import * as ui from '../ui';
+import T from '../lang';
+import Vue from 'vue';
+import { types } from '../api_types';
+
+OmegaUp.on('ready', () => {
+  const payload = types.payloadParsers.UserDetailsPayload();
+
+  const adminUser = new Vue({
+    el: '#main-container',
+    components: {
+      'omegaup-admin-user': admin_User,
+    },
+    data: () => ({
+      experiments: payload.experiments,
+      roles: payload.systemRoles,
+      verified: payload.verified,
+    }),
+    render: function (createElement) {
+      return createElement('omegaup-admin-user', {
+        props: {
+          emails: payload.emails,
+          experiments: this.experiments,
+          systemExperiments: payload.systemExperiments,
+          roleNames: payload.roleNames,
+          roles: this.roles,
+          username: payload.username,
+          verified: this.verified,
+        },
+        on: {
+          'change-experiment': (experiment: {
+            selected: boolean;
+            value: types.Experiment;
+          }): void => {
+            if (experiment.selected) {
+              api.User.addExperiment({
+                username: payload.username,
+                experiment: experiment.value.name,
+              })
+                .then(() => {
+                  ui.success(T.userEditSuccess);
+                })
+                .catch(ui.apiError);
+            } else {
+              api.User.removeExperiment({
+                username: payload.username,
+                experiment: experiment.value.name,
+              })
+                .then(() => {
+                  ui.success(T.userEditSuccess);
+                })
+                .catch(ui.apiError);
+            }
+          },
+          'change-role': (role: {
+            selected: boolean;
+            value: types.UserRole;
+          }): void => {
+            if (role.selected) {
+              api.User.addRole({
+                username: payload.username,
+                role: role.value.name,
+              })
+                .then(() => {
+                  ui.success(T.userEditSuccess);
+                })
+                .catch(ui.apiError);
+            } else {
+              api.User.removeRole({
+                username: payload.username,
+                role: role.value.name,
+              })
+                .then(() => {
+                  ui.success(T.userEditSuccess);
+                })
+                .catch(ui.apiError);
+            }
+          },
+          'verify-user': (): void => {
+            api.User.verifyEmail({ usernameOrEmail: payload.username })
+              .then(() => {
+                adminUser.verified = true;
+              })
+              .catch(ui.apiError);
+          },
+        },
+      });
+    },
+  });
+});

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1497,6 +1497,14 @@ export namespace types {
       );
     }
 
+    export function UserDetailsPayload(
+      elementId: string = 'payload',
+    ): types.UserDetailsPayload {
+      return JSON.parse(
+        (document.getElementById(elementId) as HTMLElement).innerText,
+      );
+    }
+
     export function UserProfileDetailsPayload(
       elementId: string = 'payload',
     ): types.UserProfileDetailsPayload {
@@ -2301,6 +2309,12 @@ export namespace types {
     courseName?: string;
     name: string;
     problem?: string;
+  }
+
+  export interface Experiment {
+    config: boolean;
+    hash: string;
+    name: string;
   }
 
   export interface ExtraProfileDetails {
@@ -3322,6 +3336,16 @@ export namespace types {
     teamsGroups: types.TeamsGroup[];
   }
 
+  export interface UserDetailsPayload {
+    emails: string[];
+    experiments: string[];
+    roleNames: types.UserRole[];
+    systemExperiments: types.Experiment[];
+    systemRoles: string[];
+    username: string;
+    verified: boolean;
+  }
+
   export interface UserInfoForProblem {
     admin: boolean;
     loggedIn: boolean;
@@ -3432,6 +3456,10 @@ export namespace types {
     page: number;
     pagerItems: types.PageItem[];
     ranking: types.UserRank;
+  }
+
+  export interface UserRole {
+    name: string;
   }
 }
 

--- a/frontend/www/js/omegaup/components/admin/User.vue
+++ b/frontend/www/js/omegaup/components/admin/User.vue
@@ -1,22 +1,26 @@
 <template>
-  <div class="omegaup-admin-user panel-primary panel">
-    <div class="panel-heading">
-      <h2 class="panel-title">
+  <div class="omegaup-admin-user card">
+    <div class="card-header">
+      <h2 class="card-title">
         {{ T.omegaupTitleAdminUsers }} — {{ username }}
       </h2>
     </div>
-    <div class="panel-body">
+    <div class="card-body">
       <form class="form bottom-margin" @submit.prevent="onChangePassword">
         <div class="row">
           <div class="col-md-12">
             <button
-              class="btn btn-default btn-block"
+              class="btn"
+              :class="{ 'btn-primary': !verified, 'btn-light': verified }"
               type="button"
               :disabled="verified"
               @click.prevent="onVerifyUser"
             >
-              <span v-if="verified"
-                ><span aria-hidden="true" class="glyphicon glyphicon-ok"></span>
+              <span v-if="verified">
+                <font-awesome-icon
+                  icon="check-circle"
+                  :style="{ color: 'green' }"
+                />
                 {{ T.userVerified }}</span
               ><span v-else>{{ T.userVerify }}</span>
             </button>
@@ -25,12 +29,14 @@
       </form>
       <h4>{{ T.userEmails }}</h4>
       <ul class="list-group">
-        <li v-for="email in emails" class="list-group-item">{{ email }}</li>
+        <li v-for="email in emails" :key="email" class="list-group-item">
+          {{ email }}
+        </li>
       </ul>
       <h4>{{ T.userRoles }}</h4>
       <table class="table">
         <tbody>
-          <tr v-for="role in roleNames">
+          <tr v-for="role in roleNames" :key="role.name">
             <td>
               <input
                 type="checkbox"
@@ -47,7 +53,7 @@
       <h4>{{ T.wordsExperiments }}</h4>
       <table class="table">
         <tbody>
-          <tr v-for="experiment in systemExperiments">
+          <tr v-for="experiment in systemExperiments" :key="experiment.name">
             <td>
               <input
                 type="checkbox"
@@ -71,7 +77,21 @@ import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 
-@Component
+import {
+  FontAwesomeIcon,
+  FontAwesomeLayers,
+  FontAwesomeLayersText,
+} from '@fortawesome/vue-fontawesome';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import { library } from '@fortawesome/fontawesome-svg-core';
+library.add(fas);
+@Component({
+  components: {
+    'font-awesome-icon': FontAwesomeIcon,
+    'font-awesome-layers': FontAwesomeLayers,
+    'font-awesome-layers-text': FontAwesomeLayersText,
+  },
+})
 export default class User extends Vue {
   @Prop() emails!: string[];
   @Prop() username!: string;


### PR DESCRIPTION
# Descripción

Para partir un poco el cambio de #5452 se separa la parte del cliente en un 
nuevo PR. 

Part of: #5450 

# Comentarios

En este cambio se crea el archivo .ts, pero no se usará hasta que se realicen todos 
los cambios en el servidor y en ese momento se puede eliminar el archivo .js

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas. (Las pruebas vienen en el otro PR)
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
