### PR TITLE
Usando Monolog en vez de log4php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,13 @@
     "psr-4": {"OmegaUp\\": "frontend/server/src"}
   },
   "require": {
-    "apache/log4php": "^2.3",
     "phpmailer/phpmailer": "=v5.2.21",
     "smarty/smarty": "^4.0",
     "facebook/graph-sdk": "^5.7",
     "google/apiclient": "=v1.1.9",
     "promphp/prometheus_client_php": "=v1.0.3",
-    "paragonie/paseto": "v1.*"
+    "paragonie/paseto": "v1.*",
+    "monolog/monolog": "^2.3",
+    "newrelic/monolog-enricher": "^2.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,45 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03e7f14b234978eb4856d628f1731002",
+    "content-hash": "6958414c8322c2222f06683474c0c118",
     "packages": [
-        {
-            "name": "apache/log4php",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/apache/logging-log4php.git",
-                "reference": "cac428b6f67d2035af39784da1d1a299ef42fcf2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/apache/logging-log4php/zipball/cac428b6f67d2035af39784da1d1a299ef42fcf2",
-                "reference": "cac428b6f67d2035af39784da1d1a299ef42fcf2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.7"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/main/php/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "A versatile logging framework for PHP",
-            "homepage": "http://logging.apache.org/log4php/",
-            "keywords": [
-                "log",
-                "logging",
-                "php"
-            ],
-            "abandoned": true,
-            "time": "2012-10-26T09:13:25+00:00"
-        },
         {
             "name": "facebook/graph-sdk",
             "version": "5.7.0",
@@ -143,6 +106,153 @@
                 "google"
             ],
             "time": "2020-07-22T19:51:49+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9",
+                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7",
+                "graylog2/gelf-php": "^1.4.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.3",
+                "phpspec/prophecy": "^1.6.1",
+                "phpstan/phpstan": "^0.12.91",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90@dev",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/2.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-01T21:08:31+00:00"
+        },
+        {
+            "name": "newrelic/monolog-enricher",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newrelic/newrelic-monolog-logenricher-php.git",
+                "reference": "3c22b602d3528d034684a63201fd5fba580c7cad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newrelic/newrelic-monolog-logenricher-php/zipball/3c22b602d3528d034684a63201fd5fba580c7cad",
+                "reference": "3c22b602d3528d034684a63201fd5fba580c7cad",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "^2",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4",
+                "squizlabs/php_codesniffer": ">=3.5"
+            },
+            "suggest": {
+                "ext-newrelic": "Adds support for viewing logs in context within the New Relic UI"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewRelic\\Monolog\\Enricher\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "New Relic PHP",
+                    "email": "php-agent@newrelic.com"
+                }
+            ],
+            "description": "Monolog components to enable New Relic Logs",
+            "support": {
+                "issues": "https://github.com/newrelic/newrelic-monolog-logenricher-php/issues",
+                "source": "https://github.com/newrelic/newrelic-monolog-logenricher-php/tree/2.0.0"
+            },
+            "time": "2021-03-15T16:46:34+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -596,6 +706,53 @@
             ],
             "description": "Prometheus instrumentation library for PHP applications.",
             "time": "2020-09-11T12:27:43+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "smarty/smarty",
