### PR TITLE
Primer paso para solo cargar algunas listas de concursos

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -102,8 +102,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         /** @var list<ContestListItem> */
         $contests = [];
-        $r->ensureOptionalInt('page');
-        $r->ensureOptionalInt('page_size');
         \OmegaUp\Validators::validateOptionalNumber($r['active'], 'active');
         \OmegaUp\Validators::validateOptionalNumber(
             $r['recommended'],
@@ -121,8 +119,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'past',
             ]
         );
-        $page = intval($r['page'] ?? 1);
-        $pageSize = intval($r['page_size'] ?? 20);
+        $page = $r->ensureOptionalInt('page') ?? 1;
+        $pageSize = $r->ensureOptionalInt('page_size') ?? 20;
         $activeContests = \OmegaUp\DAO\Enum\ActiveStatus::getIntValue(
             intval($r['active'] ?? \OmegaUp\DAO\Enum\ActiveStatus::ALL)
         );
@@ -1028,11 +1026,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
             // Do nothing.
             $r->identity = null;
         }
-        $r->ensureOptionalInt('page');
-        $r->ensureOptionalInt('page_size');
 
-        $page = intval($r['page'] ?? 1);
-        $pageSize = intval($r['page_size'] ?? 1000);
+        $page = $r->ensureOptionalInt('page') ?? 1;
+        $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
         \OmegaUp\Validators::validateStringOfLengthInRange(
             $r['query'],
             'query',
@@ -1141,11 +1137,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $r->identity = null;
         }
 
-        $r->ensureOptionalInt('page');
-        $r->ensureOptionalInt('page_size');
-
-        $page = intval($r['page'] ?? 1);
-        $pageSize = intval($r['page_size'] ?? 100);
+        $page = $r->ensureOptionalInt('page') ?? 1;
+        $pageSize = $r->ensureOptionalInt('page_size') ?? 100;
 
         \OmegaUp\Validators::validateStringOfLengthInRange(
             $r['query'],


### PR DESCRIPTION
# Descripción

Parte de #6357 

Con este cambio la lista de listas de concursos se convierte en una lista de configuraciones de llamadas a la api de lista de concursos. Esta lista de configuraciones después se puede replicar en el frontend para usar esas configuraciones para cargar las listas de forma asíncrona.

Eso último sigue en la 2da parte.
 
# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en varios pull requests. De preferencia uno para los controladores + phpunit y luego otro para la interfaz.