### PR TITLE
Arreglando algunas incosistencias en el UI

### DIFF
--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
@@ -97,22 +97,28 @@
                 'is-invalid': invalidParameterName === 'unlimited_duration',
               }"
             >
-              <label class="radio-inline"
-                ><input
-                  v-model="unlimitedDuration"
-                  type="radio"
-                  :value="true"
-                  :disabled="!unlimitedDurationCourse"
-                />{{ T.wordsYes }}</label
-              >
-              <label class="radio-inline ml-3"
-                ><input
-                  v-model="unlimitedDuration"
-                  type="radio"
-                  :value="false"
-                  :disabled="!unlimitedDurationCourse"
-                />{{ T.wordsNo }}</label
-              >
+              <div class="form-check form-check-inline">
+                <label class="form-check-label"
+                  ><input
+                    v-model="unlimitedDuration"
+                    class="form-check-input"
+                    type="radio"
+                    :value="true"
+                    :disabled="!unlimitedDurationCourse"
+                  />{{ T.wordsYes }}</label
+                >
+              </div>
+              <div class="form-check form-check-inline">
+                <label class="form-check-label">
+                  <input
+                    v-model="unlimitedDuration"
+                    class="form-check-input"
+                    type="radio"
+                    :value="false"
+                    :disabled="!unlimitedDurationCourse"
+                  />{{ T.wordsNo }}</label
+                >
+              </div>
             </div>
           </div>
           <div class="form-group col-md-4">

--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -106,8 +106,8 @@
           </tr>
         </tbody>
       </table>
-      <div class="row">
-        <div class="form-group">
+      <div class="row mx-1">
+        <div class="form-group w-100">
           <label class="font-weight-bold">{{ T.wordsLevel }}</label>
           <select
             v-model="problemLevelTag"


### PR DESCRIPTION
# Descripción

Se agregó margin y se expandió el input `Nivel de Problema` para que utilice el 100% del contenedor dentro del apartado de agregar un problema.

![image](https://user-images.githubusercontent.com/74751751/149705057-9537c5c5-6def-425b-b7f1-8f913100a22d.png)


También se separó el radio de `Unlimited Duration` que estaba amontonado.

![image](https://user-images.githubusercontent.com/74751751/149705001-f22f118d-e8a2-4d1f-aab9-34cd268deeef.png)

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
