### PR TITLE
Arreglando bug que no permitía agregar grupos con espacios a concurso

### DIFF
--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -13,6 +13,7 @@
  * @psalm-type GroupScoreboardContestsPayload=array{availableContests: list<ContestListItem>, contests: list<ScoreboardContest>, scoreboardAlias: string, groupAlias: string}
  * @psalm-type Group=array{alias: string, create_time: \OmegaUp\Timestamp, description: null|string, name: string}
  * @psalm-type GroupListPayload=array{groups: list<Group>}
+ * @psalm-type GroupListItem=array{label: string, value: string}
  */
 
 class Group extends \OmegaUp\Controllers\Controller {
@@ -271,7 +272,7 @@ class Group extends \OmegaUp\Controllers\Controller {
      *
      * @param \OmegaUp\Request $r
      *
-     * @return list<array{label: string, value: string}>
+     * @return list<GroupListItem>
      *
      * @omegaup-request-param null|string $query
      */

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -2235,11 +2235,7 @@ array instead of an object since it is used by typeahead.
 ### Returns
 
 ```typescript
-{
-  label: string;
-  value: string;
-}
-[];
+types.GroupListItem[]
 ```
 
 ## `/api/group/members/`

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2293,6 +2293,11 @@ export namespace types {
     scoreboards: types.GroupScoreboard[];
   }
 
+  export interface GroupListItem {
+    label: string;
+    value: string;
+  }
+
   export interface GroupListPayload {
     groups: types.Group[];
   }
@@ -3816,7 +3821,7 @@ export namespace messages {
     scoreboards: types.GroupScoreboard[];
   };
   export type GroupListRequest = { [key: string]: any };
-  export type GroupListResponse = { label: string; value: string }[];
+  export type GroupListResponse = types.GroupListItem[];
   export type GroupMembersRequest = { [key: string]: any };
   export type GroupMembersResponse = { identities: types.Identity[] };
   export type GroupMyListRequest = { [key: string]: any };

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -177,6 +177,10 @@
         ></omegaup-common-requests>
         <omegaup-contest-groups
           :groups="groups"
+          :search-result-groups="searchResultGroups"
+          @update-search-result-groups="
+            (query) => $emit('update-search-result-groups', query)
+          "
           @emit-add-group="(groupAlias) => $emit('add-group', groupAlias)"
           @emit-remove-group="(groupAlias) => $emit('remove-group', groupAlias)"
         ></omegaup-contest-groups>
@@ -268,6 +272,7 @@ export default class Edit extends Vue {
   @Prop() users!: types.ContestUser[];
   @Prop() searchResultProblems!: types.ListItem[];
   @Prop() searchResultUsers!: types.ListItem[];
+  @Prop() searchResultGroups!: types.ListItem[];
 
   T = T;
   ui = ui;

--- a/frontend/www/js/omegaup/components/contest/Groups.vue
+++ b/frontend/www/js/omegaup/components/contest/Groups.vue
@@ -1,13 +1,20 @@
 <template>
   <div class="card mt-3">
     <div class="card-body">
-      <form class="form" @submit.prevent="$emit('emit-add-group', groupName)">
+      <form
+        class="form"
+        @submit.prevent="$emit('emit-add-group', typeaheadGroup)"
+      >
         <div class="form-group">
           <label>{{ T.wordsGroup }}</label>
-          <omegaup-autocomplete
-            v-model="groupName"
-            :init="(el) => typeahead.groupTypeahead(el)"
-          ></omegaup-autocomplete>
+          <omegaup-common-typeahead
+            :existing-options="searchResultGroups"
+            :value.sync="typeaheadGroup"
+            @update-existing-options="
+              (query) => $emit('update-search-result-groups', query)
+            "
+          >
+          </omegaup-common-typeahead>
         </div>
         <button class="btn btn-primary" type="submit">
           {{ T.contestAddgroupAddGroup }}
@@ -47,25 +54,24 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
-import * as typeahead from '../../typeahead';
-import Autocomplete from '../Autocomplete.vue';
+import common_Typeahead from '../common/Typeahead.vue';
 
 @Component({
   components: {
-    'omegaup-autocomplete': Autocomplete,
+    'omegaup-common-typeahead': common_Typeahead,
   },
 })
 export default class Groups extends Vue {
   @Prop() groups!: types.ContestGroup[];
+  @Prop() searchResultGroups!: types.ListItem[];
 
   T = T;
-  typeahead = typeahead;
-  groupName = '';
+  typeaheadGroup: null | string = null;
   selected: types.ContestGroup | null = null;
 
   @Watch('groups')
   onGroupsChange(): void {
-    this.groupName = '';
+    this.typeaheadGroup = null;
     this.selected = null;
   }
 }

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -24,6 +24,7 @@ OmegaUp.on('ready', () => {
       users: payload.users,
       searchResultProblems: [] as types.ListItem[],
       searchResultUsers: [] as types.ListItem[],
+      searchResultGroups: [] as types.ListItem[],
     }),
     methods: {
       arbitrateRequest: (username: string, resolution: boolean): void => {
@@ -120,6 +121,7 @@ OmegaUp.on('ready', () => {
           users: this.users,
           searchResultProblems: this.searchResultProblems,
           searchResultUsers: this.searchResultUsers,
+          searchResultGroups: this.searchResultGroups,
         },
         on: {
           'update-search-result-problems': (query: string) => {
@@ -138,6 +140,27 @@ OmegaUp.on('ready', () => {
                     key: problem.alias,
                     value: `${ui.escape(problem.title)} (<strong>${ui.escape(
                       problem.alias,
+                    )}</strong>)`,
+                  }));
+              })
+              .catch(ui.apiError);
+          },
+          'update-search-result-groups': (query: string) => {
+            api.Group.list({
+              query,
+            })
+              .then((data) => {
+                // Groups previously added into the contest should not be
+                // shown in the dropdown
+                const addedGroups = new Set(
+                  this.groups.map((problem) => problem.alias),
+                );
+                this.searchResultGroups = data
+                  .filter((group) => !addedGroups.has(group.value))
+                  .map((group) => ({
+                    key: group.value,
+                    value: `${ui.escape(group.label)} (<strong>${ui.escape(
+                      group.value,
                     )}</strong>)`,
                   }));
               })


### PR DESCRIPTION
# Descripción

Se arregla bug que no permitía agregar grupos a un concurso si estos contaban
con más de una palabra, migrando el componente a `Typeahead`.

![FixAddGroupToContest](https://user-images.githubusercontent.com/3230352/123896794-d840a800-d927-11eb-9c81-5a011eba7c64.gif)`

Fixes: #5228 

# Comentarios

Lo ideal sería arreglar el problema de raíz (invertir esos índices), pero como
la api se utiliza en un par de lugares más, sería cuestión de ver si se puede
hacer en un cambio posterior para que este no se exceda.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
