### PR TITLE
Agregando el tab de Envíos para los concursos

### DIFF
--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -219,6 +219,15 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ContestDetailsPayload {
       return ((x) => {
+        x.allRuns = ((x) => {
+          if (!Array.isArray(x)) {
+            return x;
+          }
+          return x.map((x) => {
+            x.time = ((x: number) => new Date(x * 1000))(x.time);
+            return x;
+          });
+        })(x.allRuns);
         x.clarifications = ((x) => {
           if (!Array.isArray(x)) {
             return x;
@@ -1901,6 +1910,7 @@ export namespace types {
   }
 
   export interface ContestDetailsPayload {
+    allRuns: types.Run[];
     clarifications: types.Clarification[];
     contest: types.ContestPublicDetails;
     contestAdmin: boolean;

--- a/frontend/www/js/omegaup/components/arena/Arena.vue
+++ b/frontend/www/js/omegaup/components/arena/Arena.vue
@@ -52,7 +52,6 @@
         class="tab-pane fade"
         :class="{ 'show active': selectedTab === 'runs' }"
       >
-        <!-- TODO: Add Runs component when we migrate arena.contest.admin.tpl-->
         <slot name="arena-runs"></slot>
       </div>
       <div
@@ -74,7 +73,6 @@ import { Tab } from '../problem/Details.vue';
 @Component
 export default class Arena extends Vue {
   @Prop({ default: false }) shouldShowRuns!: boolean;
-  @Prop({ default: false }) isAdmin!: boolean;
   @Prop({ default: () => [] }) clarifications!: types.Clarification[];
   @Prop() contestTitle!: string;
   @Prop() activeTab!: string;

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -377,7 +377,7 @@ export default class ProblemDetails extends Vue {
   @Prop({ default: null }) runDetailsData!: types.RunDetails | null;
   @Prop({ default: null }) guid!: null | string;
   @Prop({ default: null }) problemAlias!: null | string;
-  @Prop() isAdmin!: boolean;
+  @Prop({ default: false }) isAdmin!: boolean;
   @Prop({ default: false }) showVisibilityIndicators!: boolean;
   @Prop() nextSubmissionTimestamp!: null | Date;
   @Prop({ default: false }) shouldShowTabs!: boolean;


### PR DESCRIPTION
# Descripción

Se agrega la primera parte para la migración de `arena.contest.admin.tpl` a la 
plantilla unificada. En este cambio se incluye el contenido del tab de Envíos.

![ContestRuns](https://user-images.githubusercontent.com/3230352/126696863-8450d052-0568-4749-9a76-84a044e4085f.gif)

Fixes: #3484 

# Comentarios

En un cambio posterior faltará dejar de usar el archivo `.tpl` y comenzar. 
Posiblemente no sea necesario agregar un nuevo endoint y sólo vlidar desde
el payload si el usuario es administrador.

En este cambio me falta arreglar que se muestre el popup de detalles de envío 
cuando se recarga la página, aún no logro que funcione.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
