### PR TITLE
Quitando un join innecesario al conseguir la lista de QualityNominations

### DIFF
--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -67,10 +67,6 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
                     qnn.contents
                 FROM
                     QualityNominations qnn
-                LEFT JOIN
-                    Identities i
-                ON
-                    qnn.user_id = i.user_id
                 WHERE
                     qnn.problem_id = ? AND
                     qnn.user_id = ? AND


### PR DESCRIPTION
# Descripción

Quitando un join innecesario al conseguir la lista de `QualityNominations`.
 
# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
