### PR TITLE
Preparando los cambios para arreglar filtros de envíos en Cursos

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -54,7 +54,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type IntroCourseDetails=array{details: CourseDetails, progress: array<string, array<string, float>>}
  * @psalm-type IntroDetailsPayload=array{course: CourseDetails, isFirstTimeAccess: bool, needsBasicInformation: bool, shouldShowAcceptTeacher: bool, shouldShowResults: bool, statements: array{acceptTeacher?: PrivacyStatement, privacy?: PrivacyStatement}, userRegistrationAccepted?: bool|null, userRegistrationAnswered?: bool, userRegistrationRequested?: bool}
  * @psalm-type NavbarProblemsetProblem=array{acceptsSubmissions: bool, alias: string, bestScore: int, hasRuns: bool, maxScore: float|int, text: string}
- * @psalm-type ArenaAssignment=array{alias: string|null, assignment_type: string, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string|null, problems: list<NavbarProblemsetProblem>, problemset_id: int, runs: list<Run>, start_time: \OmegaUp\Timestamp, totalRuns: int}
+ * @psalm-type ArenaAssignment=array{alias: string|null, assignment_type: string, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string|null, problems: list<NavbarProblemsetProblem>, problemset_id: int, runs: list<Run>, start_time: \OmegaUp\Timestamp, totalRuns: int|null}
  * @psalm-type AssignmentDetailsPayload=array{showRanking: bool, scoreboard: Scoreboard, courseDetails: CourseDetails, currentAssignment: ArenaAssignment, shouldShowFirstAssociatedIdentityRunWarning: bool}
  * @psalm-type AssignmentDetails=array{admin: bool, alias: string, assignmentType: string, courseAssignments: list<CourseAssignment>, description: string, director: string, finishTime: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetProblem>, problemsetId: int, startTime: \OmegaUp\Timestamp}
  * @psalm-type CourseScoreboardPayload=array{assignment: AssignmentDetails, problems: list<NavbarProblemsetProblem>, scoreboard: Scoreboard, scoreboardToken:null|string}
@@ -4181,7 +4181,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $scoreboard = new \OmegaUp\Scoreboard($params);
 
         $runs = [];
