### PR TITLE
Optimizando la consulta de getLatestSubmissions (10X más rápida)

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -236,7 +236,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 r.memory,
                 IFNULL(ur.classname, "user-rank-unranked") AS classname
             FROM
-                Submissions s USE INDEX(PRIMARY)
+                Submissions s
             INNER JOIN
                 Identities i ON i.identity_id = s.identity_id
             LEFT JOIN


### PR DESCRIPTION
# Descripción

La consulta de `getLatestSubmission` tiene un index hint que hace que MySQL tenga que recorrer la tabla completa de `Submissions`, según `EXPLAIN`. Pero la consulta puede hacerse más eficientemente de alguna otra manera que solo examina algunos registros de la tabla `Submissions`. En el `EXPLAIN` ejemplo que tengo baja de un `ALL` revisando 3.5M de registros a solo 64 registros, bajando el tiempo de ~1.7s a 160s:

![image](https://user-images.githubusercontent.com/189223/150667599-50dfb747-02a5-4d61-a140-17ca3b5ccc21.png)


Motivación: https://onenr.io/0xZw0KXW5Qv

![image](https://user-images.githubusercontent.com/189223/150667515-07207359-bfb9-4fbf-b70b-c1ba86d0b5db.png)


# Comentarios

Haciendo una mejora que consiste exclusivamente en borrar código! 😁 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.