### PR TITLE
Haciendo `\Omegaup\DAO\Problems::getProblemsUnsolvedByIdentity` hasta ~300x más rápido

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -676,37 +676,34 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         int $identityId
     ): array {
         $sql = "
-            SELECT DISTINCT
-                p.*
+            SELECT
+                p.*,
+                SUM(r.verdict = 'AC') AS solved_count
             FROM
                 Identities i
             INNER JOIN
                 Submissions s ON s.identity_id = i.identity_id
             INNER JOIN
+                Runs r ON r.run_id = s.current_run_id
+            INNER JOIN
                 Problems p ON p.problem_id = s.problem_id
             WHERE
                 i.identity_id = ?
-            AND
-                (SELECT
-                    COUNT(*)
-                 FROM
-                    Submissions ss
-                 INNER JOIN
-                    Runs r ON r.run_id = ss.current_run_id
-                 WHERE
-                    ss.identity_id = i.identity_id AND
-                    ss.problem_id = p.problem_id AND
-                    r.verdict = 'AC'
-                ) = 0";
+            GROUP BY
+                p.problem_id
+            HAVING
+                solved_count = 0;
+        ";
 
         $params = [$identityId];
 
-        /** @var list<array{accepted: int, acl_id: int, alias: string, allow_user_add_tags: bool, commit: string, creation_date: \OmegaUp\Timestamp, current_version: string, deprecated: bool, difficulty: float|null, difficulty_histogram: null|string, email_clarifications: bool, input_limit: int, languages: string, order: string, problem_id: int, quality: float|null, quality_histogram: null|string, quality_seal: bool, show_diff: string, source: null|string, submissions: int, title: string, visibility: int, visits: int}> */
+        /** @var list<array{accepted: int, acl_id: int, alias: string, allow_user_add_tags: bool, commit: string, creation_date: \OmegaUp\Timestamp, current_version: string, deprecated: bool, difficulty: float|null, difficulty_histogram: null|string, email_clarifications: bool, input_limit: int, languages: string, order: string, problem_id: int, quality: float|null, quality_histogram: null|string, quality_seal: bool, show_diff: string, solved_count: float|null, source: null|string, submissions: int, title: string, visibility: int, visits: int}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
 
         $problems = [];
-        foreach ($rs as $r) {
-            $problems[] = new \OmegaUp\DAO\VO\Problems($r);
+        foreach ($rs as $row) {
+            unset($row['solved_count']);
+            $problems[] = new \OmegaUp\DAO\VO\Problems($row);
         }
         return $problems;
     }


### PR DESCRIPTION
Resulta ser que en la consulta para obtener los problemas no-resueltos
de alguien, la consulta interior estaba haciendo _casi_ la misma chamba
que la consulta exterior, para cada una de las filas de la consulta
exterior! Esto quiere decir que la consulta era [accidentalmente
cuadrática](https://accidentallyquadratic.tumblr.com/)!

Este cambio ahora mueve el `JOIN` donde se obtienen los `Runs` a la
consulta exterior (donde ahora sí se está haciendo la misma chamba en
ambas) y se mueve el `COUNT(*)` interno como un `SUM()` condicional a la
consulta exterior. Con la ayuda de un `GROUP BY` y un `HAVING`, se logra
obtener exactamente el mismo resultado, pero en tiempo lineal.

Part of: #6067