### PR TITLE
Partial rollback de #6348 porque rompio el poder agregar problemas a problemsets

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3043,10 +3043,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             !\OmegaUp\Authorization::canEditProblem($identity, $problem) &&
             (
                 is_null($problemsetId) ||
-                !\OmegaUp\DAO\ProblemsetProblems::existsByPK(
-                    $problemsetId,
-                    $problem->problem_id
-                ) ||
                 !\OmegaUp\Authorization::canEditProblemset(
                     $identity,
                     $problemsetId


### PR DESCRIPTION
# Descripción

Creo que #6348 rompió el poder agregar problemas a cursos y (posiblemente) concursos. Aparentemente para poder agregar un problema necesitas poder pedir su versión. Pero la revisión de que el problema ya sea parte del problemset obviamente no puede pasar cuand apenas se está queriendo agregar.

# Comentarios

Rollback rápido para desbloquear a gente que pueda estar batallando con esto. Y mientras pienso en cómo arreglarlo y agrego una prueba que cubra este caso.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
