### PR TITLE
Usar la columna denormalizada User_Rank.classname

### DIFF
--- a/frontend/server/src/DAO/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/CourseIdentityRequest.php
@@ -21,26 +21,7 @@ class CourseIdentityRequest extends \OmegaUp\DAO\Base\CourseIdentityRequest {
                 i.identity_id,
                 i.username,
                 i.name,
-                IFNULL(
-                    (
-                        SELECT urc.classname FROM
-                            User_Rank_Cutoffs urc
-                        WHERE
-                            urc.score <= (
-                                    SELECT
-                                        ur.score
-                                    FROM
-                                        User_Rank ur
-                                    WHERE
-                                        ur.user_id = i.user_id
-                                )
-                        ORDER BY
-                            urc.percentile ASC
-                        LIMIT
-                            1
-                    ),
-                    \'user-rank-unranked\'
-                ) AS classname,
+                IFNULL(ur.classname, "user-rank-unranked") AS classname,
                 i.country_id,
                 c.name AS country,
                 r.request_time,
@@ -49,11 +30,11 @@ class CourseIdentityRequest extends \OmegaUp\DAO\Base\CourseIdentityRequest {
                 arh.username AS admin_username,
                 arh.name AS admin_name
             FROM
-                `Course_Identity_Request` r
+                Course_Identity_Request r
             INNER JOIN
-                `Identities` i
-            ON
-                i.identity_id = r.identity_id
+                Identities i ON i.identity_id = r.identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             LEFT JOIN
                 (
                     SELECT

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -283,30 +283,13 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
                     u.`hide_problem_tags`,
                     u.`verified`,
                     i.`gender`,
-                    IFNULL(
-                        (
-                            SELECT urc.classname FROM
-                                User_Rank_Cutoffs urc
-                            WHERE
-                                urc.score <= (
-                                        SELECT
-                                            ur.score
-                                        FROM
-                                            User_Rank ur
-                                        WHERE
-                                            ur.user_id = i.user_id
-                                    )
-                            ORDER BY
-                                urc.percentile ASC
-                            LIMIT
-                                1
-                        ),
-                        \'user-rank-unranked\'
-                    ) AS classname
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
                 FROM
                     Identities i
                 LEFT JOIN
                     Users u ON u.user_id = i.user_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 LEFT JOIN
                     Emails e ON u.main_email_id = e.email_id
                 LEFT JOIN
@@ -555,40 +538,17 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
     ) {
         $sql = 'SELECT
                     ti.*,
-                    IFNULL(
-                        (
-                            SELECT urc.classname FROM
-                                User_Rank_Cutoffs urc
-                            WHERE
-                                urc.score <= (
-                                        SELECT
-                                            ur.score
-                                        FROM
-                                            User_Rank ur
-                                        WHERE
-                                            ur.user_id = i.user_id
-                                    )
-                            ORDER BY
-                                urc.percentile ASC
-                            LIMIT
-                                1
-                        ),
-                        \'user-rank-unranked\'
-                    ) AS classname
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
                 FROM
                     Identities i
                 INNER JOIN
-                    Team_Users tu
-                ON
-                    tu.identity_id = i.identity_id
+                    Team_Users tu ON tu.identity_id = i.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 INNER JOIN
-                    Teams t
-                ON
-                    t.team_id = tu.team_id
+                    Teams t ON t.team_id = tu.team_id
                 INNER JOIN
-                    Identities ti
-                ON
-                    ti.identity_id = t.identity_id
+                    Identities ti ON ti.identity_id = t.identity_id
                 WHERE
                     i.identity_id = ?
                 LIMIT 1;';

--- a/frontend/server/src/DAO/Schools.php
+++ b/frontend/server/src/DAO/Schools.php
@@ -132,25 +132,7 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
         $sql = '
         SELECT
             IFNULL(i.username, "") AS `username`,
-            IFNULL(
-                (
-                    SELECT urc.classname
-                    FROM User_Rank_Cutoffs urc
-                    WHERE
-                        urc.score <= (
-                            SELECT
-                                ur.score
-                            FROM
-                                User_Rank ur
-                            WHERE
-                                ur.user_id = i.user_id
-                        )
-                    ORDER BY
-                        urc.percentile ASC
-                    LIMIT 1
-                ),
-                "user-rank-unranked"
-            ) AS classname,
+            IFNULL(ur.classname, "user-rank-unranked") AS classname,
             IFNULL(
                 (
                     SELECT
@@ -207,6 +189,8 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
             Identities_Schools isc ON isc.school_id = sc.school_id
         INNER JOIN
             Identities i ON i.current_identity_school_id = isc.identity_school_id
+        LEFT JOIN
+            User_Rank ur ON ur.user_id = i.user_id
         WHERE
             sc.school_id = ?;';
 

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -201,6 +201,8 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 Submissions s
             INNER JOIN
                 Identities i ON i.identity_id = s.identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             INNER JOIN
                 Problems p ON p.problem_id = s.problem_id
             INNER JOIN
@@ -253,25 +255,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 r.verdict,
                 r.runtime,
                 r.memory,
-                IFNULL(
-                    (
-                        SELECT urc.classname
-                        FROM User_Rank_Cutoffs urc
-                        WHERE
-                            urc.score <= (
-                                SELECT
-                                    ur.score
-                                FROM
-                                    User_Rank ur
-                                WHERE
-                                    ur.user_id = i.user_id
-                            )
-                        ORDER BY
-                            urc.percentile ASC
-                        LIMIT 1
-                    ),
-                    "user-rank-unranked"
-                ) AS classname
+                IFNULL(ur.classname, "user-rank-unranked") AS classname
         ';
 
         $sqlLimit = 'LIMIT ?, ?;';
@@ -374,25 +358,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
         $sql = '
             SELECT
                 i.username as author,
-                IFNULL(
-                    (
-                        SELECT urc.classname
-                        FROM User_Rank_Cutoffs urc
-                        WHERE
-                            urc.score <= (
-                                SELECT
-                                    ur.score
-                                FROM
-                                    User_Rank ur
-                                WHERE
-                                    ur.user_id = i.user_id
-                            )
-                        ORDER BY
-                            urc.percentile ASC
-                        LIMIT 1
-                    ),
-                    "user-rank-unranked"
-                ) AS author_classname,
+                IFNULL(ur.classname, "user-rank-unranked") AS author_classname,
                 sf.feedback,
                 sf.date
             FROM
@@ -401,6 +367,8 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 Submission_Feedback sf ON sf.submission_id = s.submission_id
             INNER JOIN
                 Identities i ON i.identity_id = sf.identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             WHERE
                 s.submission_id = ?
         ';

--- a/frontend/server/src/DAO/TeamUsers.php
+++ b/frontend/server/src/DAO/TeamUsers.php
@@ -67,44 +67,19 @@ class TeamUsers extends \OmegaUp\DAO\Base\TeamUsers {
                     it.username AS team_alias,
                     it.name AS team_name,
                     CAST(IFNULL(i.user_id, FALSE) AS UNSIGNED) AS isMainUserIdentity,
-                    IFNULL(
-                        (
-                            SELECT urc.classname FROM
-                                User_Rank_Cutoffs urc
-                            WHERE
-                                urc.score <= (
-                                        SELECT
-                                            ur.score
-                                        FROM
-                                            User_Rank ur
-                                        WHERE
-                                            ur.user_id = u.user_id
-                                    )
-                            ORDER BY
-                                urc.percentile ASC
-                            LIMIT
-                                1
-                        ),
-                        \'user-rank-unranked\'
-                    ) AS classname
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
                 FROM
                     Team_Users tu
                 INNER JOIN
-                    Teams t
-                ON
-                    t.team_id = tu.team_id
+                    Teams t ON t.team_id = tu.team_id
                 INNER JOIN
-                    Identities i
-                ON
-                    i.identity_id = tu.identity_id
-                INNER JOIN
-                    Identities it
-                ON
-                    it.identity_id = t.identity_id
+                    Identities i ON i.identity_id = tu.identity_id
                 LEFT JOIN
-                    Users u
-                ON
-                    i.user_id = u.user_id
+                    User_Rank ur ON ur.user_id = i.user_id
+                INNER JOIN
+                    Identities it ON it.identity_id = t.identity_id
+                LEFT JOIN
+                    Users u ON i.user_id = u.user_id
                 WHERE
                     team_group_id = ?
                 ';

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -207,10 +207,11 @@ class Users extends \OmegaUp\DAO\Base\Users {
                     ur.user_id = ?;';
         $params = [$userId];
         /** @var null|string */
-        return \OmegaUp\MySQLConnection::getInstance()->GetOne(
+        $className = \OmegaUp\MySQLConnection::getInstance()->GetOne(
             $sql,
             $params
-        ) ?? 'user-rank-unranked';
+        );
+        return $className ?? 'user-rank-unranked';
     }
 
     final public static function getByVerification(

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -82,30 +82,13 @@ class Users extends \OmegaUp\DAO\Base\Users {
                     IF(u.`is_private` = 1, NULL, u.`hide_problem_tags`) AS hide_problem_tags,
                     IF(u.`is_private` = 1, NULL, u.`verified`) AS verified,
                     IF(u.`is_private` = 1, NULL, i.`gender`) AS gender,
-                    IFNULL(
-                        (
-                            SELECT urc.classname FROM
-                                User_Rank_Cutoffs urc
-                            WHERE
-                                urc.score <= (
-                                        SELECT
-                                            ur.score
-                                        FROM
-                                            User_Rank ur
-                                        WHERE
-                                            ur.user_id = i.user_id
-                                    )
-                            ORDER BY
-                                urc.percentile ASC
-                            LIMIT
-                                1
-                        ),
-                        \'user-rank-unranked\'
-                    ) AS classname
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
                 FROM
                     Users u
                 INNER JOIN
                     Identities i ON u.main_identity_id = i.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 LEFT JOIN
                     Emails e ON u.main_email_id = e.email_id
                 LEFT JOIN
@@ -156,30 +139,13 @@ class Users extends \OmegaUp\DAO\Base\Users {
         $sql = 'SELECT
                     IFNULL(i.`country_id`, "xx") AS country_id,
                     e.`email`,
-                    IFNULL(
-                        (
-                            SELECT urc.classname FROM
-                                User_Rank_Cutoffs urc
-                            WHERE
-                                urc.score <= (
-                                        SELECT
-                                            ur.score
-                                        FROM
-                                            User_Rank ur
-                                        WHERE
-                                            ur.user_id = i.user_id
-                                    )
-                            ORDER BY
-                                urc.percentile ASC
-                            LIMIT
-                                1
-                        ),
-                        \'user-rank-unranked\'
-                    ) AS classname
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
                 FROM
                     Users u
                 INNER JOIN
                     Identities i ON u.main_identity_id = i.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 LEFT JOIN
                     Emails e ON u.main_email_id = e.email_id
                 WHERE
@@ -234,22 +200,11 @@ class Users extends \OmegaUp\DAO\Base\Users {
             return 'user-rank-unranked';
         }
         $sql = 'SELECT
-                    `urc`.`classname`
+                    ur.classname
                 FROM
-                    `User_Rank_Cutoffs` `urc`
+                    User_Rank ur
                 WHERE
-                    `urc`.score <= (
-                        SELECT
-                            `ur`.`score`
-                        FROM
-                            `User_Rank` `ur`
-                        WHERE
-                            `ur`.user_id = ?
-                    )
-                ORDER BY
-                    `urc`.percentile ASC
-                LIMIT
-                    1;';
+                    ur.user_id = ?;';
         $params = [$userId];
         /** @var string */
         return \OmegaUp\MySQLConnection::getInstance()->GetOne(

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -206,7 +206,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
                 WHERE
                     ur.user_id = ?;';
         $params = [$userId];
-        /** @var string */
+        /** @var null|string */
         return \OmegaUp\MySQLConnection::getInstance()->GetOne(
             $sql,
             $params


### PR DESCRIPTION
# Descripción

Tercera parte de  #6182 donde ya se consume la columna denormalizada `User_Rank.classname` directamente en lugar de calcularla en cada ocasión que se necesita.
Ya debería estar siendo poblada desde la primer corrida del cron job con los cambios en #6199

Como bono, se eliminó un join innecesario con la tabla `Emails` en `CoderOfTheMonth`
# Comentarios

Solo hay que verificar que efectivamente la columna esté adecuadamente poblada antes de darle merge a este cambio.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests: el cambio es grande pero solo son cambios en consultas.