### PR TITLE
Agregando un curso público en stuff/bootstrap.json

### DIFF
--- a/stuff/bootstrap.json
+++ b/stuff/bootstrap.json
@@ -193,9 +193,8 @@
 					"alias": "curso-prueba",
 					"description": "Curso de prueba",
 					"start_time": "$NOW$",
-					"unlimited_duration": "true",
-					"admission_mode": "public",
-					"level": "introductory",
+					"finish_time": "$NOW$+18000",
+					"admission_mode": "private",
 					"school_id": 1,
 					"needs_basic_information": "false",
 					"requests_user_information": "required",
@@ -210,7 +209,7 @@
 					"alias": "tarea-prueba",
 					"description": "Tarea de prueba",
 					"start_time": "$NOW$",
-					"unlimited_duration": "true",
+					"finish_time": "$NOW$+18000",
 					"assignment_type": "homework",
 					"max_points": 0,
 					"order": 1,
@@ -225,7 +224,7 @@
 					"alias": "examen-prueba",
 					"description": "Examen de prueba",
 					"start_time": "$NOW$",
-					"unlimited_duration": "true",
+					"finish_time": "$NOW$+18000",
 					"assignment_type": "test",
 					"max_points": 0,
 					"order": 1,
@@ -261,6 +260,83 @@
 				"params": {
 					"course_alias": "curso-prueba",
 					"assignment_alias": "examen-prueba",
+					"problem_alias": "triangulos"
+				}
+			},
+			{
+				"api": "/course/create/",
+				"params": {
+					"name": "Curso público de prueba",
+					"alias": "curso-publico",
+					"description": "Curso público de prueba",
+					"start_time": "$NOW$",
+					"unlimited_duration": "true",
+					"admission_mode": "public",
+					"school_id": 1,
+					"needs_basic_information": "false",
+					"requests_user_information": "required",
+					"languages": "py2,py3"
+				}
+			},
+			{
+				"api": "/course/createAssignment/",
+				"params": {
+					"course_alias": "curso-publico",
+					"name": "Tarea ilimitada de prueba",
+					"alias": "tarea-ilimitada",
+					"description": "Tarea ilimitada de prueba",
+					"start_time": "$NOW$",
+					"unlimited_duration": "true",
+					"assignment_type": "homework",
+					"max_points": 0,
+					"order": 1,
+					"publish_time_delay": 0
+				}
+			},
+			{
+				"api": "/course/createAssignment/",
+				"params": {
+					"course_alias": "curso-publico",
+					"name": "Examen ilimitado de prueba",
+					"alias": "examen-ilimitado",
+					"description": "Examen ilimitado de prueba",
+					"start_time": "$NOW$",
+					"unlimited_duration": "true",
+					"assignment_type": "test",
+					"max_points": 0,
+					"order": 1,
+					"publish_time_delay": 0
+				}
+			},
+			{
+				"api": "/course/addProblem/",
+				"params": {
+					"course_alias": "curso-publico",
+					"assignment_alias": "tarea-ilimitada",
+					"problem_alias": "sumas"
+				}
+			},
+			{
+				"api": "/course/addProblem/",
+				"params": {
+					"course_alias": "curso-publico",
+					"assignment_alias": "tarea-ilimitada",
+					"problem_alias": "triangulos"
+				}
+			},
+			{
+				"api": "/course/addProblem/",
+				"params": {
+					"course_alias": "curso-publico",
+					"assignment_alias": "examen-ilimitado",
+					"problem_alias": "sumas"
+				}
+			},
+			{
+				"api": "/course/addProblem/",
+				"params": {
+					"course_alias": "curso-publico",
+					"assignment_alias": "examen-ilimitado",
 					"problem_alias": "triangulos"
 				}
 			},
@@ -362,6 +438,20 @@
 				"params": {
 					"usernameOrEmail": "course_test_user_2",
 					"course_alias": "curso-prueba"
+				}
+			},
+			{
+				"api": "/course/addStudent/",
+				"params": {
+					"usernameOrEmail": "course_test_user_0",
+					"course_alias": "curso-publico"
+				}
+			},
+			{
+				"api": "/course/addStudent/",
+				"params": {
+					"usernameOrEmail": "course_test_user_1",
+					"course_alias": "curso-publico"
 				}
 			}
 		]
@@ -539,6 +629,28 @@
 				"params": {
 					"problem_alias": "sumas",
 					"problemset_id": 2,
+					"language": "py3",
+					"source": "print(1)"
+				}
+			}
+		]
+	},
+	{
+		"username": "course_test_user_1",
+		"password": "course_test_user_1",
+		"requests": [
+			{
+				"api": "/course/introDetails/",
+				"params": {
+					"course_alias": "curso-publico"
+				}
+			},
+			{
+				"api": "/run/create/",
+				"fail_ok": true,
+				"params": {
+					"problem_alias": "sumas",
+					"problemset_id": 4,
 					"language": "py3",
 					"source": "print(1)"
 				}

--- a/stuff/bootstrap.json
+++ b/stuff/bootstrap.json
@@ -189,15 +189,15 @@
 			{
 				"api": "/course/create/",
 				"params": {
-					"visibility": 1,
 					"name": "Curso de prueba",
 					"alias": "curso-prueba",
 					"description": "Curso de prueba",
 					"start_time": "$NOW$",
-					"finish_time": "$NOW$+18000",
-					"admission_mode": "private",
+					"unlimited_duration": "true",
+					"admission_mode": "public",
+					"level": "introductory",
 					"school_id": 1,
-					"needs_basic_information": 0,
+					"needs_basic_information": "false",
 					"requests_user_information": "required",
 					"languages": "py2,py3"
 				}
@@ -210,7 +210,7 @@
 					"alias": "tarea-prueba",
 					"description": "Tarea de prueba",
 					"start_time": "$NOW$",
-					"finish_time": "$NOW$+18000",
+					"unlimited_duration": "true",
 					"assignment_type": "homework",
 					"max_points": 0,
 					"order": 1,
@@ -225,7 +225,7 @@
 					"alias": "examen-prueba",
 					"description": "Examen de prueba",
 					"start_time": "$NOW$",
-					"finish_time": "$NOW$+18000",
+					"unlimited_duration": "true",
 					"assignment_type": "test",
 					"max_points": 0,
 					"order": 1,


### PR DESCRIPTION
# Descripción

Tenerlo como público y con duración ilimitada hace que se pueda seguir haciendo pruebas con el curso incluso despúes de su fecha de finalización, y lo hace accesible desde cualquier vista de Cursos.

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
