### PR TITLE
Dejando de cambiar el nombre db-migrate

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -72,7 +72,6 @@ jobs:
              omegaup/nginx:${TAG} \
              omegaup/frontend:${TAG} \
              omegaup/frontend-sidecar:${TAG} &&
-           sed -i "s/db-migrate-.*/db-migrate-${TAG}/" db-migrate-name.yaml &&
            git commit -am "omegaUp sandbox release ${TAG}" &&
            git push)
           rm -rf /tmp/prod


### PR DESCRIPTION
Este cambio hace que db-migrate ya no cambie de nombre. Esto es
necesario porque ahora se usa algo en ArgoCD que no necesita un nuevo
nombre para el hook.