### PR TITLE
Mejorando el script de migración de la base de datos

### DIFF
--- a/stuff/bootstrap-environment.py
+++ b/stuff/bootstrap-environment.py
@@ -287,7 +287,7 @@ def _main() -> None:
 
         db_migrate_args = [
             os.path.join(OMEGAUP_ROOT, 'stuff/db-migrate.py'),
-            '--kill-other-connections',
+            '--kill-blocking-connections',
         ]
         for name, value in [('--username', args.username),
                             ('--password', args.password),


### PR DESCRIPTION
Este cambio:
- Permite que el script de migración de la base de datos use la misma
  librería de logging que los demás comandos de Python, para que New
  Relic pueda obtener los logs correctamente.
- Usa una consulta distinta para obtener la lista de procesos a
  terminar. Esto es porque antes eliminábamos _todos_ los otros procesos
  (que puede ser ligeramente peligroso). Ahora nos limitamos a eliminar
  los procesos que adquirieron un lock en la base de datos.
- Usa un comando distinto para eliminar procesos. `KILL ${PID}` no
  funciona en AWS RDS porque el usuario no tiene el privilegio `SUPER`,
  así que AWS provee una función distinta que se puede invocar.