### PR TITLE
Preparando los cambios para poder utilizar mysql en las pruebas de python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,10 +504,11 @@ jobs:
 
            # Add the container names as aliases to localhost
            cat << EOF | sudo tee --append /etc/hosts
-           127.0.0.1 rabbitmq
+           127.0.0.1 rabbitmq mysql
            EOF
 
            # Wait for some of the containers
+           wait-for-it -t 30 mysql:13306
            wait-for-it -t 30 rabbitmq:5672
            docker-compose exec -T rabbitmq rabbitmqctl await_startup
 

--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -576,7 +576,7 @@ def main() -> None:
     lib.logs.init(parser.prog, args)
 
     logging.info('Started')
-    dbconn = lib.db.connect(args)
+    dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
     try:
         try:
             aggregate_reviewers_feedback(dbconn)

--- a/stuff/cron/assign_badges.py
+++ b/stuff/cron/assign_badges.py
@@ -110,7 +110,7 @@ def main() -> None:
     lib.logs.init(parser.prog, args)
 
     logging.info('Started')
-    dbconn = lib.db.connect(args)
+    dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
     try:
         with dbconn.cursor(dictionary=True) as cur:
             process_badges(args.current_timestamp, cur)

--- a/stuff/cron/build_problem_rec_model.py
+++ b/stuff/cron/build_problem_rec_model.py
@@ -76,7 +76,7 @@ def load_mysql(args: argparse.Namespace) -> pd.DataFrame:
     Ignoring problem sets helps remove bias in recommendations
     introduced by problem ordering in contests and tests.
     '''
-    dbconn = lib.db.connect(args)
+    dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
     try:
         logging.info('Reading runs from MySQL')
         runs: pd.DataFrame = pd.read_sql_query(

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -802,7 +802,7 @@ def main() -> None:
     lib.logs.init(parser.prog, args)
 
     logging.info('Started')
-    dbconn = lib.db.connect(args)
+    dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
     try:
         with dbconn.cursor(buffered=True, dictionary=True) as cur:
             update_problem_accepted_stats(cur)

--- a/stuff/lib/db.py
+++ b/stuff/lib/db.py
@@ -11,10 +11,32 @@ import configparser
 import contextlib
 import getpass
 import os
-from typing import (overload, ContextManager, Generator, Literal, Optional,
-                    Union)
+from typing import (overload, ContextManager, Generator, Literal, NamedTuple,
+                    Optional, Union)
 
 import mysql.connector
+
+
+class DatabaseConnectionArguments(NamedTuple):
+    '''Arguments for database connection.'''
+    host: str
+    user: str
+    password: str
+    mysql_config_file: str
+    database: str
+    port: int
+
+    @staticmethod
+    def from_args(args: argparse.Namespace) -> 'DatabaseConnectionArguments':
+        '''Converts arguments to a named tuple for the database connection'''
+        return DatabaseConnectionArguments(
+            host=args.host,
+            user=args.user,
+            password=args.password,
+            mysql_config_file=args.mysql_config_file,
+            database=args.database,
+            port=args.port
+        )
 
 
 class Connection:
@@ -113,9 +135,10 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
                          type=str,
                          help='MySQL database',
                          default='omegaup')
+    db_args.add_argument('--port', type=int, help='MySQL port', default=3306)
 
 
-def connect(args: argparse.Namespace) -> Connection:
+def connect(args: DatabaseConnectionArguments) -> Connection:
     '''Connects to MySQL with the arguments provided.
 
     Returns a MySQL connection.
@@ -143,6 +166,7 @@ def connect(args: argparse.Namespace) -> Connection:
             user=user,
             password=password,
             database=args.database,
+            port=args.port,
         ))
 
 

--- a/stuff/mysql/connector/cursor.pyi
+++ b/stuff/mysql/connector/cursor.pyi
@@ -1,3 +1,4 @@
+import types
 from typing import Any, Iterator, Iterable, Mapping, Optional, Sequence, Text, Tuple
 
 
@@ -41,4 +42,8 @@ class MySQLCursorDict(BaseCursor):
 
 
 class MySQLCursorBufferedDict(MySQLCursorDict):
-    ...
+    def __enter__(self):
+        ...
+
+    def __exit__(self, exc_type: Optional[types[BaseException]], exc: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        ...

--- a/stuff/mysql/connector/errors.pyi
+++ b/stuff/mysql/connector/errors.pyi
@@ -1,0 +1,3 @@
+from mysql.connector import errors
+
+IntegrityError: errors.DatabaseError

--- a/stuff/pipelines/credentials.py
+++ b/stuff/pipelines/credentials.py
@@ -6,5 +6,12 @@
 OMEGAUP_USERNAME = 'omegaup'
 OMEGAUP_PASSWORD = 'omegaup'
 
+# MySQL
+MYSQL_USER = 'root'
+MYSQL_PASSWORD = 'omegaup'
+MYSQL_HOST = 'mysql'
+MYSQL_DATABASE = 'omegaup'
+MYSQL_PORT = 13306
+
 # RabbitMQ
 RABBITMQ_HOST = 'rabbitmq'

--- a/stuff/pipelines/rabbitmq_client.py
+++ b/stuff/pipelines/rabbitmq_client.py
@@ -16,7 +16,7 @@ ClientCallback = Callable[
 
 
 def receive_messages(
-        queue: str, exchange: str, routing_key: str,
+        *, queue: str, exchange: str, routing_key: str,
         channel: pika.adapters.blocking_connection.BlockingChannel,
         callback: ClientCallback) -> None:
     '''Receive messages from a queue'''
@@ -24,6 +24,9 @@ def receive_messages(
     channel.exchange_declare(exchange=exchange,
                              durable=True,
                              exchange_type='direct')
+    channel.queue_declare(queue=queue,
+                          durable=True,
+                          exclusive=False)
     channel.queue_bind(exchange=exchange,
                        queue=queue,
                        routing_key=routing_key)
@@ -31,4 +34,7 @@ def receive_messages(
     channel.basic_consume(queue=queue,
                           on_message_callback=callback,
                           auto_ack=True)
-    channel.start_consuming()
+    try:
+        channel.start_consuming()
+    except KeyboardInterrupt:
+        channel.stop_consuming()

--- a/stuff/pipelines/test_constants.py
+++ b/stuff/pipelines/test_constants.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+
+'''Global constants for testing.'''
+
+import datetime
+
+# Credentials
+API_TOKEN = '92d8c5a0eceef3c05f4149fc04b62bb2cd50d9c6'
+OMEGAUP_API_ENDPOINT = 'http://localhost:8001'
+
+# Date limits
+DATE_LOWER_LIMIT = datetime.date(2005, 1, 1)
+DATE_UPPER_LIMIT = datetime.date.today()

--- a/stuff/standardize_tags.py
+++ b/stuff/standardize_tags.py
@@ -79,7 +79,7 @@ def main() -> None:
     logs.init(parser.prog, args)
 
     logging.info('Started')
-    dbconn = db.connect(args)
+    dbconn = db.connect(db.DatabaseConnectionArguments.from_args(args))
     try:
         standardize_tags(dbconn)
         dbconn.conn.commit()


### PR DESCRIPTION
# Descripción

Se realizan los cambios necesarios para que se pueda utilizar mysql desde las
pruebas de python. El cambio principal es dejar de recibir `argparse.Namespace`
en la función de `connect` y en lugar de eso recibir una `NamedTuple`.

Part of: #6012

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
