### PR TITLE
Quitando un poco más de trabajo al generar reportes de cursos

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -5826,11 +5826,10 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Courses $course,
         \OmegaUp\DAO\VO\Groups $group
     ): bool {
-        return \OmegaUp\Authorization::canViewCourse(
+        return $course->show_scoreboard && \OmegaUp\Authorization::canViewCourse(
             $identity,
             $course,
             $group
-        ) &&
-               $course->show_scoreboard;
+        );
     }
 }

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -522,11 +522,9 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 Problems p
             INNER JOIN
                 Problemset_Problems pp ON pp.problem_id = p.problem_id
-            INNER JOIN
-                Problemsets ps ON ps.problemset_id = pp.problemset_id
             WHERE
                 p.alias = ?
-                AND ps.problemset_id = ?
+                AND pp.problemset_id = ?
             ';
         $params = [
             $alias,


### PR DESCRIPTION
# Descripción

* Cambiando un `GROUP BY` de usar alias a usar ids.
* Quitando trabajo de post-procesamiento de la consulta para `getSortedCourseAssignments`.

# Comentarios

Creo que sería útil denormalizar `has_runs` en PRs posteriores. Parece que se calcula sobre la marcha cada vez que se accesa algo de cursos y realmente, después del primer envío, siempre va a ser `true`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.