### PR TITLE
Mejorando la manera en la que se monta la configuración de Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,8 +149,13 @@ services:
     expose:
       - '6379'
     volumes:
-      - 'redis:/data'
-      - './stuff/docker/etc/redis/redis.conf:/etc/redis/redis.conf'
+      - type: volume
+        source: redis
+        target: /data
+      - type: bind
+        source: ./stuff/docker/etc/redis/
+        target: /etc/redis
+        read_only: true
     ports:
       - target: 6379
         published: 6379


### PR DESCRIPTION
Este cambio hace que redis monte la configuración no en un archivo, sino
en un directorio.