### PR TITLE
Graduando el experimento de las identidades

### DIFF
--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -433,9 +433,7 @@ class Group extends \OmegaUp\Controllers\Controller {
         // Authenticate user
         $r->ensureMainUserIdentity();
 
-        $isOrganizer = \OmegaUp\Experiments::getInstance()->isEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        ) && \OmegaUp\Authorization::canCreateGroupIdentities(
+        $isOrganizer = \OmegaUp\Authorization::canCreateGroupIdentities(
             $r->identity
         );
 
@@ -480,9 +478,7 @@ class Group extends \OmegaUp\Controllers\Controller {
                     'identities' => \OmegaUp\DAO\GroupsIdentities::getMemberIdentities(
                         $group
                     ),
-                    'isOrganizer' => \OmegaUp\Experiments::getInstance()->isEnabled(
-                        \OmegaUp\Experiments::IDENTITIES
-                    ) && \OmegaUp\Authorization::canCreateGroupIdentities(
+                    'isOrganizer' => \OmegaUp\Authorization::canCreateGroupIdentities(
                         $r->identity
                     ),
                     'scoreboards' => $scoreboards,

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -80,9 +80,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         $group = self::validateGroupOwnership($r);
         if (is_null($group->alias)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
@@ -182,9 +179,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $username
      */
     public static function apiBulkCreate(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         $group = self::validateGroupOwnership($r);
         if (is_null($group->alias)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
@@ -293,10 +287,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $team_identities
      */
     public static function apiBulkCreateForTeams(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
-
         $r->ensureMainUserIdentity();
         if (!\OmegaUp\Authorization::isGroupIdentityCreator($r->identity)) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException(
@@ -496,9 +486,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiUpdateIdentityTeam(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         self::validateUpdateRequest($r);
         $originalUsername = $r->ensureString('original_username');
         $username = $r->ensureString('username');
@@ -799,9 +786,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         self::validateUpdateRequest($r);
         $originalUsername = $r->ensureString('original_username');
         $username = $r->ensureString('username');
@@ -888,9 +872,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiChangePassword(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['username'],
             'username'

--- a/frontend/server/src/Controllers/TeamsGroup.php
+++ b/frontend/server/src/Controllers/TeamsGroup.php
@@ -137,9 +137,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
                     'teamsMembers' => \OmegaUp\DAO\TeamUsers::getByTeamGroupId(
                         $teamGroup->team_group_id
                     )['teamsUsers'],
-                    'isOrganizer' => \OmegaUp\Experiments::getInstance()->isEnabled(
-                        \OmegaUp\Experiments::IDENTITIES
-                    ) && \OmegaUp\Authorization::canCreateGroupIdentities(
+                    'isOrganizer' => \OmegaUp\Authorization::canCreateGroupIdentities(
                         $r->identity
                     ),
                 ],

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -3478,9 +3478,6 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiAssociateIdentity(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         $r->ensureMainUserIdentity();
 
         \OmegaUp\Validators::validateStringNonEmpty($r['username'], 'username');
@@ -3538,9 +3535,6 @@ class User extends \OmegaUp\Controllers\Controller {
      * @return array{identities: list<AssociatedIdentity>}
      */
     public static function apiListAssociatedIdentities(\OmegaUp\Request $r): array {
-        \OmegaUp\Experiments::getInstance()->ensureEnabled(
-            \OmegaUp\Experiments::IDENTITIES
-        );
         $r->ensureMainUserIdentity();
 
         return [

--- a/frontend/server/src/Experiments.php
+++ b/frontend/server/src/Experiments.php
@@ -39,15 +39,9 @@ namespace OmegaUp;
  */
 class Experiments {
     /**
-     * Constant for identity management experiment.
-     */
-    const IDENTITIES = 'identities';
-
-    /**
      * An array with all the known experiments.
      */
     private const KNOWN_EXPERIMENTS = [
-        self::IDENTITIES,
     ];
 
     /**

--- a/frontend/templates/user.edit.tpl
+++ b/frontend/templates/user.edit.tpl
@@ -155,10 +155,8 @@
 				</form>
 			</div>
 		</div>
-{if !empty($ENABLED_EXPERIMENTS) && in_array('identities', $ENABLED_EXPERIMENTS)}
 		<div id="manage-identities"></div>
 		{js_include entrypoint="user_manage_identities"}
-{/if}
 		{block name="basic-content"}
 		<div class="panel panel-default">
 			<div class="panel-heading">

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -9,7 +9,6 @@ $_testShard = intval(getenv('TEST_TOKEN') ?: '0');
 # ####################################
 # EXPERIMENTS
 # ####################################
-try_define('EXPERIMENT_IDENTITIES', true);
 
 # ####################################
 # DATABASE CONFIG

--- a/frontend/www/js/omegaup/omegaup.ts
+++ b/frontend/www/js/omegaup/omegaup.ts
@@ -15,9 +15,6 @@ export class Experiments {
   }
 
   // Current frontend-available experiments:
-  static get IDENTITIES(): string {
-    return 'identities';
-  }
 
   // The list of all enabled experiments for a particular request should have
   // been injected into the DOM by Smarty.


### PR DESCRIPTION
Las identidades llevan un _muy_ buen rato habilitadas, así que no hay
razón para seguirlas teniendo detrás de una bandera.

Este cambio por fin hace que las identidades sean para siempre.