### PR TITLE
Asegurando que solo el CotM top 1 no pueda ser escogido hasta en un año.

### DIFF
--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -508,6 +508,13 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         ] = \OmegaUp\Test\Factories\User::createUser();
         self::updateIdentity($identity, $gender);
 
+        // User "B" is always the second one in the ranking based on score
+        [
+            'user' => $userBLastyear,
+            'identity' => $identityB,
+        ] = \OmegaUp\Test\Factories\User::createUser();
+        self::updateIdentity($identityB, $gender);
+
         // Using the first day of the month as "today" to avoid failures near
         // certain dates.
         $today = date('Y-m-01', \OmegaUp\Time::get());
@@ -521,6 +528,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $runCreationDate = date_format($runCreationDate, 'Y-m-d');
         $this->createRuns($identity, $runCreationDate, 10 /*numRuns*/);
+        $this->createRuns($identityB, $runCreationDate, 5 /*numRuns*/);
         \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
 
         $runCreationDate = date_create($runCreationDate);
@@ -532,9 +540,11 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $runCreationDate = date_format($runCreationDate, 'Y-m-d');
         $this->createRuns($identity, $runCreationDate, 10 /*numRuns*/);
+        $this->createRuns($identityB, $runCreationDate, 5 /*numRuns*/);
         \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
 
         $this->createRuns($identity, $today, 10 /*numRuns*/);
+        $this->createRuns($identityB, $runCreationDate, 5 /*numRuns*/);
         \OmegaUp\Test\Utils::runUpdateRanks($today);
 
         // Getting Coder Of The Month
@@ -553,7 +563,11 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             '-11 month',
             $category
         );
-        $this->assertNull($responseCoder['coderinfo']);
+        // IdentityB is the CotM as Identity has already been selected.
+        $this->assertEquals(
+            $identityB->username,
+            $responseCoder['coderinfo']['username']
+        );
 
         $responseCoder = $this->getCoderOfTheMonth(
             $today,

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -611,7 +611,8 @@ def update_coder_of_the_month_candidates(
             (
               SELECT
                 user_id,
-                MAX(time) latest_time,
+                MIN(ranking) best_ranking,
+                time,
                 selected_by
               FROM
                 Coder_Of_The_Month
@@ -619,11 +620,14 @@ def update_coder_of_the_month_candidates(
                 category = %s
               GROUP BY
                 user_id,
-                selected_by
+                selected_by,
+                time
+              HAVING
+                best_ranking = 1
             ) AS cm on i.user_id = cm.user_id
           WHERE
             (cm.user_id IS NULL OR
-            DATE_ADD(cm.latest_time, INTERVAL 1 YEAR) < %s) AND
+            DATE_ADD(cm.time, INTERVAL 1 YEAR) < %s) AND
             i.user_id IS NOT NULL
             {gender_clause}
           GROUP BY


### PR DESCRIPTION
Fixes: #5840


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
