### PR TITLE
Intentando arreglar CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use PHP 7.4
+        run: |
+          sudo update-alternatives --install /usr/bin/php php /usr/bin/php7.4 100
+          # Enable coverage for XDebug so that codecov can do its magic.
+          echo 'xdebug.mode=coverage' | sudo tee --append /etc/php/7.4/cli/conf.d/20-xdebug.ini >/dev/null
+
       - name: Install yarn dependencies
         run: yarn install
 


### PR DESCRIPTION
Parece que GitHub actualizó la imagen donde se corren las pruebas
cambió. Posiblemente cambió la versión default de PHP que se usa, que
causa que fallen las pruebas? En todo caso, a ver si esto lo arregla.