### PR TITLE
Moviendo la columna de puntaje global al principio en tabla progreso estudiante

### DIFF
--- a/frontend/www/js/omegaup/components/course/StudentProgress.vue
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.vue
@@ -10,6 +10,14 @@
         ></omegaup-user-username>
       </a>
     </td>
+    <td data-global-score class="text-center font-weight-bold align-middle">
+      <span class="d-block">{{ globalScore }}%</span>
+      <span class="d-block">{{
+        ui.formatString(T.studentProgressDescriptionTotalPoints, {
+          points: globalPoints,
+        })
+      }}</span>
+    </td>
     <td
       v-for="assignment in assignments"
       :key="assignment.alias"
@@ -44,14 +52,6 @@
           ></div>
         </div>
       </div>
-    </td>
-    <td data-global-score class="text-center font-weight-bold align-middle">
-      <span class="d-block">{{ globalScore }}%</span>
-      <span class="d-block">{{
-        ui.formatString(T.studentProgressDescriptionTotalPoints, {
-          points: globalPoints,
-        })
-      }}</span>
     </td>
   </tr>
 </template>

--- a/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
@@ -91,21 +91,19 @@ describe('ViewProgress.vue', () => {
     expect(odsContent).toBe(`<table:table table:name="${courseName}">
 <table:table-column table:number-columns-repeated="4"/>
 <table:table-row>
-<table:table-cell office:value-type="string"><text:p>${T.profileUsername}\
-</text:p></table:table-cell><table:table-cell office:value-type="string">\
-<text:p>${T.wordsName}</text:p></table:table-cell><table:table-cell \
-office:value-type="string"><text:p>${assignment.name}</text:p>\
-</table:table-cell><table:table-cell office:value-type="string"><text:p>\
-${T.courseProgressGlobalScore}</text:p></table:table-cell></table:table-row>
+<table:table-cell office:value-type="string"><text:p>${T.profileUsername}</text:p>\
+</table:table-cell><table:table-cell office:value-type="string"><text:p>${T.wordsName}\
+</text:p></table:table-cell><table:table-cell office:value-type="string"><text:p>\
+${T.courseProgressGlobalScore}</text:p></table:table-cell><table:table-cell \
+office:value-type="string"><text:p>${assignment.name}</text:p></table:table-cell>\
+</table:table-row>
 <table:table-row>
-<table:table-cell office:value-type="string"><text:p>${student.username}\
-</text:p></table:table-cell><table:table-cell office:value-type="string">\
-<text:p>${student.name}</text:p></table:table-cell><table:table-cell \
-office:value-type="float" office:value="${score}"><text:p>${score}</text:p>\
-</table:table-cell>\
-<table:table-cell office:value-type="percentage" office:value="${globalScore.value}">\
-<text:p>${globalScore}</text:p>\
-</table:table-cell></table:table-row>
+<table:table-cell office:value-type="string"><text:p>${student.username}</text:p>\
+</table:table-cell><table:table-cell office:value-type="string"><text:p>${student.name}\
+</text:p></table:table-cell><table:table-cell office:value-type="percentage" \
+office:value="${globalScore.value}"><text:p>${globalScore}</text:p>\
+</table:table-cell><table:table-cell office:value-type="float" office:value="\
+${score}"><text:p>${score}</text:p></table:table-cell></table:table-row>
 </table:table>`);
   });
 
@@ -117,8 +115,8 @@ office:value-type="float" office:value="${score}"><text:p>${score}</text:p>\
 
     const csvContent = toCsv(wrapper.vm.progressTable);
     expect(csvContent).toBe(`${T.profileUsername},${T.wordsName},${
-      assignment.name
-    },${T.courseProgressGlobalScore}\r
-${student.username},${student.name},${score.toFixed(2)},${globalScore}`);
+      T.courseProgressGlobalScore
+    },${assignment.name}\r
+${student.username},${student.name},${globalScore},${score.toFixed(2)}`);
   });
 });

--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -20,6 +20,20 @@
                     ></omegaup-common-sort-controls>
                   </span>
                 </th>
+                <th class="text-center align-middle">
+                  <span>
+                    {{ T.courseProgressGlobalScore }}
+                    <span class="d-block">{{
+                      getTotalPointsByCourse(assignments)
+                    }}</span>
+                    <omegaup-common-sort-controls
+                      column="total"
+                      :sort-order="sortOrder"
+                      :column-name="columnName"
+                      @apply-filter="onApplyFilter"
+                    ></omegaup-common-sort-controls>
+                  </span>
+                </th>
                 <th
                   v-for="assignment in assignments"
                   :key="assignment.alias"
@@ -37,20 +51,6 @@
                         ><img src="/media/question.png"
                       /></a>
                     </span>
-                  </span>
-                </th>
-                <th class="text-center align-middle">
-                  <span>
-                    {{ T.courseProgressGlobalScore }}
-                    <span class="d-block">{{
-                      getTotalPointsByCourse(assignments)
-                    }}</span>
-                    <omegaup-common-sort-controls
-                      column="total"
-                      :sort-order="sortOrder"
-                      :column-name="columnName"
-                      @apply-filter="onApplyFilter"
-                    ></omegaup-common-sort-controls>
                   </span>
                 </th>
               </tr>
@@ -268,18 +268,17 @@ export default class CourseViewProgress extends Vue {
   get progressTable(): TableCell[][] {
     const table: TableCell[][] = [];
     const header = [T.profileUsername, T.wordsName];
+    header.push(T.courseProgressGlobalScore);
     for (const assignment of this.assignments) {
       header.push(assignment.name);
     }
-    header.push(T.courseProgressGlobalScore);
     table.push(header);
     for (const student of this.students) {
       const row: TableCell[] = [student.username, student.name || ''];
-
+      row.push(this.getGlobalScoreByStudent(student));
       for (const assignment of this.assignments) {
         row.push(this.score(student, assignment));
       }
-      row.push(this.getGlobalScoreByStudent(student));
 
       table.push(row);
     }


### PR DESCRIPTION
# Descripción

Ser movió la columna de puntaje global al principio (en vez de al final) en la tabla de progreso de estudiante. 

![Captura de pantalla de 2021-07-02 13-45-28](https://user-images.githubusercontent.com/85198932/124316869-e23af480-db3b-11eb-85cc-6322ea017657.png)

Part of: #5398

# Comentarios

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
