### PR TITLE
Quitando joins innecesarios en las consultas de clarificaciones

### DIFF
--- a/frontend/server/src/DAO/Clarifications.php
+++ b/frontend/server/src/DAO/Clarifications.php
@@ -35,15 +35,10 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
             INNER JOIN
                 Problemsets ps ON ps.problemset_id = cl.problemset_id
             LEFT JOIN
-                Contests con ON (
-                    con.contest_id = ps.contest_id AND
-                    con.problemset_id = ps.problemset_id
-                )
-            LEFT JOIN
                 Assignments a ON a.problemset_id = cl.problemset_id
             WHERE
                 (
-                    con.contest_id = ? OR
+                    ps.contest_id = ? OR
                     a.course_id = ?
                 )';
 
@@ -146,8 +141,6 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
                 Identities r ON r.identity_id = c.receiver_id
             INNER JOIN
                 Problems p ON p.problem_id = c.problem_id
-            INNER JOIN
-                Problemsets ps ON ps.problemset_id = c.problemset_id
             WHERE
                 c.problemset_id = ?
                 AND p.problem_id = ?


### PR DESCRIPTION
# Descripción

Quitando joins innecesarios en las consultas de clarificaciones.

# Comentarios

Clarificaciones son de las consultas más costosas a la BD, según NewRelic:
![image](https://user-images.githubusercontent.com/189223/146908509-0cc9d983-546f-4494-b8c0-4efbcc7b40bc.png)

Dice MySQL que además de este trabajo innecesario, son caras porque no estamos usando indices adecuadamente (para el próximo pull request)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.