### PR TITLE
Separando un par de funciones con peticiones a la API

### DIFF
--- a/frontend/www/js/omegaup/arena/api_requests.ts
+++ b/frontend/www/js/omegaup/arena/api_requests.ts
@@ -1,0 +1,53 @@
+import { types } from '../api_types';
+import * as api from '../api';
+import * as ui from '../ui';
+import { trackRun } from './submissions';
+import problemsStore from './problemStore';
+
+export async function getRunDetails({
+  guid,
+  response,
+}: {
+  guid: string;
+  response: { runDetails: null | types.RunDetails };
+}): Promise<void> {
+  return api.Run.details({ run_alias: guid })
+    .then((runDetails) => {
+      response.runDetails = runDetails;
+    })
+    .catch((error) => {
+      ui.apiError(error);
+    });
+}
+
+export async function getProblemDetails({
+  problemAlias,
+  contestAlias,
+  problems,
+  response,
+}: {
+  problemAlias: string;
+  contestAlias?: string;
+  problems: types.NavbarProblemsetProblem[];
+  response: { problemInfo: null | types.ProblemInfo };
+}): Promise<void> {
+  return api.Problem.details({
+    problem_alias: problemAlias,
+    prevent_problemset_open: false,
+    contest_alias: contestAlias,
+  })
+    .then((problemInfo) => {
+      for (const run of problemInfo.runs ?? []) {
+        trackRun({ run });
+      }
+      const currentProblem = problems?.find(
+        ({ alias }: { alias: string }) => alias === problemInfo.alias,
+      );
+      problemInfo.title = currentProblem?.text ?? '';
+      response.problemInfo = problemInfo;
+      problemsStore.commit('addProblem', problemInfo);
+    })
+    .catch(() => {
+      ui.dismissNotifications();
+    });
+}


### PR DESCRIPTION
# Descripción

Para hacer más pequeño el PR con el refactor de la función `show-run`, se 
agrega este cambio por separado con la creación de funciones que envían
peticiones a la API y son recurrentes en todos algunos archivos de arena.

Part of: #5563 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