@@ -2346,53 +2503,6 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4414,5 +4524,5 @@
     "platform-overrides": {
         "php": "7.4.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/frontend/server/bootstrap.php
+++ b/frontend/server/bootstrap.php
@@ -88,94 +88,20 @@ header('Content-Security-Policy: ' . implode('; ', array_map(
 )));
 header('X-Frame-Options: DENY');
 
-/**
- * Creates a log4php appender configuration.
- */
-function appenderConfig(string $filename): array {
-    if ($filename === 'php://stderr') {
-        return [
-            'class' => 'LoggerAppenderConsole',
-            'params' => [
-                'target' => 'stderr',
-            ],
-        ];
-    }
-    return [
-        'class' => 'LoggerAppenderFile',
-        'params' => [
-            'file' => $filename,
-            'append' => true,
-        ],
-    ];
-}
+// Configure the root logger
+/** @psalm-suppress UndefinedDocblockClass Level is declared in a phpstan-type annotation. */
+$logLevel = \Monolog\Logger::toMonologLevel(OMEGAUP_LOG_LEVEL);
+$logFormatter = new \NewRelic\Monolog\Enricher\Formatter();
+$logHandler = new \Monolog\Handler\StreamHandler(OMEGAUP_LOG_FILE, $logLevel);
+$logHandler->setFormatter($logFormatter);
 
-\Logger::configure([
-    'rootLogger' => [
-        'appenders' => ['default'],
-        'level' => OMEGAUP_LOG_LEVEL,
-    ],
-    'loggers' => [
-        'csp' => [
-            'appenders' => ['csp'],
-            'additivity' => false,
-        ],
-        'jserror' => [
-            'appenders' => ['jserror'],
-            'additivity' => false,
-        ],
-        'mysqltypes' => [
-            'appenders' => ['mysqltypes'],
-            'additivity' => false,
-        ],
-    ],
-    'appenders' => [
-        'default' => array_merge(
-            appenderConfig(OMEGAUP_LOG_FILE),
-            [
-                'layout' => [
-                    'class' => 'LoggerLayoutPattern',
-                    'params' => [
-                        'conversionPattern' => (
-                            '%date [%level]: ' .
-                            \OmegaUp\Request::requestId() .
-                            ' %server{REQUEST_URI} %message (%F:%L) %newline'
-                        ),
-                    ],
-                ],
-            ],
-        ),
-        'csp' => array_merge(
-            appenderConfig(OMEGAUP_CSP_LOG_FILE),
-            [
-                'layout' => [
-                    'class' => 'LoggerLayoutPattern',
-                    'params' => [
-                        'conversionPattern' => '%date: %message %newline',
-                    ],
-                ],
-            ],
-        ),
-        'jserror' => array_merge(
-            appenderConfig(OMEGAUP_JSERROR_LOG_FILE),
-            [
-                'layout' => [
-                    'class' => 'LoggerLayoutPattern',
-                    'params' => [
-                        'conversionPattern' => '%date: %message %newline',
-                    ],
-                ],
-            ],
-        ),
-        'mysqltypes' => array_merge(
-            appenderConfig(OMEGAUP_MYSQL_TYPES_LOG_FILE),
-            [
-                'layout' => [
-                    'class' => 'LoggerLayoutPattern',
-                    'params' => [
-                        'conversionPattern' => '%message %newline',
-                    ],
-                ],
-            ],
-        ),
-    ],
-]);
+$rootLogger = new \Monolog\Logger('omegaup');
+$rootLogger->pushProcessor(
+    new \Monolog\Processor\WebProcessor()
+);
+$rootLogger->pushProcessor(
+    new \NewRelic\Monolog\Enricher\Processor()
+);
+$rootLogger->pushHandler($logHandler);
+\Monolog\Registry::addLogger($rootLogger);
+\Monolog\ErrorHandler::register($rootLogger);

--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -3,6 +3,16 @@
 define('OMEGAUP_ROOT', dirname(__DIR__, 2));
 require_once(__DIR__ . '/../../../vendor/autoload.php');
 
+$rootLogger = new \Monolog\Logger('omegaup');
+$handler = new \Monolog\Handler\StreamHandler(
+    'php://stderr',
+    \Monolog\Logger::DEBUG,
+);
+$handler->setFormatter(new \Monolog\Formatter\LineFormatter());
+$rootLogger->pushHandler($handler);
+\Monolog\Registry::addLogger($rootLogger);
+\Monolog\ErrorHandler::register($rootLogger);
+
 class ConversionResult {
     /**
      * @var string

--- a/frontend/server/cmd/LibinteractiveRefreshCmd.php
+++ b/frontend/server/cmd/LibinteractiveRefreshCmd.php
@@ -2,29 +2,6 @@
 
 require_once(__DIR__ . '/../bootstrap.php');
 
-Logger::configure([
-    'rootLogger' => [
-        'appenders' => ['default'],
-        'level' => OMEGAUP_LOG_LEVEL,
-    ],
-    'appenders' => [
-        'default' => [
-            'class' => 'LoggerAppenderConsole',
-            'layout' => [
-                'class' => 'LoggerLayoutPattern',
-                'params' => [
-                    'conversionPattern' => (
-                        '%date [%level]: %server{REQUEST_URI} %message (%F:%L) %newline'
-                    ),
-                ],
-            ],
-            'params' => [
-                'target' => 'stderr',
-            ],
-        ],
-    ],
-]);
-
 /**
  * @return Generator<int, string>
  */

--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -8,7 +8,7 @@ namespace OmegaUp;
  *
  */
 class ApiCaller {
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     public static $log;
 
     /**
@@ -152,7 +152,7 @@ class ApiCaller {
         $jsonResult = json_encode($response, $jsonEncodeFlags);
 
         if ($jsonResult === false) {
-            self::$log->warn(
+            self::$log->warning(
                 'json_encode failed for: ' . print_r(
                     $response,
                     true
@@ -357,4 +357,4 @@ class ApiCaller {
     }
 }
 
-\OmegaUp\ApiCaller::$log = \Logger::getLogger('ApiCaller');
+\OmegaUp\ApiCaller::$log = \Monolog\Registry::omegaup()->withName('ApiCaller');

--- a/frontend/server/src/Broadcaster.php
+++ b/frontend/server/src/Broadcaster.php
@@ -3,11 +3,11 @@
 namespace OmegaUp;
 
 class Broadcaster {
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     private $log;
 
     public function __construct() {
-        $this->log = \Logger::getLogger('broadcaster');
+        $this->log = \Monolog\Registry::omegaup()->withName('broadcaster');
     }
 
     public function broadcastClarification(
@@ -42,7 +42,10 @@ class Broadcaster {
                 false  // user_only
             );
         } catch (\Exception $e) {
-            $this->log->error('Failed to send to broadcaster', $e);
+            $this->log->error(
+                'Failed to send to broadcaster',
+                ['exception' => $e],
+            );
         }
         $this->sendClarificationEmail(
             $contest,

--- a/frontend/server/src/Cache.php
+++ b/frontend/server/src/Cache.php
@@ -106,7 +106,7 @@ abstract class CacheAdapter {
             }
             return $returnValue;
         }
-        $log = \Logger::getLogger('cache');
+        $log = \Monolog\Registry::omegaup()->withName('cache');
 
         // Get a lock to prevent multiple requests from trying to create the
         // same cache entry. The name of the lockfile is derived from the
@@ -547,7 +547,7 @@ class Cache {
     const DATA_CASES_FILES = 'data-cases-files-';
     const PROBLEM_CASES_METADATA = 'problem-cases-metadata-';
 
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     private $log;
 
     /** @var string */
@@ -558,7 +558,7 @@ class Cache {
      * @param string $key el id del cache
      */
     public function __construct(string $prefix, string $id = '') {
-        $this->log = \Logger::getLogger('cache');
+        $this->log = \Monolog\Registry::omegaup()->withName('cache');
 
         if (!self::isEnabled()) {
             $this->log->debug('Cache disabled');
@@ -609,7 +609,7 @@ class Cache {
             return false;
         }
         if (CacheAdapter::getInstance()->delete($this->key) !== true) {
-            $this->log->warn(
+            $this->log->warning(
                 "Failed to invalidate cache for key: {$this->key}"
             );
             return false;

--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -474,7 +474,10 @@ class Clarification extends \OmegaUp\Controllers\Controller {
                 }
             }
         } catch (\Exception $e) {
-            self::$log->error('Failed to broadcast clarification', $e);
+            self::$log->error(
+                'Failed to broadcast clarification',
+                ['exception' => $e],
+            );
             return;
         }
         self::getBroadcasterInstance()->broadcastClarification(

--- a/frontend/server/src/Controllers/Controller.php
+++ b/frontend/server/src/Controllers/Controller.php
@@ -6,7 +6,7 @@ namespace OmegaUp\Controllers;
  * Controllers parent class
  */
 class Controller {
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     public static $log;
 
     /**
@@ -182,4 +182,6 @@ class Controller {
     }
 }
 
-\OmegaUp\Controllers\Controller::$log = \Logger::getLogger('controller');
+\OmegaUp\Controllers\Controller::$log = \Monolog\Registry::omegaup()->withName(
+    'controller'
+);

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -664,7 +664,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             } catch (\Exception $e) {
                 self::$log->error(
                     "Error decoding token for course {$courseAlias}",
-                    $e
+                    ['exception' => $e],
                 );
 
                 \OmegaUp\DAO\CourseCloneLog::create(
@@ -2157,7 +2157,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 } catch (\Exception $e) {
                     self::$log->error(
                         "Error fetching source for {$run['guid']}",
-                        $e
+                        ['exception' => $e],
                     );
                 }
                 $problem['runs'][] = $run;

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -1267,7 +1267,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
                     $identity->language_id
                 );
                 if (is_null($result) || is_null($result->name)) {
-                    self::$log->warn('Invalid language id for identity');
+                    self::$log->warning('Invalid language id for identity');
                 } else {
                     return \OmegaUp\Controllers\Identity::convertToSupportedLanguage(
                         $result->name
@@ -1275,9 +1275,15 @@ class Identity extends \OmegaUp\Controllers\Controller {
                 }
             }
         } catch (\OmegaUp\Exceptions\NotFoundException $ex) {
-            self::$log->debug($ex);
+            self::$log->debug(
+                'convertToSupportedLanguage',
+                ['exception' => $ex],
+            );
         } catch (\OmegaUp\Exceptions\InvalidParameterException $ex) {
-            self::$log->debug($ex);
+            self::$log->debug(
+                'convertToSupportedLanguage',
+                ['exception' => $ex],
+            );
         }
 
         /** @var array<string, float> */

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -570,7 +570,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
             \OmegaUp\DAO\DAO::transEnd();
         } catch (\Exception $e) {
-            self::$log->error("Failed to create problem {$problem->alias}", $e);
+            self::$log->error(
+                "Failed to create problem {$problem->alias}",
+                ['exception' => $e],
+            );
 
             try {
                 // Operation failed in the data layer, try to rollback transaction
@@ -578,7 +581,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             } catch (\Exception $rollbackException) {
                 self::$log->error(
                     'Failed to roll back transaction: ',
-                    $rollbackException
+                    ['exception' => $rollbackException],
                 );
             }
 
@@ -1166,15 +1169,15 @@ class Problem extends \OmegaUp\Controllers\Controller {
         } catch (\Exception $e) {
             self::$log->error(
                 "Failed to rejudge problem {$problem->alias}",
-                $e
+                ['exception' => $e],
             );
             try {
                 // Operation failed in the data layer, try to rollback transaction
                 \OmegaUp\DAO\DAO::transRollback();
             } catch (\Exception $rollbackException) {
                 self::$log->error(
-                    'Failed to roll back transaction: ',
-                    $rollbackException
+                    'Failed to roll back transaction',
+                    ['exception' => $rollbackException],
                 );
             }
             throw $e;
@@ -1584,16 +1587,16 @@ class Problem extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\DAO::transEnd();
         } catch (\Exception $e) {
             self::$log->error(
-                "Failed to update problem {$problem->alias}: ",
-                $e
+                "Failed to update problem {$problem->alias}",
+                ['exception' => $e],
             );
             try {
                 // Operation failed in the data layer, try to rollback transaction
                 \OmegaUp\DAO\DAO::transRollback();
             } catch (\Exception $rollbackException) {
                 self::$log->error(
-                    'Failed to roll back transaction: ',
-                    $rollbackException
+                    'Failed to roll back transaction',
+                    ['exception' => $rollbackException],
                 );
             }
 
@@ -1622,7 +1625,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             } catch (\Exception $e) {
                 self::$log->error(
                     'Best effort \OmegaUp\Controllers\Problem::apiRejudge failed',
-                    $e
+                    ['exception' => $e],
                 );
             }
         }
@@ -3205,7 +3208,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         } catch (\Exception $e) {
             self::$log->error(
                 "Failed to update problem {$problem->alias}: ",
-                $e
+                ['exception' => $e],
             );
             try {
                 // Operation failed in the data layer, try to rollback transaction
@@ -3213,7 +3216,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             } catch (\Exception $rollbackException) {
                 self::$log->error(
                     'Failed to roll back transaction: ',
-                    $rollbackException
+                    ['exception' => $rollbackException],
                 );
             }
 
@@ -3243,7 +3246,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             } catch (\Exception $e) {
                 self::$log->error(
                     'Best effort \OmegaUp\Controllers\Problem::apiRejudge failed',
-                    $e
+                    ['exception' => $e],
                 );
             }
         }
@@ -4320,7 +4323,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         } catch (\Exception $e) {
             self::$log->error(
                 "Failed to update languages for problem {$problem->alias}: ",
-                $e
+                ['exception' => $e],
             );
             try {
                 // Operation failed in the data layer, try to rollback transaction
@@ -4328,7 +4331,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             } catch (\Exception $rollbackException) {
                 self::$log->error(
                     'Failed to roll back transaction: ',
-                    $rollbackException
+                    ['exception' => $rollbackException],
                 );
             }
             throw $e;
@@ -5645,7 +5648,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         } catch (\Exception $e) {
             self::$log->error(
                 "Failed to create input .zip for {$problem->alias}",
-                $e
+                ['exception' => $e],
             );
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'problemDeployerLibinteractiveValidationError',

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -824,7 +824,10 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\DAO::transEnd();
         } catch (\Exception $e) {
             \OmegaUp\DAO\DAO::transRollback();
-            self::$log->error('Failed to resolve demotion request', $e);
+            self::$log->error(
+                'Failed to resolve demotion request',
+                ['exception' => $e],
+            );
             throw $e;
         }
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -532,7 +532,10 @@ class Run extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\Submissions::update($submission);
             \OmegaUp\DAO\Runs::delete($run);
             \OmegaUp\DAO\Submissions::delete($submission);
-            self::$log->error('Call to \OmegaUp\Grader::grade() failed', $e);
+            self::$log->error(
+                'Call to \OmegaUp\Grader::grade() failed',
+                ['exception' => $e],
+            );
             throw $e;
         }
         $userId = $r->identity->user_id;
@@ -773,7 +776,10 @@ class Run extends \OmegaUp\Controllers\Controller {
                 $r['debug'] || false
             );
         } catch (\Exception $e) {
-            self::$log->error('Call to \OmegaUp\Grader::rejudge() failed', $e);
+            self::$log->error(
+                'Call to \OmegaUp\Grader::rejudge() failed',
+                ['exception' => $e],
+            );
         }
 
         self::invalidateCacheOnRejudge($run);
@@ -853,11 +859,10 @@ class Run extends \OmegaUp\Controllers\Controller {
             }
         } catch (\Exception $e) {
             // We did our best effort to invalidate the cache...
-            self::$log->warn(
-                "Failed to invalidate cache on rejudge {$run->run_id}, skipping: ",
-                $e
+            self::$log->warning(
+                "Failed to invalidate cache on rejudge {$run->run_id}, skipping",
+                ['exception' => $e],
             );
-            self::$log->warn($e);
         }
     }
 

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -302,7 +302,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 return false;
             }
         } catch (\Exception $e) {
-            self::$log->warn('Email lookup failed', $e);
+            self::$log->warning('Email lookup failed', ['exception' => $e]);
             return false;
         }
 

