### PR TITLE
Corrigiendo links rotos en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![omegaUp](frontend/www/media/omegaup.png)](https://omegaup.com)
 
-[![Build Status](https://travis-ci.com/omegaup/omegaup.svg)](https://travis-ci.com/omegaup/omegaup) [![Contributors](https://img.shields.io/github/contributors/omegaup/omegaup)](https://github.com/omegaup/omegaup/graphs/contributors) [![Issues open](https://img.shields.io/github/issues/omegaup/omegaup)](https://github.com/omegaup/omegaup/issues?q=is%3Aissue+is%3Aopen) [![Issues closed](https://img.shields.io/github/issues-closed/omegaup/omegaup)](https://github.com/omegaup/omegaup/issues?q=is%3Aissue+is%3Aclosed)
+[![Contributors](https://img.shields.io/github/contributors/omegaup/omegaup)](https://github.com/omegaup/omegaup/graphs/contributors) [![Issues open](https://img.shields.io/github/issues/omegaup/omegaup)](https://github.com/omegaup/omegaup/issues?q=is%3Aissue+is%3Aopen) [![Issues closed](https://img.shields.io/github/issues-closed/omegaup/omegaup)](https://github.com/omegaup/omegaup/issues?q=is%3Aissue+is%3Aclosed)
 
 [![Forks](https://img.shields.io/github/forks/omegaup/omegaup?style=social)](https://github.com/omegaup/omegaup/network/members) [![Stars](https://img.shields.io/github/stars/omegaup/omegaup?style=social)](https://github.com/omegaup/omegaup/stargazers) [![Twitter](https://img.shields.io/twitter/follow/omegaup.svg?style=social&label=Follow)](https://twitter.com/omegaup)
 
@@ -12,9 +12,9 @@ Directorios que se utilizan activamente en el desarrollo.
 
 | Directorio | Descripción |
 |------------|-------------|
-| [frontend/server/controllers](https://github.com/omegaup/omegaup/tree/main/frontend/server/controllers) | Lógica de negocio que implementa la API de omegaUp. |
+| [frontend/server/src/Controllers](https://github.com/omegaup/omegaup/tree/main/frontend/server/src/Controllers) | Lógica de negocio que implementa la API de omegaUp. |
 | [frontend/server/libs](https://github.com/omegaup/omegaup/tree/main/frontend/server/libs) | Bibliotecas y utilerías. |
-| [frontend/server/libs/dao](https://github.com/omegaup/omegaup/tree/main/frontend/server/libs/dao) | Los Data Access Objects [DAO] y Value Objects [VO]. Clases utilizadas para representar los esquemas de la base de datos y facilitar su consumo por los controladores. |
+| [frontend/server/src/DAO](https://github.com/omegaup/omegaup/tree/main/frontend/server/src/DAO) | Los Data Access Objects [DAO] y Value Objects [VO]. Clases utilizadas para representar los esquemas de la base de datos y facilitar su consumo por los controladores. |
 | [frontend/templates](https://github.com/omegaup/omegaup/tree/main/frontend/templates) | Plantillas de Smarty utilizadas para generar el HTML que se despliega a los usuarios. También aquí están los archivos de internacionalización para inglés, español y portugués. |
 | [frontend/www](https://github.com/omegaup/omegaup/tree/main/frontend/www) |  Los contenidos completos de la página de internet. |
 
@@ -22,7 +22,7 @@ El resto del código está en otros repositorios
 
 | Repositorio| Descripción |
 |------------|-------------|
-| [quark](https://github.com/lhchavez/quark) | Incluye el código del grader para la calificación de problemas y ejecutar los códigos bajo minijail, así como el servicio utilizado en los servidores de la nube para servir la cola de envíos. |
+| [quark](https://github.com/omegaup/quark) | Incluye el código del grader para la calificación de problemas y ejecutar los códigos bajo minijail, así como el servicio utilizado en los servidores de la nube para servir la cola de envíos. |
 | [karel.js](https://github.com/omegaup/karel.js) | La versión oficial de Karel utilizada por la Olimpiada Mexicana de Informática. |
 | [omegajail](https://github.com/omegaup/omegajail) | Un mecanismo de ejecución segura que basado en contenedores de Linux y seccomp-bpf. Utiliza [minijail](https://android.googlesource.com/platform/external/minijail/+/master), escrito por el proyecto [Chromium](https://www.chromium.org). |
 | [libinteractive](https://github.com/omegaup/libinteractive) | Una librería para hacer problemas interactivos fácilmente.


### PR DESCRIPTION
# Descripción

Corrigiendo algunos links que estaban rotos en el README. 

# Comentarios

Hice 3 cosas en este cambio:

- No conozco muy bien el codigo, pero creo que corregi a los paths correctos (parece que solo cambio la estructura). 
- Borre el link a travis CI porque daba 404, y vi que no se usa en los PR. 
- Por ultimo, cambie la referencia de quark al repo de omegaup, que me imagino es el oficial.

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.