### PR TITLE
Revert #6257

### DIFF
--- a/webpack.config-frontend.js
+++ b/webpack.config-frontend.js
@@ -109,9 +109,9 @@ module.exports = {
   },
 
   output: {
-    path: path.resolve(__dirname, './frontend/www/js/dist/'),
-    publicPath: '/js/dist/',
-    filename: '[name].js',
+    path: path.resolve(__dirname, './frontend/www/'),
+    publicPath: '/',
+    filename: 'js/dist/[name].js',
     library: '[name]',
     libraryTarget: 'umd',
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ for (const entryname of Object.keys(frontendConfig.entry)) {
     new HtmlWebpackPlugin({
       inject: false,
       chunks: [entryname],
-      filename: `${entryname}.deps.json`,
+      filename: `js/dist/${entryname}.deps.json`,
       template: path.resolve(__dirname, './stuff/webpack/deps.ejs'),
     }),
   );


### PR DESCRIPTION
This reverts commit e41f0913ef3c81bd35bce514235c49cb3b5e332e.

El problema es que en: https://github.com/omegaup/omegaup/commit/e41f0913ef3c81bd35bce514235c49cb3b5e332e#diff-e404bc3fb288556cab538bd441c9b58590c8c0e3b5114678659c8aa3902aee68R112-R114

Al hacer `publicPath: '/js/dist/',`, los íconos de badges se iban a `/js/dist/media/dist/badges/*.svg`.

Fixes: #6281 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
