### PR TITLE
Agregando el grader efímero a los problemas sueltos

### DIFF
--- a/frontend/www/js/omegaup/components/arena/EphemeralGrader.test.ts
+++ b/frontend/www/js/omegaup/components/arena/EphemeralGrader.test.ts
@@ -1,0 +1,156 @@
+import { mount } from '@vue/test-utils';
+import type { types } from '../../api_types';
+
+import arena_EphemeralGrader from './EphemeralGrader.vue';
+
+type SetSettingsMessage = {
+  method: 'setSettings';
+  params: {
+    alias: string;
+    settings: types.ProblemSettingsDistrib;
+  };
+};
+
+describe('EphemeralGrader.vue', () => {
+  beforeEach(() => {
+    const div = document.createElement('div');
+    div.id = 'root';
+    document.body.appendChild(div);
+  });
+
+  afterEach(() => {
+    const rootDiv = document.getElementById('root');
+    if (rootDiv) {
+      document.removeChild(rootDiv);
+    }
+  });
+
+  const date = new Date();
+  const problem: types.ProblemInfo = {
+    alias: 'triangulos',
+    accepts_submissions: true,
+    karel_problem: false,
+    commit: 'abc',
+    languages: ['py3'],
+    limits: {
+      input_limit: '10 KiB',
+      memory_limit: '32 MiB',
+      overall_wall_time_limit: '1s',
+      time_limit: '1s',
+    },
+    points: 100,
+    problem_id: 1,
+    problemsetter: {
+      classname: 'user-rank-unranked',
+      creation_date: date,
+      name: 'omegaUp admin',
+      username: 'omegaup',
+    },
+    quality_seal: false,
+    sample_input: undefined,
+    settings: {
+      cases: {
+        statement_001: {
+          in: '6\n2 3 2 3 2 4',
+          out: '10',
+          weight: 1,
+        },
+      },
+      limits: {
+        ExtraWallTime: '0s',
+        MemoryLimit: 33554432,
+        OutputLimit: 10240,
+        OverallWallTimeLimit: '1s',
+        TimeLimit: '1s',
+      },
+      validator: {
+        name: 'token-numeric',
+        tolerance: 1e-9,
+      },
+    },
+    source: 'omegaUp classics',
+    statement: {
+      images: {},
+      sources: {},
+      language: 'en',
+      markdown: `# test with embed code
+Here we can add code.
+<details>
+  <summary>
+    Example:
+  </summary>
+
+  {{sample.cpp}}
+
+  </details>
+      `,
+    },
+    title: 'Triangulos',
+    visibility: 2,
+    input_limit: 1000,
+  };
+
+  it('Should handle showing the ephemeral grader for a problem upon load', async () => {
+    const wrapper = mount(arena_EphemeralGrader, {
+      attachTo: '#root',
+      propsData: {
+        problem,
+      },
+    });
+    const contentWindow: Window = (wrapper.findComponent({ ref: 'grader' })
+      .element as HTMLIFrameElement).contentWindow as Window;
+
+    const postPromise = new Promise<SetSettingsMessage>((accept) => {
+      contentWindow.postMessage = jest.fn(accept);
+    });
+    wrapper.vm.iframeLoaded();
+    const settingsMessage = await postPromise;
+    expect({
+      method: settingsMessage.method,
+      params: { alias: settingsMessage.params.alias },
+    }).toEqual({
+      method: 'setSettings',
+      params: {
+        alias: problem.alias,
+      },
+    });
+
+    wrapper.destroy();
+  });
+
+  it('Should handle showing the ephemeral grader for a problem after changing settings', async () => {
+    const wrapper = mount(arena_EphemeralGrader, {
+      attachTo: '#root',
+      propsData: {
+        problem,
+      },
+    });
+    const contentWindow: Window = (wrapper.findComponent({ ref: 'grader' })
+      .element as HTMLIFrameElement).contentWindow as Window;
+
+    wrapper.vm.iframeLoaded();
+
+    const postPromise = new Promise<SetSettingsMessage>((accept) => {
+      contentWindow.postMessage = jest.fn(accept);
+    });
+    const newAlias = 'sumas2';
+    await wrapper.setProps({
+      problem: {
+        ...problem,
+        alias: newAlias,
+      },
+    });
+    const settingsMessage = await postPromise;
+    expect({
+      method: settingsMessage.method,
+      params: { alias: settingsMessage.params.alias },
+    }).toEqual({
+      method: 'setSettings',
+      params: {
+        alias: newAlias,
+      },
+    });
+
+    wrapper.destroy();
+  });
+});

