### PR TITLE
Ahora la fecha del concurso es un link a timeanddate.com

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -166,7 +166,7 @@
             <template #text-contest-date>
               <b-card-text>
                 <font-awesome-icon icon="calendar-alt" />
-                <a :href="getTimeLink(contestItem.finish_time.iso())">
+                <a :href="getTimeLink(contestItem.finish_time)">
                   {{
                     ui.formatString(T.contestEndTime, {
                       endDate: finishContestDate(contestItem),
@@ -201,7 +201,7 @@
             <template #text-contest-date>
               <b-card-text>
                 <font-awesome-icon icon="calendar-alt" />
-                <a :href="getTimeLink(contestItem.start_time.iso())">
+                <a :href="getTimeLink(contestItem.start_time)">
                   {{
                     ui.formatString(T.contestStartTime, {
                       startDate: startContestDate(contestItem),
@@ -239,7 +239,7 @@
             <template #text-contest-date>
               <b-card-text>
                 <font-awesome-icon icon="calendar-alt" />
-                <a :href="getTimeLink(contestItem.start_time.iso())">
+                <a :href="getTimeLink(contestItem.start_time)">
                   {{
                     ui.formatString(T.contestStartedTime, {
                       startedDate: startContestDate(contestItem),
@@ -344,8 +344,8 @@ export default class ArenaContestList extends Vue {
     return contest.start_time.toLocaleDateString();
   }
 
-  getTimeLink(time: string): string {
-    return `http://timeanddate.com/worldclock/fixedtime.html?iso=${time}`;
+  getTimeLink(time: Date): string {
+    return `http://timeanddate.com/worldclock/fixedtime.html?iso=${time.toISOString()}`;
   }
 
   orderByTitle() {

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -166,11 +166,13 @@
             <template #text-contest-date>
               <b-card-text>
                 <font-awesome-icon icon="calendar-alt" />
-                {{
-                  ui.formatString(T.contestEndTime, {
-                    endDate: finishContestDate(contestItem),
-                  })
-                }}
+                <a :href="getTimeLink(contestItem.finish_time.iso())">
+                  {{
+                    ui.formatString(T.contestEndTime, {
+                      endDate: finishContestDate(contestItem),
+                    })
+                  }}
+                </a>
               </b-card-text>
             </template>
             <template #contest-dropdown>
@@ -199,11 +201,13 @@
             <template #text-contest-date>
               <b-card-text>
                 <font-awesome-icon icon="calendar-alt" />
-                {{
-                  ui.formatString(T.contestStartTime, {
-                    startDate: startContestDate(contestItem),
-                  })
-                }}
+                <a :href="getTimeLink(contestItem.start_time.iso())">
+                  {{
+                    ui.formatString(T.contestStartTime, {
+                      startDate: startContestDate(contestItem),
+                    })
+                  }}
+                </a>
               </b-card-text>
             </template>
             <template #contest-button-enter>
@@ -235,11 +239,13 @@
             <template #text-contest-date>
               <b-card-text>
                 <font-awesome-icon icon="calendar-alt" />
-                {{
-                  ui.formatString(T.contestStartedTime, {
-                    startedDate: startContestDate(contestItem),
-                  })
-                }}
+                <a :href="getTimeLink(contestItem.start_time.iso())">
+                  {{
+                    ui.formatString(T.contestStartedTime, {
+                      startedDate: startContestDate(contestItem),
+                    })
+                  }}
+                </a>
               </b-card-text>
             </template>
             <template #contest-button-enter>
@@ -336,6 +342,10 @@ export default class ArenaContestList extends Vue {
 
   startContestDate(contest: types.ContestListItem): string {
     return contest.start_time.toLocaleDateString();
+  }
+
+  getTimeLink(time: string): string {
+    return `http://timeanddate.com/worldclock/fixedtime.html?iso=${time}`;
   }
 
   orderByTitle() {


### PR DESCRIPTION
# Descripción

Ahora la fecha del concurso redirecciona a https://www.timeanddate.com/worldclock/fixedtime.html?iso=2020-10-10T14:59:59.981Z con su respectivo horario
 
![image](https://user-images.githubusercontent.com/48113838/144295565-77d840fb-9f72-4925-84b7-2cbc6ee5ada5.png)

Fixes: #6066

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
