### PR TITLE
cambiando texto del dropdown de objetivos de usuario en base a la opción seleccionada

### DIFF
--- a/frontend/www/js/omegaup/components/user/PreferencesEdit.test.ts
+++ b/frontend/www/js/omegaup/components/user/PreferencesEdit.test.ts
@@ -2,6 +2,7 @@ import { shallowMount } from '@vue/test-utils';
 import { types } from '../../api_types';
 import user_Preferences_Edit from './PreferencesEdit.vue';
 import each from 'jest-each';
+import T from '../../lang';
 
 const profile: types.UserProfileInfo = {
   name: 'omegaUp admin',
@@ -75,6 +76,57 @@ describe('PreferencesEdit.vue', () => {
       ],
     ]);
   });
+
+  it('Should disable ScholarCompetitive objective select when "none" option is selected', async () => {
+    const wrapper = shallowMount(user_Preferences_Edit, {
+      propsData: { profile },
+    });
+    await wrapper
+      .find('select[data-learning-teaching-objective]')
+      .find('option[value="none"]')
+      .setSelected();
+    expect(
+      wrapper.find('select[data-scholar-competitive-objective]').element,
+    ).toBeDisabled();
+  });
+
+  each([
+    {
+      objectiveLearningTeaching: 'learning',
+      objectiveScholarCompetitiveQuestion:
+        T.userObjectivesModalDescriptionLearning,
+    },
+    {
+      objectiveLearningTeaching: 'teaching',
+      objectiveScholarCompetitiveQuestion:
+        T.userObjectivesModalDescriptionTeaching,
+    },
+    {
+      objectiveLearningTeaching: 'learningAndTeaching',
+      objectiveScholarCompetitiveQuestion:
+        T.userObjectivesModalDescriptionLearningAndTeaching,
+    },
+    {
+      objectiveLearningTeaching: 'none',
+      objectiveScholarCompetitiveQuestion:
+        T.userObjectivesModalDescriptionUsage,
+    },
+  ]).test(
+    'Should display the correct ScholarCompetitive objective question when "$objectiveLearningTeaching" option is selected',
+    async ({
+      objectiveLearningTeaching,
+      objectiveScholarCompetitiveQuestion,
+    }) => {
+      const wrapper = shallowMount(user_Preferences_Edit, {
+        propsData: { profile },
+      });
+      await wrapper
+        .find('select[data-learning-teaching-objective]')
+        .find(`option[value="${objectiveLearningTeaching}"]`)
+        .setSelected();
+      expect(wrapper.text()).toContain(objectiveScholarCompetitiveQuestion);
+    },
+  );
 
   each([
     {

--- a/frontend/www/js/omegaup/components/user/PreferencesEdit.vue
+++ b/frontend/www/js/omegaup/components/user/PreferencesEdit.vue
@@ -58,9 +58,10 @@
       </select>
     </div>
     <div class="form-group">
-      <label>{{ T.userObjectivesModalDescriptionUsage }}</label>
+      <label>{{ scholarCompetitiveObjectiveQuestion }}</label>
       <select
         v-model="scholarCompetitiveObjective"
+        :disabled="learningTeachingObjective === ObjectivesAnswers.None"
         data-scholar-competitive-objective
         class="custom-select"
       >
@@ -131,6 +132,19 @@ export default class UserPreferencesEdit extends Vue {
   hasLearningObjective = this.profile.has_learning_objective ?? true;
   hasScholarObjective = this.profile.has_scholar_objective ?? true;
   hasTeachingObjective = this.profile.has_teaching_objective ?? false;
+
+  get scholarCompetitiveObjectiveQuestion(): string {
+    if (this.hasLearningObjective && this.hasTeachingObjective) {
+      return this.T.userObjectivesModalDescriptionLearningAndTeaching;
+    }
+    if (this.hasLearningObjective) {
+      return this.T.userObjectivesModalDescriptionLearning;
+    }
+    if (this.hasTeachingObjective) {
+      return this.T.userObjectivesModalDescriptionTeaching;
+    }
+    return T.userObjectivesModalDescriptionUsage;
+  }
 
   get learningTeachingObjective(): string {
     if (this.hasLearningObjective && this.hasTeachingObjective) {


### PR DESCRIPTION
# Descripción

El texto de la segunda pregunta de los dropdowns de objetivos de usuarios cambia dependiendo de la opción seleccionada en la primera pregunta. Si selecciona "Ninguna de las anteriores" se deshabilita la segunda pregunta. 

![userObjectivesDropdown](https://user-images.githubusercontent.com/48114972/145276152-28e10616-32c9-4634-8c0f-db6fff64d5a7.gif)

Part of: #6038

# Comentarios

Continuación del PR #6039

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
