### PR TITLE
Arreglando el modo de admisión de un concurso cuando este se actualiza

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -115,6 +115,7 @@
     <div class="tab-content">
       <div v-if="showTab === 'new_form'" class="tab-pane active">
         <omegaup-contest-new-form
+          :admission-mode="details.admission_mode"
           :initial-alias="details.alias"
           :initial-title="details.title"
           :initial-description="details.description"

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -373,6 +373,7 @@ import { types } from '../../api_types';
 export default class NewForm extends Vue {
   @Prop() update!: boolean;
   @Prop() allLanguages!: string[];
+  @Prop({ default: 'private' }) admissionMode!: string;
   @Prop({ default: '' }) initialAlias!: string;
   @Prop({ default: '' }) initialDescription!: string;
   @Prop({ default: 'none' }) initialFeedback!: string;
@@ -499,7 +500,7 @@ export default class NewForm extends Vue {
   onSubmit() {
     const contest: types.ContestAdminDetails = {
       admin: true,
-      admission_mode: 'private',
+      admission_mode: this.update ? this.admissionMode : 'private',
       alias: this.alias,
       archived: false,
       available_languages: {},

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -367,6 +367,7 @@ OmegaUp.on('ready', () => {
               default_show_all_contestants_in_scoreboard: defaultShowAllContestantsInScoreboard,
             })
               .then(() => {
+                contestEdit.details.admission_mode = admissionMode;
                 ui.success(`
                   ${T.contestEditContestEdited} <a href="/arena/${payload.details.alias}/">${T.contestEditGoToContest}</a>
                 `);


### PR DESCRIPTION
# Descripción

Se arregla el formulario de Editar concurso para que se guarde el valor 
correcto para el modo de admisión. Anteriormente este formulario siempre 
estaba enviando el valor de "Privado". 

Esto estaba bien para todos los concursos que eran recién creados. Pero
para los concursos que se están editados debería guardar el valor que se
obtiene del payload, o en su defecto, el valor por el que se haya actualizado
el concurso.

Fixes: #5588 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
