### PR TITLE
Acelerando la consulta de concursos visibles para una identidad

### DIFF
--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -656,7 +656,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
      *
      * Explicación:
      *
-     * La estructura de este query optimiza el uso de indíces en mysql.
+     * La estructura de este query optimiza el uso de índices en mysql.
      *
      * El primer SELECT transforma las columnas a como las espera la API.
      * Luego:
@@ -691,279 +691,130 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $filter = self::formatSearch($query);
         $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
-        $sql = "
-                 (
-                    SELECT
-                        $columns,
-                        COUNT(contestants.identity_id) AS `contestants`,
-                        organizer.username AS `organizer`,
-                        (participating.identity_id IS NOT NULL) AS `participating`
-                    FROM
-                        Contests
-                    LEFT JOIN
-                        Problemset_Identities AS contestants
-                    ON
-                        Contests.problemset_id = contestants.problemset_id
-                    INNER JOIN
-                        ACLs AS a
-                    ON
-                        Contests.acl_id = a.acl_id
-                    INNER JOIN
-                        Identities AS organizer
-                    ON
-                        a.owner_id = organizer.user_id
-                    LEFT JOIN
-                        Problemset_Identities participating
-                    ON
-                        Contests.problemset_id = participating.problemset_id AND
-                        participating.identity_id = ?
-                    WHERE
-                        Contests.admission_mode = 'private' AND organizer.identity_id = ? AND
-                        $recommended_check AND $end_check AND $query_check
-                        AND archived = 0
-                    GROUP BY Contests.contest_id, organizer.identity_id
-                 ) ";
-        $params = [$identityId, $identityId];
-        if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
-            $params[] = $filter['query'];
-        } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {
-            $params[] = $filter['query'];
-            $params[] = $filter['query'];
-        }
+        $sql_relevant_contests = "
+        -- Organizer
+        (SELECT
+            c.contest_id,
+            FALSE AS participating
+        FROM
+            Identities organizer
+        INNER JOIN
+            ACLs a ON a.owner_id = organizer.user_id
+        INNER JOIN
+            Contests c ON c.acl_id = a.acl_id
+        WHERE
+            organizer.identity_id = ?
+        )
+        -- Direct participant
+        UNION DISTINCT
+        (SELECT
+            c.contest_id,
+            TRUE AS participating
+        FROM
+            Problemset_Identities pi
+        INNER JOIN
+            Contests c ON c.problemset_id = pi.problemset_id
+        WHERE
+            pi.identity_id = ?
+        )
+        -- Participant via Group
+        UNION DISTINCT
+        (SELECT
+            p.contest_id,
+            TRUE AS participating
+        FROM
+            Groups_Identities gi
+        INNER JOIN
+            Group_Roles gr ON gi.group_id = gr.group_id
+        INNER JOIN
+            Problemsets p ON gr.acl_id = p.acl_id
+        WHERE
+            gi.identity_id = ? AND gr.role_id = ?
+        )
+        -- Admin
+        UNION DISTINCT
+        (SELECT
+            contest_id,
+            FALSE AS participating
+        FROM
+            Identities i
+        INNER JOIN
+            User_Roles ur ON ur.user_id = i.user_id
+        INNER JOIN
+            Contests c ON c.acl_id = ur.acl_id
+        WHERE
+            i.identity_id = ? AND ur.role_id = ?
+        )
+        -- Admin via Group
+        UNION DISTINCT
+        (SELECT
+            contest_id,
+            FALSE AS participating
+        FROM
+            Groups_Identities gi
+        INNER JOIN
+            Group_Roles gr ON gi.group_id = gr.group_id
+        INNER JOIN
+            Contests c ON c.acl_id = gr.acl_id
+        WHERE
+            gi.identity_id = ? AND gr.role_id = ?
+        )
+        -- Public
+        UNION DISTINCT
+        (SELECT
+            contest_id,
+            (participating.identity_id IS NOT NULL) AS participating
+        FROM
+            Contests
+        LEFT JOIN
+            Problemset_Identities participating
+        ON
+            participating.problemset_id = Contests.problemset_id AND
+            participating.identity_id = ?
+        WHERE
+            admission_mode <> 'private'
+        )
+        ";
 
