### PR TITLE
Permitir al crawler de Google hacer llamadas a `/api/session/currentSession/`

### DIFF
--- a/frontend/www/robots.txt
+++ b/frontend/www/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Noindex: /api/session/currentSession/
+Allow: /api/session/currentSession/
 Disallow: /admin/
 Disallow: /api/
 Disallow: /install/


### PR DESCRIPTION
Al parecer no es suficiente el `Noindex: api/session/currentSession/`: https://search.google.com/test/mobile-friendly/result?id=ODxKlQ8WSkcTvpuGeZ7Qhw