### PR TITLE
Arreglando el ancho del frame del grader efímero para evitar que se intente redimensionar

### DIFF
--- a/frontend/www/grader/ephemeral/index.html
+++ b/frontend/www/grader/ephemeral/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="h-100">
+<html class="h-75">
 	<head>
 		<meta charset="UTF-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
# Descripción

Pareciera que con la migración a Bootstrap 4 se pudo haber ocasionado que
el frame del ephemeral grader se intente redimensionar y por ende parezca 
que se volvió loco.

En este PR se redimensiona el frame en un tamaño más pequeño para que esto
no suceda.

![ShakingEphemeral](https://user-images.githubusercontent.com/3230352/144929299-ceabad34-75c8-468f-bd98-0a35ac7743b6.gif)

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.