### PR TITLE
Dejando de obtener la lista de solvers dos veces

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4514,7 +4514,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $problem,
             $problemset,
             \OmegaUp\Controllers\Identity::getPreferredLanguage($r->identity),
-            /*showSolvers=*/true,
+            /*showSolvers=*/false,
             $preventProblemsetOpen,
             $contestAlias
         );


### PR DESCRIPTION
Resulta ser que para obtener los detalles de los problemas, estábamos
calculando la lista de los mejores solvers dos veces! Esto es
ineficiente!