-        $sql .= "
-                 UNION DISTINCT
-                 (
-                    SELECT
-                        $columns,
-                        COUNT(contestants.identity_id) AS `contestants`,
-                        organizer.username AS `organizer`,
-                        (participating.identity_id IS NOT NULL) AS `participating`
-                    FROM
-                        Contests
-                    INNER JOIN
-                        Problemset_Identities participating
-                    ON
-                        Contests.problemset_id = participating.problemset_id
-                    LEFT JOIN
-                        Problemset_Identities AS contestants
-                    ON
-                        Contests.problemset_id = contestants.problemset_id
-                    INNER JOIN
-                        ACLs AS a
-                    ON
-                        Contests.acl_id = a.acl_id
-                    INNER JOIN
-                        Identities AS organizer
-                    ON
-                        a.owner_id = organizer.user_id
-                    WHERE
-                        Contests.admission_mode = 'private' AND participating.identity_id = ? AND
-                        $recommended_check AND $end_check AND $query_check
-                        AND archived = 0
-                    GROUP BY Contests.contest_id, organizer.identity_id
-                 ) ";
-        $params[] = $identityId;
-        if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
-            $params[] = $filter['query'];
-        } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {
-            $params[] = $filter['query'];
-            $params[] = $filter['query'];
-        }
+        $sql = "SELECT
+            $columns,
+            COUNT(pi.identity_id) AS contestants,
+            ANY_VALUE(organizer.username) AS organizer,
+            BIT_OR(rc.participating) AS participating
+        FROM
+            ($sql_relevant_contests) rc
+        INNER JOIN
+            Contests ON Contests.contest_id = rc.contest_id
+        LEFT JOIN
+            Problemset_Identities pi ON pi.problemset_id = Contests.problemset_id
+        INNER JOIN
+            ACLs a ON a.acl_id = Contests.acl_id
+        INNER JOIN
+            Identities organizer ON organizer.user_id = a.owner_id
+        WHERE
+            $recommended_check AND $end_check AND $query_check
+            AND archived = 0
+        GROUP BY
+            Contests.contest_id
+        ORDER BY
+            CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
+            recommended DESC,
+            original_finish_time DESC
+        LIMIT ?, ?
+        ";
 
-        $sql .= "
-                 UNION DISTINCT
-                 (
-                    SELECT
-                        $columns,
-                        COUNT(contestants.identity_id) AS `contestants`,
-                        organizer.username AS `organizer`,
-                        (gi.identity_id IS NOT NULL) AS `participating`
-                    FROM
-                        Contests
-                    INNER JOIN
-                        Problemsets
-                    ON
-                        Problemsets.problemset_id = Contests.problemset_id
-                    LEFT JOIN
-                        Problemset_Identities AS contestants
-                    ON
-                        Contests.problemset_id = contestants.problemset_id
-                    INNER JOIN
-                        Group_Roles gr
-                    ON
-                        gr.acl_id = Problemsets.acl_id AND
-                        gr.role_id = ?
-                    INNER JOIN
-                        Groups_Identities gi
-                    ON
-                        gi.group_id = gr.group_id
-                    INNER JOIN
-                        ACLs AS a
-                    ON
-                        Contests.acl_id = a.acl_id
-                    INNER JOIN
-                        Identities AS organizer
-                    ON
-                        a.owner_id = organizer.user_id
-                    WHERE
-                        Contests.admission_mode = 'private' AND
-                        gi.identity_id = ? AND
-                        $recommended_check AND $end_check AND $query_check
-                        AND archived = 0
-                    GROUP BY Contests.contest_id, organizer.identity_id
-                 ) ";
-        $params[] = \OmegaUp\Authorization::CONTESTANT_ROLE;
-        $params[] = $identityId;
-        if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
-            $params[] = $filter['query'];
-        } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {
-            $params[] = $filter['query'];
-            $params[] = $filter['query'];
-        }
+        $params = [
+            $identityId,    // Organizer
+            $identityId,    // Direct participant
+            $identityId,    // Participant via Group
+            \OmegaUp\Authorization::CONTESTANT_ROLE,
+            $identityId,    // Admin
+            \OmegaUp\Authorization::ADMIN_ROLE,
+            $identityId,    // Admin via Group
+            \OmegaUp\Authorization::ADMIN_ROLE,
+            $identityId,    // Participant check
+        ];
 
