### PR TITLE
Agregar un indice a School_Of_The_Month.time

### DIFF
--- a/frontend/database/00197_add_school_of_the_month_time_index.sql
+++ b/frontend/database/00197_add_school_of_the_month_time_index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `School_Of_The_Month` ADD KEY `idx_time` (`time`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -910,6 +910,7 @@ CREATE TABLE `School_Of_The_Month` (
   KEY `school_of_the_month_id` (`school_of_the_month_id`),
   KEY `school_id` (`school_id`),
   KEY `selected_by` (`selected_by`),
+  KEY `idx_time` (`time`),
   CONSTRAINT `fk_sotmi_identity_id` FOREIGN KEY (`selected_by`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_sotms_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Escuelas del Mes';


### PR DESCRIPTION
# Descripción

Resulta que lo más lento de formar el homepage es conseguir el usuario y escuela del mes:
![image](https://user-images.githubusercontent.com/189223/149297797-9222099a-08a1-42cd-832d-10d5b5a9fc6f.png)

En este cambio se agrega un índice para la columna `time` de manera que la consulta deje de hacer un full scan para encontrar las escuelas en el mes que se busca.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.