### PR TITLE
Modifiqué consulta de problemas resueltos en el perfil para que no considere los del owner

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -626,8 +626,6 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 Runs r ON r.run_id = s.current_run_id
             INNER JOIN
                 Identities i ON i.identity_id = s.identity_id
-            INNER JOIN
-                Users u ON u.user_id = i.user_id
             WHERE
                 r.verdict = "AC" AND s.type = "normal" AND s.identity_id = ?
                 AND NOT EXISTS (
@@ -637,7 +635,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                         `Problems_Forfeited` AS `pf`
                     WHERE
                         `pf`.`problem_id` = `p`.`problem_id` AND
-                        `pf`.`user_id` = `u`.`user_id`
+                        `pf`.`user_id` = `i`.`user_id` AND
+                        `i`.`user_id` IS NOT NULL
                 )
                 AND NOT EXISTS (
                     SELECT
@@ -646,7 +645,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                         `ACLs` AS `a`
                     WHERE
                         `a`.`acl_id` = `p`.`acl_id` AND
-                        `a`.`owner_id` = `u`.`user_id`
+                        `a`.`owner_id` = `i`.`user_id` AND
+                        `i`.`user_id` IS NOT NULL
                 )
             GROUP BY
                 p.problem_id

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -624,8 +624,30 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 Submissions s ON s.problem_id = p.problem_id
             INNER JOIN
                 Runs r ON r.run_id = s.current_run_id
+            INNER JOIN
+                Identities i ON i.identity_id = s.identity_id
+            INNER JOIN
+                Users u ON u.user_id = i.user_id
             WHERE
                 r.verdict = "AC" AND s.type = "normal" AND s.identity_id = ?
+                AND NOT EXISTS (
+                    SELECT
+                        `pf`.`problem_id`, `pf`.`user_id`
+                    FROM
+                        `Problems_Forfeited` AS `pf`
+                    WHERE
+                        `pf`.`problem_id` = `p`.`problem_id` AND
+                        `pf`.`user_id` = `u`.`user_id`
+                )
+                AND NOT EXISTS (
+                    SELECT
+                        `a`.`acl_id`
+                    FROM
+                        `ACLs` AS `a`
+                    WHERE
+                        `a`.`acl_id` = `p`.`acl_id` AND
+                        `a`.`owner_id` = `u`.`user_id`
+                )
             GROUP BY
                 p.problem_id
             ORDER BY


### PR DESCRIPTION
# Descripción

Modifiqué la consulta que selecciona los problemas resueltos por un usuario para que no tome en cuenta los problemas resueltos que fueron creados por el mismo usuario ni los problemas que están en la tabla `Problems_Forfeited`, así como se hace en https://github.com/omegaup/omegaup/blob/main/stuff/cron/update_ranks.py para que la cantidad de problemas del ranking sea la misma a la del perfil. 

![problemas](https://user-images.githubusercontent.com/48114972/131024620-2a72bbe7-365c-4770-84fc-eaa898979388.gif)

Fixes: #5642

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
