### PR TITLE
Agregando plantilla para el cluster EKS

### DIFF
--- a/stuff/prod/k8s/omegaup/aws_cluster.yaml
+++ b/stuff/prod/k8s/omegaup/aws_cluster.yaml
@@ -1,0 +1,27 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: omegaup-eks-cluster
+  region: us-east-1
+
+vpc:
+  id: vpc-08928671
+  securityGroup: sg-09ab645d275d030f5
+  subnets:
+    private:
+      us-east-1a: { id: subnet-4a1e3466 }
+      us-east-1b: { id: subnet-962fc4dd }
+      us-east-1c: { id: subnet-ae3f10f4 }
+      us-east-1d: { id: subnet-7660c512 }
+      us-east-1f: { id: subnet-28d68b24 }
+
+nodeGroups:
+  - name: omegaup-eks-nodes
+    labels: { role: workers, k8s: "" }
+    instanceType: t2.medium
+    desiredCapacity: 2
+    privateNetworking: true
+    ssh:
+      allow: true
+      publicKeyPath: ~/.ssh/omegaup-eks.pem.pub


### PR DESCRIPTION
Este cambio agrega la primera versión de la plantilla del cluster EKS.
Así cuando haya necesidad de realizar, se pueda saber cuándo se hicieron
y en qué consistieron. Viva configuration-as-code!