### PR TITLE
Quitar join innecesario al revisar isInsideSubmissionGap

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -121,11 +121,9 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 SELECT
                     MAX(s.time)
                 FROM
-                    Identities AS i
-                LEFT JOIN
-                    Submissions s ON s.identity_id = i.identity_id
+                    Submissions s
                 WHERE
-                    i.identity_id = ? AND s.problem_id = ?
+                    s.identity_id = ? AND s.problem_id = ?
                 FOR UPDATE;
             ';
             $val = [$identityId, $problemId];
@@ -134,11 +132,9 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 SELECT
                     MAX(s.time)
                 FROM
-                    Identities AS i
-                LEFT JOIN
-                    Submissions s ON s.identity_id = i.identity_id
+                    Submissions s
                 WHERE
-                    i.identity_id = ? AND s.problem_id = ? AND s.problemset_id = ?
+                    s.identity_id = ? AND s.problem_id = ? AND s.problemset_id = ?
                 FOR UPDATE;
             ';
             $val = [$identityId, $problemId, $problemsetId];


### PR DESCRIPTION
# Descripción

Intentando quitar trabajo al validar que un envío está dentro del tiempo permitido.

Fixes: Ha habido reportes de lentitud a la hora de hacer submits y @lhchavez encontró que esta consulta a la base de datos es una posible causa. Si le quitamos trabajo, podría mejorar su tiempo de ejecución.

# Comentarios

No estoy seguro que cambiar esto sea 100% correcto porque el `...FOR UPDATE` está queriendo conseguir locks. Puede ser que esté hecho el join a propósito para ponerle un lock a la tabla de identidades.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.