### PR TITLE
Clickable progress bar

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -54,6 +54,7 @@ rewrite ^/course/([a-zA-Z0-9_+-]+)/edit/?$ /course/edit.php?course=$1 last;
 rewrite ^/course/([a-zA-Z0-9_+-]+)/list/?$ /course/submissionslist.php?course=$1 last;
 rewrite ^/course/([a-zA-Z0-9_+-]+)/statistics/?$ /course/statistics.php?course=$1 last;
 rewrite ^/course/([a-zA-Z0-9_+-]+)/student/([a-zA-Z0-9_+-]+)/?$ /course/student.php?course=$1&student=$2 last;
+rewrite ^/course/([a-zA-Z0-9_+-]+)/student/([a-zA-Z0-9_+-]+)/([a-zA-Z0-9_+-]+)/?$ /course/student.php?course=$1&student=$2&assignment_alias=$3 last;
 rewrite ^/course/([a-zA-Z0-9_+-]+)/students/?$ /course/students.php?course=$1 last;
 rewrite ^/course/list/(student|public)/?$ /course/singlelist.php?course_type=$1 last;
 rewrite ^/group/?$ /group/list.php last;

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1352,6 +1352,23 @@ export namespace types {
           x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
           return x;
         })(x.course);
+        x.problems = ((x) => {
+          if (!Array.isArray(x)) {
+            return x;
+          }
+          return x.map((x) => {
+            x.runs = ((x) => {
+              if (!Array.isArray(x)) {
+                return x;
+              }
+              return x.map((x) => {
+                x.time = ((x: number) => new Date(x * 1000))(x.time);
+                return x;
+              });
+            })(x.runs);
+            return x;
+          });
+        })(x.problems);
         return x;
       })(
         JSON.parse(
@@ -3277,7 +3294,9 @@ export namespace types {
   }
 
   export interface StudentProgressPayload {
+    assignment: string;
     course: types.CourseDetails;
+    problems: types.CourseProblem[];
     student: string;
     students: types.StudentProgress[];
   }

--- a/frontend/www/js/omegaup/components/course/StudentProgress.vue
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.vue
@@ -30,6 +30,7 @@
         getPointsByAsssignment(assignment.alias)
       }}</span>
       <div class="d-flex justify-content-center mt-1">
+        <!-- Inicia barra de progreso -->
         <div
           v-if="
             Object.prototype.hasOwnProperty.call(
@@ -49,8 +50,10 @@
             :class="getProblemColor(assignment.alias, problem)"
             data-toggle="tooltip"
             data-placement="bottom"
+            @click="redirectToStudentProgress(assignment.alias, problem)"
           ></div>
         </div>
+        <!-- Termina barra de progreso -->
       </div>
     </td>
   </tr>
@@ -222,6 +225,11 @@ export default class StudentProgress extends Vue {
         progress: this.getProgress(assignmentAlias, problemAlias),
       }),
     );
+  }
+
+  redirectToStudentProgress(assignmentAlias: string, problemAlias: string) {
+    console.log(assignmentAlias + ' / ' + problemAlias);
+    window.location.href = this.studentProgressUrl;
   }
 
   get studentProgressUrl(): string {

--- a/frontend/www/js/omegaup/components/course/StudentProgress.vue
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.vue
@@ -41,7 +41,7 @@
           class="d-flex"
           :class="{ invisible: points(assignment.alias) === 0 }"
         >
-          <div
+          <a
             v-for="(problem, index) in Object.keys(
               student.points[assignment.alias],
             )"
@@ -50,8 +50,14 @@
             :class="getProblemColor(assignment.alias, problem)"
             data-toggle="tooltip"
             data-placement="bottom"
-            @click="redirectToStudentProgress(assignment.alias, problem)"
-          ></div>
+            :href="
+              getStudentProgressUrlWithAssignmentAndProblem(
+                assignment.alias,
+                problem,
+              )
+            "
+          >
+          </a>
         </div>
         <!-- Termina barra de progreso -->
       </div>
@@ -227,13 +233,15 @@ export default class StudentProgress extends Vue {
     );
   }
 
