### PR TITLE
Verificando que sólo se muestre el modal de objetivos a usuarios principales

### DIFF
--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -252,7 +252,7 @@ class Driver:  # pylint: disable=too-many-instance-attributes
             yield
 
     @contextlib.contextmanager
-    def login(self, username, password):
+    def login(self, username, password, is_main_user_identity=True):
         '''Logs in as :username, and logs out when out of scope.'''
 
         # Home page
@@ -274,9 +274,10 @@ class Driver:  # pylint: disable=too-many-instance-attributes
         with self.page_transition():
             self.browser.find_element_by_name('login').click()
 
-        self.wait.until(
-            EC.element_to_be_clickable(
-                (By.CSS_SELECTOR, 'button[aria-label="Close"]'))).click()
+        if is_main_user_identity:
+            self.wait.until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, 'button[aria-label="Close"]'))).click()
         try:
             yield
         except:  # noqa: bare-except

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -35,7 +35,7 @@ def test_create_contest(driver):
     create_contest_admin(driver, contest_alias, problem, invited_users,
                          driver.user_username, access_mode='Private')
 
-    with driver.login(identity.username, identity.password):
+    with driver.login(identity.username, identity.password, False):
         create_run_user(driver, contest_alias, problem, 'Main.cpp17-gcc',
                         verdict='AC', score=1)
 
@@ -106,7 +106,8 @@ def test_user_ranking_contest(driver):
                         verdict='AC', score=1)
 
     with driver.login(uninvited_identity.username,
-                      uninvited_identity.password):
+                      uninvited_identity.password,
+                      False):
         create_run_user(driver, contest_alias, problem, 'Main.cpp17-gcc',
                         verdict='AC', score=1)
 

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -35,7 +35,9 @@ def test_create_contest(driver):
     create_contest_admin(driver, contest_alias, problem, invited_users,
                          driver.user_username, access_mode='Private')
 
-    with driver.login(identity.username, identity.password, False):
+    with driver.login(identity.username,
+                      identity.password,
+                      is_main_user_identity=False):
         create_run_user(driver, contest_alias, problem, 'Main.cpp17-gcc',
                         verdict='AC', score=1)
 
@@ -107,7 +109,7 @@ def test_user_ranking_contest(driver):
 
     with driver.login(uninvited_identity.username,
                       uninvited_identity.password,
-                      False):
+                      is_main_user_identity=False):
         create_run_user(driver, contest_alias, problem, 'Main.cpp17-gcc',
                         verdict='AC', score=1)
 

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -192,7 +192,7 @@ def test_create_identities_for_course(driver):
 
     # Unassociated identity joins the course which it was created for and
     # creates a new run
-    with driver.login(unassociated.username, unassociated.password):
+    with driver.login(unassociated.username, unassociated.password, False):
         enter_course(driver, course_alias, assignment_alias)
 
         driver.wait.until(
@@ -257,7 +257,7 @@ def test_create_identities_for_course(driver):
         assert associated_identities is not None, 'No identity matches'
 
     # The new associated identity joins the course
-    with driver.login(associated.username, associated.password):
+    with driver.login(associated.username, associated.password, False):
         enter_course(driver, course_alias, assignment_alias)
 
 

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -192,7 +192,9 @@ def test_create_identities_for_course(driver):
 
     # Unassociated identity joins the course which it was created for and
     # creates a new run
-    with driver.login(unassociated.username, unassociated.password, False):
+    with driver.login(unassociated.username,
+                      unassociated.password,
+                      is_main_user_identity=False):
         enter_course(driver, course_alias, assignment_alias)
 
         driver.wait.until(
@@ -257,7 +259,9 @@ def test_create_identities_for_course(driver):
         assert associated_identities is not None, 'No identity matches'
 
     # The new associated identity joins the course
-    with driver.login(associated.username, associated.password, False):
+    with driver.login(associated.username,
+                      associated.password,
+                      is_main_user_identity=False):
         enter_course(driver, course_alias, assignment_alias)
 
 

--- a/frontend/tests/ui/test_group.py
+++ b/frontend/tests/ui/test_group.py
@@ -45,7 +45,9 @@ def test_create_group_with_identities_and_restrictions(driver):
         group_alias = util.create_group(driver, group_title, description)
         identity, *_ = util.add_identities_group(driver, group_alias)
 
-    with driver.login(identity.username, identity.password, False):
+    with driver.login(identity.username,
+                      identity.password,
+                      is_main_user_identity=False):
         navbar = driver.wait.until(
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '.navbar-nav:first-child')))

--- a/frontend/tests/ui/test_group.py
+++ b/frontend/tests/ui/test_group.py
@@ -45,7 +45,7 @@ def test_create_group_with_identities_and_restrictions(driver):
         group_alias = util.create_group(driver, group_title, description)
         identity, *_ = util.add_identities_group(driver, group_alias)
 
-    with driver.login(identity.username, identity.password):
+    with driver.login(identity.username, identity.password, False):
         navbar = driver.wait.until(
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '.navbar-nav:first-child')))

--- a/frontend/www/js/omegaup/components/common/Navbar.test.ts
+++ b/frontend/www/js/omegaup/components/common/Navbar.test.ts
@@ -1,63 +1,48 @@
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 
 import T from '../../lang';
 
 import common_Navbar from './Navbar.vue';
