### PR TITLE
Arreglando el autogenerado de codigo para las peticiones con API Tokens (libomegaup)

### DIFF
--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -1133,7 +1133,7 @@ EOD;
         echo "                    f'Username={self.username}',\n";
         echo "                ))\n";
         echo "            else:\n";
-        echo "                headers['Authorization'] = self.api_token\n";
+        echo "                headers['Authorization'] = f'token {self.api_token}'\n";
         echo "        elif self.auth_token is not None:\n";
         echo "            payload['ouat'] = self.auth_token\n";
         echo "\n";


### PR DESCRIPTION
# Descripción

Arreglando el encabezado `Authorization`  para incluir el identificador `token` faltante.

Fixes: omegaup/libomegaup#11

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.

