### PR TITLE
Usando más sintaxis nueva de PHP 8

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -153,9 +153,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Validators::validateStringOfLengthInRange(
             $r['query'],
             'query',
-            null,
-            255,
-            false /* not required */
+            minLength: null,
+            maxLength: 255,
+            required: false,
         );
         $query = $r['query'];
 
@@ -615,11 +615,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
         return [
             'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
                 $contest,
-                /*course=*/ null,
-                $contestAdmin,
-                $identity,
+                course: null,
+                isAdmin: $contestAdmin,
+                currentIdentity: $identity,
                 offset: null,
-                rowcount: 100
+                rowcount: 100,
             )['clarifications'],
             'problems' => $problems,
             'submissionDeadline' => $contestDetails['submission_deadline'] ?? $contest->finish_time,
@@ -677,9 +677,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 \OmegaUp\Controllers\Identity::getPreferredLanguage(
                     $r->identity
                 ),
-                /*showSolvers=*/false,
-                /*preventProblemsetOpen=*/false,
-                $contestAlias
+                showSolvers: false,
+                preventProblemsetOpen: false,
+                contestAlias: $contestAlias,
             );
             $problems[$index]['letter'] = $problem['letter'] ?? '';
         }
@@ -2816,7 +2816,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $r,
             $identity,
             $contest,
-            false /* is required*/
+            isRequired: false,
         );
 
         // Prevent date changes if a contest already has runs
@@ -3764,14 +3764,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
         return [
             'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
                 $contest,
-                /* course */ null,
-                \OmegaUp\Authorization::isContestAdmin(
+                course: null,
+                isAdmin: \OmegaUp\Authorization::isContestAdmin(
                     $r->identity,
                     $contest
                 ),
-                $r->identity,
-                $offset,
-                $rowcount
+                currentIdentity: $r->identity,
+                offset: $offset,
+                rowcount: $rowcount,
             )['clarifications'],
         ];
     }
@@ -3823,9 +3823,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $r->identity,
                     $contest
                 ),
-                /* currentIdentity */ $r->identity,
-                $offset,
-                $rowcount
+                currentIdentity: $r->identity,
+                offset: $offset,
+                rowcount: $rowcount,
             ),
         ];
     }

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -371,7 +371,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r,
         string $courseAlias
     ): \OmegaUp\DAO\VO\Courses {
-        self::validateBasicCreateOrUpdate($r, true /*is update*/);
+        self::validateBasicCreateOrUpdate($r, isUpdate: true);
 
         // Get the actual start and finish time of the course, considering that
         // in case of update, parameters can be optional.
@@ -443,18 +443,18 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Validators::validateOptionalStringNonEmpty(
             $r['objective'],
             'objective',
-            /*required=*/false // TODO: This should be $isRequired when the UI is ready
+            required: false // TODO: This should be $isRequired when the UI is ready
         );
 
         $r->ensureOptionalInt('start_time', null, null, !$isUpdate);
         $r->ensureOptionalInt(
             'finish_time',
-            null,
-            null,
-            /* required */ (
+            lowerBound: null,
+            upperBound: null,
+            required: (
                 !$isUpdate &&
                 !($r->ensureOptionalBool('unlimited_duration') ?? false)
-            )
+            ),
         );
 
         $r->ensureOptionalString(
@@ -4067,7 +4067,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $params = \OmegaUp\ScoreboardParams::fromAssignment(
             $assignment,
             intval($course->group_id),
-            /*showAllRuns*/false
+            showAllRuns: false,
         );
 
         $params->admin = $isAdmin;
@@ -4212,13 +4212,13 @@ class Course extends \OmegaUp\Controllers\Controller {
             $params = \OmegaUp\ScoreboardParams::fromAssignment(
                 $assignment,
                 intval($course->group_id),
-                /*showAllRuns*/false
+                showAllRuns: false,
             );
             $params->admin = $isAdmin;
             $scoreboard = new \OmegaUp\Scoreboard($params);
             $scoreboard = $scoreboard->generate(
                 withRunDetails: false,
-                sortByName: false
+                sortByName: false,
             );
         }
 
@@ -5375,12 +5375,15 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         return [
             'clarifications' => \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
-                /* contest */                null,
-                $course,
-                \OmegaUp\Authorization::isCourseAdmin($r->identity, $course),
-                $r->identity,
-                $offset,
-                $rowcount
+                contest: null,
+                course: $course,
+                isAdmin: \OmegaUp\Authorization::isCourseAdmin(
+                    $r->identity,
+                    $course
+                ),
+                currentIdentity: $r->identity,
+                offset: $offset,
+                rowcount: $rowcount
             )['clarifications'],
         ];
     }
