### PR TITLE
Pre-calculando UserRank.classname para CoderOfTheMonth

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -4290,21 +4290,13 @@ class User extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @param list<array{country_id: string, email: null|string, rank?: int, time: string, user_id?: int, username: string}> $coders
+     * @param list<array{classname: string, country_id: string, email: null|string, rank?: int, time: string, user_id?: int, username: string}> $coders
      *
      * @return CoderOfTheMonthList
      */
     private static function processCodersList(array $coders): array {
         $response = [];
-        /** @var array{time: string, username: string, country_id: string, email: ?string} $coder */
         foreach ($coders as $coder) {
-            $userInfo = \OmegaUp\DAO\Users::FindByUsername($coder['username']);
-            if (is_null($userInfo)) {
-                throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
-            }
-            $classname = \OmegaUp\DAO\Users::getRankingClassName(
-                $userInfo->user_id
-            );
             $hashEmail = md5($coder['email'] ?? '');
             $avatar = "https://secure.gravatar.com/avatar/{$hashEmail}?s=32";
             $response[] = [
@@ -4312,7 +4304,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 'country_id' => $coder['country_id'],
                 'gravatar_32' => $avatar,
                 'date' => $coder['time'],
-                'classname' => $classname,
+                'classname' => $coder['classname'],
             ];
         }
         return $response;

--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -50,7 +50,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
 
     /**
      * Get all first coders of the month
-     * @return list<array{time: string, username: string, country_id: string, email: string|null}>
+     * @return list<array{time: string, username: string, country_id: string, email: string|null, classname: string}>
      */
     final public static function getCodersOfTheMonth(string $category = 'all'): array {
         $date = date('Y-m-01', \OmegaUp\Time::get());
@@ -59,7 +59,8 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
               cm.time,
               i.username,
               IFNULL(i.country_id, 'xx') AS country_id,
-              e.email
+              e.email,
+              IFNULL(ur.classname, 'user-rank-unranked') AS classname
           FROM
               Coder_Of_The_Month cm
           INNER JOIN
@@ -68,6 +69,8 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
               Identities i ON i.identity_id = u.main_identity_id
           LEFT JOIN
               Emails e ON e.user_id = u.user_id
+          LEFT JOIN
+              User_Rank ur ON ur.user_id = cm.user_id
           WHERE
               (cm.selected_by IS NOT NULL
               OR (
@@ -89,7 +92,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
               cm.time DESC;
       ";
 
-      /** @var list<array{country_id: string, email: null|string, time: string, username: string}> */
+      /** @var list<array{classname: string, country_id: string, email: null|string, time: string, username: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$category, $category, $date]
@@ -135,7 +138,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
 
     /**
      * Get all coder of the months based on month
-     * @return list<array{country_id: string, email: null|string, ranking: int, time: string, user_id: int, username: string}>
+     * @return list<array{classname: string, country_id: string, email: null|string, ranking: int, time: string, user_id: int, username: string}>
      */
     final public static function getMonthlyList(
         string $firstDay,
@@ -149,7 +152,8 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             i.username,
             IFNULL(i.country_id, 'xx') AS country_id,
             e.email,
-            u.user_id
+            u.user_id,
+            IFNULL(ur.classname, 'user-rank-unranked') AS classname
           FROM
             Coder_Of_The_Month cm
           INNER JOIN
@@ -158,6 +162,8 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             Identities i ON u.main_identity_id = i.identity_id
           LEFT JOIN
             Emails e ON e.email_id = u.main_email_id
+          LEFT JOIN
+            User_Rank ur ON ur.user_id = cm.user_id
           WHERE
             cm.time = ? AND
             cm.category = ?
@@ -166,7 +172,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             cm.`ranking` ASC
           LIMIT 100
         ";
-        /** @var list<array{country_id: string, email: null|string, ranking: int, time: string, user_id: int, username: string}> */
+        /** @var list<array{classname: string, country_id: string, email: null|string, ranking: int, time: string, user_id: int, username: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->getAll(
             $sql,
             [$date, $category]


### PR DESCRIPTION
# Descripción

Pre-calculando UserRank.classname para CoderOfTheMonth en las dos consultas que alimentan a `User::processCodersList` para que no tengan que hacer una secuencia de pares de llamadas a la base de datos (una para username => id y otra para id => classname).

Las vistas de Coder of the Month tarden varios cientos de milisegundos (ref: https://onenr.io/0VKQXOEDEja) porque hacen la secuencia anterior dos veces, una para los coders del mes y otra para los coders del mes pasado:
![image](https://user-images.githubusercontent.com/189223/148360172-2855ec7f-80da-4b9c-ab23-7ecb8e70acd9.png)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.