### PR TITLE
Arreglando bug donde no se podía regresar a la identidad principal en equipos

### DIFF
--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -313,7 +313,12 @@ class Session extends \OmegaUp\Controllers\Controller {
         $currentIdentity = new \OmegaUp\DAO\VO\Identities($currentIdentityExt);
         $loginIdentity = new \OmegaUp\DAO\VO\Identities($loginIdentityExt);
 
-        $associatedIdentities = [];
+        $associatedIdentities = [
+            [
+                'username' => strval($loginIdentity->username),
+                'default' => true,
+            ],
+        ];
         if (is_null($currentIdentity->user_id)) {
             $currentUser = null;
             $email = null;
@@ -759,7 +764,10 @@ class Session extends \OmegaUp\Controllers\Controller {
     ): void {
         // Only users that originally logged in from their main identities can
         // select another identity.
-        if (!$r->isLoggedAsMainIdentity()) {
+        $identityToResolve = \OmegaUp\Controllers\Identity::resolveIdentity(
+            $usernameOrEmail
+        );
+        if (!$r->isLoggedAsMainIdentity($identityToResolve)) {
             throw new \OmegaUp\Exceptions\UnauthorizedException(
                 'userNotAllowed'
             );
@@ -775,7 +783,8 @@ class Session extends \OmegaUp\Controllers\Controller {
 
         $identity = \OmegaUp\DAO\Identities::resolveAssociatedIdentity(
             $usernameOrEmail,
-            $loggedIdentity
+            $loggedIdentity,
+            $identityToResolve
         );
         if (is_null($identity) || is_null($identity->identity_id)) {
             self::$log->warn("Identity {$usernameOrEmail} not found.");

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -314,15 +314,17 @@ class Session extends \OmegaUp\Controllers\Controller {
         $loginIdentity = new \OmegaUp\DAO\VO\Identities($loginIdentityExt);
 
         $associatedIdentities = [];
+        $currentUser = null;
+        $email = null;
         if (is_null($currentIdentity->user_id)) {
-            $currentUser = null;
-            $email = null;
-            $associatedIdentities = [
-                [
-                    'username' => strval($loginIdentity->username),
-                    'default' => true,
-                ],
-            ];
+            if (\OmegaUp\DAO\Identities::isMainIdentity($loginIdentity)) {
+                $associatedIdentities = [
+                    [
+                        'username' => strval($loginIdentity->username),
+                        'default' => true,
+                    ],
+                ];
+            }
         } else {
             $currentUser = \OmegaUp\DAO\Users::getByPK(
                 $currentIdentity->user_id

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -789,15 +789,11 @@ class Session extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $userId = $loggedIdentity->user_id ?? $targetIdentity->user_id;
-        if (is_null($userId)) {
-            throw new \OmegaUp\Exceptions\UnauthorizedException(
-                'userNotAllowed'
-            );
-        }
         $identity = \OmegaUp\DAO\Identities::resolveAssociatedIdentity(
             $usernameOrEmail,
-            $userId
+            /*$currentIdentity=*/ !is_null(
+                $loggedIdentity->user_id
+            ) ? $loggedIdentity : $targetIdentity
         );
         if (is_null($identity) || is_null($identity->identity_id)) {
             self::$log->warn("Identity {$usernameOrEmail} not found.");

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -112,11 +112,19 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
 
     public static function resolveAssociatedIdentity(
         string $usernameOrEmail,
-        \OmegaUp\DAO\VO\Identities $currentIdentity
+        \OmegaUp\DAO\VO\Identities $currentIdentity,
+        \OmegaUp\DAO\VO\Identities $identityToResolve
     ): ?\OmegaUp\DAO\VO\Identities {
-        if (is_null($currentIdentity->user_id)) {
+        if (
+            is_null(
+                $currentIdentity->user_id
+            ) && is_null(
+                $identityToResolve->user_id
+            )
+        ) {
             return null;
         }
+        $userId = $currentIdentity->user_id ?? $identityToResolve->user_id;
         $sql = '(
                     SELECT
                         i.*
@@ -150,10 +158,10 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
                 )
                 LIMIT 1;';
         $args = [
-            $currentIdentity->user_id,
+            $userId,
             $usernameOrEmail,
             $usernameOrEmail,
-            $currentIdentity->user_id,
+            $userId,
             $usernameOrEmail,
         ];
 

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -112,19 +112,8 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
 
     public static function resolveAssociatedIdentity(
         string $usernameOrEmail,
-        \OmegaUp\DAO\VO\Identities $currentIdentity,
-        \OmegaUp\DAO\VO\Identities $identityToResolve
+        int $userId
     ): ?\OmegaUp\DAO\VO\Identities {
-        if (
-            is_null(
-                $currentIdentity->user_id
-            ) && is_null(
-                $identityToResolve->user_id
-            )
-        ) {
-            return null;
-        }
-        $userId = $currentIdentity->user_id ?? $identityToResolve->user_id;
         $sql = '(
                     SELECT
                         i.*

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -497,11 +497,31 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
                 ill.time BETWEEN FROM_UNIXTIME(?) AND FROM_UNIXTIME(?)
             GROUP BY
                 gender;
-';
+            ';
         /** @var array{gender: string, users: int}[] */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$startTimestamp, $endTimestamp, $startTimestamp, $endTimestamp]
         );
+    }
+
+    public static function isMainIdentity(
+        \OmegaUp\DAO\VO\Identities $identity
+    ): bool {
+        $sql = 'SELECT
+                    COUNT(*) AS main_identity
+                FROM
+                    Users u
+                WHERE
+                    u.main_identity_id = ?
+                LIMIT 1;';
+
+        return (
+            /** @var array{main_identity: int} */
+            \OmegaUp\MySQLConnection::getInstance()->GetOne(
+                $sql,
+                [$identity->identity_id]
+            )
+        ) > 0;
     }
 }

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -112,8 +112,11 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
 
     public static function resolveAssociatedIdentity(
         string $usernameOrEmail,
-        int $userId
+        \OmegaUp\DAO\VO\Identities $currentIdentity
     ): ?\OmegaUp\DAO\VO\Identities {
+        if (is_null($currentIdentity->user_id)) {
+            return null;
+        }
         $sql = '(
                     SELECT
                         i.*
@@ -147,10 +150,10 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
                 )
                 LIMIT 1;';
         $args = [
-            $userId,
+            $currentIdentity->user_id,
             $usernameOrEmail,
             $usernameOrEmail,
-            $userId,
+            $currentIdentity->user_id,
             $usernameOrEmail,
         ];
 

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -100,12 +100,16 @@ class Request extends \ArrayObject {
     /**
      * @return bool whether a user has been logged with the main identity or not
      */
-    public function isLoggedAsMainIdentity(): bool {
+    public function isLoggedAsMainIdentity(
+        \OmegaUp\DAO\VO\Identities $identity
+    ): bool {
+        if (is_null($this->loginIdentity)) {
+            return false;
+        }
         return (
             !is_null($this->user)
-            && !is_null($this->loginIdentity)
             && $this->user->main_identity_id === $this->loginIdentity->identity_id
-        );
+        ) || $identity->identity_id === $this->loginIdentity->identity_id;
     }
 
     /**

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -100,16 +100,12 @@ class Request extends \ArrayObject {
     /**
      * @return bool whether a user has been logged with the main identity or not
      */
-    public function isLoggedAsMainIdentity(
-        \OmegaUp\DAO\VO\Identities $identity
-    ): bool {
-        if (is_null($this->loginIdentity)) {
-            return false;
-        }
+    public function isLoggedAsMainIdentity(): bool {
         return (
             !is_null($this->user)
+            && !is_null($this->loginIdentity)
             && $this->user->main_identity_id === $this->loginIdentity->identity_id
-        ) || $identity->identity_id === $this->loginIdentity->identity_id;
+        );
     }
 
     /**

--- a/frontend/tests/controllers/IdentityContestsTest.php
+++ b/frontend/tests/controllers/IdentityContestsTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * Testing identity can access to contest and resolve any problem
  */
@@ -117,7 +115,7 @@ class IdentityContestsTest extends \OmegaUp\Test\ControllerTestCase {
             $contestant
         );
 
-        $detourGrader = new \OmegaUp\Test\ScopedGraderDetour();
+        new \OmegaUp\Test\ScopedGraderDetour();
 
         // Create valid run
         $contestantLogin = self::login($contestant);
@@ -181,7 +179,9 @@ class IdentityContestsTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Identity creator group member will upload csv file
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -391,9 +391,6 @@ class IdentityContestsTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     public function testAddGroupsToContestForTeams() {
-        // Create the user to associate
-        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
-
         [
             'teamGroup' => $teamGroup,
         ] = \OmegaUp\Test\Factories\Groups::createTeamsGroup();

--- a/frontend/tests/controllers/IdentityContestsTest.php
+++ b/frontend/tests/controllers/IdentityContestsTest.php
@@ -115,17 +115,20 @@ class IdentityContestsTest extends \OmegaUp\Test\ControllerTestCase {
             $contestant
         );
 
-        new \OmegaUp\Test\ScopedGraderDetour();
-
-        // Create valid run
-        $contestantLogin = self::login($contestant);
-        $runRequest = new \OmegaUp\Request([
-            'auth_token' => $contestantLogin->auth_token,
-            'contest_alias' => $contestData['request']['alias'],
-            'problem_alias' => $problemData['request']['problem_alias'],
-            'language' => 'c11-gcc',
-            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
-        ]);
+        try {
+            $detourGrader = new \OmegaUp\Test\ScopedGraderDetour();
+            // Create valid run
+            $contestantLogin = self::login($contestant);
+            $runRequest = new \OmegaUp\Request([
+                'auth_token' => $contestantLogin->auth_token,
+                'contest_alias' => $contestData['request']['alias'],
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'language' => 'c11-gcc',
+                'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
+            ]);
+        } finally {
+            unset($detourGrader);
+        }
 
         return \OmegaUp\Controllers\Run::apiCreate($runRequest);
     }


### PR DESCRIPTION
# Descripción

Se arregla la funcionalidad de cambiar entre identidades cuando el usuario
ingresa a una identidad de equipos. Ahora cuando se cambia de sesión a una 
identidad de equipo, siempre le aparecerá la identidad principal en el listado 
para que pueda regresar a esa sesión y después cambiarse a cualquier otra.

![SwitchBetweenTeamsIdentities](https://user-images.githubusercontent.com/3230352/124709157-c7aca680-dec0-11eb-9d19-fbb2a4526455.gif)

Part of: #5462 

# Comentarios

Resulta que las validaciones para poder mostrar el listado de identidades asociadas 
a una cuenta principal se basan la mayor parte en el `user_id` de la tabla `Identities`.

Esto hacía que no funcionara correctamente el cambiar entre cuentas de identidades 
de equipos, porque estas tienen un funcionamiento algo distinto. Para empezar, no se 
pueden ligar a un usuario directamente, porque existe otra tabla que permite ligar a
varios usuarios.

Entonces, para poder resolver este caso, cuando la identidad actual es un equipo, se 
toma en cuenta la información del usuario que se logueó originalmente, el cual tiene
que ser una identidad con usuario real.

Para el caso de cuando se loguean con la identidad del equipo, funcionaría de la misma
forma que cuando se loguean con una identidad no principal, que no te permite ver 
ninguna identidad asociada. 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
