### PR TITLE
Moviendo los cambios del servidor para la funcionalidad de envíos como admin

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -42,7 +42,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ScoreboardRankingProblem=array{alias: string, penalty: float, percent: float, pending?: int, place?: int, points: float, run_details?: array{cases?: list<CaseResult>, details: array{groups: list<array{cases: list<array{meta: RunMetadata}>}>}}, runs: int}
  * @psalm-type ScoreboardRankingEntry=array{classname: string, country: string, is_invited: bool, name: null|string, place?: int, problems: list<ScoreboardRankingProblem>, total: array{penalty: float, points: float}, username: string}
  * @psalm-type Scoreboard=array{finish_time: \OmegaUp\Timestamp|null, problems: list<array{alias: string, order: int}>, ranking: list<ScoreboardRankingEntry>, start_time: \OmegaUp\Timestamp, time: \OmegaUp\Timestamp, title: string}
- * @psalm-type ContestDetailsPayload=array{adminPayload?: array{allRuns: list<Run>, contestAdmin: bool, users: list<ContestUser>}, clarifications: list<Clarification>, contest: ContestPublicDetails, problems: list<NavbarProblemsetProblem>, scoreboard?: Scoreboard, scoreboardEvents?: list<ScoreboardEvent>, shouldShowFirstAssociatedIdentityRunWarning: bool, submissionDeadline: \OmegaUp\Timestamp|null}
+ * @psalm-type ContestDetailsPayload=array{adminPayload?: array{allRuns: list<Run>, users: list<ContestUser>}, clarifications: list<Clarification>, contest: ContestPublicDetails, problems: list<NavbarProblemsetProblem>, scoreboard?: Scoreboard, scoreboardEvents?: list<ScoreboardEvent>, shouldShowFirstAssociatedIdentityRunWarning: bool, submissionDeadline: \OmegaUp\Timestamp|null}
  * @psalm-type Event=array{courseAlias?: string, courseName?: string, name: string, problem?: string}
  * @psalm-type ActivityEvent=array{classname: string, event: Event, ip: int|null, time: \OmegaUp\Timestamp, username: string}
  * @psalm-type ActivityFeedPayload=array{alias: string, events: list<ActivityEvent>, type: string, page: int, length: int, pagerItems: list<PageItem>}
@@ -747,7 +747,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
                         intval($contest->problemset_id)
                     ),
                     'allRuns' => $allRuns,
-                    'contestAdmin' => true,
                 ];
             }
 

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -42,7 +42,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ScoreboardRankingProblem=array{alias: string, penalty: float, percent: float, pending?: int, place?: int, points: float, run_details?: array{cases?: list<CaseResult>, details: array{groups: list<array{cases: list<array{meta: RunMetadata}>}>}}, runs: int}
  * @psalm-type ScoreboardRankingEntry=array{classname: string, country: string, is_invited: bool, name: null|string, place?: int, problems: list<ScoreboardRankingProblem>, total: array{penalty: float, points: float}, username: string}
  * @psalm-type Scoreboard=array{finish_time: \OmegaUp\Timestamp|null, problems: list<array{alias: string, order: int}>, ranking: list<ScoreboardRankingEntry>, start_time: \OmegaUp\Timestamp, time: \OmegaUp\Timestamp, title: string}
- * @psalm-type ContestDetailsPayload=array{clarifications: list<Clarification>, contest: ContestPublicDetails, contestAdmin: bool, problems: list<NavbarProblemsetProblem>, scoreboard?: Scoreboard, scoreboardEvents?: list<ScoreboardEvent>, shouldShowFirstAssociatedIdentityRunWarning: bool, submissionDeadline: \OmegaUp\Timestamp|null, users: list<ContestUser>}
+ * @psalm-type ContestDetailsPayload=array{adminPayload?: array{allRuns: list<Run>, contestAdmin: bool, users: list<ContestUser>}, clarifications: list<Clarification>, contest: ContestPublicDetails, problems: list<NavbarProblemsetProblem>, scoreboard?: Scoreboard, scoreboardEvents?: list<ScoreboardEvent>, shouldShowFirstAssociatedIdentityRunWarning: bool, submissionDeadline: \OmegaUp\Timestamp|null}
  * @psalm-type Event=array{courseAlias?: string, courseName?: string, name: string, problem?: string}
  * @psalm-type ActivityEvent=array{classname: string, event: Event, ip: int|null, time: \OmegaUp\Timestamp, username: string}
  * @psalm-type ActivityFeedPayload=array{alias: string, events: list<ActivityEvent>, type: string, page: int, length: int, pagerItems: list<PageItem>}
