### PR TITLE
Quitando fetches innecesarios al generar Scoreboards

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -3155,16 +3155,16 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         if (self::isPublic($contest->admission_mode)) {
             // Check that contest has at least 2 problems
-            $problemset = \OmegaUp\DAO\Problemsets::getByPK(
+            $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
                 $contest->problemset_id
             );
-            if (is_null($problemset)) {
+            if (!$problemsetExists) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemsetNotFound'
                 );
             }
             $problemsInContest = \OmegaUp\DAO\ProblemsetProblems::GetRelevantProblems(
-                $problemset
+                $contest->problemset_id
             );
             if (count($problemsInContest) < 2) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -4522,10 +4522,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Enforces rules to avoid having invalid/unactionable public contests
      */
     private static function validateContestCanBePublic(\OmegaUp\DAO\VO\Contests $contest): void {
-        $problemset = \OmegaUp\DAO\Problemsets::getByPK(
+        $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
             intval($contest->problemset_id)
         );
-        if (is_null($problemset)) {
+        if (!$problemsetExists) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -4538,7 +4538,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
         // Check that contest has some problems at least 1 problem
         $problemsInProblemset = \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
-            $problemset
+            intval($contest->problemset_id)
         );
         if (count($problemsInProblemset) < 1) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -304,7 +304,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
      * @return list<\OmegaUp\DAO\VO\Problems>
      */
     final public static function getRelevantProblems(
-        \OmegaUp\DAO\VO\Problemsets $problemset
+        int $problemsetId
     ): array {
         // Build SQL statement
         $sql = '
@@ -317,7 +317,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
             WHERE
                 pp.problemset_id = ?
             ORDER BY pp.`order`, `pp`.`problem_id` ASC;';
-        $val = [$problemset->problemset_id];
+        $val = [$problemsetId];
         $result = [];
         /** @var array{alias: string, current_version: string, problem_id: int} $row */
         foreach (

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -598,7 +598,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
      * @return list<array{score: float, penalty: int, contest_score: float|null, problem_id: int, identity_id: int, type: string|null, time: \OmegaUp\Timestamp, submit_delay: int, guid: string}>
      */
     final public static function getProblemsetRuns(
-        \OmegaUp\DAO\VO\Problemsets $problemset,
+        int $problemsetId,
         bool $onlyAC = false
     ): array {
         $verdictCondition = ($onlyAC ?
@@ -647,7 +647,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         /** @var list<array{contest_score: float|null, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
-            [$problemset->problemset_id]
+            [$problemsetId]
         );
     }
 

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -71,6 +71,16 @@ class Scoreboard {
             }
         }
 
+        // Ensure the problemset exists.
+        $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
+            $this->params->problemset_id
+        );
+        if (!$problemsetExists) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'problemsetNotFound'
+            );
+        }
+
         // Get all distinct contestants participating in the given contest
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
             $this->params->problemset_id,
@@ -83,19 +93,13 @@ class Scoreboard {
         );
 
         // Get all problems given problemset
-        $problemset = \OmegaUp\DAO\Problemsets::getByPK(
-            $this->params->problemset_id
-        );
-        if (is_null($problemset)) {
-            throw new \OmegaUp\Exceptions\NotFoundException(
-                'problemsetNotFound'
-            );
-        }
         $rawProblemsetProblems =
-            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems($problemset);
+            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
+                $this->params->problemset_id
+            );
 
         $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
-            $problemset,
+            $this->params->problemset_id,
             $this->params->only_ac
         );
 
@@ -180,6 +184,16 @@ class Scoreboard {
             return $result;
         }
 
+        // Ensure the problemset exists.
+        $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
+            $this->params->problemset_id
+        );
+        if (!$problemsetExists) {
+            throw new \OmegaUp\Exceptions\NotFoundException(
+                'problemsetNotFound'
+            );
+        }
+
         // Get all distinct contestants participating in the given contest
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
             $this->params->problemset_id,
@@ -192,18 +206,14 @@ class Scoreboard {
         );
 
         // Get all problems given problemset
-        $problemset = \OmegaUp\DAO\Problemsets::getByPK(
+        $rawProblemsetProblems =
+            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
+                $this->params->problemset_id
+            );
+
+        $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
             $this->params->problemset_id
         );
-        if (is_null($problemset)) {
-            throw new \OmegaUp\Exceptions\NotFoundException(
-                'problemsetNotFound'
-            );
-        }
-        $rawProblemsetProblems =
-            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems($problemset);
-
-        $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns($problemset);
 
         $problemMapping = [];
 
@@ -274,13 +284,17 @@ class Scoreboard {
      * Force refresh of Scoreboard caches
      */
     public static function refreshScoreboardCache(\OmegaUp\ScoreboardParams $params): void {
-        $problemset = \OmegaUp\DAO\Problemsets::getByPK($params->problemset_id);
-        if (is_null($problemset)) {
+        $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
+            $params->problemset_id
+        );
+        if (!$problemsetExists) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
         }
-        $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns($problemset);
+        $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
+            $params->problemset_id
+        );
 
         // Get all distinct contestants participating in the contest
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
@@ -295,7 +309,9 @@ class Scoreboard {
 
         // Get all problems given problemset
         $rawProblemsetProblems =
-            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems($problemset);
+            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
+                $params->problemset_id
+            );
 
         $problemMapping = [];
 
@@ -396,7 +412,7 @@ class Scoreboard {
             $log->debug('Sending updated scoreboards');
             \OmegaUp\Grader::getInstance()->broadcast(
                 $params->alias,
-                intval($problemset->problemset_id),
+                intval($params->problemset_id),
                 null,
                 json_encode([
                     'message' => '/scoreboard/update/',
@@ -410,7 +426,7 @@ class Scoreboard {
             );
             \OmegaUp\Grader::getInstance()->broadcast(
                 $params->alias,
-                intval($problemset->problemset_id),
+                intval($params->problemset_id),
                 null,
                 json_encode([
                     'message' => '/scoreboard/update/',


### PR DESCRIPTION
# Descripción

En este cambio se utilizan las funciones `existsByPK` en lugar de `getByPK` para conseguir `Problemset`s. Con esto se verifica que los ids existan sin tener que traer todos los campos del registro y ahorrar un poco de trabajo en la base de datos.

# Comentarios

Como ya no tenemos un VO completo, las funciones que operan sobre Contest o sobre Problemset, pierden algo de type-safety porque ahora se les puede pasar cualquier int como `problemset_id`. Si esto es un problema, podemos empezar a definir aliases de int que representen el tipo correcto, e.g. `@psalm-type ProblemsetId=int`, aunque no sé si psalm acepte ints en lugar de `ProblemsetId` en ese caso. Podemos subirle el volumen y crear una clase propiamente para cada tabla que represente la llave primaria de esa tabla.

Ambas soluciones suenan como follow up si es que si queremos mantener ese type-safety.

Siguiente paso: 
Reutilizar trabajo compartido entre `Scoreboard::generate` y `Scoreboard::events`, son sumamente parecidos y no se están reutilizando.

Motivación: https://onenr.io/0z7wkPYMlRL

![image](https://user-images.githubusercontent.com/189223/150633889-63e79ee7-0bc6-47ec-8d23-e50297c93cfd.png)
vs.
![image](https://user-images.githubusercontent.com/189223/150633930-01c24f3e-64a7-40d3-9d32-81b507bcf83d.png)

Hacen casi lo mismo y se llaman siempre ambas funciones para `getContestDetailsForTypeScript`, haciéndola casi el doble de lenta de lo que podría ser.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.