### PR TITLE
Nueva API para ContestListV2

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -32,6 +32,7 @@
   - [`/api/contest/details/`](#apicontestdetails)
   - [`/api/contest/list/`](#apicontestlist)
   - [`/api/contest/listParticipating/`](#apicontestlistparticipating)
+  - [`/api/contest/listv2/`](#apicontestlistv2)
   - [`/api/contest/myList/`](#apicontestmylist)
   - [`/api/contest/open/`](#apicontestopen)
   - [`/api/contest/problemClarifications/`](#apicontestproblemclarifications)
@@ -840,6 +841,26 @@ Returns a list of contests where current user is participating in
 | Name       | Type              |
 | ---------- | ----------------- |
 | `contests` | `types.Contest[]` |
+
+## `/api/contest/listv2/`
+
+### Description
+
+Returns 3 list of contests (Current, past and future contests)
+
+### Parameters
+
+| Name        | Type     | Description |
+| ----------- | -------- | ----------- |
+| `page`      | `int`    |             |
+| `page_size` | `int`    |             |
+| `query`     | `string` |             |
+
+### Returns
+
+| Name       | Type                |
+| ---------- | ------------------- |
+| `contests` | `types.ContestList` |
 
 ## `/api/contest/myList/`
 

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -376,6 +376,58 @@ export const Contest = {
     })(x.contests);
     return x;
   }),
+  listv2: apiCall<
+    messages.ContestListv2Request,
+    messages._ContestListv2ServerResponse,
+    messages.ContestListv2Response
+  >('/api/contest/listv2/', (x) => {
+    x.contests = ((x) => {
+      x.current = ((x) => {
+        if (!Array.isArray(x)) {
+          return x;
+        }
+        return x.map((x) => {
+          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+          x.last_updated = ((x: number) => new Date(x * 1000))(x.last_updated);
+          x.original_finish_time = ((x: number) => new Date(x * 1000))(
+            x.original_finish_time,
+          );
+          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+          return x;
+        });
+      })(x.current);
+      x.future = ((x) => {
+        if (!Array.isArray(x)) {
+          return x;
+        }
+        return x.map((x) => {
+          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+          x.last_updated = ((x: number) => new Date(x * 1000))(x.last_updated);
+          x.original_finish_time = ((x: number) => new Date(x * 1000))(
+            x.original_finish_time,
+          );
+          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+          return x;
+        });
+      })(x.future);
+      x.past = ((x) => {
+        if (!Array.isArray(x)) {
+          return x;
+        }
+        return x.map((x) => {
+          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+          x.last_updated = ((x: number) => new Date(x * 1000))(x.last_updated);
+          x.original_finish_time = ((x: number) => new Date(x * 1000))(
+            x.original_finish_time,
+          );
+          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+          return x;
+        });
+      })(x.past);
+      return x;
+    })(x.contests);
+    return x;
+  }),
   myList: apiCall<
     messages.ContestMyListRequest,
     messages._ContestMyListServerResponse,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -4418,6 +4418,9 @@ export namespace messages {
   export type ContestListParticipatingRequest = { [key: string]: any };
   export type _ContestListParticipatingServerResponse = any;
   export type ContestListParticipatingResponse = { contests: types.Contest[] };
+  export type ContestListv2Request = { [key: string]: any };
+  export type _ContestListv2ServerResponse = any;
+  export type ContestListv2Response = { contests: types.ContestList };
   export type ContestMyListRequest = { [key: string]: any };
   export type _ContestMyListServerResponse = any;
   export type ContestMyListResponse = { contests: types.Contest[] };
@@ -5284,6 +5287,9 @@ export namespace controllers {
     listParticipating: (
       params?: messages.ContestListParticipatingRequest,
     ) => Promise<messages.ContestListParticipatingResponse>;
+    listv2: (
+      params?: messages.ContestListv2Request,
+    ) => Promise<messages.ContestListv2Response>;
     myList: (
       params?: messages.ContestMyListRequest,
     ) => Promise<messages.ContestMyListResponse>;


### PR DESCRIPTION
# Descripción

Se creó una API para obtener una lista de concursos categorizados en Actuales, pasados y futuros

Fixes: #5382

# Comentarios

No estoy seguro si está bien implementada, Creo que la API sí recibe los datos necesarios:
- Page y Page_Size para saber cuántos problemas cargar cada que se llame la API
- y Query por si se requiere cargar concursos haciendo uso del filtrado por texto

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
