### PR TITLE
Reportando vistas de diferentes listas de concursos en arena

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -230,10 +230,11 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
 import contest_FilteredList from '../contest/FilteredList.vue';
 import { types } from '../../api_types';
+import * as UI from '../../ui';
 
 export enum ContestsTab {
   Participating = 'participating',
@@ -280,6 +281,11 @@ export default class ArenaContestList extends Vue {
       default:
         return T.arenaMyActiveContests;
     }
+  }
+
+  @Watch('showTab')
+  onTabChanged(newTab: string) {
+    UI.reportPageView(location.pathname + '#' + newTab);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/ui.ts
+++ b/frontend/www/js/omegaup/ui.ts
@@ -269,6 +269,13 @@ export function reportEvent(
   window.ga('send', 'event', category, action, label);
 }
 
+export function reportPageView(page: string): void {
+  if (typeof window.ga !== 'function') {
+    return;
+  }
+  window.ga('send', 'pageview', page);
+}
+
 export function rankingUsername(
   rank: omegaup.User & { virtual?: boolean },
 ): string {


### PR DESCRIPTION
# Descripción

Con este cambio se notifica a Google Analytics cuando el usuario cambia de lista visible de concursos. Es un cambio que ahorita sucede enteramente en Vue y Analytics no se entera. 

La motivación es saber qué listas son las que los usuarios utilizan más para solo pre-cargar esas como parte del payload. Y que las restantes, menos usadas, solo se carguen cuando las intenten usar (o incluso precargarlas, pero via una llamada asíncrona a la API en lugar de incluirlas en payload). Todo esto porque la lista de concursos es la página más lenta en promedio:
![image](https://user-images.githubusercontent.com/189223/150737930-72565616-7b46-47e6-a262-5c01c266bf98.png)

En parte porque se pre-cargan 7 listas de concursos en forma secuencial:
![image](https://user-images.githubusercontent.com/189223/150738103-37165787-1d5b-4ed3-8b73-ac71660f3a00.png)

# Comentarios

Hay que implementar esto tambien para `ContestListV2`.
Estaría bien usar [Vue router](https://router.vuejs.org/) y su integración con Analytics para que esto suceda automáticamente.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
