### PR TITLE
adición de ensureIdentity al mandar llamar las colecciones de problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5798,6 +5798,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $sort_order
      */
     public static function getCollectionsDetailsByLevelForTypeScript(\OmegaUp\Request $r): array {
+        // Authenticate request
+        try {
+            $r->ensureIdentity();
+        } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
+            // Do nothing, we allow unauthenticated users to use this API
+            $r->identity = null;
+        }
+
         $collectionLevel = $r->ensureString('level');
 
         $frequentTags = [];
@@ -6026,6 +6034,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $sort_order
      */
     public static function getCollectionsDetailsByAuthorForTypeScript(\OmegaUp\Request $r): array {
+        // Authenticate request
+        try {
+            $r->ensureIdentity();
+        } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
+            // Do nothing, we allow unauthenticated users to use this API
+            $r->identity = null;
+        }
+
         $authorsRanking = [];
 
         $offset = $r->ensureOptionalInt('offset');


### PR DESCRIPTION
# Descripción

Faltaba agregar `ensureIdentity` al consultar las colecciones de problemas para verificar si el usuario autenticado quiere ocultar las etiquetas de los problemas. 

![sinEtiquetasNiveles](https://user-images.githubusercontent.com/48114972/132921886-c8111050-5d0d-4bda-8075-948a538ac38f.PNG)

![sinEtiquetasAutores](https://user-images.githubusercontent.com/48114972/132921895-bfa2658e-099f-4c1c-a8ff-a988a0ba9811.PNG)

Fixes: #5697 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
