### PR TITLE
fix showing red alert instead of warning when send verification email

### DIFF
--- a/frontend/www/js/omegaup/login/signin.ts
+++ b/frontend/www/js/omegaup/login/signin.ts
@@ -42,7 +42,7 @@ OmegaUp.on('ready', () => {
 
   const payload = types.payloadParsers.LoginDetailsPayload();
   if (payload.statusError) {
-    ui.error(payload.statusError);
+    ui.warning(payload.statusError);
   } else if (payload.verifyEmailSuccessfully) {
     ui.success(payload.verifyEmailSuccessfully);
   }


### PR DESCRIPTION
# Descripción

Se cambio el color del alert rojo a un warning, al pedir verificacion de email, para esto se cambio la funcion error por warning que es la que agrega la clase alert-warning en vez de alert-danger

Fixes: #6152 
