### PR TITLE
cambio validación problemsetProblems vacío en autocomplete de envíos de concurso

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -425,7 +425,7 @@ export default class Runs extends Vue {
 
   // eslint-disable-next-line no-undef -- This is defined in TypeScript.
   initProblemAutocomplete(el: JQuery<HTMLElement>) {
-    if (this.problemsetProblems.length !== 0) {
+    if (this.problemsetProblems !== null) {
       typeahead.problemsetProblemTypeahead(
         el,
         () => this.problemsetProblems,

--- a/frontend/www/js/omegaup/components/arena/Runsv2.vue
+++ b/frontend/www/js/omegaup/components/arena/Runsv2.vue
@@ -434,7 +434,7 @@ export default class Runsv2 extends Vue {
 
   // eslint-disable-next-line no-undef -- This is defined in TypeScript.
   initProblemAutocomplete(el: JQuery<HTMLElement>) {
-    if (this.problemsetProblems.length !== 0) {
+    if (this.problemsetProblems !== null) {
       typeahead.problemsetProblemTypeahead(
         el,
         () => this.problemsetProblems,


### PR DESCRIPTION
# Descripción

Creo que cuando se inicializa el autocomplete de problemas en los envíos de un concurso, la prop que tiene los problemas del concurso aún no los recibe(?) por lo que cambié la validación de `this.problemsetProblems.length !== 0` a `this.problemsetProblems !== null` ya que para cuando se ejecutaba `initProblemAutocomplete()`, `Problems.length` siempre era 0.

Fixes: #3861 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
