### PR TITLE
Migrando a la nueva versión de typeahead el campo de problemas en AssignmentDetails

### DIFF
--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
@@ -170,6 +170,10 @@
             :tagged-problems="taggedProblems"
             :selected-assignment="assignment"
             :assignment-form-mode.sync="assignmentFormMode"
+            :search-result-problems="searchResultProblems"
+            @update-search-result-problems="
+              (query) => $emit('update-search-result-problems', query)
+            "
             @save-problem="
               (assignment, problem) => $emit('add-problem', assignment, problem)
             "
@@ -268,6 +272,7 @@ export default class CourseAssignmentDetails extends Vue {
   @Prop({ default: true }) shouldAddProblems!: boolean;
   @Prop({ default: false }) unlimitedDurationCourse!: boolean;
   @Prop({ default: '' }) invalidParameterName!: string;
+  @Prop() searchResultProblems!: types.ListItem[];
 
   T = T;
   AssignmentFormMode = omegaup.AssignmentFormMode;

--- a/frontend/www/js/omegaup/components/course/Edit.vue
+++ b/frontend/www/js/omegaup/components/course/Edit.vue
@@ -131,6 +131,10 @@
           :tagged-problems="data.taggedProblems"
           :invalid-parameter-name="invalidParameterName"
           :assignment-form-mode.sync="assignmentFormMode"
+          :search-result-problems="searchResultProblems"
+          @update-search-result-problems="
+            (query) => $emit('update-search-result-problems', query)
+          "
           @add-problem="
             (assignment, problem) => $emit('add-problem', assignment, problem)
           "
@@ -351,6 +355,7 @@ export default class CourseEdit extends Vue {
   @Prop() invalidParameterName!: string;
   @Prop() initialTab!: string;
   @Prop() searchResultUsers!: types.ListItem[];
+  @Prop() searchResultProblems!: types.ListItem[];
 
   T = T;
   showTab = this.initialTab;

--- a/frontend/www/js/omegaup/course/edit.ts
+++ b/frontend/www/js/omegaup/course/edit.ts
@@ -32,6 +32,7 @@ OmegaUp.on('ready', () => {
       invalidParameterName: '',
       token: '',
       searchResultUsers: [] as types.ListItem[],
+      searchResultProblems: [] as types.ListItem[],
     }),
     methods: {
       refreshCourseAdminDetails: (): void => {
@@ -103,8 +104,30 @@ OmegaUp.on('ready', () => {
           invalidParameterName: this.invalidParameterName,
           token: this.token,
           searchResultUsers: this.searchResultUsers,
+          searchResultProblems: this.searchResultProblems,
         },
         on: {
+          'update-search-result-problems': (query: string) => {
+            api.Problem.list({
+              query,
+            })
+              .then((data) => {
+                // Problems previously added into the assignment should not be
+                // shown in the dropdown
+                const addedProblems = new Set(
+                  component.assignmentProblems.map((problem) => problem.alias),
+                );
+                this.searchResultProblems = data.results
+                  .filter((problem) => !addedProblems.has(problem.alias))
+                  .map((problem) => ({
+                    key: problem.alias,
+                    value: `${ui.escape(problem.title)} (<strong>${ui.escape(
+                      problem.alias,
+                    )}</strong>)`,
+                  }));
+              })
+              .catch(ui.apiError);
+          },
           'submit-edit-course': (source: course_Form) => {
             new Promise<number | null>((accept) => {
               if (source.school_id !== undefined) {


### PR DESCRIPTION
# Descripción

Se migra el campo de agregar problemas a una tarea al nuevo componente de
typeahead que estamos utilizando

# Comentarios

Poco a poco habrá que ir dejando de usar el componente de Autocomplete 
para sustituirlo por este que se está usando acá.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