-        $totalRuns = 0;
+        $totalRuns = null;
         if ($isAdmin) {
             [
                 'runs' => $runs,

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -93,6 +93,7 @@
   - [`/api/course/removeStudent/`](#apicourseremovestudent)
   - [`/api/course/requests/`](#apicourserequests)
   - [`/api/course/runs/`](#apicourseruns)
+  - [`/api/course/searchUsers/`](#apicoursesearchusers)
   - [`/api/course/studentProgress/`](#apicoursestudentprogress)
   - [`/api/course/studentsProgress/`](#apicoursestudentsprogress)
   - [`/api/course/update/`](#apicourseupdate)
@@ -2025,9 +2026,30 @@ Returns all runs for a course
 
 ### Returns
 
-| Name   | Type          |
-| ------ | ------------- |
-| `runs` | `types.Run[]` |
+| Name        | Type          |
+| ----------- | ------------- |
+| `runs`      | `types.Run[]` |
+| `totalRuns` | `number`      |
+
+## `/api/course/searchUsers/`
+
+### Description
+
+Search users in course assignment
+
+### Parameters
+
+| Name               | Type           | Description |
+| ------------------ | -------------- | ----------- |
+| `assignment_alias` | `string`       |             |
+| `course_alias`     | `string`       |             |
+| `query`            | `null\|string` |             |
+
+### Returns
+
+| Name      | Type               |
+| --------- | ------------------ |
+| `results` | `types.ListItem[]` |
 
 ## `/api/course/studentProgress/`
 
@@ -2967,9 +2989,10 @@ Entry point for Problem runs API
 
 ### Returns
 
-| Name   | Type          |
-| ------ | ------------- |
-| `runs` | `types.Run[]` |
+| Name        | Type          |
+| ----------- | ------------- |
+| `runs`      | `types.Run[]` |
+| `totalRuns` | `number`      |
 
 ## `/api/problem/runsDiff/`
 
@@ -3663,9 +3686,10 @@ Gets a list of latest runs overall
 
 ### Returns
 
-| Name   | Type          |
-| ------ | ------------- |
-| `runs` | `types.Run[]` |
+| Name        | Type          |
+| ----------- | ------------- |
+| `runs`      | `types.Run[]` |
+| `totalRuns` | `number`      |
 
 ## `/api/run/rejudge/`
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1604,7 +1604,7 @@ class Run extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of latest runs overall
      *
-     * @return array{runs: list<Run>}
+     * @return array{runs: list<Run>, totalRuns: int}
      *
      * @omegaup-request-param 'c11-clang'|'c11-gcc'|'cat'|'cpp11-clang'|'cpp11-gcc'|'cpp17-clang'|'cpp17-gcc'|'cpp20-clang'|'cpp20-gcc'|'cs'|'go'|'hs'|'java'|'js'|'kj'|'kp'|'kt'|'lua'|'pas'|'py2'|'py3'|'rb'|'rs'|null $language
      * @omegaup-request-param int $offset
@@ -1626,6 +1626,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         $languagesKeys = array_keys(self::SUPPORTED_LANGUAGES);
         [
             'runs' => $runs,
+            'totalRuns' => $totalRuns,
         ] = \OmegaUp\DAO\Runs::getAllRuns(
             null,
             $r->ensureOptionalEnum('status', self::STATUS),
@@ -1653,6 +1654,7 @@ class Run extends \OmegaUp\Controllers\Controller {
 
         return [
             'runs' => $result,
+            'totalRuns' => $totalRuns,
         ];
     }
 }

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -138,15 +138,15 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         }
 
         if (!is_null($status)) {
-            $where[] = 'r.status = ?';
+            $where[] = 's.status = ?';
             $val[] = $status;
         }
         if (!is_null($verdict)) {
             if ($verdict === 'NO-AC') {
-                $where[] = 'r.verdict <> ?';
+                $where[] = 's.verdict <> ?';
                 $val[] = 'AC';
             } else {
-                $where[] = 'r.verdict = ?';
+                $where[] = 's.verdict = ?';
                 $val[] = $verdict;
             }
         }
@@ -156,10 +156,6 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 COUNT(*) AS total
             FROM
                 Submissions s
-            INNER JOIN
-                Runs r
-            ON
-                r.submission_id = s.submission_id
         ';
         if (!empty($where)) {
             $sqlCount .= 'WHERE ' . implode(' AND ', $where) . ' ';

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -138,15 +138,15 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         }
 
         if (!is_null($status)) {
-            $where[] = 's.status = ?';
+            $where[] = 'r.status = ?';
             $val[] = $status;
         }
         if (!is_null($verdict)) {
             if ($verdict === 'NO-AC') {
-                $where[] = 's.verdict <> ?';
+                $where[] = 'r.verdict <> ?';
                 $val[] = 'AC';
             } else {
-                $where[] = 's.verdict = ?';
+                $where[] = 'r.verdict = ?';
                 $val[] = $verdict;
             }
         }
@@ -156,6 +156,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 COUNT(*) AS total
             FROM
                 Submissions s
+            INNER JOIN
+                Runs r
+            ON
+                r.submission_id = s.submission_id
         ';
         if (!empty($where)) {
             $sqlCount .= 'WHERE ' . implode(' AND ', $where) . ' ';

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -956,6 +956,10 @@ export const Course = {
     })(x.runs);
     return x;
   }),
+  searchUsers: apiCall<
+    messages.CourseSearchUsersRequest,
+    messages.CourseSearchUsersResponse
+  >('/api/course/searchUsers/'),
   studentProgress: apiCall<
     messages.CourseStudentProgressRequest,
     messages._CourseStudentProgressServerResponse,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2316,7 +2316,7 @@ export namespace types {
     problemset_id: number;
     runs: types.Run[];
     start_time: Date;
-    totalRuns: number;
+    totalRuns?: number;
   }
 
   export interface ArenaContest {

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2316,6 +2316,7 @@ export namespace types {
     problemset_id: number;
     runs: types.Run[];
     start_time: Date;
+    totalRuns: number;
   }
 
   export interface ArenaContest {
@@ -3660,6 +3661,7 @@ export namespace types {
     selectedPublicTags?: string[];
     solutionStatus?: string;
     solvers: types.BestSolvers[];
+    totalRuns?: number;
     user: types.UserInfoForProblem;
   }
 
@@ -4928,7 +4930,9 @@ export namespace messages {
   export type CourseRequestsResponse = { users: types.IdentityRequest[] };
   export type CourseRunsRequest = { [key: string]: any };
   export type _CourseRunsServerResponse = any;
-  export type CourseRunsResponse = { runs: types.Run[] };
+  export type CourseRunsResponse = { runs: types.Run[]; totalRuns: number };
+  export type CourseSearchUsersRequest = { [key: string]: any };
+  export type CourseSearchUsersResponse = { results: types.ListItem[] };
   export type CourseStudentProgressRequest = { [key: string]: any };
   export type _CourseStudentProgressServerResponse = any;
   export type CourseStudentProgressResponse = {
@@ -5088,7 +5092,7 @@ export namespace messages {
   export type ProblemRemoveTagResponse = {};
   export type ProblemRunsRequest = { [key: string]: any };
   export type _ProblemRunsServerResponse = any;
-  export type ProblemRunsResponse = { runs: types.Run[] };
+  export type ProblemRunsResponse = { runs: types.Run[]; totalRuns: number };
   export type ProblemRunsDiffRequest = { [key: string]: any };
   export type ProblemRunsDiffResponse = { diff: types.RunsDiff[] };
   export type ProblemSelectVersionRequest = { [key: string]: any };
@@ -5247,7 +5251,7 @@ export namespace messages {
   export type RunDisqualifyResponse = {};
   export type RunListRequest = { [key: string]: any };
   export type _RunListServerResponse = any;
-  export type RunListResponse = { runs: types.Run[] };
+  export type RunListResponse = { runs: types.Run[]; totalRuns: number };
   export type RunRejudgeRequest = { [key: string]: any };
   export type RunRejudgeResponse = {};
   export type RunSourceRequest = { [key: string]: any };
@@ -5744,6 +5748,9 @@ export namespace controllers {
     runs: (
       params?: messages.CourseRunsRequest,
     ) => Promise<messages.CourseRunsResponse>;
+    searchUsers: (
+      params?: messages.CourseSearchUsersRequest,
+    ) => Promise<messages.CourseSearchUsersResponse>;
     studentProgress: (
       params?: messages.CourseStudentProgressRequest,
     ) => Promise<messages.CourseStudentProgressResponse>;


### PR DESCRIPTION
# Descripción

En el PR #5997 se había arreglado la pestaña de envíos para administrador 
dentro de la vista de concursos. En ese cambio había quedado pendiente 
habilitar la solución para los cursos. En este PR se preparan todos los cambios 
en los controladores para que se pueda arreglar lo antes mencionado.  

Part of: #6374 

# Comentarios

En este cambio se aprovecha para pasar los parámetros necesarios en las
vistas de envíos globales y detalles del problema.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
