### PR TITLE
Arreglando la vista de envíos globales para que muestre detalles de envío

### DIFF
--- a/frontend/www/js/omegaup/arena/admin.ts
+++ b/frontend/www/js/omegaup/arena/admin.ts
@@ -1,153 +1,148 @@
+import Vue from 'vue';
+
+import arena_Runsv2, { PopupDisplayed } from '../components/arena/Runsv2.vue';
 import * as api from '../api';
 import T from '../lang';
-import { Arena, GetOptionsFromLocation } from './arena';
-import ArenaAdmin from './admin_arena';
 import { OmegaUp } from '../omegaup';
 import * as ui from '../ui';
 import * as time from '../time';
+import { runsStore } from './runsStore';
+import {
+  onRefreshRuns,
+  showSubmission,
+  SubmissionRequest,
+  updateRunFallback,
+} from './submissions';
+import { types } from '../api_types';
 
 OmegaUp.on('ready', () => {
-  const arenaInstance = new Arena(GetOptionsFromLocation(window.location));
-  const adminInstance = new ArenaAdmin(arenaInstance);
+  const locationHash = window.location.hash.substr(1).split('/');
+  const runsList = new Vue({
+    el: '#main-container',
+    components: {
+      'omegaup-arena-runs': arena_Runsv2,
+    },
+    data: () => ({
+      searchResultUsers: [] as types.ListItem[],
+      popupDisplayed: PopupDisplayed.None,
+      guid: null as null | string,
+    }),
+    render: function (createElement) {
+      return createElement('omegaup-arena-runs', {
+        props: {
+          contestAlias: 'admin',
+          popupDisplayed: this.popupDisplayed,
+          runs: runsStore.state.runs,
+          showContest: true,
+          showProblem: true,
+          showDetails: true,
+          showDisqualify: true,
+          showPager: true,
+          showRejudge: true,
+          showUser: true,
+          guid: this.guid,
+          globalRuns: true,
+          searchResultUsers: this.searchResultUsers,
+        },
+        on: {
+          details: (request: SubmissionRequest) => {
+            const hash = `/show-run:${request.request.guid}/`;
+            api.Run.details({ run_alias: request.request.guid })
+              .then((runDetails) => {
+                showSubmission({ request, runDetails, hash });
+              })
+              .catch((error) => {
+                ui.apiError(error);
+                this.popupDisplayed = PopupDisplayed.None;
+              });
+          },
+          disqualify: (run: types.Run) => {
+            if (!window.confirm(T.runDisqualifyConfirm)) {
+              return;
+            }
+            api.Run.disqualify({ run_alias: run.guid })
+              .then(() => {
+                run.type = 'disqualified';
+                updateRunFallback({ run });
+              })
+              .catch(ui.ignoreError);
+          },
+          'filter-changed': () => {
+            refreshRuns();
+          },
+          rejudge: (run: types.Run) => {
+            api.Run.rejudge({ run_alias: run.guid, debug: false })
+              .then(() => {
+                run.status = 'rejudging';
+                updateRunFallback({ run });
+              })
+              .catch(ui.ignoreError);
+          },
+          'update-search-result-users': ({ query }: { query: string }) => {
+            api.User.list({ query })
+              .then(({ results }) => {
+                this.searchResultUsers = results.map(
+                  ({ key, value }: types.ListItem) => ({
+                    key,
+                    value: `${ui.escape(key)} (<strong>${ui.escape(
+                      value,
+                    )}</strong>)`,
+                  }),
+                );
+              })
+              .catch(ui.apiError);
+          },
+          'update-search-result-users-contest': ({
+            query,
+            contestAlias,
+          }: {
+            query: string;
+            contestAlias: string;
+          }) => {
+            api.Contest.searchUsers({ query, contest_alias: contestAlias })
+              .then(({ results }) => {
+                this.searchResultUsers = results.map(
+                  ({ key, value }: types.ListItem) => ({
+                    key,
+                    value: `${ui.escape(key)} (<strong>${ui.escape(
+                      value,
+                    )}</strong>)`,
+                  }),
+                );
+              })
+              .catch(ui.apiError);
+          },
+        },
+      });
+    },
+  });
 
-  window.addEventListener('hashchange', () => arenaInstance.onHashChanged());
-
-  if (arenaInstance.options.contestAlias === 'admin') {
-    $('#runs').show();
-    adminInstance.refreshRuns();
-    setInterval(() => {
-      adminInstance.refreshRuns();
-    }, 5 * 60 * 1000);
-
-    // Trigger the event (useful on page load).
-    arenaInstance.onHashChanged();
-
-    $('#loading').fadeOut('slow');
-    $('#root').fadeIn('slow');
-  } else {
-    api.Contest.adminDetails({
-      contest_alias: arenaInstance.options.contestAlias,
+  function refreshRuns(): void {
+    api.Run.list({
+      show_all: true,
+      offset: runsStore.state.filters?.offset,
+      rowcount: runsStore.state.filters?.rowcount,
+      verdict: runsStore.state.filters?.verdict,
+      language: runsStore.state.filters?.language,
+      username: runsStore.state.filters?.username,
+      status: runsStore.state.filters?.status,
     })
       .then(time.remoteTimeAdapter)
-      .then((contest) => {
-        if (!contest.admin) {
-          if (!OmegaUp.loggedIn) {
-            window.location.href = `/login/?redirect=${encodeURIComponent(
-              window.location.pathname,
-            )}`;
-          } else {
-            window.location.href = '/';
-          }
-          return;
-        }
-
-        $('#title .contest-title').text(ui.contestTitle(contest));
-        arenaInstance.updateSummary(contest);
-
-        arenaInstance.submissionGap = contest.submissions_gap;
-        if (!(arenaInstance.submissionGap > 0)) arenaInstance.submissionGap = 0;
-
-        arenaInstance.initProblemsetId(contest);
-        arenaInstance.initProblems(contest);
-        arenaInstance.initClock(contest.start_time, contest.finish_time, null);
-        if (contest.problems) {
-          for (const idx in contest.problems) {
-            const problem = contest.problems[idx];
-            const problemName = `${problem.letter}. ${ui.escape(
-              problem.title,
-            )}`;
-
-            arenaInstance.problems[problem.alias] = {
-              ...problem,
-              languages: problem.languages
-                .split(',')
-                .filter((language) => language !== ''),
-            };
-            if (arenaInstance.navbarProblems) {
-              arenaInstance.navbarProblems.problems.push({
-                alias: problem.alias,
-                acceptsSubmissions: true,
-                text: problemName,
-                bestScore: 0,
-                maxScore: 0,
-                hasRuns: false,
-              });
-            }
-
-            $('#clarification select[name=problem]').append(
-              `<option value="${problem.alias}">${problemName}</option>`,
-            );
-            $('select.runsproblem').append(
-              `<option value="${problem.alias}">${problemName}</option>`,
-            );
-          }
-        }
-
-        api.Contest.users({
-          contest_alias: arenaInstance.options.contestAlias,
-        })
-          .then((data) => {
-            for (const ind in data.users) {
-              const user = data.users[ind];
-              const receiver = user.is_owner
-                ? T.wordsPublic
-                : ui.escape(user.username);
-              $('#clarification select[name=user]').append(
-                `<option value="${ui.escape(
-                  user.username,
-                )}">${receiver}</option>`,
-              );
-            }
-          })
-          .catch(ui.ignoreError);
-
-        arenaInstance.setupPolls();
-        adminInstance.refreshRuns();
-        if (!arenaInstance.socket) {
-          setInterval(() => {
-            adminInstance.refreshRuns();
-          }, 5 * 60 * 1000);
-        }
-
-        // Trigger the event (useful on page load).
-        arenaInstance.onHashChanged();
-
-        $('#loading').fadeOut('slow');
-        $('#root').fadeIn('slow');
+      .then((response) => {
+        onRefreshRuns({ runs: response.runs });
       })
-      .catch(() => {
-        if (!OmegaUp.loggedIn) {
-          window.location.href = `/login/?redirect=${encodeURIComponent(
-            window.location.pathname,
-          )}`;
-        } else {
-          window.location.href = '/';
-        }
-      });
+      .catch(ui.apiError);
   }
-  $('#rejudge-problem').on('click', () => {
-    if (
-      confirm(
-        `Deseas rejuecear el problema ${arenaInstance.currentProblem.alias}?`,
-      )
-    ) {
-      api.Problem.rejudge({
-        problem_alias: arenaInstance.currentProblem.alias,
-      })
-        .then(() => {
-          adminInstance.refreshRuns();
-        })
-        .catch(ui.ignoreError);
-    }
-    return false;
-  });
 
-  $('#update-problem').on('submit', () => {
-    $('#update-problem input[name="problem_alias"]').val(
-      arenaInstance.currentProblem.alias,
-    );
-    return confirm(
-      `Deseas actualizar el problema ${arenaInstance.currentProblem.alias}?`,
-    );
-  });
+  refreshRuns();
+  setInterval(() => {
+    refreshRuns();
+  }, 5 * 60 * 1000);
+
+  if (locationHash[1] && locationHash[1].includes('show-run:')) {
+    const showRunRegex = /.*\/show-run:([a-fA-F0-9]+)/;
+    const showRunMatch = window.location.hash.match(showRunRegex);
+    runsList.guid = showRunMatch ? showRunMatch[1] : null;
+    runsList.popupDisplayed = PopupDisplayed.RunDetails;
+  }
 });

--- a/frontend/www/js/omegaup/arena/admin_arena.ts
+++ b/frontend/www/js/omegaup/arena/admin_arena.ts
@@ -4,7 +4,6 @@ import * as api from '../api';
 import { types } from '../api_types';
 import T from '../lang';
 import arena_Runs from '../components/arena/Runs.vue';
-import arena_Runsv2 from '../components/arena/Runsv2.vue';
 import * as ui from '../ui';
 import * as time from '../time';
 
@@ -22,13 +21,12 @@ export default class ArenaAdmin {
 
     this.arena = arena;
     this.arena.problemsetAdmin = true;
-    const globalRuns = this.arena.options.contestAlias === 'admin';
 
     this.setUpPagers();
     this.runsList = new Vue({
-      el: globalRuns ? '#main-container' : '#runs table.runs',
+      el: '#runs table.runs',
       components: {
-        'omegaup-arena-runs': globalRuns ? arena_Runsv2 : arena_Runs,
+        'omegaup-arena-runs': arena_Runs,
       },
       data: () => ({
         searchResultUsers: [] as types.ListItem[],
@@ -38,7 +36,7 @@ export default class ArenaAdmin {
           props: {
             contestAlias: arena.options.contestAlias,
             runs: runsStore.state.runs,
-            showContest: arena.options.contestAlias == 'admin',
+            showContest: false,
             showProblem: true,
             showDetails: true,
             showDisqualify: true,
@@ -46,7 +44,7 @@ export default class ArenaAdmin {
             showRejudge: true,
             showUser: true,
             problemsetProblems: Object.values(arena.problems),
-            globalRuns: globalRuns,
+            globalRuns: false,
             searchResultUsers: this.searchResultUsers,
           },
           on: {
@@ -194,12 +192,7 @@ export default class ArenaAdmin {
       status: runsListComponent.filterStatus || undefined,
     };
 
-    if (this.arena.options.contestAlias === 'admin') {
-      api.Run.list(options)
-        .then(time.remoteTimeAdapter)
-        .then((response) => this.runsChanged(response))
-        .catch(ui.ignoreError);
-    } else if (this.arena.options.contestAlias != null) {
+    if (this.arena.options.contestAlias != null) {
       options.contest_alias = this.arena.options.contestAlias;
       api.Contest.runs(options)
         .then(time.remoteTimeAdapter)


### PR DESCRIPTION
# Descripción

Se arregla la vista de Envíos globales para que se puedan mostrar los detalles 
de un envío previamente seleccionado. 

Anteriormente se estaba mandando llamar el componente de envíos desde 
adentro de la instancia de ArenaAdmin, esto estaba ocasionando que chocaran
varias acciones. Ya no es necesario hacerlo de esa forma, ya que eventualmente
la instancia de Arena y ArenaAdmin van a ser reemplazadas por archivos independientes.

![RunDetailsInGlobalRunsOk](https://user-images.githubusercontent.com/3230352/128439045-158c9e6d-9673-4fc3-9841-07b04deba82c.gif)


Fixes: #5584 

# Comentarios

Se tuvieron que modificar los parámetros que emite `details` y esto posiblemente
ocasionará que algunos otros componentes dejen de funcionar correctamente.

Es por eso que este PR debería de revisarse hasta que el PR #5563 sea aprobado,
ya que en ese refactor se están arreglando los parámetros antes mencionados.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
