### PR TITLE
Arreglando link de invitación a Discord en la sección de Redes Sociales

### DIFF
--- a/frontend/www/js/omegaup/components/common/Footerv2.vue
+++ b/frontend/www/js/omegaup/components/common/Footerv2.vue
@@ -93,10 +93,7 @@
               Facebook
             </a>
             |
-            <a
-              class="text-nowrap"
-              href="https://discord.gg/K3JFd9d3wk"
-            >
+            <a class="text-nowrap" href="https://discord.gg/K3JFd9d3wk">
               <font-awesome-icon :icon="['fab', 'discord']" />
               Discord
             </a>

--- a/frontend/www/js/omegaup/components/common/Footerv2.vue
+++ b/frontend/www/js/omegaup/components/common/Footerv2.vue
@@ -95,7 +95,7 @@
             |
             <a
               class="text-nowrap"
-              href="https://discord.com/channels/832682734115094638"
+              href="https://discord.gg/K3JFd9d3wk"
             >
               <font-awesome-icon :icon="['fab', 'discord']" />
               Discord


### PR DESCRIPTION
# Descripción

Corrección al link de invitación a Discord que aparece en la sección de Redes Sociales.

Fixes: #5472

# Checklist:

- [ ] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
