### PR TITLE
utilizando user.ranking en lugar del index del payload en la tabla Ranking de Coders

### DIFF
--- a/frontend/www/js/omegaup/user/rank.ts
+++ b/frontend/www/js/omegaup/user/rank.ts
@@ -8,8 +8,8 @@ import * as api from '../api';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.UserRankTablePayload();
 
-  const ranking = payload.ranking.rank.map((user, index) => ({
-    rank: index + 1,
+  const ranking = payload.ranking.rank.map((user) => ({
+    rank: user.ranking,
     country: user.country_id,
     username: user.username,
     name: user.name,


### PR DESCRIPTION
# Descripción

Se cambió el índice del payload, que se utilizaba como ranking en la tabla, por el ranking del usuario.

![fixNumeracionCodersRanking](https://user-images.githubusercontent.com/48114972/133519163-dbdaa27a-78b4-42e4-b0f5-b5e0e132c588.gif)

Fixes: #5708 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
