### PR TITLE
Quitando la notificación para los candidatos a coder del mes

### DIFF
--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -4,7 +4,6 @@
 
 import argparse
 import datetime
-import json
 import logging
 import os
 import sys
@@ -674,32 +673,6 @@ def update_coder_of_the_month_candidates(
                         row['score'],
                         row['ProblemsSolved']
                     ))
-        cur.execute(
-            '''
-            INSERT INTO
-                `Notifications` (
-                    `user_id`,
-                    `contents`
-                )
-            VALUES (
-                %s,
-                %s
-            );
-            ''',
-            (
-                row['user_id'],
-                json.dumps({
-                    'type': 'coder-of-the-month',
-                    'body': {
-                        'localizationString': 'coderOfTheMonthNotice',
-                        'localizationParams': {
-                            'username': row['username'],
-                        },
-                        'iconUrl': '/media/info.png',
-                    },
-                }),
-            ),
-        )
 
 
 def update_users_stats(


### PR DESCRIPTION
# Descripción

En [un PR](https://github.com/omegaup/omegaup/commit/df92883630bd6c1efa42905985337ab535b392aa#diff-294fd3696f6801a66edeb50980e4448f23aa52476d46f5fc6e4a49e8f0b0a574) se agregaron las notificaciones para los coders del mes. Sin embargo, dichas notificaciones se están enviados a los candidatos, en lugar de los seleccionados.

TO DO: Determinar dónde, cuándo y cómo enviar esas notificaciones a los SELECCIONADOS.

Fixes: #5622 


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
