### PR TITLE
Arreglando `formatDelta` para deltas negativos

### DIFF
--- a/frontend/www/js/omegaup/time.test.ts
+++ b/frontend/www/js/omegaup/time.test.ts
@@ -62,6 +62,15 @@ describe('time', () => {
 
   describe('formatDelta', () => {
     it('Should handle valid dates with countdown time format', () => {
+      expect(time.formatDelta(-2500000000)).toEqual('−28:22:26:40');
+      expect(time.formatDelta(-1000000000)).toEqual('−11:13:46:40');
+      expect(time.formatDelta(-100000000)).toEqual('−1:03:46:40');
+      expect(time.formatDelta(-10000000)).toEqual('−02:46:40');
+      expect(time.formatDelta(-1000000)).toEqual('−00:16:40');
+      expect(time.formatDelta(-100000)).toEqual('−00:01:40');
+      expect(time.formatDelta(-10000)).toEqual('−00:00:10');
+      expect(time.formatDelta(-1000)).toEqual('−00:00:01');
+      expect(time.formatDelta(0)).toEqual('00:00:00');
       expect(time.formatDelta(1000)).toEqual('00:00:01');
       expect(time.formatDelta(10000)).toEqual('00:00:10');
       expect(time.formatDelta(100000)).toEqual('00:01:40');

--- a/frontend/www/js/omegaup/time.ts
+++ b/frontend/www/js/omegaup/time.ts
@@ -18,9 +18,13 @@ export function formatFutureDateRelative(futureDate: Date): string {
 }
 
 export function formatDelta(delta: number): string {
+  const sign = delta < 0 ? '−' : '';
+  if (delta < 0) {
+    delta = -delta;
+  }
   const months = delta / (30 * 24 * 60 * 60 * 1000);
   if (months >= 1.0) {
-    return formatFutureDateRelative(new Date(delta + Date.now()));
+    return sign + formatFutureDateRelative(new Date(delta + Date.now()));
   }
 
   const days = Math.floor(delta / (24 * 60 * 60 * 1000));
@@ -31,14 +35,14 @@ export function formatDelta(delta: number): string {
   delta -= minutes * (60 * 1000);
   const seconds = Math.floor(delta / 1000);
 
-  let clock = '';
-
+  let clock = sign;
   if (days > 0) {
     clock += `${days}:`;
   }
-  clock += `${String(hours).padStart(2, '0')}:`;
-  clock += `${String(minutes).padStart(2, '0')}:`;
-  clock += `${String(seconds).padStart(2, '0')}`;
+  clock += `${String(hours).padStart(2, '0')}:${String(minutes).padStart(
+    2,
+    '0',
+  )}:${String(seconds).padStart(2, '0')}`;
 
   return clock;
 }


### PR DESCRIPTION
Esta función no estaba haciendo un buen trabajo para números negativos
porque la aritmética no estaba diseñada para eso.