### PR TITLE
Usando el index hint selectivamente para getLatestSubmissions

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -222,7 +222,12 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
     public static function getLatestSubmissions(
         int $identityId = null,
     ): array {
-        $sql = '
+        if (is_null($identityId)) {
+            $indexHint = 'USE INDEX(PRIMARY)';
+        } else {
+            $indexHint = '';
+        }
+        $sql = "
             SELECT
                 s.`time`,
                 i.username,
@@ -234,9 +239,9 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 r.verdict,
                 r.runtime,
                 r.memory,
-                IFNULL(ur.classname, "user-rank-unranked") AS classname
+                IFNULL(ur.classname, 'user-rank-unranked') AS classname
             FROM
-                Submissions s
+                Submissions s $indexHint
             INNER JOIN
                 Identities i ON i.identity_id = s.identity_id
             LEFT JOIN
@@ -259,13 +264,13 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 AND p.visibility >= ?
                 AND (
                     s.problemset_id IS NULL
-                    OR ps.access_mode = "public"
+                    OR ps.access_mode = 'public'
                 )
                 AND (
                     c.contest_id IS NULL
                     OR c.finish_time < s.time
                 )
-        ';
+        ";
         $params = [
             \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
         ];


### PR DESCRIPTION
# Descripción

Follow up de la conversación en #6325. El index hint es muy útil cuando la consulta `getLatestSubmissions` es en general, pero es perjudicial cuando la consulta es para un `identityId` en particular. Con este cambio el index hint se usa selectivamente, dependiendo de si `identityId` es null o no.

`EXPLAIN` confirma que para el caso sin `identityId`, usar el index hint baja varios órdenes de magnitud los registros consultados (150k => 2k) y el tiempo baja de ~15s => 190ms.

# Comentarios

Se ve interesante la idea de https://stackoverflow.com/q/9830718 de usar un índice sobre `time` y cambiar la consulta a un range query usando `time between (NOW() - 24*3600) AND NOW()`.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.