### PR TITLE
fix broken link to pdf

### DIFF
--- a/frontend/www/js/omegaup/components/common/NavbarItems.vue
+++ b/frontend/www/js/omegaup/components/common/NavbarItems.vue
@@ -176,7 +176,7 @@
           }}</a>
           <a
             class="dropdown-item text-wrap"
-            href="https://omegaup.com/img/libropre3.pdf"
+            href="https://omegaup.com/docs/assets/libroluisvargas.pdf"
             >{{ T.navAlgorithmsBook }}</a
           >
         </div>


### PR DESCRIPTION
# Descripción

Se cambio el link del libro de luis vargas que antes estaba en /img a docs/assets para que use el pdf que se sirve desde el container de prod

[Issue mencionado](https://github.com/omegaup/prod/pull/6)

Part of: #6282 

# Comentarios

Tengo duda de si tengo que modificar el `nginx.rewrites` ya que no hay ninguna referencia del pdf ahi, la unica que encontre fue el boton este en` NavBarItems.vue` pero igual quedo al pendiente

