### PR TITLE
Agregando comando para hacer un run dentro de Cypress

### DIFF
--- a/cypress/fixtures/main.cpp
+++ b/cypress/fixtures/main.cpp
@@ -1,0 +1,1 @@
+../../frontend/tests/resources/Main.cpp17-gcc

--- a/cypress/fixtures/main_wrong.cpp
+++ b/cypress/fixtures/main_wrong.cpp
@@ -1,0 +1,1 @@
+../../frontend/tests/resources/Main_wrong.cpp17-gcc

--- a/cypress/integration/basic_commands.spec.ts
+++ b/cypress/integration/basic_commands.spec.ts
@@ -1,6 +1,12 @@
 import { v4 as uuid } from 'uuid';
 import { getISODate } from '../support/commands';
-import { CourseOptions, LoginOptions, ProblemOptions } from '../support/types';
+import {
+  CourseOptions,
+  LoginOptions,
+  ProblemOptions,
+  RunOptions,
+  Status,
+} from '../support/types';
 
 describe('Basic Commands Test', () => {
   beforeEach(() => {
@@ -214,5 +220,31 @@ describe('Basic Commands Test', () => {
       problemOptions.problemAlias,
     );
     cy.get('[name="source"]').should('have.value', problemOptions.problemAlias);
+  });
+
+  it('Should make a run of a problem', () => {
+    const problemOptions: ProblemOptions = {
+      problemAlias: 'problem-' + uuid().slice(0, 8),
+      tag: 'Recursion',
+      autoCompleteTextTag: 'Recur',
+      problemLevelIndex: 1,
+    };
+
+    const runOptions: RunOptions = {
+      problemAlias: problemOptions.problemAlias,
+      fixturePath: 'main.cpp',
+      language: 'cpp11-gcc',
+    };
+
+    const expectedStatus: Status = 'AC';
+
+    cy.login({ username: 'user', password: 'user' });
+    cy.createProblem(problemOptions);
+    cy.createRun(runOptions);
+    cy.get('[data-run-status] > span').first().should('have.text', 'new');
+    cy.wait(10000); // Wait for grader
+    cy.get('[data-run-status] > span')
+      .first()
+      .should('have.text', expectedStatus);
   });
 });

--- a/cypress/integration/basic_commands.spec.ts
+++ b/cypress/integration/basic_commands.spec.ts
@@ -15,212 +15,212 @@ describe('Basic Commands Test', () => {
     cy.visit('/');
   });
 
-  it('Should create a course with unlimited duration', () => {
-    const loginOptions: LoginOptions = {
-      username: uuid(),
-      password: uuid(),
-    };
+  // it('Should create a course with unlimited duration', () => {
+  //   const loginOptions: LoginOptions = {
+  //     username: uuid(),
+  //     password: uuid(),
+  //   };
 
-    const courseOptions: CourseOptions = {
-      courseAlias: uuid().slice(0, 10),
-      showScoreboard: true,
-      startDate: new Date(2022, 2, 2),
-      unlimitedDuration: true,
-      school: 'omegaup',
-      basicInformation: false,
-      requestParticipantInformation: 'optional',
-      problemLevel: 'intermediate',
-      objective: 'This is the objective',
-      description: 'This is the description',
-    };
+  //   const courseOptions: CourseOptions = {
+  //     courseAlias: uuid().slice(0, 10),
+  //     showScoreboard: true,
+  //     startDate: new Date(2022, 2, 2),
+  //     unlimitedDuration: true,
+  //     school: 'omegaup',
+  //     basicInformation: false,
+  //     requestParticipantInformation: 'optional',
+  //     problemLevel: 'intermediate',
+  //     objective: 'This is the objective',
+  //     description: 'This is the description',
+  //   };
 
-    cy.register(loginOptions);
-    cy.createCourse(courseOptions);
+  //   cy.register(loginOptions);
+  //   cy.createCourse(courseOptions);
 
-    // Assert
-    cy.location('href').should('include', courseOptions.courseAlias); // Url
-    cy.get('[data-course-name]').contains(courseOptions.courseAlias);
-    cy.get('[data-tab-course').click();
-    cy.get('[data-course-new-name]').should(
-      'have.value',
-      courseOptions.courseAlias,
-    );
-    cy.get('[data-course-new-alias]').should(
-      'have.value',
-      courseOptions.courseAlias,
-    );
-    cy.get('[name="show-scoreboard"]')
-      .eq(courseOptions.showScoreboard ? 0 : 1)
-      .should('be.checked');
-    cy.get('[name="start-date"]').should(
-      'have.value',
-      getISODate(courseOptions.startDate ?? new Date()),
-    );
-    cy.get('[name="unlimited-duration"]')
-      .eq(courseOptions.unlimitedDuration ? 0 : 1)
-      .should('be.checked');
-    cy.get('.tt-input').first().should('have.value', courseOptions.school);
-    cy.get('[name="basic-information"]')
-      .eq(courseOptions.basicInformation ? 0 : 1)
-      .should('be.checked');
-    cy.get('[data-course-participant-information]').should(
-      'have.value',
-      courseOptions.requestParticipantInformation,
-    );
-    cy.get('[data-course-problem-level]').should(
-      'have.value',
-      courseOptions.problemLevel,
-    );
-    cy.get('[data-course-objective]').should(
-      'have.value',
-      courseOptions.objective,
-    );
-    cy.get('[data-course-new-description]').should(
-      'have.value',
-      courseOptions.description,
-    );
-  });
+  //   // Assert
+  //   cy.location('href').should('include', courseOptions.courseAlias); // Url
+  //   cy.get('[data-course-name]').contains(courseOptions.courseAlias);
+  //   cy.get('[data-tab-course').click();
+  //   cy.get('[data-course-new-name]').should(
+  //     'have.value',
+  //     courseOptions.courseAlias,
+  //   );
+  //   cy.get('[data-course-new-alias]').should(
+  //     'have.value',
+  //     courseOptions.courseAlias,
+  //   );
+  //   cy.get('[name="show-scoreboard"]')
+  //     .eq(courseOptions.showScoreboard ? 0 : 1)
+  //     .should('be.checked');
+  //   cy.get('[name="start-date"]').should(
+  //     'have.value',
+  //     getISODate(courseOptions.startDate ?? new Date()),
+  //   );
+  //   cy.get('[name="unlimited-duration"]')
+  //     .eq(courseOptions.unlimitedDuration ? 0 : 1)
+  //     .should('be.checked');
+  //   cy.get('.tt-input').first().should('have.value', courseOptions.school);
+  //   cy.get('[name="basic-information"]')
+  //     .eq(courseOptions.basicInformation ? 0 : 1)
+  //     .should('be.checked');
+  //   cy.get('[data-course-participant-information]').should(
+  //     'have.value',
+  //     courseOptions.requestParticipantInformation,
+  //   );
+  //   cy.get('[data-course-problem-level]').should(
+  //     'have.value',
+  //     courseOptions.problemLevel,
+  //   );
+  //   cy.get('[data-course-objective]').should(
+  //     'have.value',
+  //     courseOptions.objective,
+  //   );
+  //   cy.get('[data-course-new-description]').should(
+  //     'have.value',
+  //     courseOptions.description,
+  //   );
+  // });
 
-  it('Should create a course with end date', () => {
-    const loginOptions: LoginOptions = {
-      username: uuid(),
-      password: uuid(),
-    };
+  // it('Should create a course with end date', () => {
+  //   const loginOptions: LoginOptions = {
+  //     username: uuid(),
+  //     password: uuid(),
+  //   };
 
-    const courseOptions: CourseOptions = {
-      courseAlias: uuid().slice(0, 10),
-      showScoreboard: true,
-      startDate: new Date(2022, 2, 2),
-      unlimitedDuration: false,
-      endDate: new Date(2022, 3, 3),
-      school: 'omegaup',
-      basicInformation: false,
-      requestParticipantInformation: 'optional',
-      problemLevel: 'intermediate',
-      objective: 'This is the objective',
-      description: 'This is the description',
-    };
+  //   const courseOptions: CourseOptions = {
+  //     courseAlias: uuid().slice(0, 10),
+  //     showScoreboard: true,
+  //     startDate: new Date(2022, 2, 2),
+  //     unlimitedDuration: false,
+  //     endDate: new Date(2022, 3, 3),
+  //     school: 'omegaup',
+  //     basicInformation: false,
+  //     requestParticipantInformation: 'optional',
+  //     problemLevel: 'intermediate',
+  //     objective: 'This is the objective',
+  //     description: 'This is the description',
+  //   };
 
-    cy.register(loginOptions);
-    cy.createCourse(courseOptions);
+  //   cy.register(loginOptions);
+  //   cy.createCourse(courseOptions);
 
-    // Assert
-    cy.location('href').should('include', courseOptions.courseAlias); // Url
-    cy.get('[data-course-name]').contains(courseOptions.courseAlias);
-    cy.get('[data-tab-course').click();
-    cy.get('[data-course-new-name]').should(
-      'have.value',
-      courseOptions.courseAlias,
-    );
-    cy.get('[data-course-new-alias]').should(
-      'have.value',
-      courseOptions.courseAlias,
-    );
-    cy.get('[name="show-scoreboard"]')
-      .eq(courseOptions.showScoreboard ? 0 : 1)
-      .should('be.checked');
-    cy.get('[name="start-date"]').should(
-      'have.value',
-      getISODate(courseOptions.startDate ?? new Date()),
-    );
-    cy.get('[name="unlimited-duration"]')
-      .eq(courseOptions.unlimitedDuration ? 0 : 1)
-      .should('be.checked');
-    cy.get('[name="end-date"]').should(
-      'have.value',
-      getISODate(courseOptions.endDate ?? new Date()),
-    );
-    cy.get('.tt-input').first().should('have.value', courseOptions.school); //
-    cy.get('[name="basic-information"]')
-      .eq(courseOptions.basicInformation ? 0 : 1)
-      .should('be.checked');
-    cy.get('[data-course-participant-information]').should(
-      'have.value',
-      courseOptions.requestParticipantInformation,
-    );
-    cy.get('[data-course-problem-level]').should(
-      'have.value',
-      courseOptions.problemLevel,
-    );
-    cy.get('[data-course-objective]').should(
-      'have.value',
-      courseOptions.objective,
-    );
-    cy.get('[data-course-new-description]').should(
-      'have.value',
-      courseOptions.description,
-    );
-  });
+  //   // Assert
+  //   cy.location('href').should('include', courseOptions.courseAlias); // Url
+  //   cy.get('[data-course-name]').contains(courseOptions.courseAlias);
+  //   cy.get('[data-tab-course').click();
+  //   cy.get('[data-course-new-name]').should(
+  //     'have.value',
+  //     courseOptions.courseAlias,
+  //   );
+  //   cy.get('[data-course-new-alias]').should(
+  //     'have.value',
+  //     courseOptions.courseAlias,
+  //   );
+  //   cy.get('[name="show-scoreboard"]')
+  //     .eq(courseOptions.showScoreboard ? 0 : 1)
+  //     .should('be.checked');
+  //   cy.get('[name="start-date"]').should(
+  //     'have.value',
+  //     getISODate(courseOptions.startDate ?? new Date()),
+  //   );
+  //   cy.get('[name="unlimited-duration"]')
+  //     .eq(courseOptions.unlimitedDuration ? 0 : 1)
+  //     .should('be.checked');
+  //   cy.get('[name="end-date"]').should(
+  //     'have.value',
+  //     getISODate(courseOptions.endDate ?? new Date()),
+  //   );
+  //   cy.get('.tt-input').first().should('have.value', courseOptions.school); //
+  //   cy.get('[name="basic-information"]')
+  //     .eq(courseOptions.basicInformation ? 0 : 1)
+  //     .should('be.checked');
+  //   cy.get('[data-course-participant-information]').should(
+  //     'have.value',
+  //     courseOptions.requestParticipantInformation,
+  //   );
+  //   cy.get('[data-course-problem-level]').should(
+  //     'have.value',
+  //     courseOptions.problemLevel,
+  //   );
+  //   cy.get('[data-course-objective]').should(
+  //     'have.value',
+  //     courseOptions.objective,
+  //   );
+  //   cy.get('[data-course-new-description]').should(
+  //     'have.value',
+  //     courseOptions.description,
+  //   );
+  // });
 
-  it('Should register a user using the API', () => {
-    const loginOptions: LoginOptions = {
-      username: uuid(),
-      password: uuid(),
-    };
-    cy.register(loginOptions);
-    cy.get('header .username').should('have.text', loginOptions.username);
-  });
+  // it('Should register a user using the API', () => {
+  //   const loginOptions: LoginOptions = {
+  //     username: uuid(),
+  //     password: uuid(),
+  //   };
+  //   cy.register(loginOptions);
+  //   cy.get('header .username').should('have.text', loginOptions.username);
+  // });
 
-  it('Should register a user', () => {
-    const username = uuid();
-    const password = uuid();
-    cy.get('[data-login-button]').click();
-    cy.get('[data-signup-username]').type(username);
-    cy.get('[data-signup-password]').type(password);
-    cy.get('[data-signup-repeat-password]').type(password);
-    cy.get('[data-signup-email]').type(`${username}@omegaup.com`);
-    cy.get('[data-signup-submit]').click();
-    cy.waitUntil(() =>
-      cy.get('header .username').should('have.text', username),
-    );
-  });
+  // it('Should register a user', () => {
+  //   const username = uuid();
+  //   const password = uuid();
+  //   cy.get('[data-login-button]').click();
+  //   cy.get('[data-signup-username]').type(username);
+  //   cy.get('[data-signup-password]').type(password);
+  //   cy.get('[data-signup-repeat-password]').type(password);
+  //   cy.get('[data-signup-email]').type(`${username}@omegaup.com`);
+  //   cy.get('[data-signup-submit]').click();
+  //   cy.waitUntil(() =>
+  //     cy.get('header .username').should('have.text', username),
+  //   );
+  // });
 
-  it('Should login a user using the API', () => {
-    const loginOptions: LoginOptions = {
-      username: 'user',
-      password: 'user',
-    };
-    cy.login(loginOptions);
-    cy.get('header .username').should('have.text', loginOptions.username);
-  });
+  // it('Should login a user using the API', () => {
+  //   const loginOptions: LoginOptions = {
+  //     username: 'user',
+  //     password: 'user',
+  //   };
+  //   cy.login(loginOptions);
+  //   cy.get('header .username').should('have.text', loginOptions.username);
+  // });
 
-  it('Should login a user', () => {
-    const username = 'user';
-    const password = 'user';
-    cy.get('[data-login-button]').click();
-    cy.get('[data-login-username]').type(username);
-    cy.get('[data-login-password]').type(password);
-    cy.get('[data-login-submit]').click();
-    cy.waitUntil(() =>
-      cy.get('header .username').should('have.text', username),
-    );
-  });
+  // it('Should login a user', () => {
+  //   const username = 'user';
+  //   const password = 'user';
+  //   cy.get('[data-login-button]').click();
+  //   cy.get('[data-login-username]').type(username);
+  //   cy.get('[data-login-password]').type(password);
+  //   cy.get('[data-login-submit]').click();
+  //   cy.waitUntil(() =>
+  //     cy.get('header .username').should('have.text', username),
+  //   );
+  // });
 
-  it('Should create a problem', () => {
-    const loginOptions: LoginOptions = {
-      username: uuid(),
-      password: uuid(),
-    };
+  // it('Should create a problem', () => {
+  //   const loginOptions: LoginOptions = {
+  //     username: uuid(),
+  //     password: uuid(),
+  //   };
 
-    const problemOptions: ProblemOptions = {
-      problemAlias: uuid().slice(0, 10), // Too large for the alias,
-      tag: 'Recursion',
-      autoCompleteTextTag: 'recur',
-      problemLevelIndex: 0,
-    };
+  //   const problemOptions: ProblemOptions = {
+  //     problemAlias: uuid().slice(0, 10), // Too large for the alias,
+  //     tag: 'Recursion',
+  //     autoCompleteTextTag: 'recur',
+  //     problemLevelIndex: 0,
+  //   };
 
-    cy.register(loginOptions);
-    cy.createProblem(problemOptions);
+  //   cy.register(loginOptions);
+  //   cy.createProblem(problemOptions);
 
-    // Assert problem has been created
-    cy.location('href').should('include', problemOptions.problemAlias); // Url
-    cy.get('[name="title"]').should('have.value', problemOptions.problemAlias); // Title
-    cy.get('[name="problem_alias"]').should(
-      'have.value',
-      problemOptions.problemAlias,
-    );
-    cy.get('[name="source"]').should('have.value', problemOptions.problemAlias);
-  });
+  //   // Assert problem has been created
+  //   cy.location('href').should('include', problemOptions.problemAlias); // Url
+  //   cy.get('[name="title"]').should('have.value', problemOptions.problemAlias); // Title
+  //   cy.get('[name="problem_alias"]').should(
+  //     'have.value',
+  //     problemOptions.problemAlias,
+  //   );
+  //   cy.get('[name="source"]').should('have.value', problemOptions.problemAlias);
+  // });
 
   it('Should make a run of a problem', () => {
     const problemOptions: ProblemOptions = {
@@ -242,9 +242,13 @@ describe('Basic Commands Test', () => {
     cy.createProblem(problemOptions);
     cy.createRun(runOptions);
     cy.get('[data-run-status] > span').first().should('have.text', 'new');
-    cy.wait(10000); // Wait for grader
+
+    cy.intercept({method: "POST", url: "/api/run/status/"}).as('runStatus');
+    cy.wait(["@runStatus"]);
+
     cy.get('[data-run-status] > span')
       .first()
       .should('have.text', expectedStatus);
+
   });
 });

--- a/cypress/integration/basic_commands.spec.ts
+++ b/cypress/integration/basic_commands.spec.ts
@@ -15,212 +15,212 @@ describe('Basic Commands Test', () => {
     cy.visit('/');
   });
 
-  // it('Should create a course with unlimited duration', () => {
-  //   const loginOptions: LoginOptions = {
-  //     username: uuid(),
-  //     password: uuid(),
-  //   };
+  it('Should create a course with unlimited duration', () => {
+    const loginOptions: LoginOptions = {
+      username: uuid(),
+      password: uuid(),
+    };
 
-  //   const courseOptions: CourseOptions = {
-  //     courseAlias: uuid().slice(0, 10),
-  //     showScoreboard: true,
-  //     startDate: new Date(2022, 2, 2),
-  //     unlimitedDuration: true,
-  //     school: 'omegaup',
-  //     basicInformation: false,
-  //     requestParticipantInformation: 'optional',
-  //     problemLevel: 'intermediate',
-  //     objective: 'This is the objective',
-  //     description: 'This is the description',
-  //   };
+    const courseOptions: CourseOptions = {
+      courseAlias: uuid().slice(0, 10),
+      showScoreboard: true,
+      startDate: new Date(2022, 2, 2),
+      unlimitedDuration: true,
+      school: 'omegaup',
+      basicInformation: false,
+      requestParticipantInformation: 'optional',
+      problemLevel: 'intermediate',
+      objective: 'This is the objective',
+      description: 'This is the description',
+    };
 
-  //   cy.register(loginOptions);
-  //   cy.createCourse(courseOptions);
+    cy.register(loginOptions);
+    cy.createCourse(courseOptions);
 
-  //   // Assert
-  //   cy.location('href').should('include', courseOptions.courseAlias); // Url
-  //   cy.get('[data-course-name]').contains(courseOptions.courseAlias);
-  //   cy.get('[data-tab-course').click();
-  //   cy.get('[data-course-new-name]').should(
-  //     'have.value',
-  //     courseOptions.courseAlias,
-  //   );
-  //   cy.get('[data-course-new-alias]').should(
-  //     'have.value',
-  //     courseOptions.courseAlias,
-  //   );
-  //   cy.get('[name="show-scoreboard"]')
-  //     .eq(courseOptions.showScoreboard ? 0 : 1)
-  //     .should('be.checked');
-  //   cy.get('[name="start-date"]').should(
-  //     'have.value',
-  //     getISODate(courseOptions.startDate ?? new Date()),
-  //   );
-  //   cy.get('[name="unlimited-duration"]')
-  //     .eq(courseOptions.unlimitedDuration ? 0 : 1)
-  //     .should('be.checked');
-  //   cy.get('.tt-input').first().should('have.value', courseOptions.school);
-  //   cy.get('[name="basic-information"]')
-  //     .eq(courseOptions.basicInformation ? 0 : 1)
-  //     .should('be.checked');
-  //   cy.get('[data-course-participant-information]').should(
-  //     'have.value',
-  //     courseOptions.requestParticipantInformation,
-  //   );
-  //   cy.get('[data-course-problem-level]').should(
-  //     'have.value',
-  //     courseOptions.problemLevel,
-  //   );
-  //   cy.get('[data-course-objective]').should(
-  //     'have.value',
-  //     courseOptions.objective,
-  //   );
-  //   cy.get('[data-course-new-description]').should(
-  //     'have.value',
-  //     courseOptions.description,
-  //   );
-  // });
+    // Assert
+    cy.location('href').should('include', courseOptions.courseAlias); // Url
+    cy.get('[data-course-name]').contains(courseOptions.courseAlias);
+    cy.get('[data-tab-course').click();
+    cy.get('[data-course-new-name]').should(
+      'have.value',
+      courseOptions.courseAlias,
+    );
+    cy.get('[data-course-new-alias]').should(
+      'have.value',
+      courseOptions.courseAlias,
+    );
+    cy.get('[name="show-scoreboard"]')
+      .eq(courseOptions.showScoreboard ? 0 : 1)
+      .should('be.checked');
+    cy.get('[name="start-date"]').should(
+      'have.value',
+      getISODate(courseOptions.startDate ?? new Date()),
+    );
+    cy.get('[name="unlimited-duration"]')
+      .eq(courseOptions.unlimitedDuration ? 0 : 1)
+      .should('be.checked');
+    cy.get('.tt-input').first().should('have.value', courseOptions.school);
+    cy.get('[name="basic-information"]')
+      .eq(courseOptions.basicInformation ? 0 : 1)
+      .should('be.checked');
+    cy.get('[data-course-participant-information]').should(
+      'have.value',
+      courseOptions.requestParticipantInformation,
+    );
+    cy.get('[data-course-problem-level]').should(
+      'have.value',
+      courseOptions.problemLevel,
+    );
+    cy.get('[data-course-objective]').should(
+      'have.value',
+      courseOptions.objective,
+    );
+    cy.get('[data-course-new-description]').should(
+      'have.value',
+      courseOptions.description,
+    );
+  });
 
-  // it('Should create a course with end date', () => {
-  //   const loginOptions: LoginOptions = {
-  //     username: uuid(),
-  //     password: uuid(),
-  //   };
+  it('Should create a course with end date', () => {
+    const loginOptions: LoginOptions = {
+      username: uuid(),
+      password: uuid(),
+    };
 
-  //   const courseOptions: CourseOptions = {
-  //     courseAlias: uuid().slice(0, 10),
-  //     showScoreboard: true,
-  //     startDate: new Date(2022, 2, 2),
-  //     unlimitedDuration: false,
-  //     endDate: new Date(2022, 3, 3),
-  //     school: 'omegaup',
-  //     basicInformation: false,
-  //     requestParticipantInformation: 'optional',
-  //     problemLevel: 'intermediate',
-  //     objective: 'This is the objective',
-  //     description: 'This is the description',
-  //   };
+    const courseOptions: CourseOptions = {
+      courseAlias: uuid().slice(0, 10),
+      showScoreboard: true,
+      startDate: new Date(2022, 2, 2),
+      unlimitedDuration: false,
+      endDate: new Date(2022, 3, 3),
+      school: 'omegaup',
+      basicInformation: false,
+      requestParticipantInformation: 'optional',
+      problemLevel: 'intermediate',
+      objective: 'This is the objective',
+      description: 'This is the description',
+    };
 
-  //   cy.register(loginOptions);
-  //   cy.createCourse(courseOptions);
+    cy.register(loginOptions);
+    cy.createCourse(courseOptions);
 
-  //   // Assert
-  //   cy.location('href').should('include', courseOptions.courseAlias); // Url
-  //   cy.get('[data-course-name]').contains(courseOptions.courseAlias);
-  //   cy.get('[data-tab-course').click();
-  //   cy.get('[data-course-new-name]').should(
-  //     'have.value',
-  //     courseOptions.courseAlias,
-  //   );
-  //   cy.get('[data-course-new-alias]').should(
-  //     'have.value',
-  //     courseOptions.courseAlias,
-  //   );
-  //   cy.get('[name="show-scoreboard"]')
-  //     .eq(courseOptions.showScoreboard ? 0 : 1)
-  //     .should('be.checked');
-  //   cy.get('[name="start-date"]').should(
-  //     'have.value',
-  //     getISODate(courseOptions.startDate ?? new Date()),
-  //   );
-  //   cy.get('[name="unlimited-duration"]')
-  //     .eq(courseOptions.unlimitedDuration ? 0 : 1)
-  //     .should('be.checked');
-  //   cy.get('[name="end-date"]').should(
-  //     'have.value',
-  //     getISODate(courseOptions.endDate ?? new Date()),
-  //   );
-  //   cy.get('.tt-input').first().should('have.value', courseOptions.school); //
-  //   cy.get('[name="basic-information"]')
-  //     .eq(courseOptions.basicInformation ? 0 : 1)
-  //     .should('be.checked');
-  //   cy.get('[data-course-participant-information]').should(
-  //     'have.value',
-  //     courseOptions.requestParticipantInformation,
-  //   );
-  //   cy.get('[data-course-problem-level]').should(
-  //     'have.value',
-  //     courseOptions.problemLevel,
-  //   );
-  //   cy.get('[data-course-objective]').should(
-  //     'have.value',
-  //     courseOptions.objective,
-  //   );
-  //   cy.get('[data-course-new-description]').should(
-  //     'have.value',
-  //     courseOptions.description,
-  //   );
-  // });
+    // Assert
+    cy.location('href').should('include', courseOptions.courseAlias); // Url
+    cy.get('[data-course-name]').contains(courseOptions.courseAlias);
+    cy.get('[data-tab-course').click();
+    cy.get('[data-course-new-name]').should(
+      'have.value',
+      courseOptions.courseAlias,
+    );
+    cy.get('[data-course-new-alias]').should(
+      'have.value',
+      courseOptions.courseAlias,
+    );
+    cy.get('[name="show-scoreboard"]')
+      .eq(courseOptions.showScoreboard ? 0 : 1)
+      .should('be.checked');
+    cy.get('[name="start-date"]').should(
+      'have.value',
+      getISODate(courseOptions.startDate ?? new Date()),
+    );
+    cy.get('[name="unlimited-duration"]')
+      .eq(courseOptions.unlimitedDuration ? 0 : 1)
+      .should('be.checked');
+    cy.get('[name="end-date"]').should(
+      'have.value',
+      getISODate(courseOptions.endDate ?? new Date()),
+    );
+    cy.get('.tt-input').first().should('have.value', courseOptions.school); //
+    cy.get('[name="basic-information"]')
+      .eq(courseOptions.basicInformation ? 0 : 1)
+      .should('be.checked');
+    cy.get('[data-course-participant-information]').should(
+      'have.value',
+      courseOptions.requestParticipantInformation,
+    );
+    cy.get('[data-course-problem-level]').should(
+      'have.value',
+      courseOptions.problemLevel,
+    );
+    cy.get('[data-course-objective]').should(
+      'have.value',
+      courseOptions.objective,
+    );
+    cy.get('[data-course-new-description]').should(
+      'have.value',
+      courseOptions.description,
+    );
+  });
 
-  // it('Should register a user using the API', () => {
-  //   const loginOptions: LoginOptions = {
-  //     username: uuid(),
-  //     password: uuid(),
-  //   };
-  //   cy.register(loginOptions);
-  //   cy.get('header .username').should('have.text', loginOptions.username);
-  // });
+  it('Should register a user using the API', () => {
+    const loginOptions: LoginOptions = {
+      username: uuid(),
+      password: uuid(),
+    };
+    cy.register(loginOptions);
+    cy.get('header .username').should('have.text', loginOptions.username);
+  });
 
-  // it('Should register a user', () => {
-  //   const username = uuid();
-  //   const password = uuid();
-  //   cy.get('[data-login-button]').click();
-  //   cy.get('[data-signup-username]').type(username);
-  //   cy.get('[data-signup-password]').type(password);
-  //   cy.get('[data-signup-repeat-password]').type(password);
-  //   cy.get('[data-signup-email]').type(`${username}@omegaup.com`);
-  //   cy.get('[data-signup-submit]').click();
-  //   cy.waitUntil(() =>
-  //     cy.get('header .username').should('have.text', username),
-  //   );
-  // });
+  it('Should register a user', () => {
+    const username = uuid();
+    const password = uuid();
+    cy.get('[data-login-button]').click();
+    cy.get('[data-signup-username]').type(username);
+    cy.get('[data-signup-password]').type(password);
+    cy.get('[data-signup-repeat-password]').type(password);
+    cy.get('[data-signup-email]').type(`${username}@omegaup.com`);
+    cy.get('[data-signup-submit]').click();
+    cy.waitUntil(() =>
+      cy.get('header .username').should('have.text', username),
+    );
+  });
 
-  // it('Should login a user using the API', () => {
-  //   const loginOptions: LoginOptions = {
-  //     username: 'user',
-  //     password: 'user',
-  //   };
-  //   cy.login(loginOptions);
-  //   cy.get('header .username').should('have.text', loginOptions.username);
-  // });
+  it('Should login a user using the API', () => {
+    const loginOptions: LoginOptions = {
+      username: 'user',
+      password: 'user',
+    };
+    cy.login(loginOptions);
+    cy.get('header .username').should('have.text', loginOptions.username);
+  });
 
-  // it('Should login a user', () => {
-  //   const username = 'user';
-  //   const password = 'user';
-  //   cy.get('[data-login-button]').click();
-  //   cy.get('[data-login-username]').type(username);
-  //   cy.get('[data-login-password]').type(password);
-  //   cy.get('[data-login-submit]').click();
-  //   cy.waitUntil(() =>
-  //     cy.get('header .username').should('have.text', username),
-  //   );
-  // });
+  it('Should login a user', () => {
+    const username = 'user';
+    const password = 'user';
+    cy.get('[data-login-button]').click();
+    cy.get('[data-login-username]').type(username);
+    cy.get('[data-login-password]').type(password);
+    cy.get('[data-login-submit]').click();
+    cy.waitUntil(() =>
+      cy.get('header .username').should('have.text', username),
+    );
+  });
 
-  // it('Should create a problem', () => {
-  //   const loginOptions: LoginOptions = {
-  //     username: uuid(),
-  //     password: uuid(),
-  //   };
+  it('Should create a problem', () => {
+    const loginOptions: LoginOptions = {
+      username: uuid(),
+      password: uuid(),
+    };
 
-  //   const problemOptions: ProblemOptions = {
-  //     problemAlias: uuid().slice(0, 10), // Too large for the alias,
-  //     tag: 'Recursion',
-  //     autoCompleteTextTag: 'recur',
-  //     problemLevelIndex: 0,
-  //   };
+    const problemOptions: ProblemOptions = {
+      problemAlias: uuid().slice(0, 10), // Too large for the alias,
+      tag: 'Recursion',
+      autoCompleteTextTag: 'recur',
+      problemLevelIndex: 0,
+    };
 
-  //   cy.register(loginOptions);
-  //   cy.createProblem(problemOptions);
+    cy.register(loginOptions);
+    cy.createProblem(problemOptions);
 
-  //   // Assert problem has been created
-  //   cy.location('href').should('include', problemOptions.problemAlias); // Url
-  //   cy.get('[name="title"]').should('have.value', problemOptions.problemAlias); // Title
-  //   cy.get('[name="problem_alias"]').should(
-  //     'have.value',
-  //     problemOptions.problemAlias,
-  //   );
-  //   cy.get('[name="source"]').should('have.value', problemOptions.problemAlias);
-  // });
+    // Assert problem has been created
+    cy.location('href').should('include', problemOptions.problemAlias); // Url
+    cy.get('[name="title"]').should('have.value', problemOptions.problemAlias); // Title
+    cy.get('[name="problem_alias"]').should(
+      'have.value',
+      problemOptions.problemAlias,
+    );
+    cy.get('[name="source"]').should('have.value', problemOptions.problemAlias);
+  });
 
   it('Should make a run of a problem', () => {
     const problemOptions: ProblemOptions = {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -116,7 +116,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'createRun',
   ({ problemAlias, fixturePath, language }: RunOptions) => {
-    cy.visit(`arena/problem/${problemAlias}/`);
+    cy.visit(`arena/problem/${encodeURIComponent(problemAlias)}/`);
     cy.get('[data-new-run]').click();
     cy.get('[name="language"]').select(language);
     cy.fixture(fixturePath).then((fileContent) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -116,7 +116,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'createRun',
   ({ problemAlias, fixturePath, language }: RunOptions) => {
-    cy.visit('arena/problem/' + problemAlias);
+    cy.visit(`arena/problem/${problemAlias}/`);
     cy.get('[data-new-run]').click();
     cy.get('[name="language"]').select(language);
     cy.fixture(fixturePath).then((fileContent) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -2,7 +2,12 @@
 import 'cypress-wait-until';
 import 'cypress-file-upload';
 import { buildURLQuery } from '@/js/omegaup/ui';
-import { CourseOptions, LoginOptions, ProblemOptions } from './types';
+import {
+  CourseOptions,
+  LoginOptions,
+  ProblemOptions,
+  RunOptions,
+} from './types';
 
 // Logins the user given a username and password
 Cypress.Commands.add('login', ({ username, password }: LoginOptions) => {
@@ -105,6 +110,19 @@ Cypress.Commands.add(
     cy.get('[data-course-objective]').type(objective);
     cy.get('[data-course-new-description]').type(description);
     cy.get('button[type="submit"]').click();
+  },
+);
+
+Cypress.Commands.add(
+  'createRun',
+  ({ problemAlias, fixturePath, language }: RunOptions) => {
+    cy.visit('arena/problem/' + problemAlias);
+    cy.get('[data-new-run]').click();
+    cy.get('[name="language"]').select(language);
+    cy.fixture(fixturePath).then((fileContent) => {
+      cy.get('.CodeMirror-line').type(fileContent);
+      cy.get('[data-submit-run]').click();
+    });
   },
 );
 

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -1,6 +1,11 @@
 // <reference types="cypress"/>
 
-import { CourseOptions, LoginOptions, ProblemOptions } from './types';
+import {
+  CourseOptions,
+  LoginOptions,
+  ProblemOptions,
+  RunOptions,
+} from './types';
 
 declare global {
   namespace Cypress {
@@ -17,6 +22,7 @@ declare global {
         courseOptions: Partial<CourseOptions> &
           Pick<CourseOptions, 'courseAlias'>,
       ): void;
+      createRun(problemOptions: RunOptions): void;
     }
   }
 }

--- a/cypress/support/types.d.ts
+++ b/cypress/support/types.d.ts
@@ -24,6 +24,27 @@ export interface CourseOptions {
   description?: string;
 }
 
-export type RequestParticipantInformation = 'no' | 'optional' | 'required';
+export interface RunOptions {
+  problemAlias: string;
+  fixturePath: string;
+  language: Language;
+}
 
+export type RequestParticipantInformation = 'no' | 'optional' | 'required';
 export type ProblemLevel = 'introductory' | 'intermediate' | 'advanced';
+export type Language =
+  | 'c11-gcc'
+  | 'c11-clang'
+  | 'cpp11-gcc'
+  | 'cpp11-clang'
+  | 'cpp17-gcc'
+  | 'cpp17-clang'
+  | 'java'
+  | 'py2'
+  | 'py3'
+  | 'rb'
+  | 'cs'
+  | 'pas'
+  | 'hs'
+  | 'lua';
+export type Status = 'AC' | 'TLE' | 'MLE' | 'PA';

--- a/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
@@ -53,7 +53,12 @@
       </div>
       <div class="form-group row">
         <div class="col-sm-10">
-          <button type="submit" class="btn btn-primary" :disabled="!canSubmit">
+          <button
+            type="submit"
+            class="btn btn-primary"
+            data-submit-run
+            :disabled="!canSubmit"
+          >
             <omegaup-countdown
               v-if="!canSubmit"
               :target-time="nextSubmissionTimestamp"

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -178,7 +178,7 @@
         </thead>
         <tfoot v-if="problemAlias != null">
           <tr>
-            <td colspan="10">
+            <td colspan="10" data-new-run>
               <a
                 v-if="isContestFinished"
                 :href="`/arena/${contestAlias}/practice/`"


### PR DESCRIPTION
# Descripción

Se agregó el comando para hacer un run dentro de cypress, también se agregaron múltiples tipos de apoyo.

Part of: #6149 

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
