### PR TITLE
quitando string del tipo de graduation_date

### DIFF
--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -1109,7 +1109,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
     /**
      * Get identity profile from cache
      *
-     * @return array{birth_date?: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null|string, gravatar_92: null|string, has_competitive_objective?: bool|null, has_learning_objective?: bool|null, has_scholar_objective?: bool|null, has_teaching_objective?: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: string, name: null|string, preferred_language: null|string, rankinfo: array{author_ranking: int|null, name: string|null, problems_solved: int|null, rank: int|null}, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null}
+     * @return array{birth_date?: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null, gravatar_92: null|string, has_competitive_objective?: bool|null, has_learning_objective?: bool|null, has_scholar_objective?: bool|null, has_teaching_objective?: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: string, name: null|string, preferred_language: null|string, rankinfo: array{author_ranking: int|null, name: string|null, problems_solved: int|null, rank: int|null}, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null}
      */
     public static function getProfile(
         ?\OmegaUp\DAO\VO\Identities $loggedIdentity,
@@ -1127,7 +1127,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $response = \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::USER_PROFILE,
             $identity->username,
-            /** @return array{birth_date?: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null|string, gravatar_92: null|string, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null} */
+            /** @return array{birth_date?: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null, gravatar_92: null|string, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null} */
             function () use ($identity, $user) {
                 if (!is_null($user)) {
                     return \OmegaUp\Controllers\User::getProfileImpl(
@@ -1188,7 +1188,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
     /**
      * Returns the profile of the identity given
      *
-     * @return array{birth_date: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, gender: null|string, graduation_date: null|string, gravatar_92: null, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: true, locale: string, name: null|string, preferred_language: null, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null}
+     * @return array{birth_date: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, gender: null|string, graduation_date: \OmegaUp\Timestamp|null, gravatar_92: null, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: true, locale: string, name: null|string, preferred_language: null, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null}
      */
     private static function getProfileImpl(\OmegaUp\DAO\VO\Identities $identity) {
         $extendedProfile = \OmegaUp\DAO\Identities::getExtendedProfileDataByPk(

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -21,7 +21,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type CoderOfTheMonthList=list<array{username: string, country_id: string, gravatar_32: string, date: string, classname: string}>
  * @psalm-type IndexPayload=array{coderOfTheMonthData: array{all: UserProfile|null, female: UserProfile|null}, currentUserInfo: array{username?: string}, userRank: list<CoderOfTheMonth>, schoolOfTheMonthData: array{country_id: null|string, country: null|string, name: string, school_id: int, state: null|string}|null, schoolRank: list<array{name: string, ranking: int, school_id: int, school_of_the_month_id: int, score: float}>}
  * @psalm-type CoderOfTheMonthPayload=array{codersOfCurrentMonth: CoderOfTheMonthList, codersOfPreviousMonth: CoderOfTheMonthList, candidatesToCoderOfTheMonth: list<array{category: string, classname: string, coder_of_the_month_id: int, country_id: string, description: null|string, problems_solved: int, ranking: int, school_id: int|null, score: float, selected_by: int|null, time: string, username: string}>, isMentor: bool, category: string, options?: array{canChooseCoder: bool, coderIsSelected: bool}}
- * @psalm-type UserProfileInfo=array{birth_date?: \OmegaUp\Timestamp|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null|string, gravatar_92: null|string, has_competitive_objective?: bool|null, has_learning_objective?: bool|null, has_scholar_objective?: bool|null, has_teaching_objective?: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{author_ranking: int|null, name: null|string, problems_solved: int|null, rank: int|null}, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null, programming_languages: array<string,string>}
+ * @psalm-type UserProfileInfo=array{birth_date?: \OmegaUp\Timestamp|null, classname: string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null, gravatar_92: null|string, has_competitive_objective?: bool|null, has_learning_objective?: bool|null, has_scholar_objective?: bool|null, has_teaching_objective?: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: null|string, name: null|string, preferred_language: null|string, rankinfo: array{author_ranking: int|null, name: null|string, problems_solved: int|null, rank: int|null}, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null, programming_languages: array<string,string>}
  * @psalm-type ContestParticipated=array{alias: string, title: string, start_time: \OmegaUp\Timestamp, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp}
  * @psalm-type UserProfileContests=array<string, array{data: ContestParticipated, place: int}>
  * @psalm-type UserProfileStats=array{date: null|string, runs: int, verdict: string}
@@ -1405,11 +1405,7 @@ class User extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
-        $response['graduation_date'] = is_null(
-            $userDb['graduation_date']
-        ) ? null : \OmegaUp\DAO\DAO::fromMySQLTimestamp(
-            $userDb['graduation_date']
-        );
+        $response['graduation_date'] = $userDb['graduation_date'];
         $response['email'] = $userDb['email'];
         $response['classname'] = $userDb['classname'];
         $response['country'] = $userDb['country'];
@@ -4002,7 +3998,7 @@ class User extends \OmegaUp\Controllers\Controller {
         }
         $response['smartyProperties']['payload'] = [
             'privateProfile' => false,
-            'profile' => self::getProfileDetails(
+            'profile' => self::getUserProfile(
                 $r->identity,
                 $identity
             ),
@@ -4128,7 +4124,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 );
             }
             $smartyProperties = [
-                'profile' => self::getProfileDetails($r->identity, $identity),
+                'profile' => self::getUserProfile($r->identity, $identity),
                 'PROGRAMMING_LANGUAGES' => \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES,
                 'COUNTRIES' => \OmegaUp\DAO\Countries::getAll(
                     null,
@@ -4189,7 +4185,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 'name'
             ),
             'programmingLanguages' => \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES,
-            'profile' => self::getProfileDetails($r->identity, $identity),
+            'profile' => self::getUserProfile($r->identity, $identity),
             'extraProfileDetails' => [
                 'contests' => self::getContestStats($identity),
                 'solvedProblems' => self::getSolvedProblems(
@@ -4237,7 +4233,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 'payload' => [
                     'email' => $currentSession['email'],
                 ],
-                'profile' => self::getProfileDetails(
+                'profile' => self::getUserProfile(
                     $currentSession['identity'],
                     $identity
                 ),
@@ -4252,27 +4248,6 @@ class User extends \OmegaUp\Controllers\Controller {
             'smartyProperties' => $smartyProperties,
             'template' => 'user.email.edit.tpl',
         ];
-    }
-
-    /**
-     * @return UserProfileInfo
-     */
-    private static function getProfileDetails(
-        ?\OmegaUp\DAO\VO\Identities $loggedIdentity,
-        \OmegaUp\DAO\VO\Identities $identity
-    ) {
-        $response = self::getUserProfile($loggedIdentity, $identity);
-        if (
-            !empty($response['graduation_date'])
-            && is_object($response['graduation_date'])
-        ) {
-            $response['graduation_date'] = gmdate(
-                'Y-m-d',
-                $response['graduation_date']->time
-            ) ?: null;
-        }
-
-        return $response;
     }
 
     /**

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -261,7 +261,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
     }
 
     /**
-     * @return array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: string, email: null|string, gender: null|string, graduation_date: null|string, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, locale: null|string, scholar_degree: null|string, school: null|string, state: null|string, verified: bool|null}|null
+     * @return array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: string, email: null|string, gender: null|string, graduation_date: \OmegaUp\Timestamp|null, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, locale: null|string, scholar_degree: null|string, school: null|string, state: null|string, verified: bool|null}|null
      */
     final public static function getExtendedProfileDataByPk(?int $identityId): ?array {
         if (is_null($identityId)) {
@@ -349,6 +349,9 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
         );
         $identity['birth_date'] = \OmegaUp\DAO\DAO::fromMySQLTimestamp(
             $identity['birth_date']
+        );
+        $identity['graduation_date'] = \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+            $identity['graduation_date']
         );
 
         return $identity;

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -64,7 +64,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
     }
     /**
      * @param int $user_id
-     * @return array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: string, country_id: null|string, email: null|string, gender: null|string, graduation_date: null|string, locale: null|string, school: null|string, school_id: int|null, scholar_degree: null|string, state: null|string, state_id: null|string, hide_problem_tags: bool, verified: bool|null}|null
+     * @return array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: string, country_id: null|string, email: null|string, gender: null|string, graduation_date: \OmegaUp\Timestamp|null, locale: null|string, school: null|string, school_id: int|null, scholar_degree: null|string, state: null|string, state_id: null|string, hide_problem_tags: bool, verified: bool|null}|null
     */
     final public static function getExtendedProfileDataByPk(int $userId): ?array {
         $sql = 'SELECT
@@ -136,7 +136,9 @@ class Users extends \OmegaUp\DAO\Base\Users {
         $user['birth_date'] = \OmegaUp\DAO\DAO::fromMySQLTimestamp(
             $user['birth_date']
         );
-
+        $user['graduation_date'] = \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+            $user['graduation_date']
+        );
         return $user;
     }
 

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -4165,7 +4165,7 @@ export namespace types {
     country_id?: string;
     email?: string;
     gender?: string;
-    graduation_date?: Date | string;
+    graduation_date?: Date;
     gravatar_92?: string;
     has_competitive_objective?: boolean;
     has_learning_objective?: boolean;

--- a/frontend/www/js/omegaup/components/user/BasicInfov2.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInfov2.vue
@@ -129,10 +129,10 @@ export default class UserBasicInfo extends Vue {
   }
 
   get graduationDate(): string {
-    if (this.profile.graduation_date) {
-      return this.profile.graduation_date.toLocaleDateString(T.locale);
+    if (!this.profile.graduation_date) {
+      return '';
     }
-    return '';
+    return this.profile.graduation_date.toLocaleDateString(T.locale);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/user/BasicInfov2.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInfov2.vue
@@ -69,7 +69,7 @@
             <strong>{{ T.profileGraduationDate }}</strong>
           </div>
           <div class="col-sm-9 field-data">
-            <strong>{{ profile.graduation_date }}</strong>
+            <strong>{{ graduationDate }}</strong>
           </div>
         </div>
 
@@ -126,6 +126,13 @@ export default class UserBasicInfo extends Vue {
 
   get urlUsername(): string {
     return `https://omegaup.com/profile/${this.profile.username}/`;
+  }
+
+  get graduationDate(): string {
+    if (this.profile.graduation_date) {
+      return this.profile.graduation_date.toLocaleDateString(T.locale);
+    }
+    return '';
   }
 }
 </script>


### PR DESCRIPTION
# Descripción

Quité `string` del tipo de `graduation_date` en el backend porque era inválido al parsearlo a `Date` en JS.

![graduationDateFix](https://user-images.githubusercontent.com/48114972/140469028-d48e8b64-27df-4427-b066-e26a746996d2.PNG)

Este cambio se había hecho en el PR #5882 pero se separó para partirlo en secciones más pequeñas. 

Fixes: #5243 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
