### PR TITLE
Simplficando llamada para conseguir leguaje de preferencia del usuario

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2619,18 +2619,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         // Add preferred language of the user.
-        if (!is_null($loggedIdentity) && !is_null($loggedIdentity->username)) {
-            $userData = \OmegaUp\Controllers\User::getUserProfile(
-                $loggedIdentity,
-                $loggedIdentity,
-                omitRank: true
+        if (!is_null($loggedIdentity)) {
+            $preferredLanguage = \OmegaUp\DAO\Users::getPreferredLanguage(
+                $loggedIdentity->user_id
             );
-            if (
-                !empty($userData) &&
-                !empty($userData['preferred_language'])
-            ) {
+            if (!empty($preferredLanguage)) {
                 $response['preferred_language'] = strval(
-                    $userData['preferred_language']
+                    $preferredLanguage
                 );
             }
         }

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -169,6 +169,25 @@ class Users extends \OmegaUp\DAO\Base\Users {
         return $user;
     }
 
+    public static function getPreferredLanguage(?int $userId): ?string {
+        if (is_null($userId)) {
+            return null;
+        }
+        $sql = 'SELECT
+                    preferred_language
+                FROM
+                    Users u
+                WHERE
+                    u.user_id = ?;';
+        $params = [$userId];
+        /** @var null|string */
+        $preferredLanguage = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            $sql,
+            $params
+        );
+        return $preferredLanguage;
+    }
+
     public static function getHideTags(?int $identityId): bool {
         if (is_null($identityId)) {
             return false;

--- a/frontend/tests/Factories/User.php
+++ b/frontend/tests/Factories/User.php
@@ -40,7 +40,13 @@ class UserParams {
     public $verify;
 
     /**
-     * @param array{username?: string, name?: string, password?: string, email?: string, isPrivate?: bool, verify?: bool} $params
+     * @readonly
+     * @var string|null
+     */
+    public $preferredLanguage;
+
+    /**
+     * @param array{username?: string, name?: string, password?: string, email?: string, isPrivate?: bool, verify?: bool, preferredLanguage?: string} $params
      */
     public function __construct(array $params = []) {
         $this->username = $params['username'] ?? \OmegaUp\Test\Utils::CreateRandomString();
@@ -49,6 +55,7 @@ class UserParams {
         $this->email = $params['email'] ?? \OmegaUp\Test\Utils::CreateRandomString() . '@mail.com';
         $this->isPrivate = $params['isPrivate'] ?? false;
         $this->verify = $params['verify'] ?? true;
+        $this->preferredLanguage = $params['preferredLanguage'] ?? null;
     }
 }
 
@@ -90,10 +97,20 @@ class User {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
+        $needsUpdate = false;
         if ($params->verify) {
             $user = self::verifyUser($user);
         } else {
             $user->verified = false;
+            $needsUpdate = true;
+        }
+
+        if (!empty($params->preferredLanguage)) {
+            $user->preferred_language = $params->preferredLanguage;
+            $needsUpdate = true;
+        }
+
+        if ($needsUpdate) {
             \OmegaUp\DAO\Users::update($user);
         }
 

--- a/frontend/tests/controllers/ProblemExtraInformationTest.php
+++ b/frontend/tests/controllers/ProblemExtraInformationTest.php
@@ -220,4 +220,33 @@ class ProblemExtraInformationTest extends \OmegaUp\Test\ControllerTestCase {
             $result['payload']['solutionStatus']
         );
     }
+
+    /**
+     * Test that users' preferred language is used.
+     */
+    public function testPreferredLanguage() {
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'zipName' => OMEGAUP_TEST_RESOURCES_ROOT . 'triangulos.zip',
+            ])
+        );
+
+        [
+            'user' => $user,
+            'identity' => $identity,
+        ] = \OmegaUp\Test\Factories\User::createUser(new \OmegaUp\Test\Factories\UserParams([
+            'preferredLanguage' => 'py3'
+        ]));
+        $login = self::login($identity);
+        $result = \OmegaUp\Controllers\Problem::getProblemDetailsForTypeScript(
+            new \OmegaUp\Request([
+                'problem_alias' => $problemData['request']['problem_alias'],
+                'auth_token' => $login->auth_token,
+            ])
+        )['templateProperties'];
+        $this->assertEquals(
+            'py3',
+            $result['payload']['problem']['preferred_language']
+        );
+    }
 }


### PR DESCRIPTION
# Descripción

Para desplegar problemas se utiliza el lenguaje (de programación) de preferencia del usuario. Pero para conseguirlo, `getProblemDetails` pasa a través de `getUserProfile` que luego va y hace muchas cosas de las cuales solo se utiliza el lenguaje de preferencia.

Con este cambio se va directo a la base de datos a conseguir solo el dato que se necesita.

Motivación: https://onenr.io/0xZw0x5Bnwv

La vista de problemas es de las más costosas...
![image](https://user-images.githubusercontent.com/189223/149088879-0dfa493b-0759-4b89-bc25-4d50cf8cd714.png)

... y esto es en parte por esta llamada innecesaria a `getUserProfile`:
![image](https://user-images.githubusercontent.com/189223/149088602-80880eaa-b52f-44fb-97da-260e901f41bb.png)

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.