### PR TITLE
Migrando la tabla de Carga de Identidades en equipos a Bootstrap-Vue

### DIFF
--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -5,7 +5,7 @@
 /**
  *  GroupController
  *
- * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string}
+ * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string, usernames?: string}
  * @psalm-type GroupScoreboard=array{alias: string, create_time: string, description: null|string, name: string}
  * @psalm-type GroupEditPayload=array{countries: list<\OmegaUp\DAO\VO\Countries>, groupAlias: string, groupDescription: null|string, groupName: null|string, identities: list<Identity>, isOrganizer: bool, scoreboards: list<GroupScoreboard>}
  * @psalm-type ContestListItem=array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: bool, problemset_id: int, recommended: bool, rerun_id: int, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}

--- a/frontend/server/src/Controllers/TeamsGroup.php
+++ b/frontend/server/src/Controllers/TeamsGroup.php
@@ -5,7 +5,7 @@
 /**
  *  TeamsGroupController
  *
- * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string}
+ * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string, usernames?: string}
  * @psalm-type TeamMember=array{classname: string, name: null|string, team_alias: string, team_name: null|string, username: string}
  * @psalm-type TeamGroupEditPayload=array{countries: list<\OmegaUp\DAO\VO\Countries>, identities: list<Identity>, isOrganizer: bool, teamGroup: array{alias: string, description: null|string, name: null|string}, teamsMembers: list<TeamMember>}
  * @psalm-type TeamsGroup=array{alias: string, create_time: \OmegaUp\Timestamp, description: null|string, name: string}

--- a/frontend/server/src/DAO/Teams.php
+++ b/frontend/server/src/DAO/Teams.php
@@ -12,7 +12,7 @@ namespace OmegaUp\DAO;
  * @access public
  * @package docs
  *
- * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string}
+ * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string, usernames?: string}
  */
 class Teams extends \OmegaUp\DAO\Base\Teams {
     public static function getByTeamGroupIdAndIdentityId(

--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -1197,7 +1197,6 @@ teamAliasInUse = "There is at least one duplicate team alias. Please check the C
 teamMemberUsernameInUse = "There is at least one duplicate username in the teams of the group. Please fix the information."
 teamNotExist = "Team does not exist"
 teamsGroupAddUsersDone = "Done"
-teamsGroupAddUsersToTeam = "Add users"
 teamsGroupAliasMustBeRequired = "In a contest for teams, alias must be required"
 teamsGroupCreateIdentitiesAsTeams = "Create identities as teams"
 teamsGroupEditGroupUpdated = "The teams group has been successfully updated."

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -1197,7 +1197,6 @@ teamAliasInUse = "Existe al menos un alias de equipo duplicado. Por favor revisa
 teamMemberUsernameInUse = "Existe al menos un nombre de usuario duplicado en los equipos del grupo. Por favor corrige la información."
 teamNotExist = "El equipo no existe"
 teamsGroupAddUsersDone = "Listo"
-teamsGroupAddUsersToTeam = "Agregar usuarios"
 teamsGroupAliasMustBeRequired = "En un concurso para equipos, el alias debe ser requerido."
 teamsGroupCreateIdentitiesAsTeams = "Crear identidades como equipos"
 teamsGroupEditGroupUpdated = "El grupo de equipos se actualizó correctamente."

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -1197,7 +1197,6 @@ teamAliasInUse = "(Th3r3 i5 a7 13a57 0n3 dup1ica73 73am a1ia5. P13a53 ch3ck 7h3 
 teamMemberUsernameInUse = "(Th3r3 i5 a7 13a57 0n3 dup1ica73 u53rnam3 in 7h3 73am5 0f 7h3 gr0up. P13a53 fix 7h3 inf0rma7i0n.)"
 teamNotExist = "(T3am d035 n07 3xi57)"
 teamsGroupAddUsersDone = "(D0n3)"
-teamsGroupAddUsersToTeam = "(Add u53r5)"
 teamsGroupAliasMustBeRequired = "(In a c0n7357 f0r 73am5, a1ia5 mu57 b3 r3quir3d)"
 teamsGroupCreateIdentitiesAsTeams = "(Cr3a73 id3n7i7i35 a5 73am5)"
 teamsGroupEditGroupUpdated = "(Th3 73am5 gr0up ha5 b33n 5ucc355fu11y upda73d.)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -1197,7 +1197,6 @@ teamAliasInUse = "Há pelo menos um alias de equipe duplicado. Verifique o arqui
 teamMemberUsernameInUse = "Há pelo menos um nome de usuário duplicado nas equipes do grupo. Corrija as informações."
 teamNotExist = "Equipe não existe"
 teamsGroupAddUsersDone = "Feito"
-teamsGroupAddUsersToTeam = "Adicionar usuários"
 teamsGroupAliasMustBeRequired = "Em um concurso para equipes, o alias deve ser exigido"
 teamsGroupCreateIdentitiesAsTeams = "Criar identidades como equipes"
 teamsGroupEditGroupUpdated = "O grupo de equipes foi atualizado com sucesso."

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2347,6 +2347,7 @@ export namespace types {
     state?: string;
     state_id?: string;
     username: string;
+    usernames?: string;
   }
 
   export interface IdentityExt {

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import VoerroTagsInput from '@voerro/vue-tagsinput';
 import '@voerro/vue-tagsinput/dist/style.css';
 import T from '../../lang';
@@ -30,10 +30,11 @@ import { types } from '../../api_types';
     'tags-input': VoerroTagsInput,
   },
 })
