### PR TITLE
Construyendo imágenes de Docker para k8s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,20 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Build Docker image
+        run: |
+          USE_BUILDKIT=1 TAG=${{ github.sha }} docker-compose \
+            --file docker-compose.k8s.yml \
+            build \
+            --build-arg="BRANCH=${{ steps.extract_branch.outputs.branch }}" \
+            --build-arg="COMMIT=${{ github.sha }}" \
+            frontend php nginx
+
       - name: Install Python dependencies
         run: |
           python3 -m pip install --user setuptools

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -50,3 +55,20 @@ jobs:
             --url https://api.github.com/repos/${{ github.repository }}/deployments \
             --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             --data "{\"ref\":\"${{ github.ref }}\",\"required_contexts\":[],\"environment\":\"${ENVIRONMENT}\",\"auto_merge\":false}"
+
+      - name: Build Docker image
+        run: |
+          USE_BUILDKIT=1 TAG=${{ github.sha }} docker-compose \
+            --file docker-compose.k8s.yml \
+            build \
+            --build-arg="BRANCH=${{ steps.extract_branch.outputs.branch }}" \
+            --build-arg="COMMIT=${{ github.sha }}" \
+            frontend php nginx
+
+      - name: Push container images to Docker registry
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | \
+              docker login "--username=${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          docker push "omegaup/frontend:${{ github.sha }}"
+          docker push "omegaup/php:${{ github.sha }}"
+          docker push "omegaup/nginx:${{ github.sha }}"

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -28,7 +28,18 @@ USER ubuntu
 WORKDIR /opt/omegaup
 ARG BRANCH=release
 ENV BRANCH=$BRANCH
-RUN git clone --branch=${BRANCH} --depth=1 --recurse-submodules --shallow-submodules https://github.com/omegaup/omegaup .
+ARG COMMIT=
+ENV COMMIT=$COMMIT
+RUN if [ -z "${COMMIT}" ]; then \
+      git clone --branch="${BRANCH}" --depth=1 --recurse-submodules --shallow-submodules https://github.com/omegaup/omegaup . ; \
+    else \
+      git clone https://github.com/omegaup/omegaup /tmp/omegaup && \
+      git -C /tmp/omegaup fetch origin "${BRANCH}" && \
+      git -C /tmp/omegaup switch -c "${BRANCH}" FETCH_HEAD && \
+      git -C /tmp/omegaup reset --hard "${COMMIT}" && \
+      git clone --branch="${BRANCH}" --depth=1 --recurse-submodules --shallow-submodules file:///tmp/omegaup . && \
+      rm -rf /tmp/omegaup ; \
+    fi
 RUN yarn install && yarn build
 RUN composer install --no-dev
 


### PR DESCRIPTION
Este cambio hace que cada commit de git en `main` o `release` construyan
una imagen de Docker con el tag siendo el hash del commit.