@@ -554,7 +554,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{clarifications: list<Clarification>, problems: list<NavbarProblemsetProblem>, submissionDeadline: \OmegaUp\Timestamp|null, users: list<ContestUser>}
+     * @return array{clarifications: list<Clarification>, problems: list<NavbarProblemsetProblem>, submissionDeadline: \OmegaUp\Timestamp|null}
      */
     private static function getCommonDetails(
         \OmegaUp\DAO\VO\Contests $contest,
@@ -595,9 +595,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         return [
-            'users' => \OmegaUp\DAO\ProblemsetIdentities::getWithExtraInformation(
-                intval($contest->problemset_id)
-            ),
             'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
                 $contest,
                 /*course=*/ null,
@@ -614,7 +611,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Get all the properties for smarty.
      *
-     * @return array{inContest: bool, smartyProperties: array{fullWidth: bool, payload: ContestDetailsPayload, title: \OmegaUp\TranslationString}, template: string}|array{entrypoint: string, smartyProperties: array{payload: ContestIntroPayload, title: \OmegaUp\TranslationString}}
+     * @return array{entrypoint: string, smartyProperties: array{fullWidth: bool, payload: ContestDetailsPayload, title: \OmegaUp\TranslationString}}|array{entrypoint: string, smartyProperties: array{payload: ContestIntroPayload, title: \OmegaUp\TranslationString}}
      *
      * @omegaup-request-param null|string $auth_token
      * @omegaup-request-param string $contest_alias
@@ -696,7 +693,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $result['smartyProperties']['payload'],
                 [
                     'shouldShowFirstAssociatedIdentityRunWarning' => $shouldShowFirstAssociatedIdentityRunWarning,
-                    'contestAdmin' => $contestAdmin,
                     'scoreboard' => self::getScoreboard(
                         $contest,
                         $problemset,
@@ -714,12 +710,48 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $r->identity
                 ),
             );
-            if (!$contestAdmin) {
-                $result['smartyProperties']['payload']['users'] = [];
+            if ($contestAdmin) {
+                $allRuns = [];
+
+                // Get our runs
+                $runs = \OmegaUp\DAO\Runs::getAllRuns(
+                    $problemset->problemset_id,
+                    /*$status=*/ null,
+                    /*$verdict=*/ null,
+                    /*$problem_id=*/ null,
+                    /*$language=*/ null,
+                    /*$identity_id=*/ null,
+                    /*$offset=*/ 0,
+                    /*$rowcount=*/ 100
+                );
+
+                foreach ($runs as $run) {
+                    unset($run['run_id']);
+                    if ($contest->partial_score || $run['score'] == 1) {
+                        $run['contest_score'] = round(
+                            floatval(
+                                $run['contest_score']
+                            ),
+                            2
+                        );
+                        $run['score'] = round(floatval($run['score']), 4);
+                    } else {
+                        $run['contest_score'] = 0;
+                        $run['score'] = 0;
+                    }
+                    $allRuns[] = $run;
+                }
+
+                $result['smartyProperties']['payload']['adminPayload'] = [
+                    'users' => \OmegaUp\DAO\ProblemsetIdentities::getWithExtraInformation(
+                        intval($contest->problemset_id)
+                    ),
+                    'allRuns' => $allRuns,
+                    'contestAdmin' => true,
+                ];
             }
 
             $result['smartyProperties']['fullWidth'] = true;
-            $result['inContest'] = true;
             $result['smartyProperties']['title'] = new \OmegaUp\TranslationString(
                 'omegaupTitleContest'
             );

--- a/frontend/tests/controllers/ContestRunsTest.php
+++ b/frontend/tests/controllers/ContestRunsTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * Description of ContestRunsTest
  */
@@ -23,7 +21,7 @@ class ContestRunsTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Create our contestant
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         // Create a run
         $runData = \OmegaUp\Test\Factories\Run::createRun(
@@ -37,13 +35,14 @@ class ContestRunsTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Create request
         $login = self::login($contestData['director']);
-        $r = new \OmegaUp\Request([
-            'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => $login->auth_token,
-        ]);
 
         // Call API
-        $response = \OmegaUp\Controllers\Contest::apiRuns($r);
+        $response = \OmegaUp\Controllers\Contest::apiRuns(
+            new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $login->auth_token,
+            ])
+        );
 
         // Assert
         $this->assertEquals(1, count($response['runs']));
@@ -74,6 +73,77 @@ class ContestRunsTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
+     * Contestant submits runs and admin is able to get them into the contest
+     * details for typescript
+     */
+    public function testGetRunsForContestDetails() {
+        // Get a contest
+        $contestData = \OmegaUp\Test\Factories\Contest::createContest();
+
+        // Get problems and add them to the contest
+        $problems = [];
+        foreach (range(0, 4) as $index) {
+            $problems[$index] = \OmegaUp\Test\Factories\Problem::createProblem();
+
+            \OmegaUp\Test\Factories\Contest::addProblemToContest(
+                $problems[$index],
+                $contestData
+            );
+        }
+
+        // Create our contestant
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+
+        // Create one run for every problem
+        $runs = [];
+        foreach ($problems as $index => $problem) {
+            $runs[$index] = \OmegaUp\Test\Factories\Run::createRun(
+                $problem,
+                $contestData,
+                $identity
+            );
+
+            // Grade the run
+            \OmegaUp\Test\Factories\Run::gradeRun($runs[$index]);
+        }
+
+        // Create request
+        $login = self::login($contestData['director']);
+
+        // Explicitly join contest
+        \OmegaUp\Controllers\Contest::apiOpen(
+            new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $login->auth_token,
+            ])
+        );
+
+        // Call API
+        $response = \OmegaUp\Controllers\Contest::getContestDetailsForTypeScript(
+            new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $login->auth_token,
+            ])
+        )['smartyProperties']['payload']['adminPayload'];
+
+        // Assert
+        $this->assertCount(5, $response['allRuns']);
+
+        $guidsExpected = array_map(
+            fn ($run) => $run['response']['guid'],
+            $runs
+        );
+        $guidsActual = array_reverse(
+            array_map(
+                fn ($run) => $run['guid'],
+                $response['allRuns']
+            )
+        );
+
+        $this->assertEquals($guidsExpected, $guidsActual);
+    }
+
+    /**
      * Contestant submits runs and admin edits the points of a problem
      * while the contest is active
      */
