### PR TITLE
Arreglando el build de los contenedores

### DIFF
--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -17,7 +17,7 @@ RUN apt-get update -y && \
         php8.0-gmp \
         php8.0-mbstring \
         php8.0-zip \
-        php8.0-xml
+        php8.0-xml \
         && \
     /usr/sbin/update-ca-certificates && \
     apt-get autoremove -y && \


### PR DESCRIPTION
No hemos podido construir un contenedor con PHP 8 porque el build está
roto :/