### PR TITLE
datafix cambiar status incorrecto de veredictos viejos en QualityNominations

### DIFF
--- a/frontend/database/185_qualitynomination_modify_incorrect_status.sql
+++ b/frontend/database/185_qualitynomination_modify_incorrect_status.sql
@@ -1,0 +1,11 @@
+UPDATE `QualityNominations` AS `qn`
+INNER JOIN `Problems` AS `p` ON `qn`.`problem_id` = `p`.`problem_id`
+SET `qn`.`status` = 'banned'
+WHERE `qn`.`status` = 'resolved'
+AND `p`.`visibility` <= -2;
+
+UPDATE `QualityNominations` AS `qn`
+INNER JOIN `Problems` AS `p` ON `qn`.`problem_id` = `p`.`problem_id`
+SET `qn`.`status` = 'resolved'
+WHERE `qn`.`status` = 'banned'
+AND `p`.`visibility` >= -1;

--- a/frontend/database/185_qualitynomination_modify_incorrect_status.sql
+++ b/frontend/database/185_qualitynomination_modify_incorrect_status.sql
@@ -1,11 +1,13 @@
 UPDATE `QualityNominations` AS `qn`
 INNER JOIN `Problems` AS `p` ON `qn`.`problem_id` = `p`.`problem_id`
 SET `qn`.`status` = 'banned'
-WHERE `qn`.`status` = 'resolved'
+WHERE `qn`.`nomination` = 'demotion'
+AND `qn`.`status` = 'resolved'
 AND `p`.`visibility` <= -2;
 
 UPDATE `QualityNominations` AS `qn`
 INNER JOIN `Problems` AS `p` ON `qn`.`problem_id` = `p`.`problem_id`
 SET `qn`.`status` = 'resolved'
-WHERE `qn`.`status` = 'banned'
+WHERE `qn`.`nomination` = 'demotion'
+AND `qn`.`status` = 'banned'
 AND `p`.`visibility` >= -1;

--- a/frontend/database/185_qualitynomination_modify_incorrect_status.sql
+++ b/frontend/database/185_qualitynomination_modify_incorrect_status.sql
@@ -3,7 +3,7 @@ INNER JOIN `Problems` AS `p` ON `qn`.`problem_id` = `p`.`problem_id`
 SET `qn`.`status` = 'banned'
 WHERE `qn`.`nomination` = 'demotion'
 AND `qn`.`status` = 'resolved'
-AND `p`.`visibility` <= -2;
+AND (`p`.`visibility` = -3 OR `p`.`visibility` = -2);
 
 UPDATE `QualityNominations` AS `qn`
 INNER JOIN `Problems` AS `p` ON `qn`.`problem_id` = `p`.`problem_id`


### PR DESCRIPTION
# Descripción

Agregué script que modifica la tabla de nominaciones para corregir status incorrectos de registros viejos.

Fixes: #5002

# Comentarios

No estoy seguro cuáles visibilidades de los problemas hacen a un problema "activo", creo que para la situación del issue sólo es necesario considerar las visibilidades `public` y `private` (no baneadas), pero por ahora también incluí las visibilidades con `warning ` y la de `promoted`.

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
