### PR TITLE
Aprovechando campos denormalizados en Submissions para mejorar top 10 solvers

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -40,8 +40,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 User_Rank ur ON ur.user_id = i.user_id
             WHERE
                 s.problem_id = ? AND
-                r.status = "ready" AND
-                r.verdict = "AC" AND
+                s.status = "ready" AND
+                s.verdict = "AC" AND
                 s.type = "normal"
             ORDER BY
                 per_identity_rank ASC, r.runtime ASC, s.submission_id ASC


### PR DESCRIPTION
# Descripción

La idea es que se puedan filtrar más registros antes de tener que hacer el join con `Runs`. Desafortunadamente no se ve ventaja clara en metabase (~100ms pero con muy alta varianza). `EXPLAIN` dice que el filtrado sí cambia como se esperaría:

````
id,select_type,table,partitions,type,possible_keys,key,key_len,ref,rows,filtered,Extra
1,SIMPLE,s,,ref,"problem_id,identity_id,fk_s_current_run_id",problem_id,4,const,1,33.33,Using where; Using temporary; Using filesort
1,SIMPLE,i,,eq_ref,PRIMARY,PRIMARY,4,omegaup.s.identity_id,1,100.0,
1,SIMPLE,ur,,eq_ref,PRIMARY,PRIMARY,4,omegaup.i.user_id,1,100.0,
1,SIMPLE,r,,eq_ref,"PRIMARY,status_submission_id",PRIMARY,4,omegaup.s.current_run_id,1,5.0,Using where
````
vs.
```
id,select_type,table,partitions,type,possible_keys,key,key_len,ref,rows,filtered,Extra
1,SIMPLE,s,,ref,"problem_id,identity_id,fk_s_current_run_id",problem_id,4,const,1,5.0,Using where; Using temporary; Using filesort
1,SIMPLE,i,,eq_ref,PRIMARY,PRIMARY,4,omegaup.s.identity_id,1,100.0,
1,SIMPLE,ur,,eq_ref,PRIMARY,PRIMARY,4,omegaup.i.user_id,1,100.0,
1,SIMPLE,r,,eq_ref,PRIMARY,PRIMARY,4,omegaup.s.current_run_id,1,100.0,
```

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.