### PR TITLE
fixed scroll table

### DIFF
--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -316,7 +316,6 @@ export default class Markdown extends Vue {
       border: 0;
       padding: 0;
       margin: inherit;
-      
 
       & > button {
         margin-left: 2em;

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -273,6 +273,8 @@ export default class Markdown extends Vue {
   table td {
     border: 1px solid var(--markdown-td-border-color);
     padding: 10px;
+    overflow-x: scroll;
+    max-width: 50%;
   }
 
   table th {

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -243,14 +243,11 @@ export default class Markdown extends Vue {
   }
 
   td > button.clipboard {
-    position: relative;
-    top: 0;
-    left: 0;
+    float: right;
     border-color: var(--markdown-button-clipboard-border-color);
-    margin-left: -0.1rem;
+    margin-left: 0.5em;
     margin-right: -6px;
     margin-top: -6px;
-    margin-bottom: 0.5rem;
     padding: 3px;
     font-size: 90%;
   }
@@ -276,8 +273,6 @@ export default class Markdown extends Vue {
   table td {
     border: 1px solid var(--markdown-td-border-color);
     padding: 10px;
-    max-width: 800px;
-    overflow-x: auto;
   }
 
   table th {
@@ -316,6 +311,8 @@ export default class Markdown extends Vue {
       border: 0;
       padding: 0;
       margin: inherit;
+      max-width: 800px;
+      overflow-x: auto;
 
       & > button {
         margin-left: 2em;

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -322,7 +322,6 @@ export default class Markdown extends Vue {
     }
 
     tr td:first-child pre {
-      overflow: visible;
       margin-right: 20px;
     }
   }

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -243,11 +243,14 @@ export default class Markdown extends Vue {
   }
 
   td > button.clipboard {
-    float: right;
+    position: relative;
+    top: 0;
+    left: 0;
     border-color: var(--markdown-button-clipboard-border-color);
-    margin-left: 0.5em;
+    margin-left: -0.1rem;
     margin-right: -6px;
     margin-top: -6px;
+    margin-bottom: 0.5rem;
     padding: 3px;
     font-size: 90%;
   }
@@ -273,8 +276,8 @@ export default class Markdown extends Vue {
   table td {
     border: 1px solid var(--markdown-td-border-color);
     padding: 10px;
-    overflow-x: scroll;
-    max-width: 50%;
+    max-width: 800px;
+    overflow-x: auto;
   }
 
   table th {
@@ -313,6 +316,7 @@ export default class Markdown extends Vue {
       border: 0;
       padding: 0;
       margin: inherit;
+      
 
       & > button {
         margin-left: 2em;


### PR DESCRIPTION
# Descripción

Se agregó un scroll a la tabla de casos de ejemplo para mejorar la visibilidad
![image](https://user-images.githubusercontent.com/78834191/158300868-5addf5f3-2219-4598-876e-d734094089ac.png)


Fixes: #5373 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