@@ -91,7 +161,7 @@ class ContestRunsTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Create our contestant
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         // Create a run
         $runData = \OmegaUp\Test\Factories\Run::createRun(
@@ -107,10 +177,12 @@ class ContestRunsTest extends \OmegaUp\Test\ControllerTestCase {
         $directorLogin = self::login($contestData['director']);
 
         // Call API
-        $response = \OmegaUp\Controllers\Contest::apiRuns(new \OmegaUp\Request([
-            'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => $directorLogin->auth_token,
-        ]));
+        $response = \OmegaUp\Controllers\Contest::apiRuns(
+            new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $directorLogin->auth_token,
+            ])
+        );
 
         $this->assertEquals(100, $response['runs'][0]['contest_score']);
 
@@ -126,10 +198,12 @@ class ContestRunsTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\Controllers\Contest::apiAddProblem($r);
 
         // Call API
-        $response = \OmegaUp\Controllers\Contest::apiRuns(new \OmegaUp\Request([
-            'contest_alias' => $contestData['request']['alias'],
-            'auth_token' => $directorLogin->auth_token,
-        ]));
+        $response = \OmegaUp\Controllers\Contest::apiRuns(
+            new \OmegaUp\Request([
+                'contest_alias' => $contestData['request']['alias'],
+                'auth_token' => $directorLogin->auth_token,
+            ])
+        );
 
         $this->assertEquals(80, $response['runs'][0]['contest_score']);
     }

--- a/frontend/tests/controllers/ContestUsersTest.php
+++ b/frontend/tests/controllers/ContestUsersTest.php
@@ -182,8 +182,8 @@ class ContestUsersTest extends \OmegaUp\Test\ControllerTestCase {
             ])
         )['smartyProperties']['payload'];
 