--- a/frontend/www/js/omegaup/components/arena/EphemeralGrader.vue
+++ b/frontend/www/js/omegaup/components/arena/EphemeralGrader.vue
@@ -1,0 +1,55 @@
+<template>
+  <iframe ref="grader" src="/grader/ephemeral/?embedded"></iframe>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop, Ref, Watch } from 'vue-property-decorator';
+import { types } from '../../api_types';
+
+@Component
+export default class EphemeralGrader extends Vue {
+  @Ref() grader!: HTMLIFrameElement;
+  @Prop() problem!: types.ProblemInfo;
+
+  loaded = false;
+
+  mounted(): void {
+    (this.$refs.grader as HTMLIFrameElement).onload = () => this.iframeLoaded();
+  }
+
+  @Watch('problem')
+  onProblemChanged() {
+    if (!this.loaded) {
+      // This will be updated when the component is mounted.
+      return;
+    }
+    this.setSettings();
+  }
+
+  setSettings(): void {
+    ((this.$refs.grader as HTMLIFrameElement)
+      .contentWindow as Window).postMessage(
+      {
+        method: 'setSettings',
+        params: {
+          alias: this.problem.alias,
+          settings: this.problem.settings,
+        },
+      },
+      `${window.location.origin}/grader/ephemeral/embedded/`,
+    );
+  }
+
+  iframeLoaded(): void {
+    this.loaded = true;
+    this.setSettings();
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+iframe {
+  width: 100%;
+  min-height: 40em;
+}
+</style>

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -164,16 +164,21 @@
             ></omegaup-quality-nomination-reviewer-popup>
           </template>
         </omegaup-overlay>
-        <omegaup-arena-runs
-          :problem-alias="problem.alias"
-          :contest-alias="contestAlias"
-          :runs="runs"
-          :show-details="true"
-          :problemset-problems="[]"
-          :is-contest-finished="isContestFinished"
-          @details="(run) => onRunDetails(run.guid)"
-          @new-submission="onNewSubmission"
-        ></omegaup-arena-runs>
+        <template v-if="problem.accepts_submissions">
+          <omegaup-arena-ephemeral-grader
+            :problem="problem"
+          ></omegaup-arena-ephemeral-grader>
+          <omegaup-arena-runs
+            :problem-alias="problem.alias"
+            :contest-alias="contestAlias"
+            :runs="runs"
+            :show-details="true"
+            :problemset-problems="[]"
+            :is-contest-finished="isContestFinished"
+            @details="(run) => onRunDetails(run.guid)"
+            @new-submission="onNewSubmission"
+          ></omegaup-arena-runs>
+        </template>
         <omegaup-problem-feedback
           :quality-histogram="parsedQualityHistogram"
           :difficulty-histogram="parsedDifficultyHistogram"
@@ -181,7 +186,10 @@
           :difficulty-score="histogramDifficulty"
         ></omegaup-problem-feedback>
         <slot name="best-solvers-list">
-          <omegaup-arena-solvers :solvers="solvers"></omegaup-arena-solvers>
+          <omegaup-arena-solvers
+            v-if="problem.accepts_submissions"
+            :solvers="solvers"
+          ></omegaup-arena-solvers>
         </slot>
       </div>
       <div
@@ -259,6 +267,7 @@ import T from '../../lang';
 import * as time from '../../time';
 import * as ui from '../../ui';
 import arena_ClarificationList from '../arena/ClarificationList.vue';
+import arena_EphemeralGrader from '../arena/EphemeralGrader.vue';
 import arena_Runs from '../arena/Runs.vue';
 import arena_RunSubmitPopup from '../arena/RunSubmitPopup.vue';
 import arena_RunDetailsPopup from '../arena/RunDetailsPopup.vue';
@@ -308,6 +317,7 @@ export enum PopupDisplayed {
   components: {
     FontAwesomeIcon,
     'omegaup-arena-clarification-list': arena_ClarificationList,
+    'omegaup-arena-ephemeral-grader': arena_EphemeralGrader,
     'omegaup-arena-runs': arena_Runs,
     'omegaup-arena-runsubmit-popup': arena_RunSubmitPopup,
     'omegaup-arena-rundetails-popup': arena_RunDetailsPopup,

--- a/frontend/www/js/omegaup/grader/ephemeral.js
+++ b/frontend/www/js/omegaup/grader/ephemeral.js
@@ -1499,7 +1499,10 @@ window.addEventListener(
 
     switch (e.data.method) {
       case 'setSettings':
-        setSettings(...e.data.params);
+        setSettings({
+          alias: e.data.params.alias,
+          settings: e.data.params.settings,
+        });
         break;
     }
   },

--- a/webpack.config-frontend.js
+++ b/webpack.config-frontend.js
@@ -179,7 +179,7 @@ module.exports = {
           priority: 20,
         },
         vendor: {
-          name: module => {
+          name: (module) => {
             const packageName = module.context.match(
               /\/node_modules\/([^@/]+)/,
             )[1];
@@ -232,6 +232,7 @@ module.exports = {
         test: /\.js$/,
         loader: 'babel-loader',
         options: {
+          presets: ['@babel/env'],
           cacheDirectory: true,
         },
         exclude: /node_modules/,


### PR DESCRIPTION
Este cambio hace que el grader efímero se despliegue para todos los
problemas sueltos. Esto debería permitir a la gente probar sus problemas
con todos los casos de ejemplo para encontrar errores más rápidamente.