### PR TITLE
Datafix de la denormalización de los envíos

### DIFF
--- a/frontend/database/00195_denormalize_submissions_datafix.sql
+++ b/frontend/database/00195_denormalize_submissions_datafix.sql
@@ -1,0 +1,3 @@
+UPDATE Submissions s
+INNER JOIN Runs r ON r.run_id = s.current_run_id
+SET s.verdict = r.verdict, s.status = r.status;

--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -609,6 +609,7 @@ CREATE TABLE `Problems` (
   UNIQUE KEY `problems_alias` (`alias`),
   KEY `acl_id` (`acl_id`),
   KEY `idx_problems_visibility` (`visibility`),
+  KEY `idx_quality_seal` (`quality_seal`),
   CONSTRAINT `fk_pa_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Se crea un registro por cada prob externo.';
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -996,6 +997,8 @@ CREATE TABLE `Submissions` (
   `guid` char(32) NOT NULL,
   `language` enum('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','java','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua') NOT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `status` enum('new','waiting','compiling','running','ready','uploading') NOT NULL DEFAULT 'new',
+  `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL,
   `submit_delay` int NOT NULL DEFAULT '0',
   `type` enum('normal','test','disqualified') DEFAULT 'normal',
   `school_id` int DEFAULT NULL,
@@ -1095,6 +1098,7 @@ CREATE TABLE `User_Rank` (
   `school_id` int DEFAULT NULL,
   `author_score` double NOT NULL DEFAULT '0',
   `author_ranking` int DEFAULT NULL,
+  `classname` varchar(50) DEFAULT NULL COMMENT 'Almacena la clase precalculada para no tener que determinarla en tiempo de ejecucion.',
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username` (`username`),
   KEY `rank` (`ranking`),

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -468,6 +468,8 @@ class Run extends \OmegaUp\Controllers\Controller {
             'guid' => md5(uniqid(strval(rand()), true)),
             'language' => $r['language'],
             'time' => \OmegaUp\Time::get(),
+            'status' => 'uploading',
+            'verdict' => 'JE',
             'submit_delay' => $submitDelay, /* based on penalty_type */
             'type' => $type,
         ]);

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -39,6 +39,8 @@ abstract class Submissions {
                 `guid` = ?,
                 `language` = ?,
                 `time` = ?,
+                `status` = ?,
+                `verdict` = ?,
                 `submit_delay` = ?,
                 `type` = ?,
                 `school_id` = ?
@@ -72,6 +74,8 @@ abstract class Submissions {
             \OmegaUp\DAO\DAO::toMySQLTimestamp(
                 $Submissions->time
             ),
+            $Submissions->status,
+            $Submissions->verdict,
             intval($Submissions->submit_delay),
             $Submissions->type,
             (
@@ -108,6 +112,8 @@ abstract class Submissions {
                 `Submissions`.`guid`,
                 `Submissions`.`language`,
                 `Submissions`.`time`,
+                `Submissions`.`status`,
+                `Submissions`.`verdict`,
                 `Submissions`.`submit_delay`,
                 `Submissions`.`type`,
                 `Submissions`.`school_id`
@@ -200,6 +206,8 @@ abstract class Submissions {
                 `Submissions`.`guid`,
                 `Submissions`.`language`,
                 `Submissions`.`time`,
+                `Submissions`.`status`,
+                `Submissions`.`verdict`,
                 `Submissions`.`submit_delay`,
                 `Submissions`.`type`,
                 `Submissions`.`school_id`
@@ -260,10 +268,14 @@ abstract class Submissions {
                     `guid`,
                     `language`,
                     `time`,
+                    `status`,
+                    `verdict`,
                     `submit_delay`,
                     `type`,
                     `school_id`
                 ) VALUES (
+                    ?,
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -301,6 +313,8 @@ abstract class Submissions {
             \OmegaUp\DAO\DAO::toMySQLTimestamp(
                 $Submissions->time
             ),
+            $Submissions->status,
+            $Submissions->verdict,
             intval($Submissions->submit_delay),
             $Submissions->type,
             (

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -56,8 +56,10 @@ abstract class UserRank {
                     `state_id`,
                     `school_id`,
                     `author_score`,
-                    `author_ranking`
+                    `author_ranking`,
+                    `classname`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -94,6 +96,7 @@ abstract class UserRank {
                 intval($User_Rank->author_ranking) :
                 null
             ),
+            $User_Rank->classname,
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
@@ -122,7 +125,8 @@ abstract class UserRank {
                 `state_id` = ?,
                 `school_id` = ?,
                 `author_score` = ?,
-                `author_ranking` = ?
+                `author_ranking` = ?,
+                `classname` = ?
             WHERE
                 (
                     `user_id` = ?
@@ -150,6 +154,7 @@ abstract class UserRank {
                 null :
                 intval($User_Rank->author_ranking)
             ),
+            $User_Rank->classname,
             (
                 is_null($User_Rank->user_id) ?
                 null :
@@ -185,7 +190,8 @@ abstract class UserRank {
                 `User_Rank`.`state_id`,
                 `User_Rank`.`school_id`,
                 `User_Rank`.`author_score`,
-                `User_Rank`.`author_ranking`
+                `User_Rank`.`author_ranking`,
+                `User_Rank`.`classname`
             FROM
                 `User_Rank`
             WHERE
@@ -277,7 +283,8 @@ abstract class UserRank {
                 `User_Rank`.`state_id`,
                 `User_Rank`.`school_id`,
                 `User_Rank`.`author_score`,
-                `User_Rank`.`author_ranking`
+                `User_Rank`.`author_ranking`,
+                `User_Rank`.`classname`
             FROM
                 `User_Rank`
         ';
@@ -338,8 +345,10 @@ abstract class UserRank {
                     `state_id`,
                     `school_id`,
                     `author_score`,
-                    `author_ranking`
+                    `author_ranking`,
+                    `classname`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -380,6 +389,7 @@ abstract class UserRank {
                 null :
                 intval($User_Rank->author_ranking)
             ),
+            $User_Rank->classname,
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -137,20 +137,16 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             $val[] = $identityId;
         }
 
-        $hasFilters = !empty($where);
-        $needsRuns = false;
         if (!is_null($status)) {
-            $needsRuns = true;
-            $where[] = 'r.status = ?';
+            $where[] = 's.status = ?';
             $val[] = $status;
         }
         if (!is_null($verdict)) {
-            $needsRuns = true;
             if ($verdict === 'NO-AC') {
-                $where[] = 'r.verdict <> ?';
+                $where[] = 's.verdict <> ?';
                 $val[] = 'AC';
             } else {
-                $where[] = 'r.verdict = ?';
+                $where[] = 's.verdict = ?';
                 $val[] = $verdict;
             }
         }
@@ -161,30 +157,14 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             FROM
                 Submissions s
         ';
-        $valCount = [];
-        // TODO: We're going to lie for now if we need to add a JOIN with the
-        // Runs table and have no other filters to help us. This query is
-        // completely unusable at the time because the indexes are not helping.
-        // So we'll just return the wrong answer for the time being, which will
-        // stop making the admin runs view cause a micro-incident every time
-        // it's visited.
-        if ($hasFilters || !$needsRuns) {
-            if ($needsRuns) {
-                $sqlCount .= '
-                    INNER JOIN
-                        Runs r ON r.run_id = s.current_run_id
-                ';
-            }
-            if (!empty($where)) {
-                $sqlCount .= 'WHERE ' . implode(' AND ', $where) . ' ';
-            }
-            $valCount = $val;
+        if (!empty($where)) {
+            $sqlCount .= 'WHERE ' . implode(' AND ', $where) . ' ';
         }
 
         /** @var int */
         $totalRows = \OmegaUp\MySQLConnection::getInstance()->GetOne(
             $sqlCount,
-            $valCount,
+            $val,
         );
 
         if (is_null($offset) || $offset < 0) {

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -18,7 +18,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
             ' FROM Submissions WHERE (guid = ?) LIMIT 1;';
         $params = [$guid];
 
-        /** @var array{current_run_id: int|null, guid: string, identity_id: int, language: string, problem_id: int, problemset_id: int|null, school_id: int|null, submission_id: int, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string}|null */
+        /** @var array{current_run_id: int|null, guid: string, identity_id: int, language: string, problem_id: int, problemset_id: int|null, school_id: int|null, status: string, submission_id: int, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, verdict: string}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
         if (empty($rs)) {
             return null;

--- a/frontend/server/src/DAO/VO/Submissions.php
+++ b/frontend/server/src/DAO/VO/Submissions.php
@@ -24,6 +24,8 @@ class Submissions extends \OmegaUp\DAO\VO\VO {
         'guid' => true,
         'language' => true,
         'time' => true,
+        'status' => true,
+        'verdict' => true,
         'submit_delay' => true,
         'type' => true,
         'school_id' => true,
@@ -88,6 +90,16 @@ class Submissions extends \OmegaUp\DAO\VO\VO {
             $this->time = new \OmegaUp\Timestamp(
                 \OmegaUp\Time::get()
             );
+        }
+        if (isset($data['status'])) {
+            $this->status = is_scalar(
+                $data['status']
+            ) ? strval($data['status']) : '';
+        }
+        if (isset($data['verdict'])) {
+            $this->verdict = is_scalar(
+                $data['verdict']
+            ) ? strval($data['verdict']) : '';
         }
         if (isset($data['submit_delay'])) {
             $this->submit_delay = intval(
@@ -163,6 +175,20 @@ class Submissions extends \OmegaUp\DAO\VO\VO {
      * @var \OmegaUp\Timestamp
      */
     public $time;  // CURRENT_TIMESTAMP
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string
+     */
+    public $status = 'new';
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $verdict = null;
 
     /**
      * [Campo no documentado]

--- a/frontend/server/src/DAO/VO/UserRank.php
+++ b/frontend/server/src/DAO/VO/UserRank.php
@@ -27,6 +27,7 @@ class UserRank extends \OmegaUp\DAO\VO\VO {
         'school_id' => true,
         'author_score' => true,
         'author_ranking' => true,
+        'classname' => true,
     ];
 
     public function __construct(?array $data = null) {
@@ -93,6 +94,11 @@ class UserRank extends \OmegaUp\DAO\VO\VO {
             $this->author_ranking = intval(
                 $data['author_ranking']
             );
+        }
+        if (isset($data['classname'])) {
+            $this->classname = is_scalar(
+                $data['classname']
+            ) ? strval($data['classname']) : '';
         }
     }
 
@@ -173,4 +179,11 @@ class UserRank extends \OmegaUp\DAO\VO\VO {
      * @var int|null
      */
     public $author_ranking = null;
+
+    /**
+     * Almacena la clase precalculada para no tener que determinarla en tiempo de ejecucion.
+     *
+     * @var string|null
+     */
+    public $classname = null;
 }

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -71,13 +71,15 @@ class Utils {
         $run->contest_score = $points * $problemsetPoints;
         $run->status = 'ready';
         $run->judged_by = 'J1';
+        $submission->status = $run->status;
+        $submission->verdict = $run->verdict;
 
         if (!is_null($submitDelay)) {
             $submission->submit_delay = $submitDelay;
-            \OmegaUp\DAO\Submissions::update($submission);
             $run->penalty = $submitDelay;
         }
 
+        \OmegaUp\DAO\Submissions::update($submission);
         \OmegaUp\DAO\Runs::update($run);
 
         \OmegaUp\Grader::getInstance()->setGraderResourceForTesting(


### PR DESCRIPTION
Este cambio hace un datafix de denormalización de envíos. Ahora la tabla
`Submissions` debería tener la misma información que la tabla `Runs`.

También la consulta de la lista global de envíos ahora no necesita
mentir ni mucho menos: la consulta se puede hacer directamente ahora.