--- a/frontend/server/src/Email.php
+++ b/frontend/server/src/Email.php
@@ -3,7 +3,7 @@
 namespace OmegaUp;
 
 class Email {
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     public static $log;
 
     /** @var null|\OmegaUp\EmailSender */
@@ -68,4 +68,4 @@ class Email {
     }
 }
 
-Email::$log = \Logger::getLogger('email');
+Email::$log = \Monolog\Registry::omegaup()->withName('email');

--- a/frontend/server/src/Exceptions/ApiException.php
+++ b/frontend/server/src/Exceptions/ApiException.php
@@ -6,7 +6,7 @@ namespace OmegaUp\Exceptions;
  * Exception that works with arrays instead of plain strings
  */
 abstract class ApiException extends \Exception {
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     public static $log;
 
     /** @var string */
@@ -91,4 +91,6 @@ abstract class ApiException extends \Exception {
     }
 }
 
-\OmegaUp\Exceptions\ApiException::$log = \Logger::getLogger('ApiException');
+\OmegaUp\Exceptions\ApiException::$log = \Monolog\Registry::omegaup()->withName(
+    'ApiException'
+);

--- a/frontend/server/src/FileHandler.php
+++ b/frontend/server/src/FileHandler.php
@@ -6,7 +6,7 @@ class FileHandler {
     /** @var null|\OmegaUp\FileUploader */
     protected static $fileUploader = null;
 
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     public static $log;
 
     public static function setFileUploaderForTesting(
@@ -91,4 +91,6 @@ class FileHandler {
     }
 }
 
-\OmegaUp\FileHandler::$log = \Logger::getLogger('FileHandler');
+\OmegaUp\FileHandler::$log = \Monolog\Registry::omegaup()->withName(
+    'FileHandler'
+);

--- a/frontend/server/src/Grader.php
+++ b/frontend/server/src/Grader.php
@@ -310,7 +310,10 @@ class Grader {
                 return $response;
             }
         } catch (\Exception $e) {
-            \Logger::getLogger('Grader')->error("curl failed for {$url}", $e);
+            \Monolog\Registry::omegaup()->withName('Grader')->error(
+                'curl failed',
+                ['url' => $url, 'exception' => $e],
+            );
             throw $e;
         } finally {
             if (is_resource($curl)) {

--- a/frontend/server/src/ProblemArtifacts.php
+++ b/frontend/server/src/ProblemArtifacts.php
@@ -6,7 +6,7 @@ namespace OmegaUp;
  * Class to abstract access to a problem's artifacts.
  */
 class ProblemArtifacts {
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     private $log;
 
     /** @var string */
@@ -16,7 +16,7 @@ class ProblemArtifacts {
     private $revision;
 
     public function __construct(string $alias, string $revision = 'published') {
-        $this->log = \Logger::getLogger('ProblemArtifacts');
+        $this->log = \Monolog\Registry::omegaup()->withName('ProblemArtifacts');
         $this->alias = $alias;
         $this->revision = $revision;
     }
@@ -377,7 +377,7 @@ class GitServerBrowser {
         if (!is_string($response)) {
             $curlErrno = curl_errno($this->curl);
             $curlError = curl_error($this->curl);
-            \Logger::getLogger('GitBrowser')->error(
+            \Monolog\Registry::omegaup()->withName('GitBrowser')->error(
                 "Failed to get contents for {$this->url}. " .
                 "cURL {$curlErrno}: \"{$curlError}\""
             );

--- a/frontend/server/src/ProblemDeployer.php
+++ b/frontend/server/src/ProblemDeployer.php
@@ -11,7 +11,7 @@ class ProblemDeployer {
     const UPDATE_STATEMENTS = 2;
     const CREATE = 3;
     const ZIP_MAX_SIZE = 100 * 1024 * 1024;  // 100 MiB
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     private $log;
 
     /** @var string */
@@ -65,7 +65,7 @@ class ProblemDeployer {
         bool $acceptsSubmissions = true,
         bool $updatePublished = true
     ) {
-        $this->log = \Logger::getLogger('ProblemDeployer');
+        $this->log = \Monolog\Registry::omegaup()->withName('ProblemDeployer');
         $this->alias = $alias;
 
         if (

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -20,7 +20,7 @@ class Scoreboard {
     /** @var \OmegaUp\ScoreboardParams */
     private $params;
 
-    /** @var \Logger */
+    /** @var \Monolog\Logger */
     public $log;
 
     /** @var bool */
@@ -31,7 +31,7 @@ class Scoreboard {
 
     public function __construct(\OmegaUp\ScoreboardParams $params) {
         $this->params = $params;
-        $this->log = \Logger::getLogger('Scoreboard');
+        $this->log = \Monolog\Registry::omegaup()->withName('Scoreboard');
         \OmegaUp\Scoreboard::setIsLastRunFromCacheForTesting(false);
     }
 
@@ -244,7 +244,7 @@ class Scoreboard {
      * @param \OmegaUp\ScoreboardParams $params
      */
     public static function invalidateScoreboardCache(\OmegaUp\ScoreboardParams $params): void {
-        $log = \Logger::getLogger('Scoreboard');
+        $log = \Monolog\Registry::omegaup()->withName('Scoreboard');
         $log->info('Invalidating scoreboard cache.');
 
         // Invalidar cache del contestant
@@ -388,7 +388,7 @@ class Scoreboard {
         ), $timeout);
 
         // Try to broadcast the updated scoreboards:
-        $log = \Logger::getLogger('Scoreboard');
+        $log = \Monolog\Registry::omegaup()->withName('Scoreboard');
         try {
             $log->debug('Sending updated scoreboards');
             \OmegaUp\Grader::getInstance()->broadcast(
@@ -420,7 +420,7 @@ class Scoreboard {
                 false  // user_only
             );
         } catch (\Exception $e) {
-            $log->error('Error broadcasting scoreboard', $e);
+            $log->error('Error broadcasting scoreboard', ['exception' => $e]);
         }
     }
 

--- a/frontend/server/src/Translations.php
+++ b/frontend/server/src/Translations.php
@@ -66,7 +66,7 @@ class Translations {
      */
     public function get(string $key): string {
         if (!array_key_exists($key, $this->_translations)) {
-            \Logger::getLogger('Translations')->error(
+            \Monolog\Registry::omegaup()->withName('Translations')->error(
                 "Untranslated error message: {$key}"
             );
             return "{untranslated:{$key}}";

--- a/frontend/tests/ControllerTestCase.php
+++ b/frontend/tests/ControllerTestCase.php
@@ -7,7 +7,7 @@ namespace OmegaUp\Test;
  * Implements common methods for setUp and asserts
  */
 class ControllerTestCase extends \PHPUnit\Framework\TestCase {
-    /** @var \Logger|null */
+    /** @var \Monolog\Logger|null */
     private static $logObj = null;
 
     public static function setUpBeforeClass(): void {
@@ -450,7 +450,7 @@ class ControllerTestCase extends \PHPUnit\Framework\TestCase {
 
     public static function log(string $message): void {
         if (is_null(self::$logObj)) {
-            self::$logObj = \Logger::getLogger('tests');
+            self::$logObj = \Monolog\Registry::omegaup()->withName('tests');
         }
 
         self::$logObj->info($message);

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -313,7 +313,9 @@ class Utils {
     }
 
     private static function shellExec(string $command): void {
-        $log = \Logger::getLogger('\\OmegaUp\\Test\\Utils::shellExec()');
+        $log = \Monolog\Registry::omegaup()->withName(
+            '\\OmegaUp\\Test\\Utils::shellExec()'
+        );
         $log->info("========== Starting {$command}");
         $pipes = [];
         /** @psalm-suppress ForbiddenCode this only runs in tests. */

--- a/frontend/tests/controllers/ProblemLibinteractiveGenTest.php
+++ b/frontend/tests/controllers/ProblemLibinteractiveGenTest.php
@@ -12,7 +12,6 @@ class ProblemLibinteractiveGenTest extends \OmegaUp\Test\ControllerTestCase {
         return [
             [true, [], []],
             [false, [], ['name' => 'wrong name']],
-            [false, [], []],
             [false, ['name'], []],
             [false, ['os'], []],
             [false, ['idl'], []],

--- a/frontend/www/cspreport.php
+++ b/frontend/www/cspreport.php
@@ -9,6 +9,6 @@ if (
     die();
 }
 
-$log = Logger::getLogger('csp');
+$log = \Monolog\Registry::omegaup()->withName('csp');
 $log->error(file_get_contents('php://input'));
 die();

--- a/frontend/www/jserrorreport.php
+++ b/frontend/www/jserrorreport.php
@@ -6,6 +6,6 @@ if ($_SERVER['REQUEST_METHOD'] != 'POST') {
     die();
 }
 
-$log = Logger::getLogger('jserror');
+$log = \Monolog\Registry::omegaup()->withName('jserror');
 $log->error(file_get_contents('php://input'));
 die();


### PR DESCRIPTION
Esto no tiene nada que ver con log4j, pero igual log4php es medio lento
y lleva años sin recibir mantenimiento para nada. Además, New Relic
necesita usar Monolog para inyectar información extra en los logs.