### PR TITLE
Añadir 'X-Robots-Tag: noindex' a todos los endpoints de la API

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -268,6 +268,7 @@ class ApiCaller {
         header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
         header('Cache-Control: post-check=0, pre-check=0', false);
         header('Pragma: no-cache');
+        header('X-Robots-Tag: noindex');
 
         // Set header accordingly
         if (isset($response['header']) && is_string($response['header'])) {

--- a/frontend/www/api/ApiEntryPoint.php
+++ b/frontend/www/api/ApiEntryPoint.php
@@ -1,5 +1,7 @@
 <?php
 
+header("X-Robots-Tag: noindex");
+
 require_once(__DIR__ . '/../../server/bootstrap.php');
 
 echo \OmegaUp\ApiCaller::httpEntryPoint();

--- a/frontend/www/api/ApiEntryPoint.php
+++ b/frontend/www/api/ApiEntryPoint.php
@@ -1,7 +1,5 @@
 <?php
 
-header('X-Robots-Tag: noindex');
-
 require_once(__DIR__ . '/../../server/bootstrap.php');
 
 echo \OmegaUp\ApiCaller::httpEntryPoint();

--- a/frontend/www/api/ApiEntryPoint.php
+++ b/frontend/www/api/ApiEntryPoint.php
@@ -1,6 +1,6 @@
 <?php
 
-header("X-Robots-Tag: noindex");
+header('X-Robots-Tag: noindex');
 
 require_once(__DIR__ . '/../../server/bootstrap.php');
 


### PR DESCRIPTION
En conjunto con #6345 deberían de arreglar el issue del SEO #2366.

Probé localmente que sí salga la etiqueta y que no se rompa la página:
![Screenshot from 2022-02-03 10-17-05](https://user-images.githubusercontent.com/597815/152409921-fb1d32f1-d1ac-4e6d-8b4f-f2d08d68b34a.png)
