### PR TITLE
Simplificar la busqueda de la escuela del mes

### DIFF
--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -377,7 +377,7 @@ class School extends \OmegaUp\Controllers\Controller {
      */
     public static function getSchoolOfTheMonth(string $date = null): array {
         $firstDay = self::getCurrentMonthFirstDay($date);
-        $schoolsOfTheMonth = \OmegaUp\DAO\SchoolOfTheMonth::getByTime(
+        $schoolsOfTheMonth = \OmegaUp\DAO\SchoolOfTheMonth::getByTimeAndSelected(
             $firstDay
         );
 
@@ -388,13 +388,6 @@ class School extends \OmegaUp\Controllers\Controller {
         }
 
         $schoolOfTheMonthId = $schoolsOfTheMonth[0]->school_id;
-        foreach ($schoolsOfTheMonth as $school) {
-            if (isset($school->selected_by)) {
-                $schoolOfTheMonthId = $school->school_id;
-                break;
-            }
-        }
-
         if (is_null($schoolOfTheMonthId)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'schoolOfTheMonthNotFound'


### PR DESCRIPTION
# Descripción

Resulta que lo más lento de formar el homepage es conseguir el usuario y escuela del mes:
![image](https://user-images.githubusercontent.com/189223/149095492-17cfa5bf-226a-472d-987f-6ec94062df6c.png)

En este cambio se mueve la identificación de la escuela seleccionada de PHP => SQL.
El cambio de consulta debería ayudar porque hay un índice para `selected_by` pero no para `time`; de manera que la consulta actual está haciendo un full scan para encontrar las consultas correspondientes. Con este cambio al menos se limita el scan a las escuelas seleccionadas (que debería ser uno o dos órdenes de magnitud menos que las escuelas candidatas).

Intenté agregar un índice con el par de columnas pero MySQL (`EXPLAIN`) dijo que no lo usaría, así que me enojé y no lo puse.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.