+import UserObjectivesQuestions from '../user/ObjectivesQuestions.vue';
 
 describe('Navbar.vue', () => {
-  it('Should handle empty navbar (in contest only)', async () => {
-    const wrapper = mount(common_Navbar, {
-      propsData: {
-        currentUsername: 'user',
-        errorMessage: null,
-        graderInfo: null,
-        graderQueueLength: -1,
-        gravatarURL51:
-          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
-        inContest: true,
-        clarifications: [],
-        isAdmin: false,
-        isLoggedIn: true,
-        isMainUserIdentity: true,
-        isReviewer: false,
-        lockDownImage: 'data:image/png;base64...',
-        navbarSection: '',
-        omegaUpLockDown: false,
-        allIdentities: [{ username: 'user', default: true }],
-        notifications: [],
-        fromLogin: false,
-        userTypes: [],
-      },
-    });
+  const propsData = {
+    currentUsername: 'user',
+    errorMessage: null,
+    graderInfo: null,
+    graderQueueLength: -1,
+    gravatarURL51:
+      'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
+    inContest: true,
+    clarifications: [],
+    isAdmin: false,
+    isLoggedIn: true,
+    isMainUserIdentity: false,
+    isReviewer: false,
+    lockDownImage: 'data:image/png;base64...',
+    navbarSection: '',
+    omegaUpLockDown: false,
+    associatedIdentities: [{ username: 'user', default: true }],
+    notifications: [],
+    fromLogin: false,
+    userTypes: [],
+  };
 
+  it('Should handle empty navbar (in contest only)', () => {
+    const wrapper = mount(common_Navbar, {
+      propsData,
+    });
     expect(wrapper.find('.nav-contests').exists()).toBe(false);
     expect(wrapper.find('.nav-courses').exists()).toBe(false);
     expect(wrapper.find('.nav-problems').exists()).toBe(false);
     expect(wrapper.find('.nav-rank').exists()).toBe(false);
   });
 
-  it('Should handle common navbar to logged user', async () => {
+  it('Should handle common navbar to logged user', () => {
     const wrapper = mount(common_Navbar, {
       propsData: {
-        currentUsername: 'user',
-        errorMessage: null,
-        graderInfo: null,
-        graderQueueLength: -1,
-        gravatarURL51:
-          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
-        inContest: false,
-        clarifications: [],
-        isAdmin: false,
-        isLoggedIn: true,
-        isMainUserIdentity: true,
-        isReviewer: false,
-        lockDownImage: 'data:image/png;base64...',
-        navbarSection: '',
-        omegaUpLockDown: false,
-        associatedIdentities: [{ username: 'user', default: true }],
-        notifications: [],
-        fromLogin: false,
-        userTypes: ['student', 'teacher'],
+        ...propsData,
+        ...{ inContest: false, userTypes: ['student', 'teacher'] },
       },
     });
 
@@ -67,34 +52,26 @@ describe('Navbar.vue', () => {
     expect(wrapper.find('.nav-rank').exists()).toBe(true);
   });
 
-  it('Should handle common navbar to not-logged user', async () => {
+  it('Should handle common navbar to not-logged user', () => {
     const wrapper = mount(common_Navbar, {
-      propsData: {
-        currentUsername: 'user',
-        errorMessage: null,
-        graderInfo: null,
-        graderQueueLength: -1,
-        gravatarURL51:
-          'https://secure.gravatar.com/avatar/568c0ec2147500d7cd09cc8bbc8e5ec4?s=51',
-        inContest: false,
-        clarifications: [],
-        isAdmin: false,
-        isLoggedIn: false,
-        isMainUserIdentity: true,
-        isReviewer: false,
-        lockDownImage: 'data:image/png;base64...',
-        navbarSection: '',
-        omegaUpLockDown: false,
-        associatedIdentities: [{ username: 'user', default: true }],
-        notifications: [],
-        fromLogin: false,
-        userTypes: [],
-      },
+      propsData: { ...propsData, ...{ inContest: false, isLoggedIn: false } },
     });
 
     expect(wrapper.find('.nav-problems').exists()).toBe(true);
     expect(wrapper.find('[data-nav-course]').exists()).toBe(true);
     expect(wrapper.find('.nav-rank').exists()).toBe(true);
     expect(wrapper.find('.navbar-right').text()).toBe(T.navLogIn);
+  });
+
+  it('Should show objectives modal only when a main user identity is logged', async () => {
+    const wrapper = shallowMount(common_Navbar, {
+      propsData: { ...propsData, ...{ fromLogin: true } },
+    });
+
+    expect(wrapper.findComponent(UserObjectivesQuestions).exists()).toBe(false);
+
+    await wrapper.setProps({ isMainUserIdentity: true });
+
+    expect(wrapper.findComponent(UserObjectivesQuestions).exists()).toBe(true);
   });
 });

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -298,7 +298,9 @@
       </div>
     </nav>
     <omegaup-user-objectives-questions
-      v-if="fromLogin && isLoggedIn && userTypes.length === 0"
+      v-if="
+        fromLogin && isLoggedIn && isMainUserIdentity && userTypes.length === 0
+      "
       @submit="(objectives) => $emit('update-user-objectives', objectives)"
     ></omegaup-user-objectives-questions>
   </header>


### PR DESCRIPTION
# Descripción

Se agrega la validación para que el modal de objetivos no se muestre si la cuenta
que está actualmente logueada es de una identidad que no es la principal de
un usuario.

Fixes: #6337 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.