### PR TITLE
Usando tokens en vez de login para `bootstrap-environment.py`

### DIFF
--- a/frontend/database/178_test_apitokens.sql
+++ b/frontend/database/178_test_apitokens.sql
@@ -1,0 +1,4 @@
+INSERT INTO
+  API_Tokens (user_id, name, token)
+VALUES
+  (1, 'bootstrap', '92d8c5a0eceef3c05f4149fc04b62bb2cd50d9c6');

--- a/stuff/bootstrap.json
+++ b/stuff/bootstrap.json
@@ -1,7 +1,6 @@
 [
 	{
-		"username": "omegaup",
-		"password": "omegaup",
+		"token": "92d8c5a0eceef3c05f4149fc04b62bb2cd50d9c6",
 		"requests": [
 			{
 				"api": "/problem/create/",


### PR DESCRIPTION
Este cambio hace que `bootstrap-environment.py` use un API token en vez
de hacer login (para el usuario principal).