### PR TITLE
Renombrando frontend-dev-sidecar por frontend-sidecar

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -27,6 +27,7 @@ jobs:
           docker-compose --file=docker-compose.k8s.yml build \
             --build-arg BRANCH=${{ steps.extract_branch.outputs.branch }} \
             frontend \
+            frontend-sidecar \
             nginx \
             php
 
@@ -35,23 +36,24 @@ jobs:
           echo "${{ github.token }}" | \
             docker login https://docker.pkg.github.com "--username=${{ github.actor }}" --password-stdin
 
-          container_name=docker.pkg.github.com/${{ github.repository }}/frontend:${{ github.sha }}
-          docker tag omegaup/frontend:${{ github.sha }} "${container_name}"
-          docker push "${container_name}"
-
-          container_name=docker.pkg.github.com/${{ github.repository }}/nginx:${{ github.sha }}
-          docker tag omegaup/nginx:${{ github.sha }} "${container_name}"
-          docker push "${container_name}"
-
-          container_name=docker.pkg.github.com/${{ github.repository }}/php:${{ github.sha }}
-          docker tag omegaup/php:${{ github.sha }} "${container_name}"
-          docker push "${container_name}"
+          for container in frontend frontend-sidecar nginx php; do
+            for tag in "latest-${{ steps.extract_branch.outputs.branch }}" "${{ github.sha }}"; do
+              container_name="docker.pkg.github.com/${{ github.repository }}/${container}:${tag}"
+              docker tag "omegaup/${container}:${tag}" "${container_name}"
+              docker push "${container_name}"
+            done
+          done
 
       - name: Push containers to Docker registry
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | \
             docker login "--username=${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-          docker push omegaup/frontend:${{ github.sha }}
-          docker push omegaup/nginx:${{ github.sha }}
-          docker push omegaup/php:${{ github.sha }}
+          for container in frontend frontend-sidecar nginx php; do
+            docker push "omegaup/${container}:${tag}"
+
+            container_name="omegaup/${container}:latest-${{ steps.extract_branch.outputs.branch }}"
+            docker tag "omegaup/${container}:${tag}" "${container_name}"
+            docker push "${container_name}"
+            done
+          done

--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -23,9 +23,9 @@ services:
       target: nginx
     image: omegaup/nginx:${TAG:-latest}
 
-  frontend-dev-sidecar:
+  frontend-sidecar:
     build:
       dockerfile: ./Dockerfile.frontend
       context: ./stuff/docker/
-      target: frontend-dev-sidecar
-    image: omegaup/frontend-dev-sidecar:${TAG:-latest}
+      target: frontend-sidecar
+    image: omegaup/frontend-sidecar:${TAG:-latest}

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -86,7 +86,7 @@ EXPOSE 9001
 
 CMD ["php-fpm7.4", "--nodaemonize", "--force-stderr"]
 
-FROM ubuntu:focal as frontend-dev-sidecar
+FROM ubuntu:focal as frontend-sidecar
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \

--- a/stuff/prod/k8s/omegaup/overlays/development/database.yaml
+++ b/stuff/prod/k8s/omegaup/overlays/development/database.yaml
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
       - name: db-migrate
-        image: omegaup/frontend-dev-sidecar:latest
+        image: omegaup/frontend-sidecar:latest
         imagePullPolicy: IfNotPresent
         command: [
           'bash',


### PR DESCRIPTION
Este cambio hace que el sidecar necesario para poder correr las
migraciones de las bases de datos ya no tenga `-dev-` en el nombre.