### PR TITLE
Adición validación valor nulo en updateProblemSettings

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4278,7 +4278,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'TimeLimit' => '30s',
                 ];
             }
-            $problemSettings['Validator']['Limits']['TimeLimit'] = "{$params->validatorTimeLimit}ms";
+            if (!is_null($params->validatorTimeLimit)) {
+                $problemSettings['Validator']['Limits']['TimeLimit'] = "{$params->validatorTimeLimit}ms";
+            }
         } else {
             if (!empty($problemSettings['Validator']['Limits'])) {
                 unset($problemSettings['Validator']['Limits']);


### PR DESCRIPTION
# Descripción

Agregué una validación faltante porque antes quedaba el valor `"ms"` en `'TimeLimit'`, lo que después provocaba el error del issue. 

Fixes: #5392 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
