### PR TITLE
Arreglar extensión del README en la carpeta frontend

### DIFF
--- a/frontend/README
+++ b/frontend/README
@@ -1,3 +1,0 @@
-Antes de hacer commit, por favor dale un vistazo a las [Coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines)
-
-

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,1 @@
+**Antes de hacer commit, por favor dale un vistazo a las [Coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines)**


### PR DESCRIPTION
# Descripción
Cambia la extensión del archivo readme del frontend para que se represente como texto escrito en markdown.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
