### PR TITLE
Todo ancho lista todos problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4629,7 +4629,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{smartyProperties: array{payload: ProblemListPayload, title: \OmegaUp\TranslationString}, entrypoint: string}
+     * @return array{smartyProperties: array{payload: ProblemListPayload, title: \OmegaUp\TranslationString, fullWidth: bool}, entrypoint: string}
      *
      * @omegaup-request-param null|string $difficulty_range
      * @omegaup-request-param mixed $language
@@ -4720,6 +4720,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'title' => new \OmegaUp\TranslationString(
                     'omegaupTitleProblems'
                 ),
+                'fullWidth' => true,
             ],
             'entrypoint' => 'problem_list',
         ];

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -4,7 +4,7 @@
       {{ T.wordsProblems }}
     </h5>
     <div class="table-responsive">
-      <table class="table mb-0 table-fixed">
+      <table class="table mb-0 table-fixed d-block">
         <thead>
           <tr>
             <th scope="col" class="align-middle text-nowrap">
@@ -308,12 +308,9 @@ table {
   border-spacing: 0;
 }
 
-.table-responsive {
+.table-fixed {
   max-height: 80vh;
   overflow: auto;
-}
-
-.table-fixed {
   thead {
     th {
       position: sticky;

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -4,7 +4,7 @@
       {{ T.wordsProblems }}
     </h5>
     <div class="table-responsive">
-      <table class="table mb-0 table-fixed d-block">
+      <table class="table mb-0 table-fixed">
         <thead>
           <tr>
             <th scope="col" class="align-middle text-nowrap">
@@ -308,9 +308,12 @@ table {
   border-spacing: 0;
 }
 
-.table-fixed {
+.table-responsive {
   max-height: 80vh;
   overflow: auto;
+}
+
+.table-fixed {
   thead {
     th {
       position: sticky;

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="container-fluid p-5">
     <omegaup-problem-search-bar
       :initial-language="language"
       :languages="languages"


### PR DESCRIPTION
# Descripción

Añadiendo fullWidth en el controlador de Problemas para la lista de todos los problemas.

![anchoCompletoListaProblemas0](https://user-images.githubusercontent.com/48114972/132794155-bff07778-64b0-47a0-80f8-a805aa8ad5cc.PNG)

Fixes: #5693 

# Comentarios

A partir como de 1520px de ancho el contenido de la tabla no ocupa el 100%. Al quitar `d-block` de la tabla de `BaseList.vue` se corrige, pero ya no toma en cuenta el `max-height` y `overflow` de `.table-fixed`, si los pongo en `.table-responsive` entonces sí. No sé si sea conveniente hacer esto. 

![anchoCompletoListaProblemas](https://user-images.githubusercontent.com/48114972/132794485-e6fca4b6-c873-46e5-ab50-99d6ed116d4f.PNG)

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
