### PR TITLE
Script que envia mensajes al cliente de coder del mes.

### DIFF
--- a/stuff/pipelines/producer_coder_of_month.py
+++ b/stuff/pipelines/producer_coder_of_month.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+
+'''Send message to coder_month_client'''
+
+
+import argparse
+import logging
+import os
+import sys
+import json
+from rabbitmq_database import get_coder_of_the_month
+from rabbitmq_producer import RabbitmqProducer
+import mysql.connector
+import mysql.connector.cursor
+import pika
+import rabbitmq_connection
+
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "."))
+import lib.db   # pylint: disable=wrong-import-position
+import lib.logs  # pylint: disable=wrong-import-position
+
+
+def send_message_client(
+        cur: mysql.connector.cursor.MySQLCursorDict,
+        channel:
+        pika.adapters.blocking_connection.BlockingChannel
+) -> None:
+    '''Function to send message to client'''
+    coder_month_producer = RabbitmqProducer('coder_month',
+                                            'certificates',
+                                            'CoderOfTheMonthQueue',
+                                            channel)
+    data_all = get_coder_of_the_month(cur, 'all')
+    message_all = json.dumps(data_all)
+    data_female = get_coder_of_the_month(cur, 'female')
+    message_female = json.dumps(data_female)
+    coder_month_producer.send_message(message_all)
+    coder_month_producer.send_message(message_female)
+
+
+def main() -> None:
+    '''Main entrypoint.'''
+    parser = argparse.ArgumentParser(description=__doc__)
+    lib.db.configure_parser(parser)
+    lib.logs.configure_parser(parser)
+
+    rabbitmq_connection.configure_parser(parser)
+
+    args = parser.parse_args()
+    lib.logs.init(parser.prog, args)
+    logging.info('Started')
+    dbconn = lib.db.connect(args)
+    try:
+        with dbconn.cursor(buffered=True, dictionary=True) as cur, \
+            rabbitmq_connection.connect(username='omegaup',
+                                        password='omegaup',
+                                        host='rabbitmq') as channel:
+            send_message_client(cur, channel)
+    finally:
+        dbconn.conn.close()
+        logging.info('Done')
+
+
+if __name__ == '__main__':
+    main()

--- a/stuff/pipelines/rabbitmq_database.py
+++ b/stuff/pipelines/rabbitmq_database.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+'''Mysql consults to generate messages'''
+
+import datetime
+from typing import Any, Dict
+import mysql.connector
+import mysql.connector.cursor
+
+
+def get_coder_of_the_month(cur: mysql.connector.cursor.MySQLCursorDict,
+                           category: str) -> Dict[str, Any]:
+    '''Get coder of the month'''
+    today = datetime.date.today()
+    first_day_of_current_month = today.replace(day=1)
+    if first_day_of_current_month.month == 12:
+        first_day_of_next_month = datetime.date(
+            first_day_of_current_month.year + 1,
+            1,
+            1)
+    else:
+        first_day_of_next_month = datetime.date(
+            first_day_of_current_month.year,
+            first_day_of_current_month.month + 1,
+            1)
+    cur.execute(
+        '''
+                SELECT
+                    user_id, time, category
+                FROM
+                    Coder_Of_The_Month
+                WHERE
+                    `time` = %s AND
+                    `selected_by` IS NOT NULL AND
+                    `category` = %s;
+        ''', (first_day_of_next_month, category))
+    for row in cur:
+        data = {"user_id": row['user_id'],
+                "time": row['time'],
+                "category": row['category']}
+    return data

--- a/stuff/pipelines/test_producer_coder_of_month.py
+++ b/stuff/pipelines/test_producer_coder_of_month.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+
+'''test verification_code module.'''
+
+import os
+import argparse
+import logging
+import sys
+import json
+import pytest
+import rabbitmq_connection
+from pytest_mock import MockerFixture
+from producer_coder_of_month import send_message_client
+import rabbitmq_client
+import pika
+
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), '.'))
+import lib.db   # pylint: disable=wrong-import-position
+import lib.logs  # pylint: disable=wrong-import-position
+MESSAGE = {}
+
+
+def callback(channel: pika.adapters.blocking_connection.BlockingChannel,
+             method: pika.spec.Basic.Deliver,
+             properties: pika.spec.BasicProperties,
+             # pylint: disable=unused-argument,
+             body: bytes) -> None:
+    '''Callback function to test'''
+    global MESSAGE
+    MESSAGE = json.loads(body.decode())
+    channel.close()
+
+
+# mypy has conflict with pytest decorations
+@pytest.mark.parametrize(
+    'params, expected',
+    [
+        ({'user_id': 1, 'time': '2022-01-26',
+          'category': 'all'},
+         {'user_id': 1, 'time': '2022-01-26',
+          'category': 'all'}),
+        ({'user_id': 1, 'time': '2022-01-26',
+          'category': 'female'},
+         {'user_id': 1, 'time': '2022-01-26',
+          'category': 'female'}),
+    ],
+)  # type: ignore
+def test_coder_of_the_month_queue(mocker: MockerFixture,
+                                  params, expected) -> None:
+    '''Test the message send to the coder of the month queue'''
+    mocker.patch('producer_coder_of_month.get_coder_of_the_month',
+                 return_value=params)
+    parser = argparse.ArgumentParser(description=__doc__)
+    lib.db.configure_parser(parser)
+    lib.logs.configure_parser(parser)
+    rabbitmq_connection.configure_parser(parser)
+    args = parser.parse_args()
+    lib.logs.init(parser.prog, args)
+    logging.info('Started')
+    dbconn = lib.db.connect(args)
+    try:
+        with dbconn.cursor(buffered=True, dictionary=True) as cur, \
+            rabbitmq_connection.connect(username='omegaup',
+                                        password='omegaup',
+                                        host='rabbitmq') as channel:
+            send_message_client(cur, channel)
+            rabbitmq_client.receive_messages('coder_month',
+                                             'certificates',
+                                             'CoderOfTheMonthQueue',
+                                             channel,
+                                             callback)
+            assert expected == MESSAGE
+    finally:
+        dbconn.conn.close()
+        logging.info('Done')


### PR DESCRIPTION
# Descripción

Scrip que envia mensajes al cliente de coder del mes.

Si tu cambio toca la interfaz, hay que incluir una captura de pantalla.

Fixes: #5263

# Comentarios

Se incluye test.
En rabbimq_database se propone incluir las consultas realizadas a las tablas para generar los mensajes.

Marca el siguiente error el lint:

Cannot find implementation or library stub for module named 'pytest_mock

Habiamos detectado que el error se debía al error de mypy.

Al usar python3 -m mypy, dentro del contenedor logra detectar los tipos de pytest_mock.

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
