### PR TITLE
Mostrando sólo los lenguajes configurados para un concurso

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Contest.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Contest.test.ts
@@ -34,7 +34,7 @@ describe('Contest.vue', () => {
     director: 'omegaUpDirector',
     feedback: 'detailed',
     finish_time: futureDate,
-    languages: 'py',
+    languages: 'py3',
     partial_score: true,
     penalty: 1,
     penalty_calc_policy: 'sum',

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -56,6 +56,7 @@
             <omegaup-problem-details
               :user="{ loggedIn: true, admin: false, reviewer: false }"
               :next-submission-timestamp="nextSubmissionTimestamp"
+              :languages="contest.languages"
               :problem="problemInfo"
               :active-tab="'problems'"
               :runs="runs"

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -56,7 +56,7 @@
             <omegaup-problem-details
               :user="{ loggedIn: true, admin: false, reviewer: false }"
               :next-submission-timestamp="nextSubmissionTimestamp"
-              :languages="contest.languages"
+              :languages="contest.languages.split(',')"
               :problem="problemInfo"
               :active-tab="'problems'"
               :runs="runs"

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -113,7 +113,7 @@
             <omegaup-arena-runsubmit-popup
               v-show="currentPopupDisplayed === PopupDisplayed.RunSubmit"
               :preferred-language="problem.preferred_language"
-              :languages="problem.languages"
+              :languages="filteredLanguages"
               :next-submission-timestamp="nextSubmissionTimestamp || new Date()"
               @dismiss="onPopupDismissed"
               @submit-run="onRunSubmitted"
@@ -385,6 +385,7 @@ export default class ProblemDetails extends Vue {
   @Prop({ default: false }) isContestFinished!: boolean;
   @Prop({ default: null }) contestAlias!: string | null;
   @Prop() searchResultUsers!: types.ListItem[];
+  @Prop({ default: null }) languages!: null | string[];
 
   @Ref('statement-markdown') readonly statementMarkdown!: omegaup_Markdown;
 
@@ -464,6 +465,15 @@ export default class ProblemDetails extends Vue {
 
   get runsByProblem(): types.Run[] {
     return this.runs.filter((run) => run.alias === this.problem.alias);
+  }
+
+  get filteredLanguages(): string[] {
+    if (!this.languages) {
+      return this.problem.languages;
+    }
+    return this.problem.languages.filter((language) =>
+      this.languages?.includes(language),
+    );
   }
 
   onNewSubmission(): void {

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -471,8 +471,9 @@ export default class ProblemDetails extends Vue {
     if (!this.languages) {
       return this.problem.languages;
     }
+    const languagesSet = new Set(this.languages);
     return this.problem.languages.filter((language) =>
-      this.languages?.includes(language),
+      languagesSet.has(language),
     );
   }
 


### PR DESCRIPTION
# Descripción

Se arregla el bug que estaba mostrando todos los lenguajes en el popup de 
nuevo envío, en lugar de sólo mostrar los lenguajes que se configuraron en 
el concurso.

Un componente no estaba pasando la propiedad de lenguajes del concurso, 
y en el componente de `RunSubmit` estaba tomando en cuenta todos los 
lenguajes permitidos para el problema. Ahora ya se realiza una intersección 
entre lenguajes del problema y del concurso.

![AllowedLanguagesInContest](https://user-images.githubusercontent.com/3230352/128476424-41044e02-12b6-4754-a4a8-1fdb951385af.gif)

Fixes: #5580 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.