### PR TITLE
Evitando la herencia de plantillas

### DIFF
--- a/frontend/server/cmd/CompileTemplatesCmd.php
+++ b/frontend/server/cmd/CompileTemplatesCmd.php
@@ -17,4 +17,3 @@ if ($handle = opendir($dirname)) {
     }
     closedir($handle);
 }
-$twig->load('template.tpl');

--- a/frontend/server/src/Template/EntrypointNode.php
+++ b/frontend/server/src/Template/EntrypointNode.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OmegaUp\Template;
+
+class EntrypointNode extends \Twig\Node\Node {
+    public function __construct(
+        int $line,
+        ?string $tag = null,
+    ) {
+        parent::__construct([], [], $line, $tag);
+    }
+
+    public function compile(\Twig\Compiler $compiler): void {
+        /** @var \Twig\Source */
+        $sourceContext = $this->getSourceContext();
+        $entrypoint = $sourceContext->getName();
+        $options = ['omitRuntime'];
+        $compiler->addDebugInfo($this);
+        foreach (
+            \OmegaUp\Template\JsIncludeNode::getScriptTags(
+                $entrypoint,
+                $entrypoint,
+                $options,
+            ) as $tag
+        ) {
+            $compiler
+                ->raw('echo ')
+                ->repr($tag)
+                ->raw(";\n");
+        }
+    }
+}

--- a/frontend/server/src/Template/EntrypointParser.php
+++ b/frontend/server/src/Template/EntrypointParser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OmegaUp\Template;
+
+class EntrypointParser extends \Twig\TokenParser\AbstractTokenParser {
+    public function parse(\Twig\Token $token): \Twig\Node\Node {
+        $parser = $this->parser;
+        $stream = $parser->getStream();
+
+        $stream->expect(\Twig\Token::BLOCK_END_TYPE);
+
+        return new \OmegaUp\Template\EntrypointNode(
+            $token->getLine(),
+            $this->getTag(),
+        );
+    }
+
+    public function getTag(): string {
+        return 'entrypoint';
+    }
+}

--- a/frontend/server/src/Template/Loader.php
+++ b/frontend/server/src/Template/Loader.php
@@ -16,22 +16,15 @@ class Loader implements \Twig\Loader\LoaderInterface {
     }
 
     public function getSourceContext(string $name): \Twig\Source {
-        if ($name === 'template.tpl') {
-            return $this->_loader->getSourceContext($name);
-        }
+        $originalSource = $this->_loader->getSourceContext('template.tpl');
         return new \Twig\Source(
-            '{% extends "template.tpl" %}' .
-            '{% block entrypoint %}' .
-            "{% jsInclude \"{$name}\" omitRuntime %}" .
-            '{% endblock %}',
+            $originalSource->getCode(),
             $name,
+            $originalSource->getPath(),
         );
     }
 
     public function getCacheKey(string $name): string {
-        if ($name === 'template.tpl') {
-            return $this->_loader->getCacheKey($name);
-        }
         return $name;
     }
 

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -67,6 +67,7 @@ class UITools {
             $twigOptions['debug'] = true;
         }
         $twig = new \Twig\Environment($loader, $twigOptions);
+        $twig->addTokenParser(new \OmegaUp\Template\EntrypointParser());
         $twig->addTokenParser(new \OmegaUp\Template\VersionHashParser());
         $twig->addTokenParser(new \OmegaUp\Template\JsIncludeParser());
 

--- a/frontend/templates/template.tpl
+++ b/frontend/templates/template.tpl
@@ -64,7 +64,7 @@
       {% endif %}
 
       <script type="text/json" id="payload">{{ payload|json_encode|raw }}</script>
-      {% block entrypoint %}{% endblock %}
+      {% entrypoint %}
       <div id="main-container"></div>
     </main>
     {% if OMEGAUP_GA_TRACK == 1 %}

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -49,6 +49,7 @@ RUN php frontend/server/cmd/CompileTemplatesCmd.php
 
 FROM alpine:latest AS frontend
 RUN apk add rsync
+RUN mkdir -p /var/lib/omegaup /opt/omegaup
 COPY --from=build /opt/omegaup /opt/omegaup
 COPY --from=build /var/lib/omegaup /var/lib/omegaup
 


### PR DESCRIPTION
Este cambio hace que se emita el código de todas las plantillas
completamente, sin necesidad de importar el código de otra plantilla.
Viva la precompilación!