### PR TITLE
Se verifica si 'cat' esta entre los lenguajes seleccionados para el concurso

### DIFF
--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -263,6 +263,9 @@ export default class CourseDetails extends Vue {
   }
 
   onSubmit(): void {
+    if (!this.selectedLanguages?.includes('cat')) {
+      this.selectedLanguages?.push('cat');
+    }
     this.$emit('submit', this);
   }
 


### PR DESCRIPTION
# Descripción

Cada vez que se agrega un concurso, se verifica si `cat` está presente entre los lenguajes de programación seleccionados. En caso de no estarlo, se agrega a la lista de lenguajes seleccionados.

Fixes: #5286

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
