### PR TITLE
Agregando logs en JSON en los scripts de Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           python3 -m pip install --user setuptools
           python3 -m pip install --user wheel
           python3 -m pip install --user \
-            mysqlclient==2.0.1
+            -r stuff/docker/requirements.txt
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -241,7 +241,7 @@ jobs:
           python3 -m pip install --user wheel
           python3 -m pip install --user --upgrade urllib3
           python3 -m pip install --user \
-            mysqlclient==2.0.1 \
+            -r stuff/docker/requirements.txt \
             selenium \
             pytest \
             pytest-xdist \
@@ -312,7 +312,7 @@ jobs:
           python3 -m pip install --user wheel
           python3 -m pip install --user --upgrade urllib3
           python3 -m pip install --user \
-            mysqlclient==2.0.1 \
+            -r stuff/docker/requirements.txt \
             pandas \
             pytest
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       dockerfile: ./Dockerfile.dev-php
       context: ./stuff/docker/
-    image: omegaup/dev-php:20211109
+    image: omegaup/dev-php:20211210
     user: "${UID_GID}"
     restart: always
     volumes:

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -15,13 +15,34 @@ RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        php7.4-fpm php7.4-curl php7.4-mysql php7.4-zip php7.4-mbstring \
-        php7.4-json php7.4-opcache php7.4-xml php-apcu php-redis \
-        nginx git yarn nodejs supervisor python3-jinja2 python3-requests \
-        python3-mysqldb python3-pyparsing mysql-client-core-8.0 \
-        sudo wait-for-it && \
+        git \
+        mysql-client-core-8.0 \
+        nginx \
+        nodejs \
+        php-apcu \
+        php-redis \
+        php7.4-curl \
+        php7.4-fpm \
+        php7.4-json \
+        php7.4-mbstring \
+        php7.4-mysql \
+        php7.4-opcache \
+        php7.4-xml \
+        php7.4-zip \
+        python3-pip \
+        python3-jinja2 \
+        python3-mysqldb \
+        python3-pyparsing \
+        python3-requests \
+        sudo \
+        supervisor \
+        wait-for-it \
+        yarn && \
     apt-get autoremove -y && \
     apt-get clean
+
+COPY requirements.txt /tmp/
+RUN python3 -m pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 RUN curl -sL https://getcomposer.org/download/1.10.10/composer.phar -o /usr/bin/composer
 RUN chmod +x /usr/bin/composer

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -115,6 +115,9 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
+COPY requirements.txt /tmp/
+RUN python3 -m pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 RUN useradd --create-home --shell=/bin/bash ubuntu && \
     mkdir -p /etc/omegaup/frontend && \
     mkdir -p /var/log/omegaup && chown -R ubuntu /var/log/omegaup && \

--- a/stuff/docker/requirements.txt
+++ b/stuff/docker/requirements.txt
@@ -1,0 +1,2 @@
+mysqlclient==2.0.1
+python-json-logger>=2.0.2

--- a/stuff/lib/logs.py
+++ b/stuff/lib/logs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-
 '''Library of common database code shared across cron scripts.
 
 Using this library consists of two parts:
@@ -8,17 +7,50 @@ Using this library consists of two parts:
 '''
 
 import argparse
+import datetime
 import logging
+
+from typing import Any, Dict, Mapping
+
+from pythonjsonlogger import jsonlogger  # type: ignore
+
+
+class _CustomJsonFormatter(jsonlogger.JsonFormatter):  # type: ignore
+    """A JSON formatter that adds the level."""
+    def add_fields(
+            self,
+            log_record: Dict[str, str],
+            record: logging.LogRecord,
+            message_dict: Mapping[str, Any],
+    ) -> None:
+        """Add fields to the record."""
+        super().add_fields(log_record, record, message_dict)
+        if not log_record.get('time'):
+            log_record['time'] = datetime.datetime.utcnow().strftime(
+                '%Y-%m-%dT%H:%M:%S.%fZ')
+        if log_record.get('level'):
+            log_record['level'] = log_record['level'].lower()
+        else:
+            log_record['level'] = record.levelname.lower()
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
     '''Add Logging-related arguments to `parser`'''
     logging_args = parser.add_argument_group('Logging')
-    logging_args.add_argument('--quiet', '-q', action='store_true',
+    logging_args.add_argument('--quiet',
+                              '-q',
+                              action='store_true',
                               help='Disables logging')
-    logging_args.add_argument('--verbose', '-v', action='store_true',
+    logging_args.add_argument('--verbose',
+                              '-v',
+                              action='store_true',
                               help='Enables verbose logging')
-    logging_args.add_argument('--logfile', type=str, default=None,
+    logging_args.add_argument('--log-json',
+                              action='store_true',
+                              help='Log with JSON')
+    logging_args.add_argument('--logfile',
+                              type=str,
+                              default=None,
                               help='Enables logging to a file')
 
 
@@ -31,11 +63,22 @@ def init(program: str, args: argparse.Namespace) -> None:
                                   line with a parser configured with
                                   `configure_parser`.
     '''
-    logging.basicConfig(filename=args.logfile,
-                        format='%%(asctime)s:%s:%%(message)s' % program,
-                        level=(logging.DEBUG if args.verbose else
-                               logging.INFO if not args.quiet else
-                               logging.ERROR))
+    log_level = (logging.DEBUG if args.verbose else
+                 logging.INFO if not args.quiet else logging.ERROR)
+    if args.log_json:
+        if args.logfile:
+            log_handler: logging.Handler = logging.FileHandler(args.logfile)
+        else:
+            log_handler = logging.StreamHandler()
+        formatter = _CustomJsonFormatter()
+        log_handler.setFormatter(formatter)
+        logging.basicConfig(level=log_level,
+                            handlers=[log_handler],
+                            force=True)
+    else:
+        logging.basicConfig(filename=args.logfile,
+                            format='%%(asctime)s:%s:%%(message)s' % program,
+                            level=log_level)
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Un pre-requisito para poder correr los cronjobs en k8s es poder exportar
log logs en formato JSON para que aparezcan bien en New Relic / Grafana.

Este cambio hace que eso sea posible.