### PR TITLE
Agregando el contenido de common.analytics inline para eliminar ese archivo

### DIFF
--- a/frontend/templates/common.analytics.tpl
+++ b/frontend/templates/common.analytics.tpl
@@ -1,4 +1,0 @@
-{if $OMEGAUP_GA_TRACK eq 1}
-	<script type="text/javascript" src="{version_hash src="/js/analytics.js"}"></script>
-{/if}
-

--- a/frontend/templates/footer.tpl
+++ b/frontend/templates/footer.tpl
@@ -7,7 +7,9 @@
 	{js_include entrypoint="common_footer"}
 </div>
 
-{include file='common.analytics.tpl' inline}
+{if $OMEGAUP_GA_TRACK eq 1}
+	<script type="text/javascript" src="{version_hash src="/js/analytics.js"}"></script>
+{/if}
 <!-- #root -->
 </body>
 </html>

--- a/frontend/templates/template.tpl
+++ b/frontend/templates/template.tpl
@@ -94,7 +94,9 @@
       {block name="entrypoint"}{/block}
       <div id="main-container"></div>
     </main>
-    {include file='common.analytics.tpl' inline}
+    {if $OMEGAUP_GA_TRACK eq 1}
+      <script type="text/javascript" src="{version_hash src="/js/analytics.js"}"></script>
+    {/if}
     {if $headerPayload.inContest eq false && (!isset($hideFooterAndHeader) || !$hideFooterAndHeader)}
     <div id="common-footer"></div>
     {js_include entrypoint="common_footer_v2"}


### PR DESCRIPTION
# Descripción

Se elimina el archivo `common.analytics.tpl` y el contenido se agrega inline en
los dos archivos donde se utilizaba.

Fixes: #3918 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.