### PR TITLE
Usar el nuevo metodo existsByPK

### DIFF
--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -95,10 +95,10 @@ class Clarification extends \OmegaUp\Controllers\Controller {
                     $r->identity,
                     $course
                 ) &&
-                is_null(\OmegaUp\DAO\GroupsIdentities::getByPK(
+                !\OmegaUp\DAO\GroupsIdentities::existsByPK(
                     $course->group_id,
                     $r->identity->identity_id
-                ))
+                )
             ) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'courseStudentNotInCourse'

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -468,10 +468,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
         if ($contest->admission_mode === 'private') {
             if (
-                !is_null(\OmegaUp\DAO\ProblemsetIdentities::getByPK(
+                \OmegaUp\DAO\ProblemsetIdentities::existsByPK(
                     $identity->identity_id,
                     $contest->problemset_id
-                ))
+                )
             ) {
                 return true;
             }
@@ -582,10 +582,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
             return false;
         }
         return self::isPublic($contest->admission_mode) ||
-            !is_null(\OmegaUp\DAO\ProblemsetIdentities::getByPK(
+            \OmegaUp\DAO\ProblemsetIdentities::existsByPK(
                 $identity->identity_id,
                 $contest->problemset_id
-            ));
+            );
     }
 
     /**

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2087,10 +2087,10 @@ class Course extends \OmegaUp\Controllers\Controller {
             $r['usernameOrEmail']
         );
         if (
-            is_null(\OmegaUp\DAO\GroupsIdentities::getByPK(
+            !\OmegaUp\DAO\GroupsIdentities::existsByPK(
                 $course->group_id,
                 $resolvedIdentity->identity_id
-            ))
+            )
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseStudentNotInCourse'
@@ -2490,10 +2490,10 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         if (
-            is_null(\OmegaUp\DAO\GroupsIdentities::getByPK(
+            !\OmegaUp\DAO\GroupsIdentities::existsByPK(
                 $course->group_id,
                 $resolvedIdentity->identity_id
-            ))
+            )
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseStudentNotInCourse'
@@ -3502,10 +3502,10 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         if (
-            is_null(\OmegaUp\DAO\GroupsIdentities::getByPK(
+            !\OmegaUp\DAO\GroupsIdentities::existsByPK(
                 $course->group_id,
                 $resolvedIdentity->identity_id
-            ))
+            )
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseStudentNotInCourse'

--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -180,10 +180,10 @@ class Group extends \OmegaUp\Controllers\Controller {
         );
 
         if (
-            !is_null(\OmegaUp\DAO\GroupsIdentities::getByPK(
+            \OmegaUp\DAO\GroupsIdentities::existsByPK(
                 $group->group_id,
                 $resolvedIdentity->identity_id
-            ))
+            )
         ) {
             throw new \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException(
                 'identityInGroup'

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2052,10 +2052,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
                         )
                     ) {
                         if (
-                            is_null(\OmegaUp\DAO\ProblemsetIdentities::getByPK(
+                            !\OmegaUp\DAO\ProblemsetIdentities::existsByPK(
                                 $identity->identity_id,
                                 $problemset['problemset']->problemset_id
-                            ))
+                            )
                         ) {
                             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
                         }
@@ -2434,10 +2434,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
             }
             // Is the problem actually in the problemset?
             if (
-                is_null(\OmegaUp\DAO\ProblemsetProblems::getByPK(
+                !\OmegaUp\DAO\ProblemsetProblems::existsByPK(
                     $response['problemset']->problemset_id,
                     $problem->problem_id
-                ))
+                )
             ) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFoundInContest'
@@ -2455,10 +2455,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
             }
             // Is the problem actually in the problemset?
             if (
-                is_null(\OmegaUp\DAO\ProblemsetProblems::getByPK(
+                !\OmegaUp\DAO\ProblemsetProblems::existsByPK(
                     $response['problemset']->problemset_id,
                     $problem->problem_id
-                ))
+                )
             ) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFoundInProblemset'

--- a/frontend/server/src/DAO/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/ProblemsetIdentities.php
@@ -16,7 +16,7 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
         int $identityId,
         int $problemsetId
     ): bool {
-        return !is_null(self::getByPK($identityId, $problemsetId));
+        return self::existsByPK($identityId, $problemsetId);
     }
 
     /**


### PR DESCRIPTION
# Descripción

Usar el nuevo método `existsByPK` que se agregó en #6239. Con esto, algunas consultas que sólo requieren verificar la existencia de un registro pueden hacerlo sin necesidad de extraer el registro completo.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.