### PR TITLE
Optimizando consulta getProblemsByProblemset

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1302,7 +1302,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         }
         $problems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $problemset->problemset_id
+            $problemset->problemset_id,
+            needSubmissions: true
         );
 
         // Requests
@@ -1773,7 +1774,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $result['director'] = $director;
 
                 $problemsInContest = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-                    $contest->problemset_id
+                    $contest->problemset_id,
+                    needSubmissions: true
                 );
 
                 // Add info of each problem to the contest
@@ -1793,7 +1795,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                             explode(',', $problem['languages'])
                         ));
                     }
-                    if ($problem['has_submissions'] && !$hasSubmissions) {
+                    if ($problem['has_submissions']) {
                         $hasSubmissions = true;
                     }
 
@@ -2205,7 +2207,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             }
 
             $problemsetProblems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-                $originalContest->problemset_id
+                $originalContest->problemset_id,
+                needSubmissions: false
             );
             foreach ($problemsetProblems as $problemsetProblem) {
                 $problem = new \OmegaUp\DAO\VO\Problems([
@@ -2927,7 +2930,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         }
         $problems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $problemset->problemset_id
+            $problemset->problemset_id,
+            needSubmissions: true
         );
 
         return [
@@ -4045,7 +4049,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         $problemsInContest = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $problemset->problemset_id
+            $problemset->problemset_id,
+            needSubmissions: false
         );
 
         $problemsResponseArray = [];

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -2151,7 +2151,8 @@ class Course extends \OmegaUp\Controllers\Controller {
             );
         }
         $rawProblems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $assignment->problemset_id
+            $assignment->problemset_id,
+            needSubmissions: false
         );
         $letter = 0;
         $problems = [];
@@ -3028,7 +3029,8 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $problemsInAssignment = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $tokenAuthenticationResult['assignment']->problemset_id
+            $tokenAuthenticationResult['assignment']->problemset_id,
+            needSubmissions: false
         );
 
         $problemsResponseArray = [];
@@ -4068,7 +4070,8 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         $problemsInAssignment = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            intval($assignment->problemset_id)
+            intval($assignment->problemset_id),
+            needSubmissions: false
         );
 
         $problemsResponseArray = [];
@@ -4237,7 +4240,8 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         $problemsInAssignment = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            intval($assignment->problemset_id)
+            intval($assignment->problemset_id),
+            needSubmissions: false
         );
 
         $problemsResponseArray = [];

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -114,10 +114,29 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
      * @return list<array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, order: int, points: float, problem_id: int, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}>
      */
     final public static function getProblemsByProblemset(
-        int $problemsetId
+        int $problemsetId,
+        bool $needSubmissions
     ): array {
         // Build SQL statement
-        $sql = 'SELECT
+        if ($needSubmissions) {
+            $sqlSubmissions = '
+            IFNULL(
+                COUNT(s.submission_id),
+                0
+            ) > 0';
+            $sqlSubmissionsJoin = "
+            LEFT JOIN
+                Submissions s
+            ON
+                s.problem_id = p.problem_id AND
+                s.problemset_id = pp.problemset_id AND
+                s.`type` = 'normal'
+            ";
+        } else {
+            $sqlSubmissions = 'FALSE';
+            $sqlSubmissionsJoin = '';
+        }
+        $sql = "SELECT
                     p.title,
                     p.problem_id,
                     p.alias,
@@ -130,10 +149,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                     IFNULL(p.difficulty, 0.0) AS difficulty,
                     pp.order,
                     p.languages,
-                    IFNULL(
-                        COUNT(s.submission_id),
-                        0
-                    ) > 0 AS has_submissions,
+                    $sqlSubmissions AS has_submissions,
                     pp.points,
                     pp.commit,
                     pp.version,
@@ -141,22 +157,14 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                 FROM
                     Problems p
                 INNER JOIN
-                    Problemset_Problems pp
-                ON
-                    pp.problem_id = p.problem_id
-                LEFT JOIN
-                    Submissions s
-                ON
-                    s.problem_id = p.problem_id AND
-                    s.problemset_id = pp.problemset_id AND
-                    s.`type` = "normal"
+                    Problemset_Problems pp ON pp.problem_id = p.problem_id
+                $sqlSubmissionsJoin
                 WHERE
                     pp.problemset_id = ?
                 GROUP BY
-                    p.problem_id,
-                    pp.problemset_id
+                    p.problem_id
                 ORDER BY
-                    pp.order, pp.problem_id ASC;';
+                    pp.order, pp.problem_id ASC;";
 
         /** @var list<array{accepted: int, alias: string, commit: string, difficulty: float, has_submissions: int, input_limit: int, is_extra_problem: bool, languages: string, order: int, points: float, problem_id: int, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(

--- a/frontend/tests/controllers/VirtualContestTest.php
+++ b/frontend/tests/controllers/VirtualContestTest.php
@@ -96,10 +96,12 @@ class VirtualContestTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Assert virtual contest problemset problems
         $originalProblems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $originalContest->problemset_id
+            $originalContest->problemset_id,
+            needSubmissions: false
         );
         $virtualProblems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $virtualContest->problemset_id
+            $virtualContest->problemset_id,
+            needSubmissions: false
         );
         // Number of problems must be equal
         $this->assertEquals(count($originalProblems), count($virtualProblems));


### PR DESCRIPTION
# Descripción

La consulta `getProblemsByProblemset` ahorita hace un `JOIN` con la tabla `Submissions` para determinar si un problema tiene envíos o no. Pero en varios casos no es necesario saberlo; tan es así que en varioas ocasiones el código inmediatamente después de llamar a `getProblemsByProblemset`  tiene un `problem['hasRuns'] = false`.

La expectativa es que al dejar de tener que calcular si un problema tiene envíos o no, podemos eliminar el `JOIN` ahorrando algo de tiempo al entrar a la vista de un concurso.

# Comentarios

Después: hacer lo mismo con  `getProblemsByAssignment`

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.