### PR TITLE
Agregando un par de funcionalidades de la versión anterior de Arena

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -29,7 +29,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ContestPublicDetails=array{admission_mode: string, alias: string, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, partial_score: bool, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int|null, scoreboard: int, show_penalty: bool, default_show_all_contestants_in_scoreboard: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null, window_length: int|null}
  * @psalm-type ContestVirtualDetailsPayload=array{contest: ContestPublicDetails}
  * @psalm-type ContestEditPayload=array{details: ContestAdminDetails, problems: list<ProblemsetProblemWithVersions>, users: list<ContestUser>, groups: list<ContestGroup>, teams_group: ContestGroup|null, requests: list<ContestRequest>, admins: list<ContestAdmin>, group_admins: list<ContestGroupAdmin>}
- * @psalm-type ContestIntroPayload=array{contest: ContestPublicDetails, needsBasicInformation: bool, privacyStatement: PrivacyStatement, requestsUserInformation: string, shouldShowFirstAssociatedIdentityRunWarning: bool}
+ * @psalm-type ContestIntroPayload=array{contest: ContestPublicDetails, needsBasicInformation: bool, privacyStatement: PrivacyStatement, requestsUserInformation: string}
  * @psalm-type ContestListItem=array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: bool, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}
  * @psalm-type ContestList=array{current: list<ContestListItem>, future: list<ContestListItem>, past: list<ContestListItem>}
  * @psalm-type TimeTypeContests=array<string, list<ContestListItem>>
