### PR TITLE
Denormalizando la tabla Runs un poco

### DIFF
--- a/frontend/database/00193_denormalize_submissions.sql
+++ b/frontend/database/00193_denormalize_submissions.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `Submissions`
+  ADD COLUMN `status` enum('new','waiting','compiling','running','ready','uploading') NOT NULL DEFAULT 'new' AFTER `time`,
+  ADD COLUMN `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL AFTER `status`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -996,6 +996,8 @@ CREATE TABLE `Submissions` (
   `guid` char(32) NOT NULL,
   `language` enum('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','java','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua') NOT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `status` enum('new','waiting','compiling','running','ready','uploading') NOT NULL DEFAULT 'new',
+  `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL,
   `submit_delay` int NOT NULL DEFAULT '0',
   `type` enum('normal','test','disqualified') DEFAULT 'normal',
   `school_id` int DEFAULT NULL,

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -13,7 +13,9 @@ namespace OmegaUp\DAO;
  */
 class Submissions extends \OmegaUp\DAO\Base\Submissions {
     final public static function getByGuid(string $guid): ?\OmegaUp\DAO\VO\Submissions {
-        $sql = 'SELECT * FROM Submissions WHERE (guid = ?) LIMIT 1;';
+        $sql = 'SELECT ' .
+            join(', ', array_keys(\OmegaUp\DAO\VO\Submissions::FIELD_NAMES)) .
+            ' FROM Submissions WHERE (guid = ?) LIMIT 1;';
         $params = [$guid];
 
         /** @var array{current_run_id: int|null, guid: string, identity_id: int, language: string, problem_id: int, problemset_id: int|null, school_id: int|null, submission_id: int, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string}|null */


### PR DESCRIPTION
Este cambio le agrega los campos `status` y `verdict` a `Submissions`.
Esto es para que la lista global de envíos no tenga que hacer un `JOIN`
con `Runs`, porque eso resulta que es _lentísimo_.