### PR TITLE
Permitiendo usar los nuevos lenguajes en el grader efímero

### DIFF
--- a/frontend/www/grader/ephemeral/index.html
+++ b/frontend/www/grader/ephemeral/index.html
@@ -32,14 +32,19 @@
 					<span class="fa fa-file-archive-o" title="Download" aria-hidden="true" id="download-label"></span>
 				</a>
 				<select class="form-control form-control-sm mr-sm-2" data-language-select id="language">
-					<option value="cpp17-gcc">C++17 (g++ 10.3)</option>
+					<option value="cpp20-gcc">C++20 (g++ 10.3)</option>
 					<option value="cs">C# (10, dotnet 6.0)</option>
+					<option value="go">Go (1.18.beta2)</option>
+					<option value="hs">Haskell (ghc 8.8)</option>
 					<option value="java">Java (openjdk 16.0)</option>
+					<option value="js">JavaScript (Node.js 16)</option>
+					<option value="kt">Kotlin (1.6.10)</option>
+					<option value="lua">Lua (5.3)</option>
 					<option value="py3">Python (3.9)</option>
 					<option value="rb">Ruby (2.7)</option>
-					<option value="lua">Lua (5.3)</option>
+					<option value="rs">Rust (1.56.1)</option>
 				</select>
-        <button class="btn btn-sm btn-secondary mr-2 my-sm-0 ephemeral-button" data-run-button>
+				<button class="btn btn-sm btn-secondary mr-2 my-sm-0 ephemeral-button" data-run-button>
 					<span>Run</span>
 					<img src="http://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
 				</button>


### PR DESCRIPTION
Este cambio hace que se puedan usar Kotlin, Go, Rust y JavaScript en el
grader efímero. También Haskell aunque no es nuevo, pero se nos fue
prenderlo.