### PR TITLE
Evitando que '#' se interprete como Markdown en los bloques de código de Markdown

### DIFF
--- a/frontend/www/js/omegaup/markdown.test.ts
+++ b/frontend/www/js/omegaup/markdown.test.ts
@@ -560,6 +560,20 @@ Tags &lt;b&gt;hello&lt;/b&gt;
       ).toEqual(
         '<pre><code class="language-python"><span class="token keyword">def</span> <span class="token function">foo</span><span class="token punctuation">(</span>x<span class="token punctuation">)</span><span class="token punctuation">:</span>\n  <span class="token keyword">return</span> <span class="token number">3</span>\n</code></pre>',
       );
+      expect(
+        converter.makeHtml(
+          '```\n#include <iostream>\n#include <map>\n###\n```',
+        ),
+      ).toEqual(
+        '<pre><code>#include &lt;iostream&gt;\n#include &lt;map&gt;\n###\n</code></pre>',
+      );
+      expect(
+        converter.makeHtml(
+          '```cpp\n#include <iostream>\n#include <map>\n###\n```',
+        ),
+      ).toEqual(
+        '<pre><code class="language-cpp"><span class="token macro property"><span class="token directive-hash">#</span><span class="token directive keyword">include</span> <span class="token string">&lt;iostream></span></span>\n<span class="token macro property"><span class="token directive-hash">#</span><span class="token directive keyword">include</span> <span class="token string">&lt;map></span></span>\n###\n</code></pre>',
+      );
     });
 
     it('Should handle file transclusions', () => {

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -399,23 +399,16 @@ export class Converter {
               .replace(/>/g, '&gt;');
           }
 
-          if (indentation == '') {
-            contents = escapeCharacters(
-              contents,
-              ' \t*_{}[]()<>#+=.!|`-',
-              /*afterBackslash=*/ false,
-              /*doNotEscapeTildeAnDollar=*/ true,
-            );
-            return `<pre><code${className}>${contents}</code></pre>`;
-          }
-
-          const lines = [];
-          const stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
-          for (const line of contents.split('\n')) {
-            lines.push(line.replace(stripPrefix, ''));
+          if (indentation !== '') {
+            // Delete any extra indentation spaces from each line.
+            const stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
+            contents = contents
+              .split('\n')
+              .map((line) => line.replace(stripPrefix, ''))
+              .join('\n');
           }
           contents = escapeCharacters(
-            lines.join('\n'),
+            contents,
             ' \t*_{}[]()<>#+=.!|`-',
             /*afterBackslash=*/ false,
             /*doNotEscapeTildeAnDollar=*/ true,

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -396,7 +396,8 @@ export class Converter {
             contents = contents
               .replace(/&/g, '&amp;')
               .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;');
+              .replace(/>/g, '&gt;')
+              .replace(/#/g, '&num;');
           }
           if (indentation != '') {
             const lines = [];

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -396,22 +396,30 @@ export class Converter {
             contents = contents
               .replace(/&/g, '&amp;')
               .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;')
-              .replace(/#/g, '&num;');
+              .replace(/>/g, '&gt;');
           }
-          if (indentation != '') {
-            const lines = [];
-            const stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
-            for (const line of contents.split('\n')) {
-              lines.push(line.replace(stripPrefix, ''));
-            }
+
+          if (indentation == '') {
             contents = escapeCharacters(
-              lines.join('\n'),
+              contents,
               ' \t*_{}[]()<>#+=.!|`-',
               /*afterBackslash=*/ false,
               /*doNotEscapeTildeAnDollar=*/ true,
             );
+            return `<pre><code${className}>${contents}</code></pre>`;
           }
+
+          const lines = [];
+          const stripPrefix = new RegExp('^ {0,' + indentation.length + '}');
+          for (const line of contents.split('\n')) {
+            lines.push(line.replace(stripPrefix, ''));
+          }
+          contents = escapeCharacters(
+            lines.join('\n'),
+            ' \t*_{}[]()<>#+=.!|`-',
+            /*afterBackslash=*/ false,
+            /*doNotEscapeTildeAnDollar=*/ true,
+          );
           return `<pre><code${className}>${contents}</code></pre>`;
         };
         text = text.replace(


### PR DESCRIPTION
# Descripción

Se escaparon correctamente los caracteres que se encuentran en los bloques de código de markdown que están limitados por backticks ```.

![bloqueCodigoMarkdown](https://user-images.githubusercontent.com/48114972/132633014-93f3911f-fce8-4184-83cb-b5ee29577e52.PNG)

Fixes: #5683

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
