### PR TITLE
Feat course cards

### DIFF
--- a/frontend/www/js/omegaup/components/course/CardPublic.vue
+++ b/frontend/www/js/omegaup/components/course/CardPublic.vue
@@ -8,7 +8,12 @@
             class="card-body d-flex flex-column h-100 justify-content-between"
           >
             <div>
-              <h5 class="card-title mb-0">{{ course.name }}</h5>
+              <h5 class="card-title mb-0">
+                <a v-if="loggedIn" :href="`/course/${course.alias}/`">{{
+                  course.name
+                }}</a>
+                <template v-else>{{ course.name }}</template>
+              </h5>
               <p class="card-text">
                 <small>{{ course.school_name }}</small>
               </p>


### PR DESCRIPTION
Se cambio el archivo `/omegaup/frontend/www/js/omegaup/components/course/CardPublic.vue` en la sección del titulo para hacerlo clickeable

![image](https://user-images.githubusercontent.com/78834191/155636383-1ba7a2c7-083c-472e-844b-2bcbce7c6955.png)


Fixes: #6111 

