### PR TITLE
Quitando un join innecesario al revisar roles de usuarios

### DIFF
--- a/frontend/server/src/DAO/UserRoles.php
+++ b/frontend/server/src/DAO/UserRoles.php
@@ -124,9 +124,7 @@ class UserRoles extends \OmegaUp\DAO\Base\UserRoles {
             FROM
                 User_Roles ur
             INNER JOIN
-                Users u ON u.user_id = ur.user_id
-            INNER JOIN
-                Identities i ON u.user_id = i.user_id
+                Identities i ON ur.user_id = i.user_id
             WHERE
                 i.identity_id = ? AND ur.role_id = ? AND ur.acl_id IN (?, ?);';
         $params = [


### PR DESCRIPTION
# Descripción

Quitar un join innecesario con la tabla de usuarios al verificar si una identidad tiene un rol.

# Comentarios

Esta función se llama **varias** veces por cada llamada a la API. Un estimado medio burdo es que le ahorraría 1 ms por ejecución de la consulta, al comparar con la consulta análoga de `Group_Roles` que no tiene el segundo join.

Ref: https://onenr.io/0LZQW90ExRW

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.