### PR TITLE
Copiando las plantillas compiladas a la imagen de Docker

### DIFF
--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -50,6 +50,7 @@ RUN php frontend/server/cmd/CompileTemplatesCmd.php
 FROM alpine:latest AS frontend
 RUN apk add rsync
 COPY --from=build /opt/omegaup /opt/omegaup
+COPY --from=build /var/lib/omegaup /var/lib/omegaup
 
 FROM ubuntu:focal AS nginx
 
@@ -65,7 +66,6 @@ RUN useradd --create-home --shell=/bin/bash ubuntu
 RUN mkdir -p /etc/omegaup/frontend
 RUN mkdir -p /var/log/omegaup && chown -R ubuntu /var/log/omegaup
 
-RUN mkdir /opt/omegaup && chown -R ubuntu /opt/omegaup
 USER ubuntu
 WORKDIR /opt/omegaup
 


### PR DESCRIPTION
Resulta que las plantillas no se estaban copiando! Eso causaba que se
siguieran compilando en el sandbox.