### PR TITLE
Actualizando hook_tools

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -48,6 +48,6 @@ fi
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \
 	--env "MYPYPATH=${OMEGAUP_ROOT}/stuff" \
-	omegaup/hook_tools:20210704 --command-name="./stuff/lint.sh" $ARGS
+	omegaup/hook_tools:20211028 --command-name="./stuff/lint.sh" $ARGS
 
 echo OK


### PR DESCRIPTION
Este cambio incluye más tipos de Python (pika y pytest) en hook_tools.