### PR TITLE
Agregando los detalles de envíos y problema en el payload de ContestDetails

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -24,6 +24,8 @@ rewrite ^/arena/([a-zA-Z0-9_+-]+)/print/?$ /arena/contestprint.php?alias=$1 last
 rewrite ^/arena/[a-zA-Z0-9_+-]+/admin/?$ /arena/contestadmin.php last;
 rewrite ^/arena/[a-zA-Z0-9_+-]+/scoreboard/[a-zA-Z0-9_+-]+/?$ /arena/scoreboard.php last;
 rewrite ^/arena/([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1 last;
+rewrite ^/arena/([a-zA-Z0-9_+-]+)/([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1&problem_alias=$2 last;
+rewrite ^/arena/([a-zA-Z0-9_+-]+)/([a-zA-Z0-9_+-]+)/show-run/([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1&problem_alias=$2&guid=$3 last;
 rewrite ^/arena/([a-zA-Z0-9_+-]+)/practice/?$ /arena/contest_practice.php?contest_alias=$1 last;
 rewrite ^/badge/list/?$ /badge/list.php last;
 rewrite ^/badge/([a-zA-Z0-9_-]+)/?$ /badge.php?badge_alias=$1 last;

--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -24,8 +24,8 @@ rewrite ^/arena/([a-zA-Z0-9_+-]+)/print/?$ /arena/contestprint.php?alias=$1 last
 rewrite ^/arena/[a-zA-Z0-9_+-]+/admin/?$ /arena/contestadmin.php last;
 rewrite ^/arena/[a-zA-Z0-9_+-]+/scoreboard/[a-zA-Z0-9_+-]+/?$ /arena/scoreboard.php last;
 rewrite ^/arena/([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1 last;
-rewrite ^/arena/([a-zA-Z0-9_+-]+)/([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1&problem_alias=$2 last;
-rewrite ^/arena/([a-zA-Z0-9_+-]+)/([a-zA-Z0-9_+-]+)/show-run/([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1&problem_alias=$2&guid=$3 last;
+rewrite ^/arena/([a-zA-Z0-9_+-]+)/((?!(practice)|(virtual)))([a-zA-Z0-9_+-]+)/?$ /arena/contest.php?contest_alias=$1&problem_alias=$2 last;
+rewrite ^/arena/([a-zA-Z0-9_+-]+)/((?!(practice)|(virtual)))([a-zA-Z0-9_+-]+)/show-run/([a-f0-9]+)/?$ /arena/contest.php?contest_alias=$1&problem_alias=$2&guid=$3 last;
 rewrite ^/arena/([a-zA-Z0-9_+-]+)/practice/?$ /arena/contest_practice.php?contest_alias=$1 last;
 rewrite ^/badge/list/?$ /badge/list.php last;
 rewrite ^/badge/([a-zA-Z0-9_-]+)/?$ /badge.php?badge_alias=$1 last;

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -764,7 +764,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $navbarProblem = array_filter(
                     $commonDetails['problems'],
                     fn ($problem) => ($problem['alias'] === $problemAlias)
-                )[0];
+                );
             }
             $result['smartyProperties']['payload'] = array_merge(
                 $result['smartyProperties']['payload'],
@@ -774,7 +774,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     'guid' => $guid,
                     'problemDetails' => $problemDetails,
                     'runDetails' => $runDetails,
-                    'problem' => $navbarProblem,
+                    'problem' => !is_null(
+                        $navbarProblem
+                    ) ? array_shift(
+                        $navbarProblem
+                    ) : null,
                     'scoreboard' => self::getScoreboard(
                         $contest,
                         $problemset,

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2532,7 +2532,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      *
      * @return array{problem: null|\OmegaUp\DAO\VO\Problems, problemset: null|\OmegaUp\DAO\VO\Problemsets}
      */
-    private static function getValidProblemAndProblemset(
+    public static function getValidProblemAndProblemset(
         ?\OmegaUp\DAO\VO\Identities $identity,
         ?string $contestAlias,
         string $problemAlias,
@@ -2560,7 +2560,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      *
      * @return ProblemDetails
      */
-    private static function getProblemDetails(
+    public static function getProblemDetails(
         ?\OmegaUp\DAO\VO\Identities $loggedIdentity,
         \OmegaUp\DAO\VO\Problems $problem,
         ?\OmegaUp\DAO\VO\Problemsets $problemset,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -317,6 +317,54 @@ export namespace types {
               })(x.scoreboard);
             return x;
           })(x.original);
+        if (x.problemDetails)
+          x.problemDetails = ((x) => {
+            x.creation_date = ((x: number) => new Date(x * 1000))(
+              x.creation_date,
+            );
+            if (x.nextSubmissionTimestamp)
+              x.nextSubmissionTimestamp = ((x: number) => new Date(x * 1000))(
+                x.nextSubmissionTimestamp,
+              );
+            if (x.problemsetter)
+              x.problemsetter = ((x) => {
+                if (x.creation_date)
+                  x.creation_date = ((x: number) => new Date(x * 1000))(
+                    x.creation_date,
+                  );
+                return x;
+              })(x.problemsetter);
+            if (x.runs)
+              x.runs = ((x) => {
+                if (!Array.isArray(x)) {
+                  return x;
+                }
+                return x.map((x) => {
+                  x.time = ((x: number) => new Date(x * 1000))(x.time);
+                  return x;
+                });
+              })(x.runs);
+            if (x.solvers)
+              x.solvers = ((x) => {
+                if (!Array.isArray(x)) {
+                  return x;
+                }
+                return x.map((x) => {
+                  x.time = ((x: number) => new Date(x * 1000))(x.time);
+                  return x;
+                });
+              })(x.solvers);
+            return x;
+          })(x.problemDetails);
+        if (x.runDetails)
+          x.runDetails = ((x) => {
+            if (x.feedback)
+              x.feedback = ((x) => {
+                x.date = ((x: number) => new Date(x * 1000))(x.date);
+                return x;
+              })(x.feedback);
+            return x;
+          })(x.runDetails);
         x.scoreboard = ((x) => {
           if (x.finish_time)
             x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
@@ -2089,12 +2137,17 @@ export namespace types {
     adminPayload?: { allRuns: types.Run[]; users: types.ContestUser[] };
     clarifications: types.Clarification[];
     contest: types.ContestPublicDetails;
+    guid?: string;
     original?: {
       contest: dao.Contests;
       scoreboard?: types.Scoreboard;
       scoreboardEvents?: types.ScoreboardEvent[];
     };
+    problem?: types.NavbarProblemsetProblem;
+    problemAlias?: string;
+    problemDetails?: types.ProblemDetails;
     problems: types.NavbarProblemsetProblem[];
+    runDetails?: types.RunDetails;
     scoreboard: types.Scoreboard;
     scoreboardEvents: types.ScoreboardEvent[];
     shouldShowFirstAssociatedIdentityRunWarning: boolean;


### PR DESCRIPTION
# Descripción

Como parte del refactor de `show-run`, y con la idea de dejar de usar `nextTick` 
en los componentes de Arena, es necesario obtener la información del problema
y del envío (en caso de que se reciban como parámetros) desde el servidor y 
estos se carguen una vez que se obtiene el `payload` en el navegador. 

Anteriormente ese proceso se realizaba del lado del cliente, pero esto ocasionaba 
que no siempre se cargara la información correcta al ser asíncrona.

Para que esto funcione, se tendrán que agregar nuevos `endpoints` con el 
`problemAlias` y con el `runAlias` (guid), mismos que del lado del cliente se
tendrán que enviar en el `pathname` y no en el `hash`.

Part of: #5563

# Comentarios

En caso de ser aprobado este PR, habrá que aplicar estos mismos cambios 
en todos los lugares donde se está utilizando el `nextTick` como workaround, 
hasta el momento serían:
- Course
- ContestPractice
- ContestVirtual

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
