### PR TITLE
Simplificando consulta getAllRelevantIdentities para el caso no admin

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -498,6 +498,13 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 ];
             }
         } else {
+            $val = [$problemsetId];
+            if (is_null($filterUsersBy)) {
+                $sqlUserFilter = '';
+            } else {
+                $sqlUserFilter = ' AND i.username LIKE ?';
+                $val[] = $filterUsersBy . '%';
+            }
             $sql = "
                 SELECT
                     i.identity_id,
@@ -505,30 +512,21 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                     i.name,
                     IFNULL(i.country_id, 'xx') AS country_id,
                     FALSE AS is_invited,
-                    $classNameQuery
+                    IFNULL(ur.classname, 'user-rank-unranked') AS classname
                 FROM
-                    Identities i
+                    Submissions s
                 INNER JOIN
-                    (SELECT DISTINCT
-                        s.identity_id
-                    FROM
-                        Submissions s
-                    INNER JOIN
-                        Runs r
-                    ON
-                        r.run_id = s.current_run_id
-                    WHERE
-                        r.verdict NOT IN ('CE', 'JE', 'VE') AND
-                        s.problemset_id = ? AND
-                        r.status = 'ready' AND
-                        s.type = 'normal'
-                    ) rc ON i.identity_id = rc.identity_id";
-            $val = [$problemsetId];
-            if (!is_null($filterUsersBy)) {
-                $sql .= ' WHERE i.username LIKE ?';
-                $val[] = $filterUsersBy . '%';
-            }
-            $sql .= ';';
+                    Identities i ON i.identity_id = s.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
+                WHERE
+                    s.problemset_id = ? AND
+                    s.type = 'normal' AND
+                    s.status = 'ready' AND
+                    s.verdict NOT IN ('CE', 'JE', 'VE')
+                    $sqlUserFilter
+                GROUP BY
+                    s.identity_id;";
         }
 
         $result = [];


### PR DESCRIPTION
# Descripción

Este cambio simplfica la consulta `getAllRelevantIdentities` utilizando los campos denormalizados en `Submissions` y cambiando consultas complejas por joins.

`EXPLAIN` dice mejorar de la siguiente forma:

|id|select_type|table|partitions|type|possible_keys|key|key_len|ref|rows|filtered|Extra|
|--|--|--|--|--|--|--|--|--|--|--|--|
|1|PRIMARY|<derived3>||ALL|||||199|100.0||
|1|PRIMARY|i||eq_ref|PRIMARY|PRIMARY|4|rc.identity_id|1|100.0||
|3|DERIVED|s||ref|"problemset_id,identity_id,fk_s_current_run_id"|problemset_id|5|const|1713|33.33|Using where; Using temporary|
|3|DERIVED|r||eq_ref|"PRIMARY,status_submission_id"|PRIMARY|4|omegaup.s.current_run_id|1|35.0|Using where; Distinct|
|2|DEPENDENT SUBQUERY|ur||eq_ref|PRIMARY|PRIMARY|4|omegaup.i.user_id|1|100.0||

=>

|id|select_type|table|partitions|type|possible_keys|key|key_len|ref|rows|filtered|Extra|
|--|--|--|--|--|--|--|--|--|--|--|--|
|1|SIMPLE|s||ref|"problemset_id,identity_id"|problemset_id|5|const|1713|3.89|Using where; Using temporary|
|1|SIMPLE|i||eq_ref|"PRIMARY,user_id"|PRIMARY|4|omegaup.s.identity_id|1|100.0|Using where|
|1|SIMPLE|ur||eq_ref|PRIMARY|PRIMARY|4|omegaup.i.user_id|1|100.0||


# Comentarios

Hay que hacer algo parecido con el caso de admin.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.