### PR TITLE
feat course cards

### DIFF
--- a/frontend/www/js/omegaup/components/course/CardPublic.vue
+++ b/frontend/www/js/omegaup/components/course/CardPublic.vue
@@ -8,7 +8,12 @@
             class="card-body d-flex flex-column h-100 justify-content-between"
           >
             <div>
-              <h5 class="card-title mb-0">{{ course.name }}</h5>
+              <h5 class="card-title mb-0">
+                <a v-if="loggedIn" :href="`/course/${course.alias}/`">{{
+                  course.name
+                }}</a>
+                <template v-else>{{ course.name }}</template>
+              </h5>
               <p class="card-text">
                 <small>{{ course.school_name }}</small>
               </p>


### PR DESCRIPTION
# Descripción

Se cambio el archivo `/omegaup/frontend/www/js/omegaup/components/course/CardPublic.vue` en la sección del titulo para hacerlo clickeable

![image](https://user-images.githubusercontent.com/78834191/155076081-0af5aec3-086c-43a7-9aa3-0e1607cfb2e8.png)

Fixes: #6111

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.