### PR TITLE
Texto del tooltip se muestra sin etiquetas HTML

### DIFF
--- a/frontend/www/js/omegaup/components/course/StudentProgress.vue
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.vue
@@ -63,10 +63,7 @@ import * as ui from '../../ui';
 import T from '../../lang';
 import 'v-tooltip/dist/v-tooltip.css';
 import { VTooltip } from 'v-tooltip';
-import * as markdown from '../../markdown';
 import user_Username from '../user/Username.vue';
-
-const markdownConverter = new markdown.Converter();
 
 @Component({
   directives: {
@@ -214,14 +211,12 @@ export default class StudentProgress extends Vue {
     assignmentAlias: string,
     problemAlias: string,
   ): string {
-    return markdownConverter.makeHtml(
-      ui.formatString(T.studentProgressTooltipDescription, {
-        problem: this.problemTitles[problemAlias],
-        score: this.getScore(assignmentAlias, problemAlias),
-        points: this.getPoints(assignmentAlias, problemAlias),
-        progress: this.getProgress(assignmentAlias, problemAlias),
-      }),
-    );
+    return ui.formatString(T.studentProgressTooltipDescription, {
+      problem: this.problemTitles[problemAlias],
+      score: this.getScore(assignmentAlias, problemAlias),
+      points: this.getPoints(assignmentAlias, problemAlias),
+      progress: '-> ' + this.getProgress(assignmentAlias, problemAlias),
+    });
   }
 
   get studentProgressUrl(): string {


### PR DESCRIPTION
# Descripción

El texto del Tooltip del progreso del estudiante se muestra sin las etiquetas `<p>`

![image](https://user-images.githubusercontent.com/48113838/131042432-c6476b15-a836-418e-af61-094a65dd592a.png)

Fixes: #5633

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
