### PR TITLE
Renombrando archivo de NotificationsClarifications

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -307,7 +307,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
-import notifications_Clarifications from '../notification/Clarifications.vue';
+import notifications_Clarifications from '../notification/ClarificationsBs3.vue';
 import common_GraderStatus from '../common/GraderStatus.vue';
 import common_GraderBadge from '../common/GraderBadge.vue';
 

--- a/frontend/www/js/omegaup/components/common/Navbarv2.vue
+++ b/frontend/www/js/omegaup/components/common/Navbarv2.vue
@@ -250,7 +250,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
 import notifications_List from '../notification/List.vue';
-import notifications_Clarifications from '../notification/Clarificationsv2.vue';
+import notifications_Clarifications from '../notification/Clarifications.vue';
 import common_GraderStatus from '../common/GraderStatus.vue';
 import common_GraderBadge from '../common/GraderBadge.vue';
 import user_objectives_questions from '../user/ObjectivesQuestions.vue';

--- a/frontend/www/js/omegaup/components/notification/Clarifications.test.ts
+++ b/frontend/www/js/omegaup/components/notification/Clarifications.test.ts
@@ -60,7 +60,7 @@ describe('Clarifications.vue', () => {
       T.notificationsMarkAllAsRead,
     );
     await wrapper
-      .find('li[data-clarification="1"] button[class="close"]')
+      .find('div[data-clarification="1"] button[class="close"]')
       .trigger('click');
     // There is only one notification, so "Mark as all read" button does not appear
     expect(wrapper.text()).not.toContain(T.notificationsMarkAllAsRead);

--- a/frontend/www/js/omegaup/components/notification/Clarifications.vue
+++ b/frontend/www/js/omegaup/components/notification/Clarifications.vue
@@ -1,67 +1,66 @@
 <template>
-  <li class="dropdown">
+  <li class="nav-item dropdown d-none d-lg-flex align-items-center">
     <audio v-if="isAdmin" ref="notification-audio" data-notification-audio>
       <source src="/media/notification.mp3" type="audio/mpeg" />
     </audio>
     <a
       aria-expanded="false"
       aria-haspopup="true"
-      class="notification-button dropdown-toggle"
+      class="nav-link dropdown-toggle px-2 notification-toggle"
       data-toggle="dropdown"
       href="#"
       role="button"
-      ><span class="glyphicon glyphicon-bell"></span>
+    >
+      <font-awesome-icon :icon="['fas', 'bell']" />
       <span
         v-if="unreadClarifications && unreadClarifications.length > 0"
-        class="notification-counter label"
-        :class="{ 'label-danger': unreadClarifications.length > 0 }"
+        class="badge badge-danger count-badge"
         >{{ unreadClarifications.length }}</span
       ></a
     >
-    <ul class="dropdown-menu">
-      <li
-        v-if="!unreadClarifications || unreadClarifications.length === 0"
-        class="empty"
-      >
+    <div class="dropdown-menu dropdown-menu-right notification-dropdown">
+      <div v-if="unreadClarifications.length === 0" class="text-center">
         {{ T.notificationsNoNewNotifications }}
-      </li>
-      <li v-else>
-        <ul class="notification-drawer">
-          <li
-            v-for="clarification in unreadClarifications"
-            :key="clarification.clarification_id"
-            :data-clarification="clarification.clarification_id"
-          >
+      </div>
+      <transition-group name="list">
+        <div
+          v-for="clarification in unreadClarifications"
+          :key="clarification.clarification_id"
+          :data-clarification="clarification.clarification_id"
+          class="d-flex align-items-center flex-wrap px-4"
+        >
+          <hr class="w-100 my-2" />
+          <div class="w-100 justify-content-between">
             <button
-              :aria-label="T.wordsClose"
               class="close"
-              type="button"
               @click.prevent="onCloseClicked(clarification)"
             >
-              <span aria-hidden="true">×</span>
+              ❌
             </button>
-            <a :href="anchor(clarification)"
-              ><span>{{ clarification.problem_alias }}</span> —
+          </div>
+          <div class="w-100 align-items-center pt-1 notification-link">
+            <a :href="anchor(clarification)">
+              <span>{{ clarification.problem_alias }}</span> —
               <span>{{ clarification.author }}</span>
               <pre>{{ clarification.message }}</pre>
               <template v-if="clarification.answer">
                 <hr />
                 <pre>{{ clarification.answer }}</pre>
-              </template></a
-            >
-          </li>
-        </ul>
-      </li>
+              </template>
+            </a>
+          </div>
+        </div>
+      </transition-group>
       <template v-if="unreadClarifications && unreadClarifications.length > 1">
         <li class="divider" role="separator"></li>
         <li data-mark-all-as-read-button>
           <a href="#" @click.prevent="onMarkAllAsRead"
-            ><span class="glyphicon glyphicon-align-right"></span>
+            ><font-awesome-icon :icon="['fas', 'align-right']" />
             {{ T.notificationsMarkAllAsRead }}</a
           >
         </li>
       </template>
-    </ul>
+    </div>
   </li>
 </template>
 
@@ -70,7 +69,16 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import type { types } from '../../api_types';
 import T from '../../lang';
 
-@Component
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { faBell, faAlignRight } from '@fortawesome/free-solid-svg-icons';
+library.add(faBell, faAlignRight);
+
+@Component({
+  components: {
+    FontAwesomeIcon,
+  },
+})
 export default class Clarifications extends Vue {
   @Prop({ default: () => [] }) clarifications!: types.Clarification[];
 
@@ -135,88 +143,28 @@ export default class Clarifications extends Vue {
 
 <style lang="scss" scoped>
 @import '../../../../sass/main.scss';
-.notification-button {
-  padding-top: 6px !important;
-  padding-bottom: 20px !important;
-  padding-right: 12px !important;
-  padding-left: 12px !important;
-  font-size: 22px;
+
+.close {
+  font-size: inherit;
 }
 
-.notification-counter {
-  position: absolute;
-  font-size: 16px;
-  padding: 2px 4px;
-  bottom: 4px;
-  right: 0;
-}
-
-.notification-drawer::-webkit-scrollbar-track {
-  border-radius: 10px;
-  background-color: var(
-    --notifications-clarifications-scrollbar-track-background-color
-  );
-}
-
-.notification-drawer::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-  background-color: var(
-    --notifications-clarifications-scrollbar-background-color
-  );
-}
-
-.notification-drawer::-webkit-scrollbar-thumb {
-  border-radius: 10px;
-  background-color: var(
-    --notifications-clarifications-scrollbar-thumb-background-color
-  );
-}
-
-.notification-drawer {
-  width: 320px;
-  max-width: 320px;
-  max-height: 380px;
-  overflow-y: scroll;
-}
-
-.notification-drawer li {
-  padding: 3px 20px;
-  list-style: none;
-  border-top: 1px solid
-    var(--notifications-clarifications-drawer-li-border-top-color);
-}
-
-.notification-drawer li a {
-  color: var(--notifications-clarifications-drawer-li-a-font-color);
-  text-decoration: none;
-}
-
-.notification-drawer li a pre {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.notification-drawer li:hover,
-.notification-drawer li:focus,
-.notification-drawer li:active {
+.notification-link {
   cursor: pointer;
-  background-color: var(
-    --notifications-clarifications-drawer-li-background-color--active
-  );
-  text-decoration: none;
+
+  &:hover {
+    background-color: rgba(
+      var(--notifications-notification-link-background-color--hover),
+      0.05
+    );
+  }
 }
 
-.notification-drawer li:hover > a,
-.notification-drawer li:focus > a,
-.notification-drawer li:active > a {
-  color: var(--notifications-clarifications-drawer-li-font-color--active);
-}
-
-.notification-drawer li a > h4,
-.notification-drawer li a > p {
-  word-wrap: break-word;
+pre {
+  padding: 16px;
+  background: var(--markdown-pre-background-color);
+  margin: 1em 0;
+  border-radius: 6px;
+  display: block;
+  line-height: 125%;
 }
 </style>

--- a/frontend/www/js/omegaup/components/notification/ClarificationsBs3.test.ts
+++ b/frontend/www/js/omegaup/components/notification/ClarificationsBs3.test.ts
@@ -2,9 +2,9 @@ import { mount } from '@vue/test-utils';
 import { types } from '../../api_types';
 import T from '../../lang';
 
-import notification_Clarifications from './Clarificationsv2.vue';
+import notification_Clarifications from './ClarificationsBs3.vue';
 
-describe('Clarifications.vue', () => {
+describe('ClarificationsBs3.vue', () => {
   const clarifications = [
     {
       answer: 'yes',
@@ -60,7 +60,7 @@ describe('Clarifications.vue', () => {
       T.notificationsMarkAllAsRead,
     );
     await wrapper
-      .find('div[data-clarification="1"] button[class="close"]')
+      .find('li[data-clarification="1"] button[class="close"]')
       .trigger('click');
     // There is only one notification, so "Mark as all read" button does not appear
     expect(wrapper.text()).not.toContain(T.notificationsMarkAllAsRead);

--- a/frontend/www/js/omegaup/components/notification/ClarificationsBs3.vue
+++ b/frontend/www/js/omegaup/components/notification/ClarificationsBs3.vue
@@ -1,66 +1,67 @@
 <template>
-  <li class="nav-item dropdown d-none d-lg-flex align-items-center">
+  <li class="dropdown">
     <audio v-if="isAdmin" ref="notification-audio" data-notification-audio>
       <source src="/media/notification.mp3" type="audio/mpeg" />
     </audio>
     <a
       aria-expanded="false"
       aria-haspopup="true"
-      class="nav-link dropdown-toggle px-2 notification-toggle"
+      class="notification-button dropdown-toggle"
       data-toggle="dropdown"
       href="#"
       role="button"
-    >
-      <font-awesome-icon :icon="['fas', 'bell']" />
+      ><span class="glyphicon glyphicon-bell"></span>
       <span
         v-if="unreadClarifications && unreadClarifications.length > 0"
-        class="badge badge-danger count-badge"
+        class="notification-counter label"
+        :class="{ 'label-danger': unreadClarifications.length > 0 }"
         >{{ unreadClarifications.length }}</span
       ></a
     >
-    <div class="dropdown-menu dropdown-menu-right notification-dropdown">
-      <div v-if="unreadClarifications.length === 0" class="text-center">
+    <ul class="dropdown-menu">
+      <li
+        v-if="!unreadClarifications || unreadClarifications.length === 0"
+        class="empty"
+      >
         {{ T.notificationsNoNewNotifications }}
-      </div>
-      <transition-group name="list">
-        <div
-          v-for="clarification in unreadClarifications"
-          :key="clarification.clarification_id"
-          :data-clarification="clarification.clarification_id"
-          class="d-flex align-items-center flex-wrap px-4"
-        >
-          <hr class="w-100 my-2" />
-          <div class="w-100 justify-content-between">
+      </li>
+      <li v-else>
+        <ul class="notification-drawer">
+          <li
+            v-for="clarification in unreadClarifications"
+            :key="clarification.clarification_id"
+            :data-clarification="clarification.clarification_id"
+          >
             <button
+              :aria-label="T.wordsClose"
               class="close"
+              type="button"
               @click.prevent="onCloseClicked(clarification)"
             >
-              ❌
+              <span aria-hidden="true">×</span>
             </button>
-          </div>
-          <div class="w-100 align-items-center pt-1 notification-link">
-            <a :href="anchor(clarification)">
-              <span>{{ clarification.problem_alias }}</span> —
+            <a :href="anchor(clarification)"
+              ><span>{{ clarification.problem_alias }}</span> —
               <span>{{ clarification.author }}</span>
               <pre>{{ clarification.message }}</pre>
               <template v-if="clarification.answer">
                 <hr />
                 <pre>{{ clarification.answer }}</pre>
-              </template>
-            </a>
-          </div>
-        </div>
-      </transition-group>
+              </template></a
+            >
+          </li>
+        </ul>
+      </li>
       <template v-if="unreadClarifications && unreadClarifications.length > 1">
         <li class="divider" role="separator"></li>
         <li data-mark-all-as-read-button>
           <a href="#" @click.prevent="onMarkAllAsRead"
-            ><font-awesome-icon :icon="['fas', 'align-right']" />
+            ><span class="glyphicon glyphicon-align-right"></span>
             {{ T.notificationsMarkAllAsRead }}</a
           >
         </li>
       </template>
-    </div>
+    </ul>
   </li>
 </template>
 
@@ -69,16 +70,7 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import type { types } from '../../api_types';
 import T from '../../lang';
 
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faBell, faAlignRight } from '@fortawesome/free-solid-svg-icons';
-library.add(faBell, faAlignRight);
-
-@Component({
-  components: {
-    FontAwesomeIcon,
-  },
-})
+@Component
 export default class Clarifications extends Vue {
   @Prop({ default: () => [] }) clarifications!: types.Clarification[];
 
@@ -143,28 +135,88 @@ export default class Clarifications extends Vue {
 
 <style lang="scss" scoped>
 @import '../../../../sass/main.scss';
-
-.close {
-  font-size: inherit;
+.notification-button {
+  padding-top: 6px !important;
+  padding-bottom: 20px !important;
+  padding-right: 12px !important;
+  padding-left: 12px !important;
+  font-size: 22px;
 }
 
-.notification-link {
+.notification-counter {
+  position: absolute;
+  font-size: 16px;
+  padding: 2px 4px;
+  bottom: 4px;
+  right: 0;
+}
+
+.notification-drawer::-webkit-scrollbar-track {
+  border-radius: 10px;
+  background-color: var(
+    --notifications-clarifications-scrollbar-track-background-color
+  );
+}
+
+.notification-drawer::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background-color: var(
+    --notifications-clarifications-scrollbar-background-color
+  );
+}
+
+.notification-drawer::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  background-color: var(
+    --notifications-clarifications-scrollbar-thumb-background-color
+  );
+}
+
+.notification-drawer {
+  width: 320px;
+  max-width: 320px;
+  max-height: 380px;
+  overflow-y: scroll;
+}
+
+.notification-drawer li {
+  padding: 3px 20px;
+  list-style: none;
+  border-top: 1px solid
+    var(--notifications-clarifications-drawer-li-border-top-color);
+}
+
+.notification-drawer li a {
+  color: var(--notifications-clarifications-drawer-li-a-font-color);
+  text-decoration: none;
+}
+
+.notification-drawer li a pre {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.notification-drawer li:hover,
+.notification-drawer li:focus,
+.notification-drawer li:active {
   cursor: pointer;
-
-  &:hover {
-    background-color: rgba(
-      var(--notifications-notification-link-background-color--hover),
-      0.05
-    );
-  }
+  background-color: var(
+    --notifications-clarifications-drawer-li-background-color--active
+  );
+  text-decoration: none;
 }
 
-pre {
-  padding: 16px;
-  background: var(--markdown-pre-background-color);
-  margin: 1em 0;
-  border-radius: 6px;
-  display: block;
-  line-height: 125%;
+.notification-drawer li:hover > a,
+.notification-drawer li:focus > a,
+.notification-drawer li:active > a {
+  color: var(--notifications-clarifications-drawer-li-font-color--active);
+}
+
+.notification-drawer li a > h4,
+.notification-drawer li a > p {
+  word-wrap: break-word;
 }
 </style>


### PR DESCRIPTION
# Descripción

Para poder realizar la migración a Bootstrap 4 es necesario borrar todos los
archivos de los cuales se tuvo que generar una copia con las clases correctas.
Al eliminar la versión que teníamos, Github detecta como que se renombró 
el archivo y esto ocasiona que el cambio parezca muy grande.

La forma de evitar ese tamaño tan extenso es renombrar dichos archivos 
en PRs separados.

Part of: #6030 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
