### PR TITLE
Haciendo realmente público el link del scoreboard público

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -4015,7 +4015,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'contest_admin' => $contestAdmin,
             'problemset' => $problemset
-        ] = self::validateDetails($contestAlias, $identity);
+        ] = self::validateDetails($contestAlias, $identity, $scoreboardToken);
 
         if (is_null($problemset->problemset_id)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
@@ -4049,7 +4049,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $contestDetails = self::getContestDetails(
             $contest,
             $contestAdmin,
-            $identity
+            $identity,
+            $scoreboardToken
         );
 
         return [


### PR DESCRIPTION
# Descripción

Resulta que la url del scoreboard público en los concursos no estaba contemplando
el token para poder mostrarse aunque no hubiera sesión abierta. Con este cambio
ya se puede ver correctamente el scoreboard.

![PublicScoreboard](https://user-images.githubusercontent.com/3230352/144648750-2642dbce-5992-44e3-8ca8-bac56dc6ea6f.gif)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
