### PR TITLE
adición ancho máximo en colecciones de problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5777,7 +5777,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      *
-     * @return array{smartyProperties: array{payload: CollectionDetailsByLevelPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
+     * @return array{smartyProperties: array{payload: CollectionDetailsByLevelPayload, title: \OmegaUp\TranslationString, fullWidth: bool}, entrypoint: string}
      *
      * @omegaup-request-param string $level
      * @omegaup-request-param null|string $difficulty
@@ -5877,6 +5877,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'title' => new \OmegaUp\TranslationString(
                     'omegaupTitleCollectionsByLevel'
                 ),
+                'fullWidth' => true,
             ],
             'entrypoint' => 'problem_collection_list',
         ];
@@ -6005,7 +6006,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
     /**
      *
-     * @return array{smartyProperties: array{payload: CollectionDetailsByAuthorPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
+     * @return array{smartyProperties: array{payload: CollectionDetailsByAuthorPayload, title: \OmegaUp\TranslationString, fullWidth: bool}, entrypoint: string}
      *
      * @omegaup-request-param null|string $difficulty
      * @omegaup-request-param null|string $difficulty_range
@@ -6097,6 +6098,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'title' => new \OmegaUp\TranslationString(
                     'omegaupTitleCollectionsByAuthor'
                 ),
+                'fullWidth' => true,
             ],
             'entrypoint' => 'problem_collection_list_by_author',
         ];

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="container-fluid p-5">
     <div class="row">
       <div class="col col-md-4 d-flex align-items-center">
         <a href="/problem/collection/" data-nav-problems-collection>{{

--- a/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionListAuthor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="container-fluid p-5">
     <div class="row">
       <div class="col col-md-4 d-flex align-items-center">
         <a href="/problem/collection/" data-nav-problems-collection>{{


### PR DESCRIPTION
# Descripción

Añadiendo `fullWidth` en el controlador de Problemas para las colecciones por niveles y autores. 

![anchoCompletoProblemas](https://user-images.githubusercontent.com/48114972/132437569-21dcab1e-5b74-4a4a-a63d-a6d374d6eed0.PNG)

Fixes: #5686 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
