### PR TITLE
Agregando columna en la BD para guardar la clase de rank de cada usuario

### DIFF
--- a/frontend/database/00192_classname_in_user_ranks.sql
+++ b/frontend/database/00192_classname_in_user_ranks.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `User_Rank`
+    ADD COLUMN `classname` varchar(50) DEFAULT NULL COMMENT 'Almacena la clase precalculada para no tener que determinarla en tiempo de ejecucion.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1095,6 +1095,7 @@ CREATE TABLE `User_Rank` (
   `school_id` int DEFAULT NULL,
   `author_score` double NOT NULL DEFAULT '0',
   `author_ranking` int DEFAULT NULL,
+  `classname` varchar(50) DEFAULT NULL COMMENT 'Almacena la clase precalculada para no tener que determinarla en tiempo de ejecucion.',
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username` (`username`),
   KEY `rank` (`ranking`),


### PR DESCRIPTION
# Descripción

Se agrega una columna a la BD para guardar la clase de rank de cada usuario. En un pull request posterior podemos poblar esta columna en `update_ranks.py`. Una vez que se haya poblado podemos cambiar todas las consultas que calculan la clase de rank por usuario sobre la marcha a solp consumir esta columna.

# Comentarios

Esta consulta es de las más costosas según NewRelic:
![image](https://user-images.githubusercontent.com/189223/146889530-ad15a8a4-f6a9-4619-a631-8989c4abc4ef.png)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.