### PR TITLE
Aumentando el numero de estudiantes que se piden a la vez en la vista de progreso

### DIFF
--- a/frontend/www/js/omegaup/course/students.ts
+++ b/frontend/www/js/omegaup/course/students.ts
@@ -42,7 +42,7 @@ OmegaUp.on('ready', function () {
           progress: types.StudentProgressInCourse[];
         } = await api.Course.studentsProgress({
           page: nextPage,
-          length: 1,
+          length: 100,
           course: payload.course.alias,
         });
         completeStudentsProgress = completeStudentsProgress.concat(


### PR DESCRIPTION
# Descripción

Parece que para construir la vista de progreso de estudiantes se pide el progreso de un estudiante a la vez.
Esto hace que para mostrar la página completa en el curso de `ResolviendoProblemas2021` se tarde minutos (2000 estudiantes x 140ms por petición ~ 280s!).

Con este cambio se pide de a 100 estudiantes a la vez. Según dev tools eso varía entre 100 y 200ms (pidiendo la página 1 y la página 3, respectivamente). Digamos que en el peor caso se tarda 200ms, eso deja el total en 20 peticiones x 200 ms / petición ~ 4s).

Así se ve la cadena actual de peticiones en mi devtools:
![image](https://user-images.githubusercontent.com/189223/148722986-15c6dc26-090f-4544-8755-4987e027b55a.png)

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.