### PR TITLE
Haciendo la consulta de las pestañas entre 2 y 6 órdenes de magnitud más rápida

### DIFF
--- a/frontend/tests/controllers/CourseTabsTest.php
+++ b/frontend/tests/controllers/CourseTabsTest.php
@@ -244,16 +244,16 @@ class CourseTabsTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertEmpty(
             $response['templateProperties']['payload']['courses']['public']
         );
-        $this->assertCount(
-            1,
+        $this->assertEmpty(
             $response['templateProperties']['payload']['courses']['enrolled']
         );
-        $this->assertEmpty(
+        $this->assertCount(
+            1,
             $response['templateProperties']['payload']['courses']['finished']
         );
         $this->assertEquals(
             $courseData['course_alias'],
-            $response['templateProperties']['payload']['courses']['enrolled'][0]['alias']
+            $response['templateProperties']['payload']['courses']['finished'][0]['alias']
         );
     }
 }


### PR DESCRIPTION
Este cambio hace que la consulta de las pestañas ya no tenga que
escanaer _todos_ los registros de `Submissions` _y_ `Runs` (~varias
decenas de millones en total entre todos los joins). Ahora MySQL puede
usar una tabla materializada para hacer tanto el filtro de los
assignments de un curso donde se han hecho envíos así como la agrupación
de cursos donde se han hecho envíos.