### PR TITLE
Moviendo el componente de EditTeamsGroup a un directorio dedicado a los grupos de equipos

### DIFF
--- a/frontend/www/js/omegaup/components/teamsgroup/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/teamsgroup/Edit.test.ts
@@ -4,9 +4,9 @@ import { types } from '../../api_types';
 import T from '../../lang';
 import * as ui from '../../ui';
 
-import group_EditTeamsGroup, { AvailableTabs } from './EditTeamsGroup.vue';
+import teamsgroup_Edit, { AvailableTabs } from './Edit.vue';
 
-describe('EditTeamsGroup.vue', () => {
+describe('Edit.vue', () => {
   const propsData = {
     teamsGroupAlias: 'Hello',
     teamsGroupName: 'Hello omegaUp',
@@ -18,7 +18,7 @@ describe('EditTeamsGroup.vue', () => {
   };
 
   it('Should handle edit view with empty teams list', () => {
-    const wrapper = shallowMount(group_EditTeamsGroup, {
+    const wrapper = shallowMount(teamsgroup_Edit, {
       propsData,
     });
 
@@ -28,7 +28,7 @@ describe('EditTeamsGroup.vue', () => {
   });
 
   it('Should change a valid tab', async () => {
-    const wrapper = shallowMount(group_EditTeamsGroup, {
+    const wrapper = shallowMount(teamsgroup_Edit, {
       propsData,
     });
 
@@ -37,7 +37,7 @@ describe('EditTeamsGroup.vue', () => {
   });
 
   it('Should change an invalid tab', async () => {
-    const wrapper = shallowMount(group_EditTeamsGroup, {
+    const wrapper = shallowMount(teamsgroup_Edit, {
       propsData,
     });
 
@@ -46,7 +46,7 @@ describe('EditTeamsGroup.vue', () => {
   });
 
   it('Should change teams identities and team identities in csv lists', async () => {
-    const wrapper = shallowMount(group_EditTeamsGroup, {
+    const wrapper = shallowMount(teamsgroup_Edit, {
       propsData,
     });
     const identities: types.Identity[] = [

--- a/frontend/www/js/omegaup/components/teamsgroup/Edit.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Edit.vue
@@ -119,7 +119,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import group_Form from './Form.vue';
+import group_Form from '../group/Form.vue';
 // Include next two components
 // import group_UploadTeams from './UploadTeams.vue';
 // import group_Teams from './Teams.vue';

--- a/frontend/www/js/omegaup/components/teamsgroup/Edit.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Edit.vue
@@ -50,10 +50,9 @@
       >
         <omegaup-group-form
           :is-update="true"
-          :group-name="teamGroupName"
+          :group-name="teamsGroupName"
           :group-alias="teamsGroupAlias"
           :group-description="teamsGroupDescription"
-          :number-of-teams="teamsGroupNumber"
           @update-group="
             (name, description) =>
               $emit('update-teams-group', name, description)


### PR DESCRIPTION
# Descripción

Para tener una separación de la lógica entre grupos y grupos de equipos, es 
importante también mover a un directorio separado los componentes que se
van a requerir para el feature de Concursos para equipos.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
