### PR TITLE
Ligera optimizacion de Contest::apiProblems

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2926,16 +2926,16 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        $problemset = \OmegaUp\DAO\Problemsets::getByPK(
+        $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
             $contest->problemset_id
         );
-        if (is_null($problemset) || is_null($problemset->problemset_id)) {
+        if (!$problemsetExists) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
         }
         $problems = \OmegaUp\DAO\ProblemsetProblems::getProblemsByProblemset(
-            $problemset->problemset_id,
+            $contest->problemset_id,
             needSubmissions: true
         );
 
@@ -2943,7 +2943,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'problems' => self::addVersionsToProblems(
                 $problems,
                 $r->identity,
-                $problemset->problemset_id
+                $contest->problemset_id
             ),
         ];
     }


### PR DESCRIPTION
# Descripción

Aprovechando `existsByPK` en lugar de `getByPK` en `Contest::apiProblems`.

Motivación: https://onenr.io/0xVwgp0xdRJ

Hay llamadas a esa API que tardan segundos. Este cambio en sí no lo va a arreglar, pero quita un poco de trabajo.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.