### PR TITLE
Usar la columna denormalizada User_Rank.classname (parte 2)

### DIFF
--- a/frontend/server/src/DAO/APITokens.php
+++ b/frontend/server/src/DAO/APITokens.php
@@ -28,36 +28,15 @@ class APITokens extends \OmegaUp\DAO\Base\APITokens {
                 at.apitoken_id,
                 1 as is_main_identity,
                 i.*,
-                IFNULL(
-                    (
-                        SELECT `urc`.`classname` FROM
-                            `User_Rank_Cutoffs` `urc`
-                        WHERE
-                            `urc`.`score` <= (
-                                    SELECT
-                                        `ur`.`score`
-                                    FROM
-                                        `User_Rank` `ur`
-                                    WHERE
-                                        `ur`.`user_id` = `i`.`user_id`
-                                )
-                        ORDER BY
-                            `urc`.`percentile` ASC
-                        LIMIT
-                            1
-                    ),
-                    'user-rank-unranked'
-                ) `classname`
+                IFNULL(ur.classname, 'user-rank-unranked') AS classname
             FROM
                 `API_Tokens` at
             INNER JOIN
-                `Users` u
-            ON
-                u.user_id = at.user_id
+                `Users` u ON u.user_id = at.user_id
             INNER JOIN
-                `Identities` i
-            ON
-                i.identity_id = u.main_identity_id
+                `Identities` i ON i.identity_id = u.main_identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             WHERE
                 at.token = ?
         ";
@@ -69,32 +48,13 @@ class APITokens extends \OmegaUp\DAO\Base\APITokens {
                     at.apitoken_id,
                     0 as is_main_identity,
                     i.*,
-                    IFNULL(
-                        (
-                            SELECT `urc`.`classname` FROM
-                                `User_Rank_Cutoffs` `urc`
-                            WHERE
-                                `urc`.`score` <= (
-                                        SELECT
-                                            `ur`.`score`
-                                        FROM
-                                            `User_Rank` `ur`
-                                        WHERE
-                                            `ur`.`user_id` = `i`.`user_id`
-                                    )
-                            ORDER BY
-                                `urc`.`percentile` ASC
-                            LIMIT
-                                1
-                        ),
-                        'user-rank-unranked'
-                    ) `classname`
+                    IFNULL(ur.classname, 'user-rank-unranked') AS classname
                 FROM
                     `API_Tokens` at
                 INNER JOIN
-                    `Identities` i
-                ON
-                    i.user_id = at.user_id
+                    `Identities` i ON i.user_id = at.user_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 WHERE
                     at.token = ? AND i.username = ?
             ";

--- a/frontend/server/src/DAO/AuthTokens.php
+++ b/frontend/server/src/DAO/AuthTokens.php
@@ -45,32 +45,13 @@ class AuthTokens extends \OmegaUp\DAO\Base\AuthTokens {
         $sql = "SELECT
                     i.*,
                     aut.identity_id = i.identity_id AS `is_main_identity`,
-                    IFNULL(
-                        (
-                            SELECT `urc`.`classname` FROM
-                                `User_Rank_Cutoffs` `urc`
-                            WHERE
-                                `urc`.`score` <= (
-                                        SELECT
-                                            `ur`.`score`
-                                        FROM
-                                            `User_Rank` `ur`
-                                        WHERE
-                                            `ur`.`user_id` = `i`.`user_id`
-                                    )
-                            ORDER BY
-                                `urc`.`percentile` ASC
-                            LIMIT
-                                1
-                        ),
-                        'user-rank-unranked'
-                    ) `classname`
+                    IFNULL(ur.classname, 'user-rank-unranked') AS classname
                 FROM
                     `Auth_Tokens` aut
                 INNER JOIN
-                    `Identities` i
-                ON
-                    i.identity_id IN (aut.identity_id, aut.acting_identity_id)
+                    `Identities` i ON i.identity_id IN (aut.identity_id, aut.acting_identity_id)
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 WHERE
                     aut.token = ?
                 ORDER BY

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -1293,26 +1293,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 NULL AS alias,
                 pal.ip,
                 pal.`time`,
-                IFNULL(
-                    (
-                        SELECT `urc`.classname FROM
-                            `User_Rank_Cutoffs` urc
-                        WHERE
-                            `urc`.score <= (
-                                    SELECT
-                                        `ur`.`score`
-                                    FROM
-                                        `User_Rank` `ur`
-                                    WHERE
-                                        `ur`.user_id = `i`.`user_id`
-                                )
-                        ORDER BY
-                            `urc`.percentile ASC
-                        LIMIT
-                            1
-                    ),
-                    "user-rank-unranked"
-                ) `classname`,
+                IFNULL(ur.classname, "user-rank-unranked") AS classname,
                 "open" AS event_type,
                 NULL AS clone_result,
                 NULL AS clone_token_payload,
@@ -1320,9 +1301,9 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             FROM
                 Problemset_Access_Log pal
             INNER JOIN
-                Identities i
-            ON
-                i.identity_id = pal.identity_id
+                Identities i ON i.identity_id = pal.identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             WHERE
                 pal.problemset_id = ?
         ) UNION (
@@ -1331,26 +1312,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 p.alias,
                 sl.ip,
                 sl.`time`,
-                IFNULL(
-                    (
-                        SELECT `urc`.classname FROM
-                            `User_Rank_Cutoffs` urc
-                        WHERE
-                            `urc`.score <= (
-                                    SELECT
-                                        `ur`.`score`
-                                    FROM
-                                        `User_Rank` `ur`
-                                    WHERE
-                                        `ur`.user_id = `i`.`user_id`
-                                )
-                        ORDER BY
-                            `urc`.percentile ASC
-                        LIMIT
-                            1
-                    ),
-                    "user-rank-unranked"
-                ) `classname`,
+                IFNULL(ur.classname, "user-rank-unranked") AS classname,
                 "submit" AS event_type,
                 NULL AS clone_result,
                 NULL AS clone_token_payload,
@@ -1358,17 +1320,13 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             FROM
                 Submission_Log sl
             INNER JOIN
-                Identities i
-            ON
-                i.identity_id = sl.identity_id
+                Identities i ON i.identity_id = sl.identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             INNER JOIN
-                Submissions s
-            ON
-                s.submission_id = sl.submission_id
+                Submissions s ON s.submission_id = sl.submission_id
             INNER JOIN
-                Problems p
-            ON
-                p.problem_id = s.problem_id
+                Problems p ON p.problem_id = s.problem_id
             WHERE
                 sl.problemset_id = ?
         ) ORDER BY

--- a/frontend/server/src/DAO/GroupsIdentities.php
+++ b/frontend/server/src/DAO/GroupsIdentities.php
@@ -27,30 +27,13 @@ class GroupsIdentities extends \OmegaUp\DAO\Base\GroupsIdentities {
                 s.state_id,
                 sc.name as school,
                 sc.school_id as school_id,
-                IFNULL(
-                    (
-                        SELECT `urc`.classname FROM
-                            `User_Rank_Cutoffs` urc
-                        WHERE
-                            `urc`.score <= (
-                                    SELECT
-                                        `ur`.`score`
-                                    FROM
-                                        `User_Rank` `ur`
-                                    WHERE
-                                        `ur`.user_id = `i`.`user_id`
-                                )
-                        ORDER BY
-                            `urc`.percentile ASC
-                        LIMIT
-                            1
-                    ),
-                    "user-rank-unranked"
-                ) `classname`
+                IFNULL(ur.classname, "user-rank-unranked") AS classname
             FROM
                 Groups_Identities gi
             INNER JOIN
                 Identities i ON i.identity_id = gi.identity_id
+            LEFT JOIN
+                User_Rank ur ON ur.user_id = i.user_id
             LEFT JOIN
                 States s ON s.state_id = i.state_id AND s.country_id = i.country_id
             LEFT JOIN
@@ -59,8 +42,6 @@ class GroupsIdentities extends \OmegaUp\DAO\Base\GroupsIdentities {
                 Identities_Schools isc ON isc.identity_school_id = i.current_identity_school_id
             LEFT JOIN
                 Schools sc ON sc.school_id = isc.school_id
-            LEFT JOIN
-                Users u ON u.user_id = i.user_id
             WHERE
                 gi.group_id = ?;';
 

--- a/frontend/server/src/DAO/Teams.php
+++ b/frontend/server/src/DAO/Teams.php
@@ -75,32 +75,15 @@ class Teams extends \OmegaUp\DAO\Base\Teams {
                     s.state_id,
                     sc.name AS school,
                     sc.school_id AS school_id,
-                    IFNULL(
-                        (
-                            SELECT `urc`.classname FROM
-                                `User_Rank_Cutoffs` urc
-                            WHERE
-                                `urc`.score <= (
-                                        SELECT
-                                            `ur`.`score`
-                                        FROM
-                                            `User_Rank` `ur`
-                                        WHERE
-                                            `ur`.`user_id` = `i`.`user_id`
-                                    )
-                            ORDER BY
-                                `urc`.percentile ASC
-                            LIMIT
-                                1
-                        ),
-                        "user-rank-unranked"
-                    ) `classname`
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
                 FROM
                     Teams t
                 INNER JOIN
                     Team_Groups tg ON tg.team_group_id = t.team_group_id
                 INNER JOIN
                     Identities i ON i.identity_id = t.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
                 LEFT JOIN
                     States s ON s.state_id = i.state_id AND s.country_id = i.country_id
                 LEFT JOIN

--- a/frontend/server/src/DAO/UserRank.php
+++ b/frontend/server/src/DAO/UserRank.php
@@ -35,20 +35,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
                 `ur`.`username`,
                 `ur`.`name`,
                 `ur`.`country_id`,
-                IFNULL(
-                    (
-                        SELECT
-                            `urc`.`classname`
-                        FROM
-                            `User_Rank_Cutoffs` `urc`
-                        WHERE
-                            `urc`.`score` <= `ur`.`score`
-                        ORDER BY
-                            `urc`.`percentile` ASC
-                        LIMIT 1
-                    ),
-                    "user-rank-unranked"
-                ) as `classname`';
+                IFNULL(`ur`.`classname`, "user-rank-unranked") AS classname';
         $sqlCount = '
               SELECT
                 COUNT(1)';
@@ -114,21 +101,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
                 `ur`.`username`,
                 `ur`.`country_id`,
                 `ur`.`name`,
-                `ur`.`country_id`,
-                IFNULL(
-                    (
-                        SELECT
-                            `urc`.`classname`
-                        FROM
-                            `User_Rank_Cutoffs` `urc`
-                        WHERE
-                            `urc`.`score` <= `ur`.`score`
-                        ORDER BY
-                            `urc`.`percentile` ASC
-                        LIMIT 1
-                    ),
-                    "user-rank-unranked"
-                ) as `classname`
+                IFNULL(`ur`.`classname`, "user-rank-unranked") AS classname
         ';
         $sqlCount = '
             SELECT
@@ -153,7 +126,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
             []
         ) ?? 0;
 
-        /** @var list<array{author_ranking: int|null, author_score: float, classname: string, country_id: null|string, country_id: null|string, name: null|string, username: string}> */
+        /** @var list<array{author_ranking: int|null, author_score: float, classname: string, country_id: null|string, name: null|string, username: string}> */
         $allData = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             "{$sqlSelect}{$sqlFrom}{$sqlOrderBy}{$sqlLimit}",
             [
@@ -181,20 +154,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
                 `ur`.`country_id`,
                 `ur`.`username`,
                 `ur`.`name`,
-                IFNULL(
-                    (
-                        SELECT
-                            `urc`.`classname`
-                        FROM
-                            `User_Rank_Cutoffs` `urc`
-                        WHERE
-                            `urc`.`score` <= `ur`.`score`
-                        ORDER BY
-                            `urc`.`percentile` ASC
-                        LIMIT 1
-                    ),
-                    "user-rank-unranked"
-                ) as `classname`
+                IFNULL(`ur`.`classname`, "user-rank-unranked") AS classname
         ';
         $sqlFrom = '
             FROM


### PR DESCRIPTION
# Descripción

Cuarta parte de #6182 en la que usamos la columna denormalizada `User_rank.classname` porque resulta que en #6213 se me pasaron algunos usos y el acceso a la tabla `User_rank_cutoffs` sigue siendo el más costoso según NewRelic (https://onenr.io/01qwLbVb3j5).

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.