### PR TITLE
Arreglando un tipo para que `./stuff/runtests.sh` pueda correr

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -438,7 +438,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                         i.username,
                         i.name,
                         IFNULL(i.country_id, 'xx') AS country_id,
-                        IFNULL(ri.is_invited, FALSE) AS is_invited,
+                        CAST(IFNULL(ri.is_invited, FALSE) AS UNSIGNED) AS is_invited,
                         $classNameQuery
                     FROM
                         (

--- a/stuff/mysql_types.sh
+++ b/stuff/mysql_types.sh
@@ -7,6 +7,11 @@ set -e
 
 OMEGAUP_ROOT=$(/usr/bin/git rev-parse --show-toplevel)
 
+# Clean up anything that might have been left from a previous run.
+if [[ -d "${OMEGAUP_ROOT}/frontend/tests/runfiles/" ]]; then
+	find "${OMEGAUP_ROOT}/frontend/tests/runfiles/" -mindepth 2 -name mysql_types.log -exec rm -f {} \;
+fi
+
 "${OMEGAUP_ROOT}/vendor/bin/phpunit" \
 	--bootstrap "${OMEGAUP_ROOT}/frontend/tests/bootstrap.php" \
 	--configuration="${OMEGAUP_ROOT}/frontend/tests/phpunit.xml" \
@@ -17,7 +22,7 @@ sort --unique \
 	--output "${OMEGAUP_ROOT}/frontend/tests/runfiles/mysql_types.log" \
 	"${OMEGAUP_ROOT}"/frontend/tests/runfiles/*/mysql_types.log
 
-rm "${OMEGAUP_ROOT}"/frontend/tests/runfiles/*/mysql_types.log
+find "${OMEGAUP_ROOT}/frontend/tests/runfiles/" -mindepth 2 -name mysql_types.log -exec rm -f {} \;
 
 python3 "${OMEGAUP_ROOT}/stuff/process_mysql_return_types.py" \
 	"${OMEGAUP_ROOT}/frontend/tests/runfiles/mysql_types.log"

--- a/stuff/runtests.sh
+++ b/stuff/runtests.sh
@@ -25,7 +25,7 @@ fi
 # This runs the controllers + badges PHPUnit tests, as well as the MySQL return
 # type check.
 "${OMEGAUP_ROOT}/stuff/mysql_types.sh"
-"${OMEGAUP_ROOT}/vendor/bin/psalm" --update-baseline --show-info=false
+"${OMEGAUP_ROOT}/vendor/bin/psalm" --show-info=false
 
 if [[ "${IN_DOCKER}" == 1 ]]; then
 	echo "Please run \`./stuff/lint.sh ${REF}\` outside the container after this."


### PR DESCRIPTION
Este cambio hace que `./stuff/runtests.sh` pueda volver a correr localmente.

Fixes: #5802