@@ -5418,12 +5421,15 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         $list = \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
-            /* contest */            null,
-            $course,
-            \OmegaUp\Authorization::isCourseAdmin($r->identity, $course),
-            $r->identity,
-            $page,
-            $pageSize
+            contest: null,
+            course: $course,
+            isAdmin: \OmegaUp\Authorization::isCourseAdmin(
+                $r->identity,
+                $course
+            ),
+            currentIdentity: $r->identity,
+            offset: $page,
+            rowcount: $pageSize
         );
 
         return [
@@ -5516,9 +5522,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                     $r->identity,
                     $course
                 ),
-                /* currentIdentity */ $r->identity,
-                $offset,
-                $rowcount
+                currentIdentity: $r->identity,
+                offset: $offset,
+                rowcount: $rowcount,
             ),
         ];
     }
@@ -5623,7 +5629,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             \OmegaUp\ScoreboardParams::fromAssignment(
                 $tokenAuthenticationResult['assignment'],
                 $tokenAuthenticationResult['course']->group_id,
-                $tokenAuthenticationResult['courseAdmin']/*show_all_runs*/
+                showAllRuns: $tokenAuthenticationResult['courseAdmin'],
             )
         );
 

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -618,8 +618,8 @@ class Identity extends \OmegaUp\Controllers\Controller {
         if ($originalSchoolId !== $schoolId) {
             $newIdentitySchool = \OmegaUp\DAO\IdentitiesSchools::createNewSchoolForIdentity(
                 $identity,
-                $schoolId, /* new school_id */
-                null /* graduation_date */
+                schoolId: $schoolId,
+                graduationDate: null,
             );
             $identity->current_identity_school_id = $newIdentitySchool->identity_school_id;
         }
@@ -917,8 +917,8 @@ class Identity extends \OmegaUp\Controllers\Controller {
         if ($originalSchoolId !== $schoolId) {
             $newIdentitySchool = \OmegaUp\DAO\IdentitiesSchools::createNewSchoolForIdentity(
                 $identity,
-                $schoolId, /* new school_id */
-                null /* graduation_date */
+                schoolId: $schoolId,
+                graduationDate: null,
             );
             $identity->current_identity_school_id = $newIdentitySchool->identity_school_id;
         }

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2623,7 +2623,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $userData = \OmegaUp\Controllers\User::getUserProfile(
                 $loggedIdentity,
                 $loggedIdentity,
-                /**$omitRank=*/true
+                omitRank: true
             );
             if (
                 !empty($userData) &&
@@ -3687,11 +3687,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $detailsJson = \OmegaUp\Grader::getInstance()->getGraderResource(
                 $run,
                 'details.json',
-                /*missingOk=*/true
+                missingOk: true
             );
             if (!is_null($detailsJson)) {
                 /** @var null|array{verdict: string, compile_meta: array{Main: RunMetadata}, score: int, contest_score: int, max_score: int, time: float, wall_time: float, memory: int, judged_by: string, groups: list<array{group: string, score: float, contest_score: int, max_score: int, cases: list<CaseResult>}>} */
-                $details = json_decode($detailsJson, /*associative=*/true);
+                $details = json_decode($detailsJson, associative: true);
                 if (!is_array($details)) {
                     self::$log->error(
                         "Failed to interpret run details: {$detailsJson}"
@@ -4528,9 +4528,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $problem,
             $problemset,
             \OmegaUp\Controllers\Identity::getPreferredLanguage($r->identity),
-            /*showSolvers=*/false,
-            $preventProblemsetOpen,
-            $contestAlias
+            showSolvers: false,
+            preventProblemsetOpen: $preventProblemsetOpen,
+            contestAlias: $contestAlias,
         );
         if (is_null($details)) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
@@ -5135,10 +5135,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $details = self::getProblemDetails(
             $identity,
             $problem,
-            /*$problemset*/null,
-            /*$statementLanguage*/'',
-            /*$showSolvers*/false,
-            /*$preventProblemsetOpen*/false
+            problemset: null,
+            statementLanguage: '',
+            showSolvers: false,
+            preventProblemsetOpen: false,
         );
         if (is_null($details)) {
             throw new \OmegaUp\Exceptions\NotFoundException(

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -645,7 +645,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         /**
          * @var null|array{tags?: mixed, before_ac?: mixed, difficulty?: mixed, quality?: mixed, statements?: mixed, source?: mixed, reason?: mixed, original?: mixed} $contents
          */
-        $contents = json_decode($r['contents'], true /*assoc*/);
+        $contents = json_decode($r['contents'], associative: true);
         if (!is_array($contents)) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterInvalid',
@@ -1040,14 +1040,14 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         );
 
         $response = \OmegaUp\DAO\QualityNominations::getNominations(
-            /* nominator */            null,
-            /* assignee */ null,
-            $offset,
-            $rowCount,
-            $types,
-            $status,
-            $query,
-            $column
+            nominatorUserId: null,
+            assigneeUserId: null,
+            page: $offset,
+            rowcount: $rowCount,
+            types: $types,
+            status: $status,
+            query: $query,
+            column: $column,
         );
 
         $pagerItems = \OmegaUp\Pager::paginate(
@@ -1083,7 +1083,11 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         $r->ensureMainUserIdentity();
         self::validateMemberOfReviewerGroup($r);
 
-        return self::getListImpl($r, null /* nominator */, $r->user->user_id);
+        return self::getListImpl(
+            $r,
+            nominator: null,
+            assignee: $r->user->user_id,
+        );
     }
 
     /**
@@ -1115,11 +1119,11 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         }
 
         $response = \OmegaUp\DAO\QualityNominations::getNominations(
-            $r->user->user_id,
-            /* assignee */ null,
-            $offset,
-            $rowCount,
-            $types
+            nominatorUserId: $r->user->user_id,
+            assigneeUserId: null,
+            page: $offset,
+            rowcount: $rowCount,
+            types: $types,
         );
 
         $pagerItems = \OmegaUp\Pager::paginate(

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -62,7 +62,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     ];
 
     /** @var int */
-    public static $defaultSubmissionGap = 60; /*seconds*/
+    public static $defaultSubmissionGap = 60; // seconds.
 
     public const VERDICTS = [
         'AC',
@@ -586,7 +586,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         // Happy ending
         $response['nextSubmissionTimestamp'] = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(
             $contest,
-            /*lastSubmissionTime=*/$submission->time
+            lastSubmissionTime: $submission->time
         );
 
         if (is_null($submission->guid)) {
@@ -1152,7 +1152,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         return self::getOptionalRunDetails(
             $submission,
             $run,
-            /*$contest*/ null,
+            contest: null,
             showDetails: false
         );
     }
@@ -1310,12 +1310,12 @@ class Run extends \OmegaUp\Controllers\Controller {
         $result = \OmegaUp\Grader::getInstance()->getGraderResource(
             $run,
             $filename,
-            /*missingOk=*/true
+            missingOk: true
         );
         if (is_null($result)) {
             $result = self::downloadResourceFromS3(
                 "{$run->run_id}/{$filename}",
-                /*passthru=*/false
+                passthru: false
             );
         }
         return $result;
@@ -1333,14 +1333,14 @@ class Run extends \OmegaUp\Controllers\Controller {
         $result = \OmegaUp\Grader::getInstance()->getGraderResourcePassthru(
             $run,
             $filename,
-            /*missingOk=*/true,
-            $headers
+            missingOk: true,
+            fileHeaders: $headers,
         );
         if (is_null($result)) {
             $result = self::downloadResourceFromS3(
                 "{$run->run_id}/{$filename}",
-                /*passthru=*/true,
-                $headers
+                passthru: true,
+                httpHeaders: $headers,
             );
         }
         return $result;

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -789,8 +789,8 @@ class Session extends \OmegaUp\Controllers\Controller {
                         'username' => $username,
                         'email' => $email,
                     ]),
-                    /*ignorePassword=*/true,
-                    /*forceVerification=*/true
+                    ignorePassword: true,
+                    forceVerification: true
                 );
             } catch (\OmegaUp\Exceptions\ApiException $e) {
                 self::$log->error(

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -98,8 +98,8 @@ class User extends \OmegaUp\Controllers\Controller {
         $createUserParams = new \OmegaUp\CreateUserParams($r->toStringArray());
         self::createUser(
             $createUserParams,
-            /*ignorePassword=*/false,
-            /*forceVerification=*/false
+            ignorePassword: false,
+            forceVerification: false
         );
         return [
             'username' => strval($createUserParams->username),
@@ -214,7 +214,7 @@ class User extends \OmegaUp\Controllers\Controller {
             }
 
             /** @var null|mixed */
-            $resultAsJson = json_decode($result, /*assoc=*/true);
+            $resultAsJson = json_decode($result, associative: true);
             if (is_null($resultAsJson)) {
                 self::$log->error('Captcha response was not a json');
                 self::$log->error("Here is the result: {$result}");
@@ -1818,8 +1818,8 @@ class User extends \OmegaUp\Controllers\Controller {
 
         $codersOfTheMonth = \OmegaUp\DAO\CoderOfTheMonth::getByTimeAndSelected(
             $dateToSelect,
-            /*autoselected=*/false,
-            $category
+            autoselected: false,
+            category: $category,
         );
         if (!empty($codersOfTheMonth)) {
             throw new \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException(
@@ -3944,8 +3944,8 @@ class User extends \OmegaUp\Controllers\Controller {
                 !empty(
                     \OmegaUp\DAO\CoderOfTheMonth::getByTimeAndSelected(
                         $dateToSelect,
-                        false,
-                        $category
+                        autoselected: false,
+                        category: $category,
                     )
                 ),
         ];

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -52,7 +52,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             /** @var array{before_ac?: mixed} */
             $suggestionContents = json_decode(
                 $suggestion['contents'],
-                /*assoc=*/true
+                associative: true
             );
             if (
                 isset($suggestionContents['before_ac']) &&
@@ -88,7 +88,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             /** @var array $dismissalContents */
             $dismissalContents = json_decode(
                 $dismissal['contents'],
-                /*assoc=*/true
+                associative: true
             );
             if (
                 isset($dismissalContents['before_ac']) &&
@@ -231,7 +231,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             /** @var array{before_ac?: bool, difficulty?: int, quality?: int, rationale?: string, reason?: string, statements?: array<string, string>, tags?: list<string>} */
             $nomination['contents'] = json_decode(
                 $nomination['contents'],
-                /*assoc=*/true
+                associative: true
             );
         } else {
             unset($nomination['contents']);
@@ -254,7 +254,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
      */
     public static function getNominations(
         ?int $nominatorUserId,
-        ?int $asigneeUserId,
+        ?int $assigneeUserId,
         int $page,
         int $rowcount,
         array $types = ['demotion', 'promotion'],
@@ -303,7 +303,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         $params = [];
         $conditions = [];
 
-        if (!is_null($asigneeUserId)) {
+        if (!is_null($assigneeUserId)) {
             $sqlFrom .= '
             INNER JOIN
                 QualityNomination_Reviewers qnr
@@ -311,7 +311,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
                 qnr.qualitynomination_id = qn.qualitynomination_id';
 
             $conditions[] = ' qnr.user_id = ?';
-            $params[] = $asigneeUserId;
+            $params[] = $assigneeUserId;
         }
 
         if (!empty($types)) {
@@ -486,7 +486,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
 
         foreach ($contents as $nomination) {
             /** @var array{quality?: mixed, difficulty?: mixed, tags?: mixed} */
-            $feedback = json_decode($nomination['contents'], /*assoc=*/true);
+            $feedback = json_decode($nomination['contents'], associative: true);
             if (isset($feedback['quality']) && is_int($feedback['quality'])) {
                 $qualitySum += $feedback['quality'];
                 $qualityN++;
@@ -571,7 +571,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
 
         foreach ($contents as $nomination) {
             /** @var array{quality?: mixed, difficulty?: mixed, tags?: mixed} */
-            $feedback = json_decode($nomination['contents'], /*assoc=*/true);
+            $feedback = json_decode($nomination['contents'], associative: true);
 
             if (isset($feedback['quality']) && is_int($feedback['quality'])) {
                 $problemAggregates['quality_sum'] += intval(

--- a/frontend/server/src/ProblemArtifacts.php
+++ b/frontend/server/src/ProblemArtifacts.php
@@ -127,7 +127,7 @@ class ProblemArtifacts {
             return [];
         }
         /** @var null|array{id: string, entries?: null|list<array{mode: int, type: string, id: string, name: string, size: int}>} */
-        $response = json_decode($response, /*assoc=*/true);
+        $response = json_decode($response, associative: true);
         if (!is_array($response) || !array_key_exists('entries', $response)) {
             $this->log->error(
                 "Failed to get entries of {$path} for problem {$this->alias} at revision {$this->revision}"
@@ -207,7 +207,7 @@ class ProblemArtifacts {
             return null;
         }
         /** @var null|array{commit: string, tree: string, parents: list<string>, author: array{name: string, email: string, time: string}, committer: array{name: string, email: string, time: string}, message: string} */
-        $response = json_decode($response, /*assoc=*/true);
+        $response = json_decode($response, associative: true);
         if (!is_array($response)) {
             $this->log->error(
                 "Invalid commit for problem {$this->alias} at revision {$this->revision}"
@@ -240,7 +240,7 @@ class ProblemArtifacts {
             return [];
         }
         /** @var null|array{log?: null|list<array{commit: string, tree: string, parents: list<string>, author: array{name: string, email: string, time: string}, committer: array{name: string, email: string, time: string}, message: string}>, next?: string} */
-        $response = json_decode($response, /*assoc=*/true);
+        $response = json_decode($response, associative: true);
         if (!is_array($response) || !array_key_exists('log', $response)) {
             $this->log->error(
                 "Failed to get log for problem {$this->alias} at revision {$this->revision}"
@@ -262,7 +262,7 @@ class ProblemArtifacts {
         $browser = new GitServerBrowser(
             $this->alias,
             GitServerBrowser::buildArchiveURL($this->alias, $this->revision),
-            /*passthru=*/true
+            passthru: true
         );
         $browser->headers[] = 'Accept: application/zip';
         $response = $browser->exec();

--- a/frontend/server/src/ProblemDeployer.php
+++ b/frontend/server/src/ProblemDeployer.php
@@ -185,7 +185,7 @@ class ProblemDeployer {
         /** @var null|array{interactive?: array{module_name: string, language: string}, cases: array<string, mixed>} */
         $distribSettings = json_decode(
             $problemArtifacts->get('settings.distrib.json'),
-            /*assoc=*/true
+            associative: true
         );
         if (empty($distribSettings['interactive'])) {
             // oops, this was not an interactive problem.
@@ -453,7 +453,7 @@ class ProblemDeployer {
             $context = null;
             if (!empty($result['output'])) {
                 /** @var null|array{error: string} */
-                $output = json_decode($result['output'], /*assoc=*/true);
+                $output = json_decode($result['output'], associative: true);
                 if (is_null($output)) {
                     $context = $result['output'];
                 } else {
@@ -480,7 +480,7 @@ class ProblemDeployer {
         }
 
         /** @var array{status: string, error?: string, updated_refs?: array{name: string, from: string, to: string, from_tree: string, to_tree: string}[], updated_files: array{path: string, type: string}[]} */
-        return json_decode($result['output'], /*assoc=*/true);
+        return json_decode($result['output'], associative: true);
     }
 
     /**

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -75,10 +75,11 @@ class Scoreboard {
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
             $this->params->problemset_id,
             $this->params->acl_id,
-            true /* show all runs */,
-            $filterUsersBy,
-            $this->params->group_id,
-            !$this->params->virtual /* Treat admin as contestant in virtual contest*/
+            showAllRuns: true,
+            filterUsersBy: $filterUsersBy,
+            groupId: $this->params->group_id,
+            // Treat admin as contestant in virtual contest.
+            excludeAdmin: !$this->params->virtual,
         );
 
         // Get all problems given problemset
@@ -183,10 +184,11 @@ class Scoreboard {
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
             $this->params->problemset_id,
             $this->params->acl_id,
-            $this->params->admin,
-            null,
-            null,
-            !$this->params->virtual /* Treat admin as contestant */
+            showAllRuns: $this->params->admin,
+            filterUsersBy: null,
+            groupId: null,
+            // Treat admin as contestant.
+            excludeAdmin: !$this->params->virtual,
         );
 
         // Get all problems given problemset
@@ -284,10 +286,11 @@ class Scoreboard {
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
             $params->problemset_id,
             $params->acl_id,
-            true /* show all runs */,
-            null,
-            null,
-            !$params->virtual /* Treat admin as contestant in virtual contest */
+            showAllRuns: true,
+            filterUsersBy: null,
+            groupId: null,
+            // Treat admin as contestant in virtual contest.
+            excludeAdmin: !$params->virtual,
         );
 
         // Get all problems given problemset
@@ -335,7 +338,7 @@ class Scoreboard {
             $params->finish_time,
             $params->admin,
             $params->scoreboard_pct,
-            false  /* sortByName */
+            sortByName: false,
         );
 
         $contestantEventCache = new \OmegaUp\Cache(
@@ -371,7 +374,7 @@ class Scoreboard {
             $params->finish_time,
             $params->admin,
             $params->scoreboard_pct,
-            false /* sortByName */
+            sortByName: false,
         );
         $adminScoreboardCache->set($adminScoreboard, $timeout);
         $params->admin = false;

--- a/frontend/server/src/ScoreboardParams.php
+++ b/frontend/server/src/ScoreboardParams.php
@@ -61,28 +61,28 @@ class ScoreboardParams {
         ScoreboardParams::validateParameter(
             'alias',
             $params,
-            true /*is_required*/
+            required: true,
         );
         $this->alias = strval($params['alias']);
 
         ScoreboardParams::validateParameter(
             'title',
             $params,
-            true /*is_required*/
+            required: true,
         );
         $this->title = strval($params['title']);
 
         ScoreboardParams::validateParameter(
             'problemset_id',
             $params,
-            true /*is_required*/
+            required: true,
         );
         $this->problemset_id = intval($params['problemset_id']);
 
         ScoreboardParams::validateParameter(
             'start_time',
             $params,
-            true /*is_required*/
+            required: true,
         );
         if ($params['start_time'] instanceof \OmegaUp\Timestamp) {
             $this->start_time = $params['start_time'];
@@ -99,7 +99,7 @@ class ScoreboardParams {
         ScoreboardParams::validateParameter(
             'finish_time',
             $params,
-            false /*is_required*/
+            required: false,
         );
         if (!is_null($params['finish_time'])) {
             if ($params['finish_time'] instanceof \OmegaUp\Timestamp) {
@@ -120,15 +120,15 @@ class ScoreboardParams {
         ScoreboardParams::validateParameter(
             'acl_id',
             $params,
-            true /*is_required*/
+            required: true,
         );
         $this->acl_id = intval($params['acl_id']);
 
         ScoreboardParams::validateParameter(
             'group_id',
             $params,
-            false /*is_required*/,
-            null
+            required: false,
+            default: null,
         );
         $this->group_id = is_null(
             $params['group_id']
@@ -139,32 +139,32 @@ class ScoreboardParams {
         ScoreboardParams::validateParameter(
             'penalty',
             $params,
-            false /*is_required*/,
-            0
+            required: false,
+            default: 0,
         );
         $this->penalty = intval($params['penalty']);
 
         ScoreboardParams::validateParameter(
             'virtual',
             $params,
-            false /*is_required */,
-            false
+            required: false,
+            default: false,
         );
         $this->virtual = boolval($params['virtual']);
 
         ScoreboardParams::validateParameter(
             'penalty_calc_policy',
             $params,
-            false /*is_required*/,
-            'sum'
+            required: false,
+            default: 'sum',
         );
         $this->penalty_calc_policy = strval($params['penalty_calc_policy']);
 
         ScoreboardParams::validateParameter(
             'show_scoreboard_after',
             $params,
-            false /*is_required*/,
-            1
+            required: false,
+            default: 1,
         );
         $this->show_scoreboard_after = boolval(
             $params['show_scoreboard_after']
@@ -173,24 +173,24 @@ class ScoreboardParams {
         ScoreboardParams::validateParameter(
             'scoreboard_pct',
             $params,
-            false /*is_required*/,
-            100
+            required: false,
+            default: 100,
         );
         $this->scoreboard_pct = intval($params['scoreboard_pct']);
 
         ScoreboardParams::validateParameter(
             'admin',
             $params,
-            false /*is_required*/,
-            false
+            required: false,
+            default: false,
         );
         $this->admin = boolval($params['admin']);
 
         ScoreboardParams::validateParameter(
             'auth_token',
             $params,
-            false /*is_required*/,
-            null
+            required: false,
+            default: null,
         );
         $this->auth_token = is_null(
             $params['auth_token']
@@ -201,16 +201,16 @@ class ScoreboardParams {
         ScoreboardParams::validateParameter(
             'only_ac',
             $params,
-            false /*is_required*/,
-            false
+            required: false,
+            default: false,
         );
         $this->only_ac = boolval($params['only_ac']);
 
         ScoreboardParams::validateParameter(
             'show_all_runs',
             $params,
-            false /*is_required*/,
-            true
+            required: false,
+            default: true,
         );
         $this->show_all_runs = boolval($params['show_all_runs']);
     }

--- a/frontend/server/src/UrlHelper.php
+++ b/frontend/server/src/UrlHelper.php
@@ -10,6 +10,10 @@ class UrlHelper {
      * @param null|resource $context
      */
     public function fetchUrl(string $url, $context = null): string {
-        return file_get_contents($url, /*use_include_path=*/false, $context);
+        return file_get_contents(
+            $url,
+            use_include_path: false,
+            context: $context,
+        );
     }
 }

--- a/frontend/smarty_plugins/compiler.js_include.php
+++ b/frontend/smarty_plugins/compiler.js_include.php
@@ -12,7 +12,7 @@ function getJavaScriptDeps(string $entrypoint): array {
         );
     }
     /** @var array{css: list<string>, js: list<string>} */
-    $jsonContents = json_decode($textContents, /*assoc=*/true);
+    $jsonContents = json_decode($textContents, associative: true);
     return $jsonContents['js'];
 }
 

--- a/frontend/tests/Factories/User.php
+++ b/frontend/tests/Factories/User.php
@@ -76,8 +76,8 @@ class User {
                 'email' => $params->email,
                 'is_private' => strval($params->isPrivate),
             ]),
-            /*ignorePassword=*/false,
-            /*forceVerification=*/true
+            ignorePassword: false,
+            forceVerification: true
         );
 
         // Get user from db

--- a/frontend/tests/controllers/CourseStudentListTest.php
+++ b/frontend/tests/controllers/CourseStudentListTest.php
@@ -594,7 +594,7 @@ class CourseStudentListTest extends \OmegaUp\Test\ControllerTestCase {
             $course->alias,
             $assignmentAliases[0],
             [ $problemsData[4], $problemsData[5] ],
-            /*extraProblems=*/true
+            extraProblems: true
         );
 
         $runData = \OmegaUp\Test\Factories\Run::createAssignmentRun(

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -1058,7 +1058,6 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
                 $problemData['author'],
                 $problemData['problem']
             ),
-            /*public=*/ false
         );
         $this->assertEquals($testTags, $privateTags);
 
@@ -1069,7 +1068,6 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
                 $extraIdentity,
                 $problemData['problem']
             ),
-            /*public=*/ false
         );
         $this->assertEmpty($privateTags);
     }


### PR DESCRIPTION
Resulta que varios usos de la vieja sintaxis se fueron porque no usaban
_exactamente_ la misma sintaxis ^^;;