### PR TITLE
Instalando el módulo de newrelic para PHP en k8s

### DIFF
--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -62,9 +62,14 @@ FROM ubuntu:focal AS php
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y curl gnupg ca-certificates && \
+    /usr/sbin/update-ca-certificates && \
+    echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' > /etc/apt/sources.list.d/newrelic.list && \
+    curl -sL https://download.newrelic.com/548C16BF.gpg | apt-key add - && \
+    apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        php7.4-fpm php7.4-curl php7.4-mysql php7.4-zip \
-        php7.4-mbstring php7.4-json php7.4-opcache php7.4-xml php-apcu php-apcu-bc && \
+        php7.4-fpm php7.4-curl php7.4-mysql php7.4-zip php7.4-mbstring \
+        php7.4-json php7.4-opcache php7.4-xml php-apcu php-apcu-bc newrelic-php5 && \
     apt-get autoremove -y && \
     apt-get clean
 
@@ -91,8 +96,7 @@ FROM ubuntu:focal as frontend-sidecar
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        curl git ca-certificates python3-jinja2 python3-requests \
-        python3-mysqldb python3-pyparsing mysql-client-core-8.0 && \
+        curl git ca-certificates python3-pip python3-mysqldb mysql-client-core-8.0 && \
     apt-get autoremove -y && \
     apt-get clean
 


### PR DESCRIPTION
Esta era una diferencia entre producción y k8s. Deberíamos de
eliminarla.