### PR TITLE
Cambiando el nombre de las transacciones New Relic del API

### DIFF
--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -67,8 +67,11 @@ class Request extends \ArrayObject {
      * @return array<int, mixed>|array<string, mixed>
      */
     public function execute(): array {
-        if (is_null($this->method)) {
+        if (is_null($this->method) || is_null($this->methodName)) {
             throw new \OmegaUp\Exceptions\NotFoundException('apiNotFound');
+        }
+        if (extension_loaded('newrelic')) {
+            newrelic_name_transaction("/api/{$this->methodName}");
         }
 
         /** @var mixed */

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -42,6 +42,7 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
             }
             $r = new \OmegaUp\Request($params);
             $r->method = $req['api'];
+            $r->methodName = $req['api'];
             $fullResponse = \OmegaUp\ApiCaller::call($r);
             self::assertEquals(
                 'ok',


### PR DESCRIPTION
Este cambio hace que New Relic pueda distinguir entre todas las APIs.

Fixes: #6053