### PR TITLE
Arreglando la generación de la documentación de libomegaup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-progress
 
+      - name: Install Python dependencies
+        run: python3 -m pip install --user yapf==0.30.0
+
       - name: Get docker container
         run: ./stuff/lint.sh ensure-container
 
@@ -213,6 +216,9 @@ jobs:
 
       - name: Find unused translation strings
         run: ./stuff/unused_translation_strings.py
+
+      - name: Validate generated Python API syntax
+        run: php frontend/server/cmd/APITool.php --file api.py | yapf > /dev/null
 
   cypress:
     runs-on: ubuntu-20.04

--- a/frontend/server/cmd/APITool.php
+++ b/frontend/server/cmd/APITool.php
@@ -162,7 +162,7 @@ class RequestParam {
                 $splitTypes[] = 'str';
                 continue;
             }
-            if ($splitType == 'OmegaUp\\Timestamp') {
+            if ($splitType == '\\OmegaUp\\Timestamp') {
                 $splitTypes[] = 'datetime.datetime';
                 continue;
             }

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -4569,7 +4569,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param 'no'|'optional'|'required'|null $requests_user_information
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
-     * @omegaup-request-param OmegaUp\Timestamp|null $start_time
+     * @omegaup-request-param \OmegaUp\Timestamp|null $start_time
      * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title
@@ -4841,7 +4841,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      *
      * @omegaup-request-param string $contest_alias
-     * @omegaup-request-param OmegaUp\Timestamp $end_time
+     * @omegaup-request-param \OmegaUp\Timestamp $end_time
      * @omegaup-request-param string $username
      */
     public static function apiUpdateEndTimeForIdentity(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1311,7 +1311,7 @@ Update a Contest
 | `requests_user_information`                  | `'no'\|'optional'\|'required'\|null` |             |
 | `scoreboard`                                 | `float\|null`                        |             |
 | `show_scoreboard_after`                      | `bool\|null`                         |             |
-| `start_time`                                 | `OmegaUp\Timestamp\|null`            |             |
+| `start_time`                                 | `\OmegaUp\Timestamp\|null`           |             |
 | `teams_group_alias`                          | `null\|string`                       |             |
 | `title`                                      | `null\|string`                       |             |
 
@@ -1331,11 +1331,11 @@ option is turned on
 
 ### Parameters
 
-| Name            | Type                | Description |
-| --------------- | ------------------- | ----------- |
-| `contest_alias` | `string`            |             |
-| `end_time`      | `OmegaUp\Timestamp` |             |
-| `username`      | `string`            |             |
+| Name            | Type                 | Description |
+| --------------- | -------------------- | ----------- |
+| `contest_alias` | `string`             |             |
+| `end_time`      | `\OmegaUp\Timestamp` |             |
+| `username`      | `string`             |             |
 
 ### Returns
 


### PR DESCRIPTION
Un cambio reciente rompió la generación de la documentación de
libomegaup y no nos dimos cuenta.

Este cambio hace que se valide la sintaxis del código generado en CI y
además arregla la generación de la documentación.