### PR TITLE
Haciendo menos trabajo para conseguir el nombre del director de un curso y concurso

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1745,19 +1745,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
                         'contestNotFound'
                     );
                 }
-                $acl = \OmegaUp\DAO\ACLs::getByPK($contest->acl_id);
-                if (is_null($acl) || is_null($acl->owner_id)) {
-                    throw new \OmegaUp\Exceptions\NotFoundException();
-                }
-                $director = \OmegaUp\DAO\Identities::findByUserId(
-                    $acl->owner_id
+                $director = \OmegaUp\DAO\UserRoles::getOwner(
+                    $contest->acl_id
                 );
-                if (is_null($director) || is_null($director->username)) {
+                if (is_null($director)) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'userNotExist'
                     );
                 }
-                $result['director'] = $director->username;
+                $result['director'] = $director;
 
                 $problemsInContest = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
                     $contest->problemset_id

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2987,16 +2987,8 @@ class Course extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $acl = \OmegaUp\DAO\ACLs::getByPK(
+        $director = \OmegaUp\DAO\UserRoles::getOwner(
             $tokenAuthenticationResult['course']->acl_id
-        );
-        if (is_null($acl) || is_null($acl->owner_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException();
-        }
-        $director = \OmegaUp\DAO\Identities::findByUserId(
-            intval(
-                $acl->owner_id
-            )
         );
         if (is_null($director)) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
@@ -3063,7 +3055,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                             $courseAlias,
                             $tokenAuthenticationResult['courseAdmin']
                         ),
-                        'director' => strval($director->username),
+                        'director' => $director,
                         'problemsetId' => $tokenAuthenticationResult['assignment']->problemset_id,
                         'admin' => $tokenAuthenticationResult['courseAdmin'],
                     ],
@@ -4966,16 +4958,8 @@ class Course extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $acl = \OmegaUp\DAO\ACLs::getByPK(
+        $director = \OmegaUp\DAO\UserRoles::getOwner(
             $tokenAuthenticationResult['course']->acl_id
-        );
-        if (is_null($acl) || is_null($acl->owner_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException();
-        }
-        $director = \OmegaUp\DAO\Identities::findByUserId(
-            intval(
-                $acl->owner_id
-            )
         );
         if (is_null($director)) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
@@ -5011,7 +4995,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 $courseAlias,
                 $tokenAuthenticationResult['courseAdmin']
             ),
-            'director' => strval($director->username),
+            'director' => $director,
             'problemset_id' => $tokenAuthenticationResult['assignment']->problemset_id,
             'admin' => $tokenAuthenticationResult['courseAdmin'],
         ];


### PR DESCRIPTION
# Descripción

Dejar de pedir todo el registro de la identidad del director de un curso cuando realmente solo se necesita su `username`. Además, cambia de ejecutar la búsqueda de un par de consultas a la base de datos (una para el `ACL` y otra para la identidad) a una sola aprovechando la función de  `UserRoles::getOwner` que supongo que se agregó después del código que se está cambiando en este Pull request.

# Comentarios

Motivación: dice NewRelic que esta es una de las consultas tardadas: https://onenr.io/0x0jl996PQW

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.