### PR TITLE
Arreglando los filtros de envíos en los cursos

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -390,7 +390,7 @@ OmegaUp.on('ready', async () => {
     })
       .then(time.remoteTimeAdapter)
       .then((response) => {
-        onRefreshRuns({ runs: response.runs });
+        onRefreshRuns({ runs: response.runs, totalRuns: response.totalRuns });
       })
       .catch(ui.apiError);
   }

--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -9,6 +9,7 @@ import Vue from 'vue';
 import arena_Course from '../components/arena/Course.vue';
 import { getOptionsFromLocation, getProblemAndRunDetails } from './location';
 import {
+  onRefreshRuns,
   showSubmission,
   SubmissionRequest,
   submitRun,
@@ -26,7 +27,7 @@ import {
 import { EventsSocket } from './events_socket';
 import clarificationStore from './clarificationsStore';
 import socketStore from './socketStore';
-import { myRunsStore, runsStore } from './runsStore';
+import { myRunsStore, RunFilters, runsStore } from './runsStore';
 
 OmegaUp.on('ready', async () => {
   time.setSugarLocale();
@@ -98,6 +99,7 @@ OmegaUp.on('ready', async () => {
           guid: this.guid,
           runs: myRunsStore.state.runs,
           allRuns: runsStore.state.runs,
+          totalRuns: runsStore.state.totalRuns,
           searchResultUsers: this.searchResultUsers,
           runDetailsData: this.runDetailsData,
           nextSubmissionTimestamp: this.nextSubmissionTimestamp,
@@ -127,6 +129,28 @@ OmegaUp.on('ready', async () => {
               problems: this.problems,
               problemsetId: payload.currentAssignment.problemset_id,
             });
+          },
+          'update-search-result-users-assignment': ({
+            query,
+          }: {
+            query: string;
+          }) => {
+            api.Course.searchUsers({
+              query,
+              course_alias: payload.courseDetails.alias,
+              assignment_alias: payload.currentAssignment.alias,
+            })
+              .then(({ results }) => {
+                this.searchResultUsers = results.map(
+                  ({ key, value }: types.ListItem) => ({
+                    key,
+                    value: `${ui.escape(key)} (<strong>${ui.escape(
+                      value,
+                    )}</strong>)`,
+                  }),
+                );
+              })
+              .catch(ui.apiError);
           },
           'show-run': (request: SubmissionRequest) => {
             api.Run.details({ run_alias: request.guid })
@@ -224,6 +248,21 @@ OmegaUp.on('ready', async () => {
                 updateRunFallback({ run });
               })
               .catch(ui.ignoreError);
+          },
+          'apply-filter': ({
+            filter,
+            value,
+          }: {
+            filter: 'verdict' | 'language' | 'username' | 'status' | 'offset';
+            value: string;
+          }) => {
+            if (value != '') {
+              const newFilter: RunFilters = { [filter]: value };
+              runsStore.commit('applyFilter', newFilter);
+            } else {
+              runsStore.commit('removeFilter', filter);
+            }
+            refreshRuns();
           },
           disqualify: (run: types.Run) => {
             if (!window.confirm(T.runDisqualifyConfirm)) {
@@ -367,7 +406,27 @@ OmegaUp.on('ready', async () => {
     return isValidTab ? tab : defaultTab;
   }
 
+  function refreshRuns(): void {
+    api.Course.runs({
+      course_alias: payload.courseDetails.alias,
+      assignment_alias: payload.currentAssignment.alias,
+      problem_alias: runsStore.state.filters?.problem,
+      offset: runsStore.state.filters?.offset,
+      rowcount: runsStore.state.filters?.rowcount,
+      verdict: runsStore.state.filters?.verdict,
+      language: runsStore.state.filters?.language,
+      username: runsStore.state.filters?.username,
+      status: runsStore.state.filters?.status,
+    })
+      .then(time.remoteTimeAdapter)
+      .then((response) => {
+        onRefreshRuns({ runs: response.runs, totalRuns: response.totalRuns });
+      })
+      .catch(ui.apiError);
+  }
+
   if (payload.currentAssignment.runs) {
+    runsStore.commit('setTotalRuns', payload.currentAssignment.totalRuns);
     for (const run of payload.currentAssignment.runs) {
       trackRun({ run });
     }

--- a/frontend/www/js/omegaup/arena/global_runs.ts
+++ b/frontend/www/js/omegaup/arena/global_runs.ts
@@ -53,6 +53,7 @@ OmegaUp.on('ready', async () => {
           guid: this.guid,
           searchResultUsers: this.searchResultUsers,
           runDetailsData: this.runDetailsData,
+          totalRuns: runsStore.state.totalRuns,
         },
         on: {
           details: (request: SubmissionRequest) => {
@@ -144,7 +145,7 @@ OmegaUp.on('ready', async () => {
     })
       .then(time.remoteTimeAdapter)
       .then((response) => {
-        onRefreshRuns({ runs: response.runs });
+        onRefreshRuns({ runs: response.runs, totalRuns: response.totalRuns });
       })
       .catch(ui.apiError);
   }

--- a/frontend/www/js/omegaup/arena/submissions.ts
+++ b/frontend/www/js/omegaup/arena/submissions.ts
@@ -250,7 +250,14 @@ export function onSetNominationStatus({
   }
 }
 
-export function onRefreshRuns({ runs }: { runs: types.Run[] }): void {
+export function onRefreshRuns({
+  runs,
+  totalRuns,
+}: {
+  runs: types.Run[];
+  totalRuns: number;
+}): void {
+  runsStore.commit('setTotalRuns', totalRuns);
   runsStore.commit('clear');
   for (const run of runs) {
     trackRun({ run });

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -115,6 +115,7 @@
         v-if="contestAdmin"
         :contest-alias="contest.alias"
         :runs="allRuns"
+        :total-runs="totalRuns"
         :show-all-runs="true"
         :show-contest="false"
         :show-problem="true"
@@ -124,7 +125,6 @@
         :show-rejudge="true"
         :show-user="true"
         :problemset-problems="Object.values(problems)"
-        :global-runs="false"
         :is-contest-finished="isContestFinished"
         :search-result-users="searchResultUsers"
         @details="(run) => onRunAdminDetails(run.guid)"
@@ -249,6 +249,7 @@ export default class ArenaContest extends Vue {
   @Prop({ default: false }) showNewClarificationPopup!: boolean;
   @Prop({ default: PopupDisplayed.None }) popupDisplayed!: PopupDisplayed;
   @Prop() activeTab!: string;
+  @Prop() totalRuns!: number;
   @Prop({ default: null }) guid!: null | string;
   @Prop() miniRankingUsers!: omegaup.UserRank[];
   @Prop() ranking!: types.ScoreboardRankingEntry[];

--- a/frontend/www/js/omegaup/components/arena/Course.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Course.test.ts
@@ -17,6 +17,7 @@ describe('Course.vue', () => {
     start_time: new Date(),
     problems: [],
     runs: [],
+    totalRuns: 0,
   };
 
   const course: types.CourseDetails = {

--- a/frontend/www/js/omegaup/components/arena/Course.vue
+++ b/frontend/www/js/omegaup/components/arena/Course.vue
@@ -141,6 +141,7 @@
         :show-all-runs="true"
         :contest-alias="currentAssignment.alias"
         :runs="allRuns"
+        :total-runs="totalRuns"
         :show-problem="true"
         :show-details="true"
         :show-disqualify="true"
@@ -148,9 +149,14 @@
         :show-rejudge="true"
         :show-user="true"
         :problemset-problems="Object.values(problems)"
+        :search-result-users="searchResultUsers"
         @details="onRunAdminDetails"
         @rejudge="(run) => $emit('rejudge', run)"
         @disqualify="(run) => $emit('disqualify', run)"
+        @filter-changed="(request) => $emit('apply-filter', request)"
+        @update-search-result-users-contest="
+          (request) => $emit('update-search-result-users-assignment', request)
+        "
       >
         <template #title><div></div></template>
         <template #runs><div></div></template>
@@ -264,6 +270,8 @@ export default class ArenaCourse extends Vue {
   @Prop({ default: null }) nextSubmissionTimestamp!: Date | null;
   @Prop({ default: false })
   shouldShowFirstAssociatedIdentityRunWarning!: boolean;
+  @Prop() totalRuns!: number;
+  @Prop() searchResultUsers!: types.ListItem[];
 
   T = T;
   omegaup = omegaup;

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -26,10 +26,12 @@
               >
                 &lt;
               </button>
-              {{ filterOffset + 1 }}
+              {{ currentPage }}
               <button
                 data-button-page-next
-                :disabled="runs && runs.length < rowCount"
+                :disabled="
+                  totalRuns && Math.ceil(totalRuns / rowCount) == currentPage
+                "
                 @click="filterOffset++"
               >
                 &gt;
@@ -429,6 +431,7 @@ export default class Runs extends Vue {
   @Prop({ default: PopupDisplayed.None }) popupDisplayed!: PopupDisplayed;
   @Prop({ default: null }) guid!: null | string;
   @Prop({ default: false }) showAllRuns!: boolean;
+  @Prop() totalRuns!: number;
 
   PopupDisplayed = PopupDisplayed;
   T = T;
@@ -445,6 +448,10 @@ export default class Runs extends Vue {
   filters: { name: string; value: string }[] = [];
   currentRunDetailsData = this.runDetailsData;
   currentPopupDisplayed = this.popupDisplayed;
+
+  get currentPage(): number {
+    return this.filterOffset + 1;
+  }
 
   get filteredRuns(): types.Run[] {
     if (

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -241,6 +241,7 @@
           :show-disqualify="true"
           :problemset-problems="[]"
           :search-result-users="searchResultUsers"
+          :total-runs="totalRuns"
           @details="(request) => onRunDetails(request, 'runs')"
           @rejudge="(run) => $emit('rejudge', run)"
           @disqualify="(run) => $emit('disqualify', run)"
@@ -402,6 +403,7 @@ export default class ProblemDetails extends Vue {
   @Prop({ default: null }) contestAlias!: string | null;
   @Prop() searchResultUsers!: types.ListItem[];
   @Prop({ default: null }) languages!: null | string[];
+  @Prop() totalRuns!: number;
 
   @Ref('statement-markdown') readonly statementMarkdown!: omegaup_Markdown;
 

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -105,6 +105,7 @@ OmegaUp.on('ready', async () => {
           shouldShowTabs: true,
           searchResultUsers: this.searchResultUsers,
           problemAlias: payload.problem.alias,
+          totalRuns: runsStore.state.totalRuns,
         },
         on: {
           'show-run': (request: SubmissionRequest) => {
@@ -438,7 +439,7 @@ OmegaUp.on('ready', async () => {
       .then(time.remoteTimeAdapter)
       .then((response) => {
         if (!problemDetailsView.nominationStatus) return;
-        onRefreshRuns({ runs: response.runs });
+        onRefreshRuns({ runs: response.runs, totalRuns: response.totalRuns });
         setNominationStatus({
           runs: response.runs,
           nominationStatus: problemDetailsView.nominationStatus,
@@ -448,6 +449,7 @@ OmegaUp.on('ready', async () => {
   }
 
   if (runs) {
+    runsStore.commit('setTotalRuns', payload.totalRuns);
     for (const run of runs) {
       trackRun({ run });
     }


### PR DESCRIPTION
# Descripción

En el PR #6005 se arregló la funcionalidad de filtros en el tab de Envíos de un 
concurso. Había quedado pendiente aplicar los cambios para que también 
funcionaran correctamente esos filtros en la vista de cursos. 

En este PR se aplican dichos cambios.

![RunsFilters](https://user-images.githubusercontent.com/3230352/155251011-75b10ba2-007a-4b76-a786-069219e69ea9.gif)

Fixes: #6374 

# Comentarios

Este cambio depende del PR #6384, así que se puede revisar una vez que el
otro sea aprobado


# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
