### PR TITLE
Más deployments de k8s

### DIFF
--- a/stuff/prod/k8s/argocd/overlays/production/ingress.yaml
+++ b/stuff/prod/k8s/argocd/overlays/production/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server-ingress
+  namespace: argocd
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  defaultBackend:
+    service:
+      name: argocd-server
+      port:
+        number: 443
+  rules:
+  - host: argocd.omegaup.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: argocd-server
+            port:
+              number: 443
+  tls:
+  - hosts:
+    - argocd.omegaup.com
+    secretName: argocd-secret

--- a/stuff/prod/k8s/argocd/overlays/production/kustomization.yaml
+++ b/stuff/prod/k8s/argocd/overlays/production/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+
+bases:
+- ../../base
+
+resources:
+- ingress.yaml

--- a/stuff/prod/k8s/cert-manager/base/kustomization.yaml
+++ b/stuff/prod/k8s/cert-manager/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml

--- a/stuff/prod/k8s/cert-manager/overlays/production/cert-manager-issuer.yaml
+++ b/stuff/prod/k8s/cert-manager/overlays/production/cert-manager-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: lhchavez@omegaup.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    preferredChain: "ISRG Root X1"
+    privateKeySecretRef:
+      name: cert-manager-issuer-account-key
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/stuff/prod/k8s/cert-manager/overlays/production/kustomization.yaml
+++ b/stuff/prod/k8s/cert-manager/overlays/production/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+
+resources:
+- cert-manager-issuer.yaml

--- a/stuff/prod/k8s/ingress-nginx/base/kustomization.yaml
+++ b/stuff/prod/k8s/ingress-nginx/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ingress-nginx
+
+resources:
+  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.47.0/deploy/static/provider/aws/deploy.yaml

--- a/stuff/prod/k8s/ingress-nginx/overlays/production/kustomization.yaml
+++ b/stuff/prod/k8s/ingress-nginx/overlays/production/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ingress-nginx
+
+bases:
+- ../../base

--- a/stuff/prod/k8s/omegaup/aws_cluster.yaml
+++ b/stuff/prod/k8s/omegaup/aws_cluster.yaml
@@ -4,24 +4,39 @@ kind: ClusterConfig
 metadata:
   name: omegaup-eks-cluster
   region: us-east-1
+  version: "1.20"
+  tags: { k8s: "" }
 
 vpc:
-  id: vpc-08928671
-  securityGroup: sg-09ab645d275d030f5
+  id: vpc-0184b58c0938e54cd
+  securityGroup: sg-0d971795d82c9af80
+  cidr: 192.168.0.0/16
   subnets:
     private:
-      us-east-1a: { id: subnet-4a1e3466 }
-      us-east-1b: { id: subnet-962fc4dd }
-      us-east-1c: { id: subnet-ae3f10f4 }
-      us-east-1d: { id: subnet-7660c512 }
-      us-east-1f: { id: subnet-28d68b24 }
+      us-east-1a: { id: subnet-0201c193734a01645 }
+      us-east-1b: { id: subnet-04b2d4d5664c55ecd }
+    public:
+      us-east-1a: { id: subnet-0770ecf68cf733eb6 }
+      us-east-1b: { id: subnet-0372ef2108c0387da }
+  autoAllocateIPv6: true
 
 nodeGroups:
-  - name: omegaup-eks-nodes
-    labels: { role: workers, k8s: "" }
-    instanceType: t2.medium
-    desiredCapacity: 2
-    privateNetworking: true
-    ssh:
-      allow: true
-      publicKeyPath: ~/.ssh/omegaup-eks.pem.pub
+- name: omegaup-eks-nodes
+  labels: { role: workers, k8s: "" }
+  instanceType: t2.medium
+  desiredCapacity: 2
+  privateNetworking: true
+  ssh:
+    allow: true
+    publicKeyPath: ~/.ssh/omegaup-eks.pem.pub
+
+secretsEncryption:
+  keyARN: arn:aws:kms:us-east-1:273107833591:key/mrk-b51dea56f02f4964835066e80ee531b0
+
+addons:
+- name: vpc-cni
+  version: 1.8.0
+- name: coredns
+  version: 1.8.3
+- name: kube-proxy
+  version: 1.19.6

--- a/stuff/prod/k8s/omegaup/base/kustomization.yaml
+++ b/stuff/prod/k8s/omegaup/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: default
+namespace: omegaup
 
 resources:
 - deployment.yaml

--- a/stuff/prod/k8s/omegaup/overlays/production/kustomization.yaml
+++ b/stuff/prod/k8s/omegaup/overlays/production/kustomization.yaml
@@ -1,8 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: omegaup
+
 metadata:
   name: kustomization
+  namespace: omegaup
 
 resources:
 - grader-metrics.yaml


### PR DESCRIPTION
Este cambio agrega los siguientes deployments en k8s:

* ingress-nginx, para poder tener un sólo load-balancer en AWS y tener
  la flexibilidad de redirigir a todos los nodos que necesitemos
  internamente.
* cert-manager, para poder tener certificados TLS automágicos para todos
  los servicios.
* Argo CD: para eventualmente poder tener CD de k8s en el cluster.

También corrige el cluster de AWS, que se creó con un VPC equivocado, y
con subnets privados (entonces no se podía hacer el enrutamiento
correctamente).