### PR TITLE
Corrigiendo problemas de k8s

### DIFF
--- a/stuff/bootstrap-environment.py
+++ b/stuff/bootstrap-environment.py
@@ -102,11 +102,13 @@ class Session:
                                     files=f.files,
                                     data=data,
                                     cookies=self.jar,
-                                    headers=headers)
+                                    headers=headers,
+                                    timeout=(3, 9))
         else:
             req = requests.get(f'{self.url}/api{api}',
                                cookies=self.jar,
-                               headers=headers)
+                               headers=headers,
+                               timeout=(3, 9))
         cookies: ItemsView[str, str] = req.cookies.items()  # type: ignore
         for name, value in cookies:
             self.jar[name] = value

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -15,7 +15,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        php7.4-fpm php7.4-curl php7.4-mysql php7.4-sqlite3 php7.4-zip \
+        php7.4-fpm php7.4-curl php7.4-mysql php7.4-zip \
         php7.4-mbstring php7.4-json php7.4-opcache php7.4-xml php-apcu \
         nginx git yarn nodejs supervisor python3-jinja2 python3-requests \
         python3-mysqldb python3-pyparsing mysql-client-core-8.0 \

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -63,8 +63,8 @@ FROM ubuntu:focal AS php
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        php7.4-fpm php7.4-curl php7.4-mysql php7.4-sqlite3 php7.4-zip \
-        php7.4-mbstring php7.4-json php7.4-opcache php7.4-xml php-apcu && \
+        php7.4-fpm php7.4-curl php7.4-mysql php7.4-zip \
+        php7.4-mbstring php7.4-json php7.4-opcache php7.4-xml php-apcu php-apcu-bc && \
     apt-get autoremove -y && \
     apt-get clean
 


### PR DESCRIPTION
Este cambio hace dos cosas para mejorar k8s:

* Le agrega un timeout a los requests de
  `stuff/bootstrap-environment.py` para evitar que el contenedor que
  hace eso se quede esperando eternamente.
* Instala el módulo apcu_bc en la imagen de Docker. Esto es para que el
  cache esté habilitado, porque si no, va a ser lentísimo.

Part of: https://github.com/omegaup/prod/issues/2