### PR TITLE
Arreglando las pruebas de fechas

### DIFF
--- a/frontend/www/js/omegaup/time.test.ts
+++ b/frontend/www/js/omegaup/time.test.ts
@@ -195,7 +195,7 @@ describe('time', () => {
       const hoursSeconds = 60 * 60 * 1000;
       const minutesSeconds = 60 * 1000;
       const seconds = 1000;
-      const today = new Date();
+      const today = new Date('2021-01-01 00:00:00+00:00');
       const tomorrow = new Date(today.getTime() + daySeconds);
       const millMapping = [
         [


### PR DESCRIPTION
Como cada vez que nos acercamos a Febrero, una prueba que tiene que ver
con fechas está fallando.

Este cambio hace que la prueba de formateo de duración deje de usar la
hora actual y use una fecha hardcodeda para evitar diferencias
inesperadas.