-export default class Typeahead extends Vue {
+export default class MultiTypeahead extends Vue {
   @Prop() existingOptions!: types.ListItem[];
   @Prop({ default: 3 }) activationThreshold!: number;
   @Prop({ default: 10 }) maxResults!: number;
+  @Prop({ default: null }) value!: null | types.ListItem[];
 
   T = T;
   selectedOptions: types.ListItem[] = [];
@@ -41,6 +42,20 @@ export default class Typeahead extends Vue {
   updateExistingOptions(query: string): void {
     if (query.length < this.activationThreshold) return;
     this.$emit('update-existing-options', query);
+  }
+
+  @Watch('value')
+  onValueChanged(newValue: null | types.ListItem[]): void {
+    if (!newValue) {
+      this.selectedOptions = [];
+      return;
+    }
+    for (const item of newValue) {
+      this.existingOptions.push(item);
+    }
+    this.selectedOptions = this.existingOptions.filter((option) =>
+      newValue?.some((opt) => option.key === opt['key']),
+    );
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
@@ -46,13 +46,6 @@ export default class MultiTypeahead extends Vue {
 
   @Watch('value')
   onValueChanged(newValue: null | types.ListItem[]): void {
-    if (!newValue) {
-      this.selectedOptions = [];
-      return;
-    }
-    for (const item of newValue) {
-      this.existingOptions.push(item);
-    }
     this.selectedOptions = this.existingOptions.filter((option) =>
       newValue?.some((opt) => option.key === opt['key']),
     );

--- a/frontend/www/js/omegaup/components/teamsgroup/Teams.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Teams.vue
@@ -47,7 +47,7 @@
               :title="T.groupEditMembersAddMembers"
               @click="onAddMembers(identity.username)"
             >
-              <font-awesome-icon :icon="['fas', 'user']" />
+              <font-awesome-icon :icon="['fas', 'users']" />
             </button>
             <button
               class="btn btn-link"
@@ -106,9 +106,9 @@ import {
   faEdit,
   faLock,
   faTrashAlt,
-  faUser,
+  faUsers,
 } from '@fortawesome/free-solid-svg-icons';
-library.add(faEdit, faLock, faTrashAlt, faUser);
+library.add(faEdit, faLock, faTrashAlt, faUsers);
 
 export enum AvailableForms {
   None,

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.test.ts
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.test.ts
@@ -26,7 +26,6 @@ describe('Upload.vue', () => {
       },
     ] as types.Identity[];
     await wrapper.setData({ identities });
-    //expect(wrapper.text()).toContain('Hola crayola');
     expect(wrapper.vm.items).toEqual([
       {
         username: 'team_user_1',

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.test.ts
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.test.ts
@@ -1,24 +1,49 @@
 import { mount, shallowMount } from '@vue/test-utils';
+import { types } from '../../api_types';
 
 import T from '../../lang';
 
 import teamsgroup_Upload from './Upload.vue';
 
 describe('Upload.vue', () => {
-  it('Should handle upload teams view', () => {
+  it('Should handle upload teams view with identities', async () => {
     const wrapper = shallowMount(teamsgroup_Upload, {
       propsData: {
-        groupAlias: 'Hello',
+        searchResultUsers: [] as types.ListItem[],
       },
     });
 
     expect(wrapper.text()).toContain(T.groupsUploadCsvFile);
+
+    const identities = [
+      {
+        username: 'team_user_1',
+        name: 'user 1',
+        country_id: 'MX',
+        state_id: 'QUE',
+        gender: 'decline',
+        school_name: 'First School',
+      },
+    ] as types.Identity[];
+    await wrapper.setData({ identities });
+    //expect(wrapper.text()).toContain('Hola crayola');
+    expect(wrapper.vm.items).toEqual([
+      {
+        username: 'team_user_1',
+        name: 'user 1',
+        country_id: 'MX',
+        state_id: 'QUE',
+        gender: 'decline',
+        school_name: 'First School',
+        usernames: [],
+      },
+    ]);
   });
 
   it('Should handle an invalid csv file', async () => {
     const wrapper = mount(teamsgroup_Upload, {
       propsData: {
-        groupAlias: 'Hello',
+        searchResultUsers: [] as types.ListItem[],
       },
     });
 
@@ -36,7 +61,7 @@ describe('Upload.vue', () => {
   it('Should handle a valid csv file', async () => {
     const wrapper = mount(teamsgroup_Upload, {
       propsData: {
-        groupAlias: 'Hello',
+        searchResultUsers: [] as types.ListItem[],
       },
     });
 

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.test.ts
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.test.ts
@@ -15,26 +15,30 @@ describe('Upload.vue', () => {
 
     expect(wrapper.text()).toContain(T.groupsUploadCsvFile);
 
-    const identities = [
+    const identities: types.Identity[] = [
       {
-        username: 'team_user_1',
+        username: 'teams:group:team_1',
         name: 'user 1',
         country_id: 'MX',
         state_id: 'QUE',
         gender: 'decline',
         school_name: 'First School',
+        usernames: 'user_1;user_2',
       },
-    ] as types.Identity[];
-    await wrapper.setData({ identities });
+    ];
+    const identitiesTeams: { [team: string]: string[] } = {
+      'teams:group:team_1': ['user_1', 'user_2'],
+    };
+    await wrapper.setData({ identities, identitiesTeams });
     expect(wrapper.vm.items).toEqual([
       {
-        username: 'team_user_1',
+        username: 'teams:group:team_1',
         name: 'user 1',
         country_id: 'MX',
         state_id: 'QUE',
         gender: 'decline',
         school_name: 'First School',
-        usernames: [],
+        usernames: ['user_1', 'user_2'],
       },
     ]);
   });

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
@@ -23,21 +23,19 @@
       </div>
       <template v-if="identities.length > 0">
         <h3 class="card-header">{{ T.teamsGroupEditTeams }}</h3>
-        <div>
-          <b-table striped hover :items="items" :fields="columns">
-            <template #cell(usernames)="row">
-              <b-button
-                class="d-inline-block mb-2"
-                variant="primary"
-                @click="row.toggleDetails"
-              >
-                {{ T.teamsGroupAddUsersToTeam }}
-                <b-badge variant="light">{{
-                  row.item.usernames.length
-                }}</b-badge>
-              </b-button>
-            </template>
-            <template #row-details="row">
+        <b-table responsive striped hover :items="items" :fields="columns">
+          <template #cell(usernames)="row">
+            <b-button
+              class="d-inline-block mb-2"
+              variant="primary"
+              @click="row.toggleDetails"
+            >
+              {{ T.teamsGroupAddUsersToTeam }}
+              <b-badge variant="light">{{ row.item.usernames.length }}</b-badge>
+            </b-button>
+          </template>
+          <template #row-details="row">
+            <b-form @submit.prevent="onAddUsers(row)">
               <b-card>
                 <b-row class="mb-2">
                   <b-col sm="3" class="text-sm-right">
@@ -64,17 +62,17 @@
                   >
                   </omegaup-common-multi-typeahead>
                   <b-button
+                    type="submit"
                     variant="primary"
                     class="d-inline-block mb-2"
-                    @click="onAddUsers(row, row.item.username)"
                   >
                     {{ T.teamsGroupAddUsersDone }}
                   </b-button>
                 </b-row>
               </b-card>
-            </template>
-          </b-table>
-        </div>
+            </b-form>
+          </template>
+        </b-table>
         <div class="card-footer">
           <button
             class="btn btn-primary d-inline-block mb-2"
@@ -120,6 +118,7 @@ import {
   ButtonPlugin,
   BadgePlugin,
   CardPlugin,
+  BForm,
   BRow,
   BCol,
 } from 'bootstrap-vue';
@@ -134,6 +133,7 @@ library.add(faDownload);
     FontAwesomeIcon,
     'omegaup-common-multi-typeahead': common_MultiTypeahead,
     'omegaup-markdown': omegaup_Markdown,
+    BForm,
     BRow,
     BCol,
   },
@@ -148,7 +148,12 @@ export default class Upload extends Vue {
   humanReadable = false;
   typeaheadUsers: types.ListItem[] = [];
   columns = [
-    { key: 'username', label: T.teamsGroupTeamName },
+    {
+      key: 'username',
+      label: T.teamsGroupTeamName,
+      stickyColumn: true,
+      isRowHeader: true,
+    },
     { key: 'name', label: T.profile },
     { key: 'password', label: T.loginPassword },
     { key: 'country_id', label: T.profileCountry },
@@ -189,6 +194,7 @@ export default class Upload extends Vue {
       (user) => user.key,
     );
     Vue.set(row.item, 'usernames', this.identitiesTeams[row.item.username]);
+    row.toggleDetails();
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
@@ -139,7 +139,7 @@ library.add(faDownload);
   },
 })
 export default class Upload extends Vue {
-  @Prop() userErrorRow!: string | null;
+  @Prop({ default: null }) userErrorRow!: string | null;
   @Prop() searchResultUsers!: types.ListItem[];
 
   T = T;

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
@@ -26,11 +26,15 @@
         <b-table responsive striped hover :items="items" :fields="columns">
           <template #cell(usernames)="row">
             <b-button
+              :title="T.groupEditMembersAddMembers"
               class="d-inline-block mb-2"
               variant="primary"
               @click="row.toggleDetails"
             >
-              {{ T.teamsGroupAddUsersToTeam }}
+              <font-awesome-icon
+                :icon="['fas', 'user-plus']"
+                class="mr-2"
+              ></font-awesome-icon>
               <b-badge variant="light">{{ row.item.usernames.length }}</b-badge>
             </b-button>
           </template>
@@ -105,7 +109,7 @@ import T from '../../lang';
 import omegaup_Markdown from '../Markdown.vue';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faDownload } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import common_MultiTypeahead from '../common/MultiTypeahead.vue';
 
 // Import Bootstrap an BootstrapVue CSS files (order is important)
@@ -127,7 +131,7 @@ Vue.use(ButtonPlugin);
 Vue.use(BadgePlugin);
 Vue.use(CardPlugin);
 
-library.add(faDownload);
+library.add(faDownload, faUserPlus);
 @Component({
   components: {
     FontAwesomeIcon,
@@ -164,7 +168,10 @@ export default class Upload extends Vue {
   ];
 
   get items() {
-    return this.identities.map((identity) => ({ ...identity, usernames: [] }));
+    return this.identities.map((identity) => ({
+      ...identity,
+      usernames: this.identitiesTeams[identity.username],
+    }));
   }
 
   readFile(e: HTMLInputElement): File | null {

--- a/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
+++ b/frontend/www/js/omegaup/components/teamsgroup/Upload.vue
@@ -23,68 +23,57 @@
       </div>
       <template v-if="identities.length > 0">
         <h3 class="card-header">{{ T.teamsGroupEditTeams }}</h3>
-        <div class="table-responsive">
-          <table class="table" data-identities-as-team--table>
-            <thead>
-              <tr>
-                <th>{{ T.teamsGroupTeamName }}</th>
-                <th>{{ T.profile }}</th>
-                <th>{{ T.loginPassword }}</th>
-                <th>{{ T.profileCountry }}</th>
-                <th>{{ T.profileState }}</th>
-                <th>{{ T.wordsGender }}</th>
-                <th>{{ T.profileSchool }}</th>
-                <th>{{ T.teamsGroupUsernames }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="identity in identities"
-                :key="identity.username"
-                :class="{ 'alert-danger': userErrorRow === identity.username }"
+        <div>
+          <b-table striped hover :items="items" :fields="columns">
+            <template #cell(usernames)="row">
+              <b-button
+                class="d-inline-block mb-2"
+                variant="primary"
+                @click="row.toggleDetails"
               >
-                <td class="username">
-                  <strong>{{ identity.username }}</strong>
-                </td>
-                <td>{{ identity.name }}</td>
-                <td class="password">
-                  {{ identity.password }}
-                </td>
-                <td>{{ identity.country_id }}</td>
-                <td>{{ identity.state_id }}</td>
-                <td>{{ identity.gender }}</td>
-                <td>{{ identity.school_name }}</td>
-                <td>
-                  <button
-                    v-if="teamToAddUsers !== identity.username"
-                    class="btn btn-primary d-inline-block mb-2"
-                    @click="teamToAddUsers = identity.username"
+                {{ T.teamsGroupAddUsersToTeam }}
+                <b-badge variant="light">{{
+                  row.item.usernames.length
+                }}</b-badge>
+              </b-button>
+            </template>
+            <template #row-details="row">
+              <b-card>
+                <b-row class="mb-2">
+                  <b-col sm="3" class="text-sm-right">
+                    <b>{{ T.teamsGroupUsernames }}:</b>
+                  </b-col>
+                  <b-col>
+                    <b-badge
+                      v-for="username of row.item.usernames"
+                      :key="username"
+                      variant="primary"
+                      class="ml-2"
+                    >
+                      {{ username }}
+                    </b-badge>
+                  </b-col>
+                </b-row>
+                <b-row>
+                  <omegaup-common-multi-typeahead
+                    :existing-options="searchResultUsers"
+                    :value.sync="typeaheadUsers"
+                    @update-existing-options="
+                      (query) => $emit('update-search-result-users', query)
+                    "
                   >
-                    {{ T.teamsGroupAddUsersToTeam }}
-                    <span class="badge badge-light">
-                      {{ identitiesTeams[identity.username].length }}
-                    </span>
-                  </button>
-                  <template v-else>
-                    <omegaup-common-multi-typeahead
-                      :existing-options="searchResultUsers"
-                      :value.sync="typeaheadUsers"
-                      @update-existing-options="
-                        (query) => $emit('update-search-result-users', query)
-                      "
-                    >
-                    </omegaup-common-multi-typeahead>
-                    <button
-                      class="btn btn-primary d-inline-block mb-2"
-                      @click="onAddUsers(identity.username)"
-                    >
-                      {{ T.teamsGroupAddUsersDone }}
-                    </button>
-                  </template>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  </omegaup-common-multi-typeahead>
+                  <b-button
+                    variant="primary"
+                    class="d-inline-block mb-2"
+                    @click="onAddUsers(row, row.item.username)"
+                  >
+                    {{ T.teamsGroupAddUsersDone }}
+                  </b-button>
+                </b-row>
+              </b-card>
+            </template>
+          </b-table>
         </div>
         <div class="card-footer">
           <button
@@ -121,15 +110,35 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import common_MultiTypeahead from '../common/MultiTypeahead.vue';
 
+// Import Bootstrap an BootstrapVue CSS files (order is important)
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue/dist/bootstrap-vue.css';
+
+// Import Only Required Plugins
+import {
+  TablePlugin,
+  ButtonPlugin,
+  BadgePlugin,
+  CardPlugin,
+  BRow,
+  BCol,
+} from 'bootstrap-vue';
+Vue.use(TablePlugin);
+Vue.use(ButtonPlugin);
+Vue.use(BadgePlugin);
+Vue.use(CardPlugin);
+
 library.add(faDownload);
 @Component({
   components: {
     FontAwesomeIcon,
     'omegaup-common-multi-typeahead': common_MultiTypeahead,
     'omegaup-markdown': omegaup_Markdown,
+    BRow,
+    BCol,
   },
 })
-export default class Identities extends Vue {
+export default class Upload extends Vue {
   @Prop() userErrorRow!: string | null;
   @Prop() searchResultUsers!: types.ListItem[];
 
@@ -137,8 +146,21 @@ export default class Identities extends Vue {
   identities: types.Identity[] = [];
   identitiesTeams: { [team: string]: string[] } = {};
   humanReadable = false;
-  teamToAddUsers = null;
   typeaheadUsers: types.ListItem[] = [];
+  columns = [
+    { key: 'username', label: T.teamsGroupTeamName },
+    { key: 'name', label: T.profile },
+    { key: 'password', label: T.loginPassword },
+    { key: 'country_id', label: T.profileCountry },
+    { key: 'state_id', label: T.profileState },
+    { key: 'gender', label: T.wordsGender },
+    { key: 'school_name', label: T.profileSchool },
+    { key: 'usernames', label: T.teamsGroupUsernames },
+  ];
+
+  get items() {
+    return this.identities.map((identity) => ({ ...identity, usernames: [] }));
+  }
 
   readFile(e: HTMLInputElement): File | null {
     return (e.files && e.files[0]) || null;
@@ -162,11 +184,11 @@ export default class Identities extends Vue {
     });
   }
 
-  onAddUsers(username: string): void {
-    this.teamToAddUsers = null;
-    this.identitiesTeams[username] = this.typeaheadUsers.map(
+  onAddUsers(row: BRow): void {
+    this.identitiesTeams[row.item.username] = this.typeaheadUsers.map(
       (user) => user.key,
     );
+    Vue.set(row.item, 'usernames', this.identitiesTeams[row.item.username]);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/group/edit.ts
+++ b/frontend/www/js/omegaup/group/edit.ts
@@ -13,17 +13,9 @@ import {
   generateHumanReadablePassword,
   generatePassword,
   getCSVRecords,
+  identityOptionalFields,
+  identityRequiredFields,
 } from '../groups';
-
-export const groupRequiredFields = new Set(['username']);
-
-export const groupOptionalFields = new Set([
-  'name',
-  'country_id',
-  'state_id',
-  'gender',
-  'school_name',
-]);
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.GroupEditPayload();
@@ -250,8 +242,8 @@ OmegaUp.on('ready', () => {
                 const records = getCSVRecords<types.Identity>({
                   fields: dataset.fields,
                   records: dataset.records,
-                  requiredFields: groupRequiredFields,
-                  optionalFields: groupOptionalFields,
+                  requiredFields: identityRequiredFields,
+                  optionalFields: identityOptionalFields,
                 });
                 for (const {
                   username,

--- a/frontend/www/js/omegaup/groups.test.ts
+++ b/frontend/www/js/omegaup/groups.test.ts
@@ -1,9 +1,10 @@
 import { types } from './api_types';
-import { groupOptionalFields, groupRequiredFields } from './group/edit';
 import {
   generatePassword,
   generateHumanReadablePassword,
   getCSVRecords,
+  identityRequiredFields,
+  identityOptionalFields,
 } from './groups';
 import T from './lang';
 import * as ui from './ui';
@@ -110,8 +111,8 @@ describe('groups_utils', () => {
       const formattedRecords = getCSVRecords<types.Identity>({
         fields,
         records,
-        requiredFields: groupRequiredFields,
-        optionalFields: groupOptionalFields,
+        requiredFields: identityRequiredFields,
+        optionalFields: identityOptionalFields,
       });
 
       expect(formattedRecords).toEqual(expectedFormattedRecords);
@@ -128,8 +129,8 @@ describe('groups_utils', () => {
       const formattedRecords = getCSVRecords<types.Identity>({
         fields,
         records: localRecords,
-        requiredFields: groupRequiredFields,
-        optionalFields: groupOptionalFields,
+        requiredFields: identityRequiredFields,
+        optionalFields: identityOptionalFields,
       });
 
       expect(formattedRecords).toEqual(localExpectedFormattedRecords);
@@ -147,8 +148,8 @@ describe('groups_utils', () => {
         getCSVRecords<types.Identity>({
           fields,
           records: localRecords,
-          requiredFields: groupRequiredFields,
-          optionalFields: groupOptionalFields,
+          requiredFields: identityRequiredFields,
+          optionalFields: identityOptionalFields,
         }),
       ).toThrow(
         ui.formatString(T.teamsGroupsErrorFieldIsRequired, {
@@ -161,8 +162,8 @@ describe('groups_utils', () => {
       const formattedRecords = getCSVRecords<types.Identity>({
         fields: fields.concat(['birthday']),
         records,
-        requiredFields: groupRequiredFields,
-        optionalFields: groupOptionalFields,
+        requiredFields: identityRequiredFields,
+        optionalFields: identityOptionalFields,
       });
 
       expect(formattedRecords).toEqual(formattedRecords);
@@ -176,8 +177,8 @@ describe('groups_utils', () => {
         getCSVRecords<types.Identity>({
           fields: localFields,
           records,
-          requiredFields: groupRequiredFields,
-          optionalFields: groupOptionalFields,
+          requiredFields: identityRequiredFields,
+          optionalFields: identityOptionalFields,
         }),
       ).toThrow(
         ui.formatString(T.teamsGroupsErrorFieldIsNotPresentInCsv, {

--- a/frontend/www/js/omegaup/groups.ts
+++ b/frontend/www/js/omegaup/groups.ts
@@ -3,6 +3,17 @@ import T from './lang';
 import * as ui from './ui';
 import * as CSV from '@/third_party/js/csv.js/csv.js';
 
+export const identityRequiredFields = new Set(['username']);
+
+export const identityOptionalFields = new Set([
+  'name',
+  'country_id',
+  'state_id',
+  'gender',
+  'school_name',
+  'usernames',
+]);
+
 export function downloadCsvFile({
   fileName,
   columns,

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -1198,7 +1198,6 @@
 	"teamMemberUsernameInUse": "There is at least one duplicate username in the teams of the group. Please fix the information.",
 	"teamNotExist": "Team does not exist",
 	"teamsGroupAddUsersDone": "Done",
-	"teamsGroupAddUsersToTeam": "Add users",
 	"teamsGroupAliasMustBeRequired": "In a contest for teams, alias must be required",
 	"teamsGroupCreateIdentitiesAsTeams": "Create identities as teams",
 	"teamsGroupEditGroupUpdated": "The teams group has been successfully updated.",

--- a/frontend/www/js/omegaup/lang.en.ts
+++ b/frontend/www/js/omegaup/lang.en.ts
@@ -1199,7 +1199,6 @@ const translations: { [key: string]: string; } = {
   teamMemberUsernameInUse: "There is at least one duplicate username in the teams of the group. Please fix the information.",
   teamNotExist: "Team does not exist",
   teamsGroupAddUsersDone: "Done",
-  teamsGroupAddUsersToTeam: "Add users",
   teamsGroupAliasMustBeRequired: "In a contest for teams, alias must be required",
   teamsGroupCreateIdentitiesAsTeams: "Create identities as teams",
   teamsGroupEditGroupUpdated: "The teams group has been successfully updated.",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -1198,7 +1198,6 @@
 	"teamMemberUsernameInUse": "Existe al menos un nombre de usuario duplicado en los equipos del grupo. Por favor corrige la informaci\u00f3n.",
 	"teamNotExist": "El equipo no existe",
 	"teamsGroupAddUsersDone": "Listo",
-	"teamsGroupAddUsersToTeam": "Agregar usuarios",
 	"teamsGroupAliasMustBeRequired": "En un concurso para equipos, el alias debe ser requerido.",
 	"teamsGroupCreateIdentitiesAsTeams": "Crear identidades como equipos",
 	"teamsGroupEditGroupUpdated": "El grupo de equipos se actualiz\u00f3 correctamente.",

--- a/frontend/www/js/omegaup/lang.es.ts
+++ b/frontend/www/js/omegaup/lang.es.ts
@@ -1199,7 +1199,6 @@ const translations: { [key: string]: string; } = {
   teamMemberUsernameInUse: "Existe al menos un nombre de usuario duplicado en los equipos del grupo. Por favor corrige la informaci\u00f3n.",
   teamNotExist: "El equipo no existe",
   teamsGroupAddUsersDone: "Listo",
-  teamsGroupAddUsersToTeam: "Agregar usuarios",
   teamsGroupAliasMustBeRequired: "En un concurso para equipos, el alias debe ser requerido.",
   teamsGroupCreateIdentitiesAsTeams: "Crear identidades como equipos",
   teamsGroupEditGroupUpdated: "El grupo de equipos se actualiz\u00f3 correctamente.",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -1198,7 +1198,6 @@
 	"teamMemberUsernameInUse": "(Th3r3 i5 a7 13a57 0n3 dup1ica73 u53rnam3 in 7h3 73am5 0f 7h3 gr0up. P13a53 fix 7h3 inf0rma7i0n.)",
 	"teamNotExist": "(T3am d035 n07 3xi57)",
 	"teamsGroupAddUsersDone": "(D0n3)",
-	"teamsGroupAddUsersToTeam": "(Add u53r5)",
 	"teamsGroupAliasMustBeRequired": "(In a c0n7357 f0r 73am5, a1ia5 mu57 b3 r3quir3d)",
 	"teamsGroupCreateIdentitiesAsTeams": "(Cr3a73 id3n7i7i35 a5 73am5)",
 	"teamsGroupEditGroupUpdated": "(Th3 73am5 gr0up ha5 b33n 5ucc355fu11y upda73d.)",

--- a/frontend/www/js/omegaup/lang.pseudo.ts
+++ b/frontend/www/js/omegaup/lang.pseudo.ts
@@ -1199,7 +1199,6 @@ const translations: { [key: string]: string; } = {
   teamMemberUsernameInUse: "(Th3r3 i5 a7 13a57 0n3 dup1ica73 u53rnam3 in 7h3 73am5 0f 7h3 gr0up. P13a53 fix 7h3 inf0rma7i0n.)",
   teamNotExist: "(T3am d035 n07 3xi57)",
   teamsGroupAddUsersDone: "(D0n3)",
-  teamsGroupAddUsersToTeam: "(Add u53r5)",
   teamsGroupAliasMustBeRequired: "(In a c0n7357 f0r 73am5, a1ia5 mu57 b3 r3quir3d)",
   teamsGroupCreateIdentitiesAsTeams: "(Cr3a73 id3n7i7i35 a5 73am5)",
   teamsGroupEditGroupUpdated: "(Th3 73am5 gr0up ha5 b33n 5ucc355fu11y upda73d.)",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -1198,7 +1198,6 @@
 	"teamMemberUsernameInUse": "H\u00e1 pelo menos um nome de usu\u00e1rio duplicado nas equipes do grupo. Corrija as informa\u00e7\u00f5es.",
 	"teamNotExist": "Equipe n\u00e3o existe",
 	"teamsGroupAddUsersDone": "Feito",
-	"teamsGroupAddUsersToTeam": "Adicionar usu\u00e1rios",
 	"teamsGroupAliasMustBeRequired": "Em um concurso para equipes, o alias deve ser exigido",
 	"teamsGroupCreateIdentitiesAsTeams": "Criar identidades como equipes",
 	"teamsGroupEditGroupUpdated": "O grupo de equipes foi atualizado com sucesso.",

--- a/frontend/www/js/omegaup/lang.pt.ts
+++ b/frontend/www/js/omegaup/lang.pt.ts
@@ -1199,7 +1199,6 @@ const translations: { [key: string]: string; } = {
   teamMemberUsernameInUse: "H\u00e1 pelo menos um nome de usu\u00e1rio duplicado nas equipes do grupo. Corrija as informa\u00e7\u00f5es.",
   teamNotExist: "Equipe n\u00e3o existe",
   teamsGroupAddUsersDone: "Feito",
-  teamsGroupAddUsersToTeam: "Adicionar usu\u00e1rios",
   teamsGroupAliasMustBeRequired: "Em um concurso para equipes, o alias deve ser exigido",
   teamsGroupCreateIdentitiesAsTeams: "Criar identidades como equipes",
   teamsGroupEditGroupUpdated: "O grupo de equipes foi atualizado com sucesso.",

--- a/frontend/www/js/omegaup/teamsgroup/edit.ts
+++ b/frontend/www/js/omegaup/teamsgroup/edit.ts
@@ -13,6 +13,8 @@ import {
   generateHumanReadablePassword,
   generatePassword,
   getCSVRecords,
+  identityOptionalFields,
+  identityRequiredFields,
 } from '../groups';
 
 OmegaUp.on('ready', () => {
@@ -231,6 +233,7 @@ OmegaUp.on('ready', () => {
                 'state_id',
                 'gender',
                 'school_name',
+                'usernames',
               ],
               records: identities,
             });
@@ -254,14 +257,8 @@ OmegaUp.on('ready', () => {
               const records = getCSVRecords<types.Identity>({
                 fields: dataset.fields,
                 records: dataset.records,
-                requiredFields: new Set([
-                  'username',
-                  'name',
-                  'country_id',
-                  'state_id',
-                  'gender',
-                  'school_name',
-                ]),
+                requiredFields: identityRequiredFields,
+                optionalFields: identityOptionalFields,
               });
               for (const {
                 username,
@@ -270,6 +267,7 @@ OmegaUp.on('ready', () => {
                 state_id,
                 gender,
                 school_name,
+                usernames,
               } of records) {
                 identities.push({
                   username: `teams:${payload.teamGroup.alias}:${username}`,
@@ -281,10 +279,11 @@ OmegaUp.on('ready', () => {
                   state_id,
                   school_name,
                   gender: gender ?? 'decline',
+                  usernames,
                 });
                 identitiesTeams[
                   `teams:${payload.teamGroup.alias}:${username}`
-                ] = [];
+                ] = usernames?.split(';') ?? [];
               }
               ui.dismissNotifications();
               this.userErrorRow = null;


### PR DESCRIPTION
# Descripción

Se migra la tabla de cargar identidades para equipos a bootstrap-vue. Se 
aprovecha para arreglar la vista y que se acomoden mejor los elementos,
ya que en la versión inicial la parte de agregar identidades aparecía muy
amontonada.

También se habilita la funcionalidad de que se puedan agregar los miembros
de un equipo desde el archivo .csv para que no haya necesidad de cargarlos
manualmente.

![UploadTeamsIdentitiesWithBootstrapVue](https://user-images.githubusercontent.com/3230352/125131765-e1203f00-e0c8-11eb-9e52-ff27882e7e11.gif)

Part of: #5462

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
