### PR TITLE
Agregando campo contest_place a tabla Certificates.

### DIFF
--- a/frontend/database/189_contest_place.sql
+++ b/frontend/database/189_contest_place.sql
@@ -1,0 +1,4 @@
+-- Certificates
+ALTER TABLE `Certificates`
+  ADD COLUMN `contest_place` int(11) DEFAULT NULL
+    COMMENT 'Se guarda el lugar en el que quedo un estudiante si es menor o igual a certificate_cutoff';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -94,6 +94,7 @@ CREATE TABLE `Certificates` (
   `course_id` int DEFAULT NULL,
   `contest_id` int DEFAULT NULL,
   `verification_code` varchar(10) NOT NULL COMMENT 'Código de verificación del diploma',
+  `contest_place` int DEFAULT NULL COMMENT 'Se guarda el lugar en el que quedo un estudiante si es menor o igual a certificate_cutoff',
   PRIMARY KEY (`certificate_id`),
   UNIQUE KEY `verification_code` (`verification_code`),
   KEY `identity_id` (`identity_id`),

--- a/frontend/server/src/DAO/Base/Certificates.php
+++ b/frontend/server/src/DAO/Base/Certificates.php
@@ -37,7 +37,8 @@ abstract class Certificates {
                 `certificate_type` = ?,
                 `course_id` = ?,
                 `contest_id` = ?,
-                `verification_code` = ?
+                `verification_code` = ?,
+                `contest_place` = ?
             WHERE
                 (
                     `certificate_id` = ?
@@ -63,6 +64,11 @@ abstract class Certificates {
                 intval($Certificates->contest_id)
             ),
             $Certificates->verification_code,
+            (
+                is_null($Certificates->contest_place) ?
+                null :
+                intval($Certificates->contest_place)
+            ),
             intval($Certificates->certificate_id),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
@@ -90,7 +96,8 @@ abstract class Certificates {
                 `Certificates`.`certificate_type`,
                 `Certificates`.`course_id`,
                 `Certificates`.`contest_id`,
-                `Certificates`.`verification_code`
+                `Certificates`.`verification_code`,
+                `Certificates`.`contest_place`
             FROM
                 `Certificates`
             WHERE
@@ -178,7 +185,8 @@ abstract class Certificates {
                 `Certificates`.`certificate_type`,
                 `Certificates`.`course_id`,
                 `Certificates`.`contest_id`,
-                `Certificates`.`verification_code`
+                `Certificates`.`verification_code`,
+                `Certificates`.`contest_place`
             FROM
                 `Certificates`
         ';
@@ -234,8 +242,10 @@ abstract class Certificates {
                     `certificate_type`,
                     `course_id`,
                     `contest_id`,
-                    `verification_code`
+                    `verification_code`,
+                    `contest_place`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -264,6 +274,11 @@ abstract class Certificates {
                 intval($Certificates->contest_id)
             ),
             $Certificates->verification_code,
+            (
+                is_null($Certificates->contest_place) ?
+                null :
+                intval($Certificates->contest_place)
+            ),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();

--- a/frontend/server/src/DAO/VO/Certificates.php
+++ b/frontend/server/src/DAO/VO/Certificates.php
@@ -23,6 +23,7 @@ class Certificates extends \OmegaUp\DAO\VO\VO {
         'course_id' => true,
         'contest_id' => true,
         'verification_code' => true,
+        'contest_place' => true,
     ];
 
     public function __construct(?array $data = null) {
@@ -80,6 +81,11 @@ class Certificates extends \OmegaUp\DAO\VO\VO {
                 $data['verification_code']
             ) ? strval($data['verification_code']) : '';
         }
+        if (isset($data['contest_place'])) {
+            $this->contest_place = intval(
+                $data['contest_place']
+            );
+        }
     }
 
     /**
@@ -132,4 +138,11 @@ class Certificates extends \OmegaUp\DAO\VO\VO {
      * @var string|null
      */
     public $verification_code = null;
+
+    /**
+     * Se guarda el lugar en el que quedo un estudiante si es menor o igual a certificate_cutoff
+     *
+     * @var int|null
+     */
+    public $contest_place = null;
 }


### PR DESCRIPTION
# Descripción

Se agrego campo contest_place a la tabla certificates.

Si el tipo de certificado es CONTEST y el lugar en el que quedo el estudiante es menor o igual a `certificate_cutoff` entonces en este campo se guarda el lugar en el que quedó. Si no, NULL

Part of: #5259

# Comentarios

Proyecto certificados.

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