-        // Users list should be empty
-        $this->assertEmpty($contestDetails['users']);
+        // adminPayload object should not exist
+        $this->assertArrayNotHasKey('adminPayload', $contestDetails);
     }
 
     public function testContestParticipantsReport() {

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1941,11 +1941,7 @@ export namespace types {
   }
 
   export interface ContestDetailsPayload {
-    adminPayload?: {
-      allRuns: types.Run[];
-      contestAdmin: boolean;
-      users: types.ContestUser[];
-    };
+    adminPayload?: { allRuns: types.Run[]; users: types.ContestUser[] };
     clarifications: types.Clarification[];
     contest: types.ContestPublicDetails;
     problems: types.NavbarProblemsetProblem[];

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -219,6 +219,33 @@ export namespace types {
       elementId: string = 'payload',
     ): types.ContestDetailsPayload {
       return ((x) => {
+        if (x.adminPayload)
+          x.adminPayload = ((x) => {
+            x.allRuns = ((x) => {
+              if (!Array.isArray(x)) {
+                return x;
+              }
+              return x.map((x) => {
+                x.time = ((x: number) => new Date(x * 1000))(x.time);
+                return x;
+              });
+            })(x.allRuns);
+            x.users = ((x) => {
+              if (!Array.isArray(x)) {
+                return x;
+              }
+              return x.map((x) => {
+                if (x.access_time)
+                  x.access_time = ((x: number) => new Date(x * 1000))(
+                    x.access_time,
+                  );
+                if (x.end_time)
+                  x.end_time = ((x: number) => new Date(x * 1000))(x.end_time);
+                return x;
+              });
+            })(x.users);
+            return x;
+          })(x.adminPayload);
         x.clarifications = ((x) => {
           if (!Array.isArray(x)) {
             return x;
@@ -247,20 +274,6 @@ export namespace types {
           x.submissionDeadline = ((x: number) => new Date(x * 1000))(
             x.submissionDeadline,
           );
-        x.users = ((x) => {
-          if (!Array.isArray(x)) {
-            return x;
-          }
-          return x.map((x) => {
-            if (x.access_time)
-              x.access_time = ((x: number) => new Date(x * 1000))(
-                x.access_time,
-              );
-            if (x.end_time)
-              x.end_time = ((x: number) => new Date(x * 1000))(x.end_time);
-            return x;
-          });
-        })(x.users);
         return x;
       })(
         JSON.parse(
@@ -1928,15 +1941,18 @@ export namespace types {
   }
 
   export interface ContestDetailsPayload {
+    adminPayload?: {
+      allRuns: types.Run[];
+      contestAdmin: boolean;
+      users: types.ContestUser[];
+    };
     clarifications: types.Clarification[];
     contest: types.ContestPublicDetails;
-    contestAdmin: boolean;
     problems: types.NavbarProblemsetProblem[];
     scoreboard?: types.Scoreboard;
     scoreboardEvents?: types.ScoreboardEvent[];
     shouldShowFirstAssociatedIdentityRunWarning: boolean;
     submissionDeadline?: Date;
-    users: types.ContestUser[];
   }
 
   export interface ContestEditPayload {

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -33,7 +33,7 @@ OmegaUp.on('ready', () => {
   time.setSugarLocale();
   const payload = types.payloadParsers.ContestDetailsPayload();
   const commonPayload = types.payloadParsers.CommonPayload();
-  const contestAdmin = payload.adminPayload?.contestAdmin ?? false;
+  const contestAdmin = payload.adminPayload;
   const activeTab = window.location.hash
     ? window.location.hash.substr(1).split('/')[0]
     : 'problems';

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -33,7 +33,7 @@ OmegaUp.on('ready', () => {
   time.setSugarLocale();
   const payload = types.payloadParsers.ContestDetailsPayload();
   const commonPayload = types.payloadParsers.CommonPayload();
-  const contestAdmin = payload.adminPayload;
+  const contestAdmin = Boolean(payload.adminPayload);
   const activeTab = window.location.hash
     ? window.location.hash.substr(1).split('/')[0]
     : 'problems';

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -33,6 +33,7 @@ OmegaUp.on('ready', () => {
   time.setSugarLocale();
   const payload = types.payloadParsers.ContestDetailsPayload();
   const commonPayload = types.payloadParsers.CommonPayload();
+  const contestAdmin = payload.adminPayload?.contestAdmin ?? false;
   const activeTab = window.location.hash
     ? window.location.hash.substr(1).split('/')[0]
     : 'problems';
@@ -96,9 +97,9 @@ OmegaUp.on('ready', () => {
       return createElement('omegaup-arena-contest', {
         props: {
           contest: payload.contest,
-          contestAdmin: payload.contestAdmin,
+          contestAdmin,
           problems: this.problems,
-          users: payload.users,
+          users: payload.adminPayload?.users,
           problemInfo: this.problemInfo,
           problem: this.problem,
           clarifications: clarificationStore.state.clarifications,

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -51,9 +51,9 @@ OmegaUp.on('ready', () => {
       return createElement('omegaup-arena-contest-practice', {
         props: {
           contest: payload.contest,
-          contestAdmin: payload.contestAdmin,
+          contestAdmin: payload.adminPayload?.contestAdmin ?? false,
           problems: this.problems,
-          users: payload.users,
+          users: payload.adminPayload?.users,
           problemInfo: this.problemInfo,
           problem: this.problem,
           clarifications: clarificationStore.state.clarifications,

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -51,7 +51,7 @@ OmegaUp.on('ready', () => {
       return createElement('omegaup-arena-contest-practice', {
         props: {
           contest: payload.contest,
-          contestAdmin: payload.adminPayload,
+          contestAdmin: Boolean(payload.adminPayload),
           problems: this.problems,
           users: payload.adminPayload?.users,
           problemInfo: this.problemInfo,

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -51,7 +51,7 @@ OmegaUp.on('ready', () => {
       return createElement('omegaup-arena-contest-practice', {
         props: {
           contest: payload.contest,
-          contestAdmin: payload.adminPayload?.contestAdmin ?? false,
+          contestAdmin: payload.adminPayload,
           problems: this.problems,
           users: payload.adminPayload?.users,
           problemInfo: this.problemInfo,


### PR DESCRIPTION
# Descripción

Como parte del PR que agrega el Tab de Envíos en los concursos modo admin,
se mueve todo lo referente al lado del servidor para hacer el otro PR más pequeño.

Part of: #5546 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
