### PR TITLE
Multicase add

### DIFF
--- a/frontend/www/js/omegaup/components/problem/creator/cases/AddPanel.test.ts
+++ b/frontend/www/js/omegaup/components/problem/creator/cases/AddPanel.test.ts
@@ -79,6 +79,49 @@ describe('AddPanel.vue', () => {
     expect(groups[0].points).toBe(10);
     expect(groups[0].ungroupedCase).toBe(false);
   });
+  it('Should add multiple cases to the store', async () => {
+    const wrapper: Wrapper<AddPanel> = mount(AddPanel, {
+      localVue,
+      store: vuexStore,
+    });
+
+    wrapper.setData({ tab: 'multiplecases' });
+
+    await Vue.nextTick();
+
+    const prefixInput = wrapper.find('input[name="multiple-cases-prefix"]');
+    const suffixInput = wrapper.find('input[name="multiple-cases-suffix"]');
+    const countInput = wrapper.find('input[name="multiple-cases-count"]');
+
+    await prefixInput.setValue('case-');
+    await suffixInput.setValue('-easy');
+    await countInput.setValue(3);
+
+    const updatedPrefixInput = wrapper.find(
+      'input[name="multiple-cases-prefix"]',
+    ).element as HTMLInputElement;
+    const updatedSuffixInput = wrapper.find(
+      'input[name="multiple-cases-suffix"]',
+    ).element as HTMLInputElement;
+    const updatedCountInput = wrapper.find('input[name="multiple-cases-count"]')
+      .element as HTMLInputElement;
+
+    expect(updatedPrefixInput.value).toBe('case-');
+    expect(updatedSuffixInput.value).toBe('-easy');
+    expect(updatedCountInput.value).toBe('3');
+
+    await (wrapper.vm as any).addItemToStore();
+
+    const store = wrapper.vm.$store as Store<StoreState>;
+    const groups = store.state.casesStore.groups;
+
+    expect(groups.length).toBe(3);
+    for (let i = 0; i < 3; i++) {
+      expect(groups[i].name).toBe(`case-${i + 1}-easy`);
+      expect(groups[i].autoPoints).toBe(true);
+      expect(groups[i].ungroupedCase).toBe(true);
+    }
+  });
   it('Should contain 3 tabs', async () => {
     const wrapper = mount(AddPanel, {
       localVue,

--- a/frontend/www/js/omegaup/components/problem/creator/cases/AddPanel.vue
+++ b/frontend/www/js/omegaup/components/problem/creator/cases/AddPanel.vue
@@ -41,7 +41,7 @@
             name="modal-form"
             @click="tab = 'multiplecases'"
           >
-            <multiple-cases-input />
+            <multiple-cases-input ref="multiple-cases-input" />
           </b-tab>
         </b-tabs>
       </div>
@@ -70,6 +70,7 @@ import {
   Group,
   CaseRequest,
   AddTabTypes,
+  MultipleCaseAddRequest,
 } from '@/js/omegaup/problem/creator/types';
 import { NIL, v4 as uuid } from 'uuid';
 
@@ -91,9 +92,13 @@ export default class AddPanel extends Vue {
 
   @Ref('case-input') caseInputRef!: cases_CaseInput;
   @Ref('group-input') groupInputRef!: cases_GroupInput;
+  @Ref('multiple-cases-input') multipleCasesInputRef!: cases_MultipleCasesInput;
 
   @casesStore.Mutation('addCase') addCase!: (caseRequest: CaseRequest) => void;
   @casesStore.Mutation('addGroup') addGroup!: (groupRequest: Group) => void;
+  @casesStore.Action('addMultipleCases') addMultipleCases!: (
+    multipleCasesRequest: MultipleCaseAddRequest,
+  ) => void;
   @casesStore.State('groups') groups!: Group[];
 
   addItemToStore() {
@@ -133,6 +138,7 @@ export default class AddPanel extends Vue {
         autoPoints: caseAutoPoints,
       });
     } else if (this.tab === 'group') {
+      // Group input
       const groupName = this.groupInputRef.groupName;
       const groupPoints = this.groupInputRef.groupPoints;
       const groupAutoPoints = groupPoints === null;
@@ -152,8 +158,23 @@ export default class AddPanel extends Vue {
         ungroupedCase: false,
         cases: [],
       });
+    } else if (this.tab === 'multiplecases') {
+      // Multiple cases input
+      const multipleCasesPrefix = this.multipleCasesInputRef
+        .multipleCasesPrefix;
+      const multipleCasesSuffix = this.multipleCasesInputRef
+        .multipleCasesSuffix;
+      const multipleCasesCount = this.multipleCasesInputRef.multipleCasesCount;
+      const multipleCasesGroup = this.multipleCasesInputRef.multipleCasesGroup;
+
+      this.addMultipleCases({
+        prefix: multipleCasesPrefix,
+        suffix: multipleCasesSuffix,
+        numberOfCases: multipleCasesCount,
+        groupID: multipleCasesGroup,
+      });
     }
-    this.$emit('close-add-window');
+    // this.$emit('close-add-window');
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/creator/cases/MultipleCasesInput.test.ts
+++ b/frontend/www/js/omegaup/components/problem/creator/cases/MultipleCasesInput.test.ts
@@ -4,6 +4,7 @@ import MultipleCasesInput from './MultipleCasesInput.vue';
 import BootstrapVue, { IconsPlugin } from 'bootstrap-vue';
 import T from '../../../../lang';
 import Vue from 'vue';
+import store from '@/js/omegaup/problem/creator/store';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -13,6 +14,7 @@ describe('MultipleCasesInput.vue', () => {
   it('Should contain all 4 inputs', async () => {
     const wrapper = shallowMount(MultipleCasesInput, {
       localVue,
+      store,
     });
 
     const expectedTextInputText = [
@@ -46,6 +48,7 @@ describe('MultipleCasesInput.vue', () => {
   it('Should handle autoformatting', () => {
     const wrapper = shallowMount(MultipleCasesInput, {
       localVue,
+      store,
     });
 
     // These any are neccesary since wrapper.vm doesn't load the component's methods to typescript, even if they exist
@@ -55,6 +58,6 @@ describe('MultipleCasesInput.vue', () => {
 
     const invalidNumber = -2;
     const numberResult = (wrapper.vm as any).numberFormatter(invalidNumber);
-    expect(numberResult).toBe(1);
+    expect(numberResult).toBe(0);
   });
 });

--- a/frontend/www/js/omegaup/components/problem/creator/cases/MultipleCasesInput.vue
+++ b/frontend/www/js/omegaup/components/problem/creator/cases/MultipleCasesInput.vue
@@ -10,6 +10,7 @@
           class="mb-4"
         >
           <b-form-input
+            name="multiple-cases-prefix"
             v-model="multipleCasesPrefix"
             :formatter="formatter"
             autocomplete="off"
@@ -23,6 +24,7 @@
           class="mb-4"
         >
           <b-form-input
+            name="multiple-cases-suffix"
             v-model="multipleCasesSuffix"
             :formatter="formatter"
             autocomplete="off"
@@ -36,6 +38,7 @@
       label-for="case-points"
     >
       <b-form-input
+        name="multiple-cases-count"
         v-model="multipleCasesCount"
         :formatter="numberFormatter"
         type="number"
@@ -43,7 +46,11 @@
       />
     </b-form-group>
     <b-form-group :label="T.problemCreatorGroupName" label-for="case-group">
-      <b-form-select v-model="multipleCasesGroup" />
+      <b-form-select
+        name="multiple-cases-group"
+        v-model="multipleCasesGroup"
+        :options="options"
+      />
     </b-form-group>
   </div>
 </template>
@@ -53,15 +60,32 @@ import { GroupID } from '../../../../problem/creator/types';
 import { NIL } from 'uuid';
 import { Component, Vue } from 'vue-property-decorator';
 import T from '../../../../lang';
+import { namespace } from 'vuex-class';
+
+const casesStore = namespace('casesStore');
 
 @Component
 export default class MultipleCasesInput extends Vue {
+  @casesStore.Getter('getGroupIdsAndNames') storedGroups!: {
+    value: string;
+    text: string;
+  }[];
+
   multipleCasesPrefix = '';
   multipleCasesSuffix = '';
   multipleCasesCount = 1;
   multipleCasesGroup: GroupID = NIL;
 
   T = T;
+
+  // getGroupIdsAndNames getter is not instant, we need to wait for it to be defined otherwise the app will crash
+  get options() {
+    const noGroup = { value: NIL, text: T.problemCreatorNoGroup };
+    if (!this.storedGroups) {
+      return [noGroup];
+    }
+    return [noGroup, ...this.storedGroups];
+  }
 
   get caseNamePreview() {
     return `${this.multipleCasesPrefix}1${this.multipleCasesSuffix}, ${this.multipleCasesPrefix}2${this.multipleCasesSuffix}...`;
@@ -74,7 +98,7 @@ export default class MultipleCasesInput extends Vue {
 
   // Ensures the numebr is always above 1
   numberFormatter(number: number) {
-    return Math.max(number, 1);
+    return Math.max(number, 0);
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/problem/creator/cases/MultipleCasesInput.vue
+++ b/frontend/www/js/omegaup/components/problem/creator/cases/MultipleCasesInput.vue
@@ -10,8 +10,8 @@
           class="mb-4"
         >
           <b-form-input
-            name="multiple-cases-prefix"
             v-model="multipleCasesPrefix"
+            name="multiple-cases-prefix"
             :formatter="formatter"
             autocomplete="off"
           />
@@ -24,8 +24,8 @@
           class="mb-4"
         >
           <b-form-input
-            name="multiple-cases-suffix"
             v-model="multipleCasesSuffix"
+            name="multiple-cases-suffix"
             :formatter="formatter"
             autocomplete="off"
           />
@@ -38,8 +38,8 @@
       label-for="case-points"
     >
       <b-form-input
-        name="multiple-cases-count"
         v-model="multipleCasesCount"
+        name="multiple-cases-count"
         :formatter="numberFormatter"
         type="number"
         number
@@ -47,8 +47,8 @@
     </b-form-group>
     <b-form-group :label="T.problemCreatorGroupName" label-for="case-group">
       <b-form-select
-        name="multiple-cases-group"
         v-model="multipleCasesGroup"
+        name="multiple-cases-group"
         :options="options"
       />
     </b-form-group>

--- a/frontend/www/js/omegaup/problem/creator/modules/cases.ts
+++ b/frontend/www/js/omegaup/problem/creator/modules/cases.ts
@@ -266,10 +266,10 @@ export const casesStore: Module<CasesState, RootState> = {
           name: caseName,
           groupID: multipleCaseRequest.groupID,
         });
+        // Autopoints depends if the group is ungrouped
         const caseRequest = generateCaseRequest({
           ...newCase,
-          points: 0,
-          autoPoints: false,
+          autoPoints: multipleCaseRequest.groupID === UUID_NIL,
         });
         commit('addCase', caseRequest);
       }


### PR DESCRIPTION
# Descripción

Se agregó la lógica necesaria para poder subir múltiples casos a la store de Vuex y se agregó una prueba unitaria. También se modificó un poco la store (se agregó un campo) para que se pueda agregar puntaje a los casos agrupados. Por último, ahora puedes agregar casos a grupos que tú creaste

https://user-images.githubusercontent.com/74751751/150846237-711f3d6f-6f31-4c10-b209-021bd45acb1e.mp4

2aaef4.mp4



Fixes: #6329


# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
