### PR TITLE
Evitando un flake en la prueba de Selenium

### DIFF
--- a/frontend/tests/ui/test_smoke.py
+++ b/frontend/tests/ui/test_smoke.py
@@ -157,7 +157,7 @@ def test_create_problem(driver):
             '//table[contains(concat(" ", normalize-space(@class), " "), " '
             'global ")]/tbody/tr/td[@data-run-status]/span')
 
-        assert global_run.text == 'rejudging'
+        assert global_run.text in ('rejudging', 'AC')
 
 
 @util.annotate


### PR DESCRIPTION
Este cambio hace que uno de los veredictos de los envíos en las pruebas
de Selenium pueda ser `rejudging` o `AC`.