-        $sql .= "
-                 UNION DISTINCT
-                 (
-                     SELECT
-                         $columns,
-                         COUNT(contestants.identity_id) AS `contestants`,
-                         organizer.username AS `organizer`,
-                         (participating.identity_id IS NOT NULL) AS `participating`
-                     FROM
-                         Contests
-                     INNER JOIN
-                         User_Roles
-                     ON
-                         User_Roles.acl_id = Contests.acl_id
-                     INNER JOIN
-                         Identities
-                     ON
-                         Identities.user_id = User_Roles.user_id
-                     LEFT JOIN
-                         Problemset_Identities AS contestants
-                     ON
-                         Contests.problemset_id = contestants.problemset_id
-                     INNER JOIN
-                         ACLs AS a
-                     ON
-                         Contests.acl_id = a.acl_id
-                     INNER JOIN
-                         Identities AS organizer
-                     ON
-                         a.owner_id = organizer.user_id
-                     LEFT JOIN
-                         Problemset_Identities participating
-                     ON
-                         Contests.problemset_id = participating.problemset_id AND
-                         participating.identity_id = ?
-                     WHERE
-                         Contests.admission_mode = 'private' AND
-                         Identities.identity_id = ? AND
-                         User_Roles.role_id = ? AND
-                         $recommended_check AND $end_check AND $query_check
-                        AND archived = 0
-                    GROUP BY Contests.contest_id, organizer.identity_id
-                 ) ";
-        $params[] = $identityId;
-        $params[] = $identityId;
-        $params[] = \OmegaUp\Authorization::ADMIN_ROLE;
-        if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
-            $params[] = $filter['query'];
-        } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {
-            $params[] = $filter['query'];
-            $params[] = $filter['query'];
-        }
-
-        $sql .= "
-                 UNION DISTINCT
-                 (
-                     SELECT
-                         $columns,
-                         COUNT(contestants.identity_id) AS `contestants`,
-                         organizer.username AS `organizer`,
-                         (participating.identity_id IS NOT NULL) AS `participating`
-                     FROM
-                         Contests
-                     INNER JOIN
-                         Group_Roles ON Contests.acl_id = Group_Roles.acl_id
-                     INNER JOIN
-                         Groups_Identities
-                     ON
-                         Groups_Identities.group_id = Group_Roles.group_id
-                     LEFT JOIN
-                         Problemset_Identities AS contestants
-                     ON
-                         Contests.problemset_id = contestants.problemset_id
-                     INNER JOIN
-                         ACLs AS a
-                     ON
-                         Contests.acl_id = a.acl_id
-                     INNER JOIN
-                         Identities AS organizer
-                     ON
-                         a.owner_id = organizer.user_id
-                     LEFT JOIN
-                         Problemset_Identities participating
-                     ON
-                         Contests.problemset_id = participating.problemset_id AND
-                         participating.identity_id = ?
-                     WHERE
-                         Contests.admission_mode = 'private' AND
-                         Groups_Identities.identity_id = ? AND
-                         Group_Roles.role_id = ? AND
-                         $recommended_check AND $end_check AND $query_check
-                        AND archived = 0
-                     GROUP BY Contests.contest_id, organizer.identity_id
-                 ) ";
-        $params[] = $identityId;
-        $params[] = $identityId;
-        $params[] = \OmegaUp\Authorization::ADMIN_ROLE;
-        if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
-            $params[] = $filter['query'];
-        } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {
-            $params[] = $filter['query'];
-            $params[] = $filter['query'];
-        }
-        $sql .= "
-                 UNION DISTINCT
-                 (
-                     SELECT
-                         $columns,
-                         COUNT(contestants.identity_id) AS `contestants`,
-                         organizer.username AS `organizer`,
-                         (participating.identity_id IS NOT NULL) AS `participating`
-                     FROM
-                         Contests
-                     LEFT JOIN
-                         Problemset_Identities AS contestants
-                     ON
-                        Contests.problemset_id = contestants.problemset_id
-                     INNER JOIN
-                         ACLs AS a
-                     ON
-                         Contests.acl_id = a.acl_id
-                     INNER JOIN
-                         Identities AS organizer
-                     ON
-                         a.owner_id = organizer.user_id
-                     LEFT JOIN
-                         Problemset_Identities participating
-                     ON
-                         Contests.problemset_id = participating.problemset_id AND
-                         participating.identity_id = ?
-                     WHERE
-                         admission_mode <> 'private' AND $recommended_check AND $end_check AND $query_check
-                        AND archived = 0
-                     GROUP BY Contests.contest_id, organizer.identity_id
-                 )
-                 ORDER BY
-                     CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
-                     `recommended` DESC,
-                     `original_finish_time` DESC
-                 LIMIT ?, ?
-                ";
-        $params[] = $identityId;
         if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
             $params[] = $filter['query'];
         } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {


### PR DESCRIPTION
# Descripción

Este cambio sigue la idea de #6268 de invertir el orden en que se consiguen cosas; primero la identidad y después el registro completo de concursos que se quiere producir. Los resultados en Metabase no son idénticos, pero hasta donde puedo ver solo se reordenan contest_ids un poco pero el resultado final sigue siendo el mismo.

Esto es para mejorar arena/index, que a pesar de haber mejorado significativamente, sigue siendo la consulta más lenta (ref: https://onenr.io/0nVjYEmP0j0). En particular, `getAllContestForIdentity` sigue costando múltiples cientos de milisegundos:
![image](https://user-images.githubusercontent.com/189223/148910293-833287d0-6741-428e-9a51-b1d6205afdd7.png)

Con este cambio, se reduce el tiempod de esa consulta por ~40% (de como 500ms a como 300ms en Metabase):

## Antes:
![image](https://user-images.githubusercontent.com/189223/148910587-47d6093d-42ad-46e1-95a9-b842f42a1f03.png)

## Después:
![image](https://user-images.githubusercontent.com/189223/148910631-82050af8-6098-4ef2-8306-8b1a5950d8f6.png)

# Comentarios

Tal vez se deba agregar un índice a `admission_mode` para que la consulta de concursos públicos sea más rápida.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.