### PR TITLE
Agregando file-upload y wait-for a cypress

### DIFF
--- a/cypress/integration/sample.spec.ts
+++ b/cypress/integration/sample.spec.ts
@@ -3,13 +3,37 @@ describe('Test', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
   });
-  it('Check if contests exist', () => {
-    cy.visit('/');
-    cy.get('[data-nav-problems]').click();
-    cy.get('[data-nav-problems-collection]').click();
-    cy.get('[data-nav-problems-all]').click();
-    cy.get('[href="/arena/problem/karel-helloworld/"]').contains(
-      'Karel Hello World',
+
+  it('Should create a new problem (Cypress Studio Test)', function () {
+    cy.login('user', 'user');
+    cy.waitUntil(() =>
+      cy.get('.active > .container-lg > .slide > :nth-child(1) > h2'),
     );
+    cy.get('.nav-problems > .nav-link').click();
+    cy.get('.dropdown-menu > [href="/problem/new/"]').click();
+    cy.get(
+      ':nth-child(1) > .collapse > :nth-child(1) > :nth-child(1) > .form-control',
+    ).clear();
+    cy.get(
+      ':nth-child(1) > .collapse > :nth-child(1) > :nth-child(1) > .form-control',
+    ).type('name');
+    cy.get(
+      ':nth-child(1) > .collapse > :nth-child(1) > :nth-child(2) > .form-control',
+    ).click();
+    cy.get('.collapse > :nth-child(2) > :nth-child(1) > .form-control').clear();
+    cy.get('.collapse > :nth-child(2) > :nth-child(1) > .form-control').type(
+      'name',
+    );
+    cy.get('input[type="file"]').attachFile(
+      '../../frontend/tests/resources/testproblem.zip',
+    );
+    cy.get(':nth-child(2) > .card-header > .mb-0 > .btn').click();
+    cy.get('[required="required"] > .input-group > .form-control').clear();
+    cy.get('[required="required"] > .input-group > .form-control').type('rec');
+    cy.get('.list-group > :nth-child(1) > :nth-child(1)').click();
+    cy.get(
+      '.tags > .card > .card-body > .row > .form-group > .form-control',
+    ).select('problemLevelBasicIntroductionToProgramming');
+    cy.get('.form-group > .btn').click();
   });
 });

--- a/cypress/integration/sample.spec.ts
+++ b/cypress/integration/sample.spec.ts
@@ -4,36 +4,7 @@ describe('Test', () => {
     cy.clearLocalStorage();
   });
 
-  it('Should create a new problem (Cypress Studio Test)', function () {
-    cy.login('user', 'user');
-    cy.waitUntil(() =>
-      cy.get('.active > .container-lg > .slide > :nth-child(1) > h2'),
-    );
-    cy.get('.nav-problems > .nav-link').click();
-    cy.get('.dropdown-menu > [href="/problem/new/"]').click();
-    cy.get(
-      ':nth-child(1) > .collapse > :nth-child(1) > :nth-child(1) > .form-control',
-    ).clear();
-    cy.get(
-      ':nth-child(1) > .collapse > :nth-child(1) > :nth-child(1) > .form-control',
-    ).type('name');
-    cy.get(
-      ':nth-child(1) > .collapse > :nth-child(1) > :nth-child(2) > .form-control',
-    ).click();
-    cy.get('.collapse > :nth-child(2) > :nth-child(1) > .form-control').clear();
-    cy.get('.collapse > :nth-child(2) > :nth-child(1) > .form-control').type(
-      'name',
-    );
-    cy.get('input[type="file"]').attachFile(
-      '../../frontend/tests/resources/testproblem.zip',
-    );
-    cy.get(':nth-child(2) > .card-header > .mb-0 > .btn').click();
-    cy.get('[required="required"] > .input-group > .form-control').clear();
-    cy.get('[required="required"] > .input-group > .form-control').type('rec');
-    cy.get('.list-group > :nth-child(1) > :nth-child(1)').click();
-    cy.get(
-      '.tags > .card > .card-body > .row > .form-group > .form-control',
-    ).select('problemLevelBasicIntroductionToProgramming');
-    cy.get('.form-group > .btn').click();
+  it('Should go to the landing page', () => {
+    cy.visit('/');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,6 +2,7 @@
 import 'cypress-wait-until';
 import 'cypress-file-upload';
 
+// Example command
 Cypress.Commands.add('login', (username, password) => {
   cy.visit('/');
   cy.get('.navbar-right > .nav-item > .nav-link').click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,1 +1,13 @@
 // https://on.cypress.io/custom-commands
+import 'cypress-wait-until';
+import 'cypress-file-upload';
+
+Cypress.Commands.add('login', (username, password) => {
+  cy.visit('/');
+  cy.get('.navbar-right > .nav-item > .nav-link').click();
+  cy.get('.form-horizontal > :nth-child(1) > .form-control').clear();
+  cy.get('.form-horizontal > :nth-child(1) > .form-control').type(username);
+  cy.get(':nth-child(2) > .form-control').clear();
+  cy.get(':nth-child(2) > .form-control').type(password);
+  cy.get(':nth-child(3) > .btn').click();
+});

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -1,0 +1,12 @@
+// <reference types="cypress"/>
+
+declare namespace Cypress {
+  // Includes custom omegaup API error types
+  interface Error {
+    error: string;
+  }
+
+  interface Chainable {
+    login(username: string, password: string): void;
+  }
+}

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,10 @@
 // https://on.cypress.io/configuration
 
 import './commands';
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+  if (err.error.includes('idpiframe_initialization_failed')) {
+    // Google API sign in error
+    return false;
+  }
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "cross-env": "^6.0.3",
     "css-loader": "^3.6",
     "cypress": "^9.1.1",
+    "cypress-file-upload": "^5.0.8",
+    "cypress-wait-until": "^1.7.2",
     "eslint": "^7.24",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-jest-dom": "^3.6.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "lib": ["DOM", "ES5", "ScriptHost", "ES2020.Promise"],
     "types": [
       "cypress",
+      "cypress-wait-until",
+      "cypress-file-upload",
       "gapi",
       "gapi.auth2",
       "bootstrap-datepicker",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,6 +3976,16 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
+cypress-file-upload@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
+  integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
+
+cypress-wait-until@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
+  integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
+
 cypress@*, cypress@^9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.1.1.tgz#26720ca5a22077cd85f49745616b7a08152a298f"


### PR DESCRIPTION
# Descripción

Cypress no incluye por defecto estos comandos. `Wait-for` es necesario para poder realizar tests de manera que no se intente dar click a un elemento que todavia no este visible. `File-upload` es necesario para poder subir un zip al momento de crear un problema. 

Tambien se agrego un test hecho con Cypress Studio para mostrarlo hoy dentro de la junta de Ingenieria.

Fixes: #6137 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
