### PR TITLE
Solo contar clarificaciones cuando sea necesario contarlas

### DIFF
--- a/frontend/server/src/DAO/Clarifications.php
+++ b/frontend/server/src/DAO/Clarifications.php
@@ -103,7 +103,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         // If we didn't get an offset, we know the total number of rows
         // already, no need to query the database for it.
         $totalRows = count($clarifications);
-        if (!is_null($offset)) {
+        if (!is_null($offset) && $offset != 0) {
             if ($totalRows != $rowcount) {
                 // If we did get an offset, but the number of rows we got is
                 // less than what we allowed, we've already reached the end

--- a/frontend/server/src/DAO/Clarifications.php
+++ b/frontend/server/src/DAO/Clarifications.php
@@ -85,12 +85,6 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         $query = $sql . $sqlFrom;
         $countQuery = $sqlCount . $sqlFrom;
 
-        /** @var int */
-        $totalRows = \OmegaUp\MySQLConnection::getInstance()->GetOne(
-            $countQuery,
-            $params
-        ) ?? 0;
-
         $sqlLimit = '';
         if (!is_null($offset)) {
             $sqlLimit = 'LIMIT ?, ?';
@@ -105,6 +99,28 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
             $query,
             $params
         );
+
+        // If we didn't get an offset, we know the total number of rows
+        // already, no need to query the database for it.
+        $totalRows = count($clarifications);
+        if (!is_null($offset)) {
+            if ($totalRows != $rowcount) {
+                // If we did get an offset, but the number of rows we got is
+                // less than what we allowed, we've already reached the end
+                // of the list so just bump up the count to account for the
+                // starting position.
+                $totalRows += ($offset - 1) * $rowcount;
+            } else {
+                // If we exhausted the maximum number of rows to fetch it's
+                // possible there are more rows than we know about at this
+                // point, thus we need to actually query the database.
+                /** @var int */
+                $totalRows = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+                    $countQuery,
+                    $params
+                ) ?? 0;
+            }
+        }
 
         return [
             'totalRows' => $totalRows,


### PR DESCRIPTION
# Descripción

Intentando eliminar una consulta a la BD para contar el total de clarificaciones cuando el total sea conocido (que creo debería cubrir la gran mayoría de las veces).

# Comentarios

Seguimos con el tema de que consultas a clarificaciones son de las consultas más caras a la BD ahorita. En esta ronda quitamos una consulta complete si no es necesaria, y en rondas posteriores podemos optimizar la consulta en sí.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.