### PR TITLE
Fix error al cargar concurso en modo practica

### DIFF
--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -317,13 +317,14 @@ export namespace types {
               })(x.scoreboard);
             return x;
           })(x.original);
-        x.scoreboard = ((x) => {
-          if (x.finish_time)
-            x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
-          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
-          x.time = ((x: number) => new Date(x * 1000))(x.time);
-          return x;
-        })(x.scoreboard);
+        if (x.scoreboard)
+          x.scoreboard = ((x) => {
+            if (x.finish_time)
+              x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+            x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+            x.time = ((x: number) => new Date(x * 1000))(x.time);
+            return x;
+          })(x.scoreboard);
         if (x.submissionDeadline)
           x.submissionDeadline = ((x: number) => new Date(x * 1000))(
             x.submissionDeadline,


### PR DESCRIPTION
Solucionado el bug que no permitia cargar el concurso en modo práctica, faltaba una validación para verificar que un campo no fuera undefined

# Descripción

Bug Fix  Cargar concurso modo práctica
Fixes: #5636

# Comentarios

  No se si esto vaya aquí o sea conveniente abir un issue aparte pero nunca pude hacer el commit hacia mi repositorio desde CLI, ya que siempre me aperecia el siguiente error:
```
  error: cannot spawn .git/hooks/pre-push: No such file or directory
  error: waitpid for .git/hooks/pre-push failed: No child processes
```
Seguí su documentación y todo para crear la rama y hacer el PR, y por aparte crear una rama sencilla en mi repositorio pero nunca me dejo, no se muy bien cual sea el tema. 

PD: es mi primer contribución aún repo Open Source, cualquier comentario quedo al pendiente

# Checklist:

- [ x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
