### PR TITLE
Permitiendo aceptar más dominios para fines de CSRF

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -9,6 +9,7 @@ try_define('OMEGAUP_COOKIE_DOMAIN', '');
 try_define('OMEGAUP_AUTH_TOKEN_COOKIE_NAME', 'ouat');
 try_define('OMEGAUP_MD5_SALT', 'omegaup');
 try_define('OMEGAUP_URL', 'http://localhost');
+try_define('OMEGAUP_CSRF_HOSTS', []);
 try_define('OMEGAUP_ENVIRONMENT', 'production');
 try_define('OMEGAUP_MAINTENANCE', null);
 try_define('OMEGAUP_SESSION_API_HOURLY_LIMIT', 1000);

--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -78,7 +78,7 @@ class ApiCaller {
         $allowedHosts = [
             parse_url(OMEGAUP_URL, PHP_URL_HOST),
             OMEGAUP_LOCKDOWN_DOMAIN,
-        ];
+        ] + OMEGAUP_CSRF_HOSTS;
         return !in_array($referrerHost, $allowedHosts, true);
     }
 


### PR DESCRIPTION
Este cambio hace que sea posible tener más de un nombre de dominio
aceptable para recibir tráfico. Esto hace que cuando se haga la
migración a k8s, se pueda aceptar tráfico como ambos nombres y la
migración sea más suave.