-  redirectToStudentProgress(assignmentAlias: string, problemAlias: string) {
-    console.log(assignmentAlias + ' / ' + problemAlias);
-    window.location.href = this.studentProgressUrl;
-  }
-
   get studentProgressUrl(): string {
     return `/course/${this.course.alias}/student/${this.student.username}/`;
+  }
+
+  getStudentProgressUrlWithAssignmentAndProblem(
+    selectedAssignment: string,
+    selectedProblem: string,
+  ): string {
+    return `/course/${this.course.alias}/student/${this.student.username}/${selectedAssignment}/#${selectedProblem}`;
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/course/ViewStudent.vue
+++ b/frontend/www/js/omegaup/components/course/ViewStudent.vue
@@ -149,14 +149,14 @@ export default class CourseViewStudent extends Vue {
   @Prop() assignments!: omegaup.Assignment[];
   @Prop() course!: types.CourseDetails;
   @Prop() initialStudent!: types.StudentProgress;
-  @Prop({default: null}) initialProblem!: types.CourseProblem | null;
-  @Prop({default: null}) initialAssignment!: omegaup.Assignment | null;
+  @Prop({ default: null }) initialProblem!: types.CourseProblem | null;
+  @Prop({ default: null }) initialAssignment!: omegaup.Assignment | null;
   @Prop() problems!: types.CourseProblem[];
   @Prop() students!: types.StudentProgress[];
 
   T = T;
   time = time;
-  selectedAssignment: string | null = this.initialAssignment?.alias??null;
+  selectedAssignment: string | null = this.initialAssignment?.alias ?? null;
   selectedProblem: Partial<types.CourseProblem> | null = this.initialProblem;
   selectedStudent: Partial<types.StudentProgress> = this.initialStudent || {};
   selectedRun: Partial<types.CourseRun> | null = null;
@@ -217,7 +217,7 @@ export default class CourseViewStudent extends Vue {
     return `/course/${this.course.alias}/`;
   }
 
-  selectProblem(selectedProblem: types.CourseProblem){
+  selectProblem(selectedProblem: types.CourseProblem) {
     this.selectedProblem = selectedProblem;
     window.location.hash = `#${selectedProblem.alias}`;
   }
@@ -227,40 +227,32 @@ export default class CourseViewStudent extends Vue {
     newVal?: types.StudentProgress,
     oldVal?: types.StudentProgress,
   ) {
-    let url: string = "";
+    let url: string = '';
     this.$emit('update', this.selectedStudent, this.selectedAssignment);
     if (!newVal || newVal?.username === oldVal?.username) {
       return;
     }
     if (this.selectedAssignment !== null) {
       url = `/course/${this.course.alias}/student/${newVal.username}/${this.selectedAssignment}/#${this.selectedProblem?.alias}`;
-    }else{
+    } else {
       url = `/course/${this.course.alias}/student/${newVal.username}/`;
     }
-    window.history.pushState(
-      { student: newVal },
-      document.title,
-      url,
-    );
+    window.history.pushState({ student: newVal }, document.title, url);
   }
 
   @Watch('selectedAssignment')
   onSelectedAssignmentChange(newVal?: string, oldVal?: string) {
-    let url: string = "";
+    let url: string = '';
     this.$emit('update', this.selectedStudent, this.selectedAssignment);
     if (!newVal || newVal === oldVal) {
       return;
     }
     if (this.selectedProblem !== null) {
       url = `/course/${this.course.alias}/student/${this.selectedStudent.username}/${newVal}/#${this.selectedProblem?.alias}`;
-    }else{
+    } else {
       url = `/course/${this.course.alias}/student/${this.selectedStudent.username}/${newVal}/`;
     }
-    window.history.pushState(
-      { assignment: newVal },
-      document.title,
-      url,
-    );
+    window.history.pushState({ assignment: newVal }, document.title, url);
   }
 
   @Watch('problems')

--- a/frontend/www/js/omegaup/course/student.ts
+++ b/frontend/www/js/omegaup/course/student.ts
@@ -8,9 +8,7 @@ import Vue from 'vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.StudentProgressPayload();
 
-  const match = /#(?<alias>[^/]+)?/g.exec(
-    window.location.hash,
-  );
+  const match = /#(?<alias>[^/]+)?/g.exec(window.location.hash);
   const selectedProblem = match?.groups?.alias;
 
   const initialStudent = payload.students.find(

--- a/frontend/www/js/omegaup/course/student.ts
+++ b/frontend/www/js/omegaup/course/student.ts
@@ -8,16 +8,24 @@ import Vue from 'vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.StudentProgressPayload();
 
-  let initialStudent: types.StudentProgress | null = null;
-  if (payload.students && payload.students.length > 0) {
-    initialStudent = payload.students[0];
-    for (const student of payload.students) {
-      if (student.username == payload.student) {
-        initialStudent = student;
-        break;
-      }
-    }
-  }
+  const match = /#(?<alias>[^/]+)?/g.exec(
+    window.location.hash,
+  );
+  const selectedProblem = match?.groups?.alias;
+
+  const initialStudent = payload.students.find(
+    (student) => payload.student === student.username,
+  );
+
+  const initialAssignment = payload.course.assignments.find(
+    (assignment) => payload.assignment === assignment.alias,
+  );
+
+  const initialProblem = payload.problems.find(
+    (problem) => selectedProblem === problem.alias,
+  );
+
+  const problems: types.CourseProblem[] = payload.problems;
 
   const viewStudent = new Vue({
     el: '#main-container',
@@ -25,14 +33,16 @@ OmegaUp.on('ready', () => {
       'omegaup-course-viewstudent': course_ViewStudent,
     },
     data: () => ({
-      problems: [] as types.CourseProblem[],
+      problems,
     }),
     render: function (createElement) {
       return createElement('omegaup-course-viewstudent', {
         props: {
           assignments: payload.course.assignments,
           course: payload.course,
-          initialStudent: initialStudent,
+          initialStudent,
+          initialAssignment,
+          initialProblem,
           problems: this.problems,
           students: payload.students,
         },


### PR DESCRIPTION
# Descripción

La barra de progreso que aparece en la tabla con los problemas de un curso ahora es clickable y redirige `https://omegaup.com/course/<COURSE_ALIAS>/student/<USERNAME>/` con los datos correspondientes al cuadro clickeado

![Feature4649](https://user-images.githubusercontent.com/48113838/130702263-c22da04b-e34b-49f8-8eff-7e8ab05547f8.gif)

Fixes: #4649

# Comentarios

Hay un bug que sucede cuando cambio de estudiante en el combobox. La página se actualiza automáticamente al usuario que se seleccionó previamente si se intenta navegar en las pestañas de problemas.

![Feature4649-2](https://user-images.githubusercontent.com/48113838/130702512-444f83aa-a1d5-493f-ac11-54ac30086951.gif)

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
