### PR TITLE
Optimizando la consulta de clarificaciones

### DIFF
--- a/frontend/server/src/DAO/Clarifications.php
+++ b/frontend/server/src/DAO/Clarifications.php
@@ -23,29 +23,48 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         ?int $offset,
         int $rowcount
     ): array {
-        $sqlFrom = '
+        if (!is_null($contest)) {
+            $sqlProblemsets = '
+            SELECT
+                problemset_id,
+                "" AS assignment_alias
             FROM
-                Clarifications cl
+                Problemsets
+            WHERE
+                contest_id = ?
+            ';
+            $params = [$contest->contest_id];
+        } elseif (!is_null($course)) {
+            $sqlProblemsets = '
+            SELECT
+                problemset_id,
+                alias AS assignment_alias
+            FROM
+                Assignments
+            WHERE
+                course_id = ?
+            ';
+            $params = [$course->course_id];
+        } else {
+            // This shouldn't happen!
+            return [
+                'totalRows' => 0,
+                'clarifications' => [],
+            ];
+        }
+
+        $sqlFrom = "
+            FROM
+                ($sqlProblemsets) ps
+            INNER JOIN
+                Clarifications cl ON cl.problemset_id = ps.problemset_id
             INNER JOIN
                 Identities i ON i.identity_id = cl.author_id
             LEFT JOIN
                 Identities r ON r.identity_id = cl.receiver_id
             INNER JOIN
                 Problems p ON p.problem_id = cl.problem_id
-            INNER JOIN
-                Problemsets ps ON ps.problemset_id = cl.problemset_id
-            LEFT JOIN
-                Assignments a ON a.problemset_id = cl.problemset_id
-            WHERE
-                (
-                    ps.contest_id = ? OR
-                    a.course_id = ?
-                )';
-
-        $params = [
-            is_null($contest) ? null : $contest->contest_id,
-            is_null($course) ? null : $course->course_id,
-        ];
+            ";
 
         if (!$isAdmin) {
             $sqlFrom .= '
@@ -72,7 +91,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         $sql = '
             SELECT
                 cl.clarification_id,
-                a.alias AS assignment_alias,
+                ps.assignment_alias AS assignment_alias,
                 p.alias AS problem_alias,
                 i.username AS author,
                 r.username AS receiver,
@@ -94,7 +113,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
 
         $query .= $sqlOrderBy . $sqlLimit;
 
-        /** @var list<array{answer: null|string, assignment_alias: null|string, author: string, clarification_id: int, message: string, problem_alias: string, public: bool, receiver: null|string, time: \OmegaUp\Timestamp}> */
+        /** @var list<array{answer: null|string, assignment_alias: string, author: string, clarification_id: int, message: string, problem_alias: string, public: bool, receiver: null|string, time: \OmegaUp\Timestamp}> */
         $clarifications = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $query,
             $params


### PR DESCRIPTION
# Descripción

Este cambio trata de mejorar el desempeño de la consulta de clarificaciones en un problemset que parece ser compleja por tener que lidiar con `Contests` y con `Problemsets`. 
Ahorita la consulta hace un full scan de la tabla de clarificaciones. Con este cambio deberían poder usar índices de las tablas de `Problemsets` o de `Assignments`.

Motivación: https://onenr.io/0a2wdb71XjE

La vista de un concurso parece ser lenta por tener que conseguir clarificaciones:
![image](https://user-images.githubusercontent.com/189223/149475238-f9afbba2-25f2-4d0d-adb8-2d5c4caef7d6.png)

MySQL explain dice que esto funciona correctamente para `Contests` pero por algún motivo `Assignments` no coopera. Aún y cuando agrego un índice en la columna course_id. Aún así, esto atienede la motivación original de acelerar la página de concursos y puedo investigar el problema con cursos más adelante.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.