### PR TITLE
Nueva versión de hook_tools

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -48,6 +48,6 @@ fi
 	--volume "${OMEGAUP_ROOT}:${OMEGAUP_ROOT}" \
 	--env 'PYTHONIOENCODING=utf-8' \
 	--env "MYPYPATH=${OMEGAUP_ROOT}/stuff" \
-	omegaup/hook_tools:20211204 --command-name="./stuff/lint.sh" $ARGS
+	omegaup/hook_tools:20211205 --command-name="./stuff/lint.sh" $ARGS
 
 echo OK


### PR DESCRIPTION
Este cambio arregla un error que causaba que si había una anotación del
linter en un archivo extra (para dar más contexto alrededor de un
error), esto causaba que el linter no pudiera identificar qué salió mal
y fallara.