@@ -745,7 +745,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $result = [
             'smartyProperties' => [
                 'payload' => [
-                    'shouldShowFirstAssociatedIdentityRunWarning' => false,
                     'contest' => self::getPublicDetails(
                         $contestWithDirector,
                         $r->identity
@@ -776,7 +775,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 \OmegaUp\DAO\Problemsets::shouldShowFirstAssociatedIdentityRunWarning(
                     $r->user
                 )
-                );
+            );
             if (is_null($r->identity)) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'userNotExist'

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -50,13 +50,13 @@ namespace OmegaUp\Controllers;
  * @psalm-type CourseProblem=array{accepted: int, alias: string, commit: string, difficulty: float, languages: string, letter: string, order: int, points: float, submissions: int, title: string, version: string, visibility: int, visits: int, runs: list<CourseRun>}
  * @psalm-type StudentProgressPayload=array{course: CourseDetails, students: list<StudentProgress>, student: string}
  * @psalm-type StudentProgressByAssignmentPayload=array{course: CourseDetails, students: list<StudentProgress>, student: string, problems: list<CourseProblem>, assignment: string}
- * @psalm-type CourseDetailsPayload=array{details: CourseDetails, progress?: AssignmentProgress, shouldShowFirstAssociatedIdentityRunWarning: bool}
+ * @psalm-type CourseDetailsPayload=array{details: CourseDetails, progress?: AssignmentProgress}
  * @psalm-type PrivacyStatement=array{markdown: string, statementType: string, gitObjectId?: string}
- * @psalm-type IntroCourseDetails=array{details: CourseDetails, progress: array<string, array<string, float>>, shouldShowFirstAssociatedIdentityRunWarning: bool}
- * @psalm-type IntroDetailsPayload=array{course: CourseDetails, isFirstTimeAccess: bool, needsBasicInformation: bool, shouldShowAcceptTeacher: bool, shouldShowFirstAssociatedIdentityRunWarning: bool, shouldShowResults: bool, statements: array{acceptTeacher?: PrivacyStatement, privacy?: PrivacyStatement}, userRegistrationAccepted?: bool|null, userRegistrationAnswered?: bool, userRegistrationRequested?: bool}
+ * @psalm-type IntroCourseDetails=array{details: CourseDetails, progress: array<string, array<string, float>>}
+ * @psalm-type IntroDetailsPayload=array{course: CourseDetails, isFirstTimeAccess: bool, needsBasicInformation: bool, shouldShowAcceptTeacher: bool, shouldShowResults: bool, statements: array{acceptTeacher?: PrivacyStatement, privacy?: PrivacyStatement}, userRegistrationAccepted?: bool|null, userRegistrationAnswered?: bool, userRegistrationRequested?: bool}
  * @psalm-type NavbarProblemsetProblem=array{acceptsSubmissions: bool, alias: string, bestScore: int, hasRuns: bool, maxScore: float|int, text: string}
  * @psalm-type ArenaAssignment=array{alias: string|null, assignment_type: string, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string|null, problems: list<NavbarProblemsetProblem>, problemset_id: int, runs: null|list<Run>, start_time: \OmegaUp\Timestamp}
- * @psalm-type AssignmentDetailsPayload=array{showRanking: bool, scoreboard: Scoreboard, courseDetails: CourseDetails, currentAssignment: ArenaAssignment}
+ * @psalm-type AssignmentDetailsPayload=array{showRanking: bool, scoreboard: Scoreboard, courseDetails: CourseDetails, currentAssignment: ArenaAssignment, shouldShowFirstAssociatedIdentityRunWarning: bool}
  * @psalm-type AssignmentDetails=array{admin: bool, alias: string, assignmentType: string, courseAssignments: list<CourseAssignment>, description: string, director: string, finishTime: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetProblem>, problemsetId: int, startTime: \OmegaUp\Timestamp}
  * @psalm-type CourseScoreboardPayload=array{assignment: AssignmentDetails, problems: list<NavbarProblemsetProblem>, scoreboard: Scoreboard, scoreboardToken:null|string}
  * @psalm-type AddedProblem=array{alias: string, commit?: string, points: float, is_extra_problem?: bool}
@@ -2903,6 +2903,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         return self::getAssignmentDetails(
             $r->identity,
+            $r->user,
             $course,
             $group,
             $assignmentAlias
@@ -4012,7 +4013,6 @@ class Course extends \OmegaUp\Controllers\Controller {
         $detailsResponse = [
             'smartyProperties' => [
                 'payload' => [
-                    'shouldShowFirstAssociatedIdentityRunWarning' => false,
                     'details' => self::getCommonCourseDetails(
                         $course,
                         $r->identity
@@ -4062,6 +4062,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      */
     private static function getAssignmentDetails(
         \OmegaUp\DAO\VO\Identities $currentIdentity,
+        ?\OmegaUp\DAO\VO\Users $currentUser,
         \OmegaUp\DAO\VO\Courses $course,
         \OmegaUp\DAO\VO\Groups $group,
         string $assignmentAlias
@@ -4125,6 +4126,16 @@ class Course extends \OmegaUp\Controllers\Controller {
         return [
             'smartyProperties' => [
                 'payload' => [
+                    'shouldShowFirstAssociatedIdentityRunWarning' => (
+                        !is_null($currentUser) &&
+                        !\OmegaUp\Controllers\User::isMainIdentity(
+                            $currentUser,
+                            $currentIdentity
+                        ) &&
+                        \OmegaUp\DAO\Problemsets::shouldShowFirstAssociatedIdentityRunWarning(
+                            $currentUser
+                        )
+                    ),
                     'showRanking' => \OmegaUp\Controllers\Course::shouldShowScoreboard(
                         $currentIdentity,
                         $course,
@@ -4260,7 +4271,6 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'statements' => $statements,
                 'isFirstTimeAccess' => !$hasSharedUserInformation,
                 'shouldShowResults' => $shouldShowIntro,
-                'shouldShowFirstAssociatedIdentityRunWarning' => false,
             ]
         );
         return [

--- a/frontend/templates/template.tpl
+++ b/frontend/templates/template.tpl
@@ -56,7 +56,7 @@
     {/if}
   </head>
 
-  <body class="d-flex flex-column h-100">
+  <body class="d-flex flex-column h-100{if $smarty.const.OMEGAUP_LOCKDOWN} lockdown{/if}">
     <script type="text/json" id="header-payload">{$headerPayload|json_encode}</script>
     {if !isset($hideFooterAndHeader) || !$hideFooterAndHeader}
       <div id="common-navbar"></div>

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2162,6 +2162,7 @@ export namespace types {
     courseDetails: types.CourseDetails;
     currentAssignment: types.ArenaAssignment;
     scoreboard: types.Scoreboard;
+    shouldShowFirstAssociatedIdentityRunWarning: boolean;
     showRanking: boolean;
   }
 
@@ -2538,7 +2539,6 @@ export namespace types {
     needsBasicInformation: boolean;
     privacyStatement: types.PrivacyStatement;
     requestsUserInformation: string;
-    shouldShowFirstAssociatedIdentityRunWarning: boolean;
   }
 
   export interface ContestList {
@@ -2780,7 +2780,6 @@ export namespace types {
   export interface CourseDetailsPayload {
     details: types.CourseDetails;
     progress?: types.AssignmentProgress;
-    shouldShowFirstAssociatedIdentityRunWarning: boolean;
   }
 
   export interface CourseEditPayload {
@@ -3139,7 +3138,6 @@ export namespace types {
   export interface IntroCourseDetails {
     details: types.CourseDetails;
     progress: { [key: string]: { [key: string]: number } };
-    shouldShowFirstAssociatedIdentityRunWarning: boolean;
   }
 
   export interface IntroDetailsPayload {
@@ -3147,7 +3145,6 @@ export namespace types {
     isFirstTimeAccess: boolean;
     needsBasicInformation: boolean;
     shouldShowAcceptTeacher: boolean;
-    shouldShowFirstAssociatedIdentityRunWarning: boolean;
     shouldShowResults: boolean;
     statements: {
       acceptTeacher?: types.PrivacyStatement;

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -118,10 +118,13 @@ OmegaUp.on('ready', async () => {
       searchResultUsers: [] as types.ListItem[],
       nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
       runDetailsData: runDetails,
+      shouldShowFirstAssociatedIdentityRunWarning:
+        payload.shouldShowFirstAssociatedIdentityRunWarning,
     }),
     render: function (createElement) {
       return createElement('omegaup-arena-contest', {
         props: {
+          lockdown: commonPayload.omegaUpLockDown,
           contest: payload.contest,
           contestAdmin,
           problems: this.problems,
@@ -146,6 +149,8 @@ OmegaUp.on('ready', async () => {
           searchResultUsers: this.searchResultUsers,
           runDetailsData: this.runDetailsData,
           nextSubmissionTimestamp: this.nextSubmissionTimestamp,
+          shouldShowFirstAssociatedIdentityRunWarning: this
+            .shouldShowFirstAssociatedIdentityRunWarning,
         },
         on: {
           'navigate-to-problem': ({
@@ -325,6 +330,12 @@ OmegaUp.on('ready', async () => {
               'resetHash',
               `#${selectedTab}/${alias}`,
             );
+          },
+          'new-submission-popup-displayed': () => {
+            if (this.shouldShowFirstAssociatedIdentityRunWarning) {
+              this.shouldShowFirstAssociatedIdentityRunWarning = false;
+              ui.warning(T.firstSumbissionWithIdentity);
+            }
           },
         },
       });

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -4,6 +4,7 @@ import { types } from '../api_types';
 import * as api from '../api';
 import * as ui from '../ui';
 import Vue from 'vue';
+import T from '../lang';
 import arena_ContestPractice from '../components/arena/ContestPractice.vue';
 import {
   showSubmission,
@@ -63,6 +64,8 @@ OmegaUp.on('ready', async () => {
       problemAlias,
       nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
       runDetailsData: runDetails,
+      shouldShowFirstAssociatedIdentityRunWarning:
+        payload.shouldShowFirstAssociatedIdentityRunWarning,
     }),
     render: function (createElement) {
       return createElement('omegaup-arena-contest-practice', {
@@ -82,6 +85,8 @@ OmegaUp.on('ready', async () => {
           runs: myRunsStore.state.runs,
           nextSubmissionTimestamp: this.nextSubmissionTimestamp,
           runDetailsData: this.runDetailsData,
+          shouldShowFirstAssociatedIdentityRunWarning: this
+            .shouldShowFirstAssociatedIdentityRunWarning,
         },
         on: {
           'navigate-to-problem': ({
@@ -198,6 +203,12 @@ OmegaUp.on('ready', async () => {
               'resetHash',
               `#${selectedTab}/${alias}`,
             );
+          },
+          'new-submission-popup-displayed': () => {
+            if (this.shouldShowFirstAssociatedIdentityRunWarning) {
+              this.shouldShowFirstAssociatedIdentityRunWarning = false;
+              ui.warning(T.firstSumbissionWithIdentity);
+            }
           },
         },
       });

--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -77,6 +77,8 @@ OmegaUp.on('ready', async () => {
       searchResultUsers: [] as types.ListItem[],
       runDetailsData: runDetails,
       nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
+      shouldShowFirstAssociatedIdentityRunWarning:
+        payload.shouldShowFirstAssociatedIdentityRunWarning,
     }),
     render: function (createElement) {
       return createElement('omegaup-arena-course', {
@@ -100,6 +102,8 @@ OmegaUp.on('ready', async () => {
           runDetailsData: this.runDetailsData,
           nextSubmissionTimestamp: this.nextSubmissionTimestamp,
           socketStatus: socketStore.state.socketStatus,
+          shouldShowFirstAssociatedIdentityRunWarning: this
+            .shouldShowFirstAssociatedIdentityRunWarning,
         },
         on: {
           'navigate-to-assignment': ({
@@ -341,6 +345,12 @@ OmegaUp.on('ready', async () => {
                 );
               })
               .catch(ui.error);
+          },
+          'new-submission-popup-displayed': () => {
+            if (this.shouldShowFirstAssociatedIdentityRunWarning) {
+              this.shouldShowFirstAssociatedIdentityRunWarning = false;
+              ui.warning(T.firstSumbissionWithIdentity);
+            }
           },
         },
       });

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -74,6 +74,9 @@
               "
               @submit-run="onRunSubmitted"
               @show-run="onRunDetails"
+              @new-submission-popup-displayed="
+                $emit('new-submission-popup-displayed')
+              "
             >
               <template #quality-nomination-buttons><div></div></template>
               <template #best-solvers-list><div></div></template>
@@ -252,6 +255,9 @@ export default class ArenaContest extends Vue {
   @Prop() searchResultUsers!: types.ListItem[];
   @Prop({ default: null }) runDetailsData!: null | types.RunDetails;
   @Prop({ default: null }) nextSubmissionTimestamp!: Date | null;
+  @Prop({ default: false }) lockdown!: boolean;
+  @Prop({ default: false })
+  shouldShowFirstAssociatedIdentityRunWarning!: boolean;
 
   T = T;
   ui = ui;
@@ -299,6 +305,31 @@ export default class ArenaContest extends Vue {
 
   get urlPractice(): string {
     return `/arena/${this.contest.alias}/practice/`;
+  }
+
+  created() {
+    if (this.lockdown) {
+      window.addEventListener('beforeunload', this.beforeWindowUnload);
+    }
+  }
+
+  beforeDestroy() {
+    if (this.lockdown) {
+      window.removeEventListener('beforeunload', this.beforeWindowUnload);
+    }
+  }
+
+  confirmLeave() {
+    return window.confirm(T.lockdownMessageWarning);
+  }
+
+  beforeWindowUnload(e: BeforeUnloadEvent) {
+    if (!this.confirmLeave()) {
+      // Cancel the event
+      e.preventDefault();
+      // Chrome requires returnValue to be set
+      e.returnValue = true;
+    }
   }
 
   onNavigateToProblem(problem: types.NavbarProblemsetProblem) {

--- a/frontend/www/js/omegaup/components/arena/ContestPractice.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestPractice.vue
@@ -51,6 +51,9 @@
               "
               @submit-run="onRunSubmitted"
               @show-run="onRunDetails"
+              @new-submission-popup-displayed="
+                $emit('new-submission-popup-displayed')
+              "
             >
               <template #quality-nomination-buttons><div></div></template>
               <template #best-solvers-list><div></div></template>
@@ -154,6 +157,8 @@ export default class ArenaContestPractice extends Vue {
   @Prop({ default: () => [] }) runs!: types.Run[];
   @Prop({ default: null }) runDetailsData!: null | types.RunDetails;
   @Prop({ default: null }) nextSubmissionTimestamp!: Date | null;
+  @Prop({ default: false })
+  shouldShowFirstAssociatedIdentityRunWarning!: boolean;
 
   T = T;
   ui = ui;

--- a/frontend/www/js/omegaup/components/arena/Course.vue
+++ b/frontend/www/js/omegaup/components/arena/Course.vue
@@ -92,6 +92,9 @@
                     isDismissed,
                   })
               "
+              @new-submission-popup-displayed="
+                $emit('new-submission-popup-displayed')
+              "
             >
               <template #quality-nomination-buttons>
                 <div></div>
@@ -248,6 +251,8 @@ export default class ArenaCourse extends Vue {
   @Prop({ default: null }) allRuns!: null | types.Run[];
   @Prop({ default: null }) runDetailsData!: types.RunDetails | null;
   @Prop({ default: null }) nextSubmissionTimestamp!: Date | null;
+  @Prop({ default: false })
+  shouldShowFirstAssociatedIdentityRunWarning!: boolean;
 
   T = T;
   PopupDisplayed = PopupDisplayed;

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -498,6 +498,7 @@ export default class ProblemDetails extends Vue {
       return;
     }
     this.currentPopupDisplayed = PopupDisplayed.RunSubmit;
+    this.$emit('new-submission-popup-displayed');
   }
 
   onRunDetails(request: SubmissionRequest, tab: string): void {


### PR DESCRIPTION
# Descripción

Al migrar `Arena` a la plantilla unificada se fueron moviendo cada una de las 
funcionalidades a los nuevos componentes. Hubo un par du funcionalidades
que no se habían implementado, pero al intentar eliminar el archivo donde 
se contenía toda la lógica, aparecieron dos cadenas de traducción que ya
no se estaban utilizando:

- `firstSumbissionWithIdentity`. Cuando una identidad que ya fue ligada a un
   un usuario existente, se le debe mostrar una notificación que está intentando
   realizar envíos desde una identidad y no de un usuario real.
![ShowFirstAssociatedIdentityRunWarning](https://user-images.githubusercontent.com/3230352/139733334-100980a5-3416-436d-b43b-7b0c3aab30df.gif)

- `lockdownMessageWarning`. El modo `LockDown` debería arrojar un mensaje
   de alerta cuando el usuario intenta salir del concurso. 
![LockModeWarnings](https://user-images.githubusercontent.com/3230352/139733521-5f8ba8a7-71cf-4350-ae5d-43ca9227b560.gif)

Part of: #5895 

# Comentarios

En el caso del Modo `LockDown` no estoy logrando que se muestre el mensaje 
personalizado de `omegaUp`, lo único que me aparece es un warning en la consola
de desarrollador, pero no supe como arreglarla. En el demo se muestra el error.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
