### PR TITLE
Correccion a numeracion de ranking de usuarios que interactua mal con…

### DIFF
--- a/frontend/www/js/omegaup/components/user/Rank.vue
+++ b/frontend/www/js/omegaup/components/user/Rank.vue
@@ -59,7 +59,7 @@
       </thead>
       <tbody>
         <tr v-for="(user, index) in ranking" :key="index">
-          <th scope="row">{{ user.rank }}</th>
+          <th scope="row">{{ (page - 1) * length + 1 + index }}</th>
           <td>
             <omegaup-countryflag :country="user.country"></omegaup-countryflag>
             <omegaup-user-username


### PR DESCRIPTION
… el paginado

# Descripción
Se corrigio que la numeracion del ranking de usuario interactuaba incorrectamente con el paginado. Numeracion se reiniciaba cuando se cambiaba de pagina. 

Fixes: #5439

# Checklist:

- [ x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
