### PR TITLE
Haciendo un refactor de la función 'show-run'

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -130,13 +130,10 @@ OmegaUp.on('ready', () => {
               contestAlias: payload.contest.alias,
             });
           },
-          'show-run': (request: SubmissionRequest) => {
-            const hash = `#problems/${
-              this.problemAlias ?? request.request.problemAlias
-            }/show-run:${request.request.guid}/`;
-            api.Run.details({ run_alias: request.request.guid })
+          'show-run': (source: SubmissionRequest) => {
+            api.Run.details({ run_alias: source.request.guid })
               .then((runDetails) => {
-                showSubmission({ request, runDetails, hash });
+                showSubmission({ source, runDetails });
               })
               .catch((error) => {
                 ui.apiError(error);
@@ -266,7 +263,7 @@ OmegaUp.on('ready', () => {
     refreshContestClarifications({
       type: ContestClarificationType.AllProblems,
       contestAlias: payload.contest.alias,
-      offset: 0,
+      offset: 1,
       rowcount: 100,
     });
   }, 5 * 60 * 1000);

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -79,13 +79,10 @@ OmegaUp.on('ready', () => {
               contestAlias: payload.contest.alias,
             });
           },
-          'show-run': (request: SubmissionRequest) => {
-            const hash = `#problems/${
-              this.problemAlias ?? request.request.problemAlias
-            }/show-run:${request.request.guid}/`;
-            api.Run.details({ run_alias: request.request.guid })
+          'show-run': (source: SubmissionRequest) => {
+            api.Run.details({ run_alias: source.request.guid })
               .then((runDetails) => {
-                showSubmission({ request, runDetails, hash });
+                showSubmission({ source, runDetails });
               })
               .catch((error) => {
                 ui.apiError(error);
@@ -181,7 +178,7 @@ OmegaUp.on('ready', () => {
       type: ContestClarificationType.AllProblems,
       contestAlias: payload.contest.alias,
       rowcount: 20,
-      offset: 0,
+      offset: 1,
     });
   }, 5 * 60 * 1000);
 });

--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -7,6 +7,7 @@ import * as ui from '../ui';
 import Vue from 'vue';
 import arena_Course from '../components/arena/Course.vue';
 import { getOptionsFromLocation } from './location';
+import { PopupDisplayed } from '../components/problem/Details.vue';
 import {
   showSubmission,
   SubmissionRequest,
@@ -41,6 +42,7 @@ OmegaUp.on('ready', () => {
     data: () => ({
       problemInfo: null as types.ProblemInfo | null,
       problem: null as types.NavbarProblemsetProblem | null,
+      popupDisplayed: PopupDisplayed.None,
       problems: payload.currentAssignment
         .problems as types.NavbarProblemsetProblem[],
       showNewClarificationPopup: false,
@@ -53,6 +55,7 @@ OmegaUp.on('ready', () => {
           clarifications: clarificationStore.state.clarifications,
           course: payload.courseDetails,
           currentAssignment: payload.currentAssignment,
+          popupDisplayed: this.popupDisplayed,
           problemInfo: this.problemInfo,
           problem: this.problem,
           problemAlias: this.problemAlias,
@@ -79,16 +82,14 @@ OmegaUp.on('ready', () => {
               problems: this.problems,
             });
           },
-          'show-run': (request: SubmissionRequest) => {
-            const hash = `#problems/${
-              this.problemAlias ?? request.request.problemAlias
-            }/show-run:${request.request.guid}/`;
-            api.Run.details({ run_alias: request.request.guid })
+          'show-run': (source: SubmissionRequest) => {
+            api.Run.details({ run_alias: source.request.guid })
               .then((runDetails) => {
-                showSubmission({ request, runDetails, hash });
+                showSubmission({ source, runDetails });
               })
               .catch((error) => {
                 ui.apiError(error);
+                this.popupDisplayed = PopupDisplayed.None;
               });
           },
           'submit-run': ({

--- a/frontend/www/js/omegaup/arena/submissions.ts
+++ b/frontend/www/js/omegaup/arena/submissions.ts
@@ -19,13 +19,17 @@ interface RunSubmit {
 }
 
 interface SubmissionResponse {
-  hash: string;
-  request: SubmissionRequest;
+  source: SubmissionRequest;
   runDetails: types.RunDetails;
 }
 
 export interface SubmissionRequest {
-  request: { guid: string; isAdmin: boolean; problemAlias: string };
+  request: {
+    guid: string;
+    hash: string;
+    isAdmin: boolean;
+    problemAlias: string;
+  };
   target: problem_Details;
 }
 
@@ -72,20 +76,15 @@ export function submitRunFailed({
   }
 }
 
-export function showSubmission({
-  request,
-  runDetails,
-  hash,
-}: SubmissionResponse) {
-  if (runDetails.show_diff === 'none' || !request.request.isAdmin) {
+export function showSubmission({ source, runDetails }: SubmissionResponse) {
+  if (runDetails.show_diff === 'none' || !source.request.isAdmin) {
     displayRunDetails({
-      request,
+      source,
       runDetails,
-      hash,
     });
     return;
   }
-  fetch(`/api/run/download/run_alias/${request.request.guid}/show_diff/true/`)
+  fetch(`/api/run/download/run_alias/${source.request.guid}/show_diff/true/`)
     .then((response) => {
       if (!response.ok) {
         return Promise.reject(new Error(response.statusText));
@@ -125,7 +124,7 @@ export function showSubmission({
           }
         });
       });
-      displayRunDetails({ request, runDetails, hash });
+      displayRunDetails({ source, runDetails });
     })
     .catch(ui.apiError);
 }
@@ -157,9 +156,8 @@ function numericSort<T extends { [key: string]: any }>(key: string) {
 }
 
 function displayRunDetails({
-  request: { request, target },
+  source: { request, target },
   runDetails,
-  hash,
 }: SubmissionResponse): void {
   let sourceHTML,
     sourceLink = false;
@@ -206,7 +204,7 @@ function displayRunDetails({
       feedback: omegaup.SubmissionFeedback.None as omegaup.SubmissionFeedback,
     }),
   );
-  window.location.hash = hash;
+  window.location.hash = request.hash;
 }
 
 export function updateRun({ run }: { run: types.Run }): void {

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -72,7 +72,7 @@
                   })
               "
               @submit-run="onRunSubmitted"
-              @show-run="(source) => $emit('show-run', source)"
+              @show-run="onRunDetails"
             >
               <template #quality-nomination-buttons><div></div></template>
               <template #best-solvers-list><div></div></template>
@@ -148,6 +148,7 @@ import problem_Details, { PopupDisplayed } from '../problem/Details.vue';
 import { omegaup } from '../../omegaup';
 import { ContestClarificationType } from '../../arena/clarifications';
 import { SocketStatus } from '../../arena/events_socket';
+import { SubmissionRequest } from '../../arena/submissions';
 
 @Component({
   components: {
@@ -247,6 +248,18 @@ export default class ArenaContest extends Vue {
       ...request,
       problem: this.activeProblem,
       target: this,
+    });
+  }
+
+  onRunDetails(source: SubmissionRequest): void {
+    this.$emit('show-run', {
+      ...source,
+      request: {
+        ...source.request,
+        hash: `#problems/${
+          this.activeProblemAlias ?? source.request.problemAlias
+        }/show-run:${source.request.guid}/`,
+      },
     });
   }
 

--- a/frontend/www/js/omegaup/components/arena/ContestPractice.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.vue
@@ -49,7 +49,7 @@
                   })
               "
               @submit-run="onRunSubmitted"
-              @show-run="(source) => $emit('show-run', source)"
+              @show-run="onRunDetails"
             >
               <template #quality-nomination-buttons><div></div></template>
               <template #best-solvers-list><div></div></template>
@@ -124,6 +124,7 @@ import arena_Summary from './Summary.vue';
 import omegaup_Markdown from '../Markdown.vue';
 import problem_Details, { PopupDisplayed } from '../problem/Details.vue';
 import { ContestClarificationType } from '../../arena/clarifications';
+import { SubmissionRequest } from '../../arena/submissions';
 
 @Component({
   components: {
@@ -169,6 +170,18 @@ export default class ArenaContestPractice extends Vue {
 
   onRunSubmitted(run: { code: string; language: string }): void {
     this.$emit('submit-run', { ...run, problem: this.activeProblem });
+  }
+
+  onRunDetails(source: SubmissionRequest): void {
+    this.$emit('show-run', {
+      ...source,
+      request: {
+        ...source.request,
+        hash: `#problems/${
+          this.activeProblemAlias ?? source.request.problemAlias
+        }/show-run:${source.request.guid}/`,
+      },
+    });
   }
 
   onClarificationResponse(response: types.Clarification): void {

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -377,7 +377,7 @@ export default class ProblemDetails extends Vue {
   @Prop({ default: null }) runDetailsData!: types.RunDetails | null;
   @Prop({ default: null }) guid!: null | string;
   @Prop({ default: null }) problemAlias!: null | string;
-  @Prop() isAdmin!: boolean;
+  @Prop({ default: false }) isAdmin!: boolean;
   @Prop({ default: false }) showVisibilityIndicators!: boolean;
   @Prop() nextSubmissionTimestamp!: null | Date;
   @Prop({ default: false }) shouldShowTabs!: boolean;
@@ -474,6 +474,7 @@ export default class ProblemDetails extends Vue {
     this.$emit('show-run', {
       request: {
         guid,
+        hash: `#problems/show-run:${guid}/`,
         isAdmin: this.isAdmin,
         problemAlias: this.problem.alias,
       },
@@ -652,6 +653,7 @@ export default class ProblemDetails extends Vue {
       this.$emit('show-run', {
         request: {
           guid: this.guid,
+          hash: `#problems/show-run:${this.guid}/`,
           isAdmin: this.isAdmin,
           problemAlias: this.currentRunDetailsData?.alias,
         },

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -92,11 +92,10 @@ OmegaUp.on('ready', () => {
           searchResultUsers: this.searchResultUsers,
         },
         on: {
-          'show-run': (request: SubmissionRequest) => {
-            const hash = `#problems/show-run:${request.request.guid}/`;
-            api.Run.details({ run_alias: request.request.guid })
+          'show-run': (source: SubmissionRequest) => {
+            api.Run.details({ run_alias: source.request.guid })
               .then((runDetails) => {
-                showSubmission({ request, runDetails, hash });
+                showSubmission({ source, runDetails });
               })
               .catch((error) => {
                 ui.apiError(error);
@@ -303,7 +302,7 @@ OmegaUp.on('ready', () => {
                 refreshProblemClarifications({
                   problemAlias: payload.problem.alias,
                   rowcount: 20,
-                  offset: 0,
+                  offset: 1,
                 });
               })
               .catch(ui.apiError);
@@ -409,7 +408,7 @@ OmegaUp.on('ready', () => {
       refreshProblemClarifications({
         problemAlias: payload.problem.alias,
         rowcount: 20,
-        offset: 0,
+        offset: 1,
       });
     }, 5 * 60 * 1000);
   }


### PR DESCRIPTION
# Descripción

Se manda el hash a pintar desde el objeto que emite `show-run` para que la 
función sólo se encargue de mandar llamar `api.Run.details`

Part of: #5546 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
