### PR TITLE
Permitiendo correr todos los comandos adentro del contenedor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,14 @@ jobs:
       mysql:
         image: mysql:8.0.23
         ports:
-          - 3306:3306
+          - 13306:13306
         env:
           MYSQL_ROOT_PASSWORD:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_USER: omegaup
           MYSQL_PASSWORD: omegaup
           MYSQL_DATABASE: omegaup-test
+          MYSQL_TCP_PORT: 13306
 
       redis:
         image: redis
@@ -49,6 +50,7 @@ jobs:
         run: |
           cat > frontend/tests/test_config.php <<EOF
           <?php
+          define('OMEGAUP_DB_HOST', 'localhost:13306');
           define('REDIS_HOST', 'localhost');
           define('REDIS_PASS', '');
           EOF
@@ -80,25 +82,31 @@ jobs:
       - name: Create database users
         run: |
           mysql \
-            -uroot --skip-password --protocol=TCP \
+            -uroot --skip-password --port=13306 --protocol=TCP \
             -e 'CREATE USER "omegaup"@"localhost" IDENTIFIED BY "omegaup";'
 
       - name: Validate database migration scripts
-        run: python3 stuff/db-migrate.py validate
+        run: |
+          python3 stuff/db-migrate.py --skip-container-check validate
 
       - name: Create test database
         run: |
           python3 stuff/db-migrate.py \
-            --username=root --password= --hostname=localhost \
+            --skip-container-check \
+            --username=root --password= --hostname=localhost --port=13306 \
             migrate --databases=omegaup-test
 
       - name: Validate database schema
         run: |
           python3 stuff/policy-tool.py \
-            --username=root --password= --hostname=localhost --database=omegaup-test \
+            --skip-container-check \
+            --username=root --password= --hostname=localhost --port=13306 \
+            --database=omegaup-test \
             validate
           python3 stuff/database_schema.py \
-            --username=root --password= --hostname=localhost --database=omegaup-test \
+            --skip-container-check \
+            --username=root --password= --hostname=localhost --port=13306 \
+            --database=omegaup-test \
             validate --all < /dev/null
 
       - name: Run tests
@@ -252,7 +260,7 @@ jobs:
 
           for i in $(seq 10); do
             if [[ "$(mysql \
-                     -uomegaup -pomegaup --host=mysql --port= 13306 --skip-column-names --batch \
+                     -uomegaup -pomegaup --host=mysql --port=13306 --skip-column-names --batch \
                      -e 'SELECT 1;' || echo 0)" == "1" ]]; then
               break
             fi
@@ -265,7 +273,7 @@ jobs:
           <?php
           define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', true);
           define('OMEGAUP_CSP_LOG_FILE', '/tmp/csp.log');
-          define('OMEGAUP_DB_HOST', 'mysql');
+          define('OMEGAUP_DB_HOST', 'mysql:13306');
           define('OMEGAUP_DB_NAME', 'omegaup');
           define('OMEGAUP_DB_PASS', 'omegaup');
           define('OMEGAUP_DB_USER', 'omegaup');
@@ -308,7 +316,7 @@ jobs:
           # Create directory to prevent --purge from failing.
           sudo mkdir -p /var/lib/omegaup
           sudo chown "$(id -u)":"$(id -g)" /var/lib/omegaup
-          python3 stuff/bootstrap-environment.py --purge --verbose
+          docker-compose exec -T frontend python3 stuff/bootstrap-environment.py --purge --verbose
 
       - name: Install yarn dependencies
         run: yarn install
@@ -376,6 +384,7 @@ jobs:
           wait-for-it -t 30 mysql:13306
           wait-for-it -t 30 gitserver:33861
           wait-for-it -t 30 redis:6379
+          wait-for-it -t 30 grader:21680
 
       - name: Create default configuration files
         run: |
@@ -383,7 +392,7 @@ jobs:
           <?php
           define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', true);
           define('OMEGAUP_CSP_LOG_FILE', '/tmp/csp.log');
-          define('OMEGAUP_DB_HOST', 'mysql');
+          define('OMEGAUP_DB_HOST', 'mysql:13306');
           define('OMEGAUP_DB_NAME', 'omegaup');
           define('OMEGAUP_DB_PASS', 'omegaup');
           define('OMEGAUP_DB_USER', 'omegaup');
@@ -430,17 +439,13 @@ jobs:
           # Create directory to prevent --purge from failing.
           sudo mkdir -p /var/lib/omegaup
           sudo chown "$(id -u)":"$(id -g)" /var/lib/omegaup
-          python3 stuff/bootstrap-environment.py --purge --verbose
+          docker-compose exec -T frontend python3 stuff/bootstrap-environment.py --purge --verbose
 
       - name: Install yarn dependencies
         run: yarn install
 
       - name: Build webpack resources
         run: yarn build
-
-      - name: Wait for dependencies
-        run: |
-          wait-for-it -t 30 grader:21680
 
       - name: Run Selenium tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,6 @@ frontend/www/docs/java
 
 # Ignore omegaup.db
 omegaup.db
-.my.cnf
 
 # Ignore backend stuff
 stuff/docker/go/*/

--- a/docker-compose.local-backend.yml
+++ b/docker-compose.local-backend.yml
@@ -10,7 +10,7 @@ services:
     user: "${UID_GID}"
     entrypoint: [
       "wait-for-it",
-      "mysql:3306",
+      "mysql:13306",
       "--",
       "/bin/bash",
       "-c",
@@ -23,7 +23,7 @@ services:
       context: ./stuff/docker/
     image: omegaup/local-backend
     user: "${UID_GID}"
-    entrypoint: ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-grader"]
+    entrypoint: ["wait-for-it", "mysql:13306", "--", "/usr/bin/omegaup-grader"]
 
   broadcaster:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       dockerfile: ./Dockerfile.dev-php
       context: ./stuff/docker/
-    image: omegaup/dev-php:20220115
+    image: omegaup/dev-php:20220320
     user: "${UID_GID}"
     restart: always
     volumes:
@@ -28,7 +28,7 @@ services:
 
   gitserver:
     image: omegaup/gitserver:v1.8.11
-    entrypoint: ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-gitserver"]
+    entrypoint: ["wait-for-it", "mysql:13306", "--", "/usr/bin/omegaup-gitserver"]
     user: "${UID_GID}"
     restart: always
     depends_on:
@@ -68,7 +68,7 @@ services:
 
   grader:
     image: omegaup/backend:v1.6.3
-    entrypoint: ["wait-for-it", "mysql:3306", "--", "/usr/bin/omegaup-grader"]
+    entrypoint: ["wait-for-it", "mysql:13306", "--", "/usr/bin/omegaup-grader"]
     user: "${UID_GID}"
     restart: always
     depends_on:
@@ -111,12 +111,13 @@ services:
       MYSQL_USER: 'omegaup'
       MYSQL_PASSWORD: 'omegaup'
       MYSQL_ROOT_PASSWORD: 'omegaup'
+      MYSQL_TCP_PORT: 13306
     expose:
-      - '3306'
+      - '13306'
     volumes:
       - 'dbdata:/var/lib/mysql'
     ports:
-      - target: 3306
+      - target: 13306
         published: 13306
         protocol: tcp
         mode: host

--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -34,7 +34,7 @@ try_define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', false);
 # ####################################
 try_define('OMEGAUP_DB_USER', 'omegaup');
 try_define('OMEGAUP_DB_PASS', '');
-try_define('OMEGAUP_DB_HOST', 'localhost');
+try_define('OMEGAUP_DB_HOST', 'mysql:13306');
 try_define('OMEGAUP_DB_NAME', 'omegaup');
 
 # ####################################

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -365,12 +365,22 @@ class Utils {
                 $runDate
             )
         ));
+        $host_arg = '';
+        $host_chunks = explode(':', OMEGAUP_DB_HOST, 2);
+        if (count($host_chunks) == 2) {
+            [$hostname, $port] = $host_chunks;
+            $host_arg .= ' --host ' . escapeshellarg($hostname);
+            $host_arg .= ' --port ' . escapeshellarg($port);
+        } else {
+            [$hostname] = $host_chunks;
+            $host_arg .= ' --host ' . escapeshellarg($hostname);
+        }
         self::shellExec(
             ('python3 ' .
              dirname(__DIR__, 2) . '/stuff/cron/update_ranks.py' .
              ' --verbose ' .
              ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
-             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             $host_arg .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
             ' --password ' . escapeshellarg(OMEGAUP_DB_PASS) .
@@ -382,12 +392,22 @@ class Utils {
         // Ensure all suggestions are written to the database before invoking
         // the external script.
         self::commit();
+        $host_arg = '';
+        $host_chunks = explode(':', OMEGAUP_DB_HOST, 2);
+        if (count($host_chunks) == 2) {
+            [$hostname, $port] = $host_chunks;
+            $host_arg .= ' --host ' . escapeshellarg($hostname);
+            $host_arg .= ' --port ' . escapeshellarg($port);
+        } else {
+            [$hostname] = $host_chunks;
+            $host_arg .= ' --host ' . escapeshellarg($hostname);
+        }
         self::shellExec(
             ('python3 ' .
              dirname(__DIR__, 2) . '/stuff/cron/aggregate_feedback.py' .
              ' --verbose ' .
              ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
-             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             $host_arg .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
              ' --password ' . escapeshellarg(OMEGAUP_DB_PASS))
@@ -397,12 +417,22 @@ class Utils {
     public static function runAssignBadges(): void {
         // Ensure everything is commited before invoking external script
         self::commit();
+        $host_arg = '';
+        $host_chunks = explode(':', OMEGAUP_DB_HOST, 2);
+        if (count($host_chunks) == 2) {
+            [$hostname, $port] = $host_chunks;
+            $host_arg .= ' --host ' . escapeshellarg($hostname);
+            $host_arg .= ' --port ' . escapeshellarg($port);
+        } else {
+            [$hostname] = $host_chunks;
+            $host_arg .= ' --host ' . escapeshellarg($hostname);
+        }
         self::shellExec(
             ('python3 ' .
              dirname(__DIR__, 2) . '/stuff/cron/assign_badges.py' .
              ' --verbose ' .
              ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
-             ' --host ' . escapeshellarg(OMEGAUP_DB_HOST) .
+             $host_arg .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .
              ' --database ' . escapeshellarg(OMEGAUP_DB_NAME) .
              ' --password ' . escapeshellarg(OMEGAUP_DB_PASS))

--- a/stuff/database_utils.py
+++ b/stuff/database_utils.py
@@ -7,12 +7,46 @@
 import os
 import shlex
 import subprocess
+import sys
 import tempfile
 from typing import Optional, Sequence
 
 
-_MYSQL_BINARY = 'mysql'
-_MYSQLDUMP_BINARY = 'mysqldump'
+_MYSQL_BINARY = '/usr/bin/mysql'
+_MYSQLDUMP_BINARY = '/usr/bin/mysqldump'
+
+
+def inside_container() -> bool:
+    '''Returns whether this command is run inside a container.'''
+    return os.path.isdir('/opt/omegaup')
+
+
+def check_inside_container() -> None:
+    '''Re-runs the current command inside the container if needed.'''
+    if inside_container():
+        return
+    sys.stderr.write(
+        '\033[91mThis command needs to be run inside the container.\033[0m\n')
+    sys.stderr.write('\n')
+    answer = 'n'
+    if sys.stdin.isatty():
+        try:
+            answer = input(
+                '\033[95mDo you want to run this now?\033[0m [y/N]: ')
+            answer = answer.lower().strip()
+        except KeyboardInterrupt:
+            sys.stderr.write('\n')
+    if answer != 'y':
+        sys.stderr.write('\nYou can use the following command to run '
+                         'it inside the container:\n\n')
+        sys.stderr.write(
+            f'    docker-compose exec -T frontend {shlex.join(sys.argv)}\n')
+        sys.stderr.write('\n')
+        sys.exit(1)
+    result = subprocess.run(['docker-compose', 'exec', '-T', 'frontend'] +
+                            sys.argv,
+                            check=False)
+    sys.exit(result.returncode)
 
 
 def quote(s: str) -> str:
@@ -28,14 +62,8 @@ def quote(s: str) -> str:
 def default_config_file() -> Optional[str]:
     '''Returns the default config file path for MySQL.'''
     for candidate_path in (
-            # ${OMEGAUP_ROOT}/.my.cnf
-            os.path.join(
-                os.path.abspath(
-                    os.path.join(os.path.dirname(__file__), '..')),
-                '.my.cnf'),
             # ~/.my.cnf
             os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
-            '/etc/mysql/conf.d/mysql_password.cnf',
     ):
         if os.path.isfile(candidate_path):
             return candidate_path
@@ -46,7 +74,8 @@ def authentication(*,
                    config_file: Optional[str] = default_config_file(),
                    username: Optional[str] = None,
                    password: Optional[str] = None,
-                   hostname: Optional[str] = None) -> Sequence[str]:
+                   hostname: Optional[str] = None,
+                   port: Optional[int] = None) -> Sequence[str]:
     '''Computes the authentication arguments for mysql binaries.'''
     if config_file and os.path.isfile(config_file):
         return ['--defaults-file=%s' % quote(config_file)]
@@ -59,15 +88,21 @@ def authentication(*,
             args.append('--skip-password')
     if hostname is not None:
         args.extend(['--protocol=TCP', '--host=%s' % quote(hostname)])
+        if port is not None:
+            args.extend(['--port=%d' % port])
     return args
 
 
 def mysql(query: str,
           *,
+          container_check: bool = True,
           dbname: Optional[str] = None,
           auth: Sequence[str] = ()) -> str:
     '''Runs the MySQL commandline client with |query| as query.'''
-    args = [_MYSQL_BINARY] + list(auth)
+    args = []
+    if container_check and not inside_container():
+        args.extend(['docker-compose', 'exec', '-T', 'frontend'])
+    args += [_MYSQL_BINARY] + list(auth)
     if dbname:
         args.append(dbname)
     args.append('-NBe')
@@ -76,10 +111,14 @@ def mysql(query: str,
 
 
 def mysqldump(*,
+              container_check: bool = True,
               dbname: Optional[str] = None,
               auth: Sequence[str] = ()) -> bytes:
     '''Runs the mysqldump commandline tool.'''
-    args = [_MYSQLDUMP_BINARY] + list(auth)
+    args = []
+    if container_check and not inside_container():
+        args.extend(['docker-compose', 'exec', '-T', 'frontend'])
+    args += [_MYSQLDUMP_BINARY] + list(auth)
     if dbname:
         args.append(dbname)
     with tempfile.NamedTemporaryFile(mode='rb') as outfile:

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -83,6 +83,6 @@ EXPOSE 8001
 
 ENV CI=false
 
-CMD ["wait-for-it", "grader:36663", "gitserver:33861", "broadcaster:22291", "mysql:3306", "--", \
+CMD ["wait-for-it", "grader:36663", "gitserver:33861", "broadcaster:22291", "mysql:13306", "--", \
      "/bin/bash", "-c", \
      "while [[ ! -d /opt/omegaup/frontend/server ]]; do sleep 1; done; exec /usr/bin/supervisord"]

--- a/stuff/docker/etc/omegaup/gitserver/config.json
+++ b/stuff/docker/etc/omegaup/gitserver/config.json
@@ -4,7 +4,7 @@
 	},
 	"DB": {
 		"Driver": "mysql",
-		"DataSourceName": "omegaup:omegaup@tcp(mysql)/omegaup"
+		"DataSourceName": "omegaup:omegaup@tcp(mysql:13306)/omegaup"
 	},
 	"Gitserver": {
 		"PublicKey": "",

--- a/stuff/docker/etc/omegaup/grader/config.json
+++ b/stuff/docker/etc/omegaup/grader/config.json
@@ -7,7 +7,7 @@
 	},
 	"DB": {
 		"Driver": "mysql",
-		"DataSourceName": "omegaup:omegaup@tcp(mysql)/omegaup?parseTime=true"
+		"DataSourceName": "omegaup:omegaup@tcp(mysql:13306)/omegaup?parseTime=true"
 	},
 	"Grader": {
 		"BroadcasterURL": "https://broadcaster:32672/broadcast/",

--- a/stuff/docker/etc/supervisor/supervisord.conf
+++ b/stuff/docker/etc/supervisor/supervisord.conf
@@ -18,7 +18,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:developer-environment]
-command=/usr/bin/developer-environment.sh
+command=/usr/bin/developer-environment.sh --mysql-config-file="%(ENV_HOME)s/.my.cnf"
 autorestart=unexpected
 startsecs=0
 exitcodes=0

--- a/stuff/docker/my.cnf
+++ b/stuff/docker/my.cnf
@@ -1,5 +1,5 @@
 [client]
-port=3306
+port=13306
 host=mysql
 user=root
 password=omegaup

--- a/stuff/docker/usr/bin/developer-environment.sh
+++ b/stuff/docker/usr/bin/developer-environment.sh
@@ -33,7 +33,7 @@ fi
 define('OMEGAUP_ALLOW_PRIVILEGE_SELF_ASSIGNMENT', true);
 define('OMEGAUP_CACHE_IMPLEMENTATION', 'redis');
 define('OMEGAUP_CSP_LOG_FILE', '/tmp/csp.log');
-define('OMEGAUP_DB_HOST', 'mysql');
+define('OMEGAUP_DB_HOST', 'mysql:13306');
 define('OMEGAUP_DB_NAME', 'omegaup');
 define('OMEGAUP_DB_PASS', 'omegaup');
 define('OMEGAUP_DB_USER', 'omegaup');
@@ -50,7 +50,7 @@ ensure_contents "/opt/omegaup/frontend/server/config.php" "${config_contents}"
 
 ! read -r -d '' test_config_contents <<EOF
 <?php
-define('OMEGAUP_DB_HOST', 'mysql');
+define('OMEGAUP_DB_HOST', 'mysql:13306');
 define('OMEGAUP_DB_PASS', 'omegaup');
 define('OMEGAUP_DB_USER', 'omegaup');
 EOF
@@ -67,7 +67,7 @@ done
 
 # Ensure that the database version is up to date.
 if ! /opt/omegaup/stuff/db-migrate.py --mysql-config-file="${HOME}/.my.cnf" exists ; then
-  mysql --defaults-file=/home/ubuntu/.my.cnf \
+  mysql --defaults-file="${HOME}/.my.cnf" \
     -e "CREATE USER IF NOT EXISTS 'omegaup'@'localhost' IDENTIFIED BY 'omegaup';"
   mysql --defaults-file="${HOME}/.my.cnf" \
     -e 'GRANT ALL PRIVILEGES ON `omegaup-test%`.* TO "omegaup"@"%";'
@@ -76,7 +76,7 @@ if ! /opt/omegaup/stuff/db-migrate.py --mysql-config-file="${HOME}/.my.cnf" exis
     --purge --verbose --root-url=http://localhost:8001/
 else
   /opt/omegaup/stuff/db-migrate.py \
-    --mysql-config-file=/home/ubuntu/.my.cnf migrate
+    --mysql-config-file="${HOME}/.my.cnf" migrate
 fi
 
 # If this is a local-backend build, ensure that the built omegaup-gitserver is

--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -58,6 +58,16 @@ if [ $GIT_PUSH -eq 1 ]; then
 	fi
 fi
 
-python3 "${OMEGAUP_ROOT}/stuff/database_schema.py" validate $ARGS
-python3 "${OMEGAUP_ROOT}/stuff/policy-tool.py" validate
+if ! which docker-compose >/dev/null; then
+	echo -e "\033[0;31mERROR\033[0m: \`docker-compose\` not found. Please run \`git push\` outside the container."
+	exit 1
+fi
+
+if ! docker-compose exec -T frontend true 2>/dev/null ; then
+	echo -e "\033[0;31mERROR\033[0m: The container is not running. Please run \`docker-compose up\` and try again."
+	exit 1
+fi
+
+docker-compose exec -T frontend python3 /opt/omegaup/stuff/database_schema.py validate $ARGS
+docker-compose exec -T frontend python3 /opt/omegaup/stuff/policy-tool.py validate
 exec "${OMEGAUP_ROOT}/stuff/lint.sh" $PRE_UPLOAD_ARGS validate $ARGS

--- a/stuff/lib/db.py
+++ b/stuff/lib/db.py
@@ -104,14 +104,8 @@ class Connection:
 def default_config_file_path() -> Optional[str]:
     '''Try to autodetect the config file path.'''
     for candidate_path in (
-            # ${OMEGAUP_ROOT}/.my.cnf
-            os.path.join(
-                os.path.abspath(
-                    os.path.join(os.path.dirname(__file__), '..', '..')),
-                '.my.cnf'),
             # ~/.my.cnf
             os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
-            '/etc/mysql/conf.d/mysql_password.cnf',
     ):
         if os.path.isfile(candidate_path):
             return candidate_path

--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -26,7 +26,7 @@ else
 	TTY_ARGS=""
 fi
 
-if [[ -d /proc ]] && grep -q pids:/docker /proc/1/cgroup; then
+if [[ "${OMEGAUP_ROOT}" == "/opt/omegaup" ]]; then
 	echo "Running ./stuff/lint.sh inside a container is not supported." 1>&2
 	echo "Please run this command outside the container" 1>&2
 	exit 1

--- a/stuff/runtests.sh
+++ b/stuff/runtests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OMEGAUP_ROOT=$(/usr/bin/git rev-parse --show-toplevel)
+OMEGAUP_ROOT=$(git rev-parse --show-toplevel)
 REF=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true)
 
 if [[ "$REF" = "" ]]; then
@@ -13,18 +13,26 @@ if [[ "$REF" = "" ]]; then
 	echo >&2
 fi
 
-if grep -q pids:/docker /proc/1/cgroup; then
+if [[ "${OMEGAUP_ROOT}" == "/opt/omegaup" ]]; then
 	IN_DOCKER=1
 else
 	IN_DOCKER=0
 fi
 
-python3 "${OMEGAUP_ROOT}/stuff/db-migrate.py" validate
-python3 "${OMEGAUP_ROOT}/stuff/policy-tool.py" validate
+if [[ "${IN_DOCKER}" == 1 ]]; then
+	python3 "${OMEGAUP_ROOT}/stuff/db-migrate.py" validate
+	python3 "${OMEGAUP_ROOT}/stuff/policy-tool.py" validate
+	# This runs the controllers + badges PHPUnit tests, as well as the MySQL return
+	# type check.
+	"${OMEGAUP_ROOT}/stuff/mysql_types.sh"
+else
+	docker-compose exec -T frontend python3 "./stuff/db-migrate.py" validate
+	docker-compose exec -T frontend python3 "./stuff/policy-tool.py" validate
+	# This runs the controllers + badges PHPUnit tests, as well as the MySQL return
+	# type check.
+	docker-compose exec -T frontend "./stuff/mysql_types.sh"
+fi
 
-# This runs the controllers + badges PHPUnit tests, as well as the MySQL return
-# type check.
-"${OMEGAUP_ROOT}/stuff/mysql_types.sh"
 "${OMEGAUP_ROOT}/vendor/bin/psalm" --show-info=false
 
 if [[ "${IN_DOCKER}" == 1 ]]; then


### PR DESCRIPTION
Era un poco engorroso el hecho de que algunos comandos se tenían que
correr adentro / afuera del contenedor.

Ahora el puerto de MySQL tanto afuera como adentro del contenedor es
13306. Esto implica que ahora todos los comandos se _tienen_ que correr
adentro del contenedor con la notable excepción de los dos comandos que
usan `docker`:

* `stuff/lint.sh` (necesita correr el contenedor del linter)
* `stuff/git-hooks/pre-push` (porque corre `stuff/lint.sh` internamente)

Y esos dos comandos ahora dicen explícitamente qué hay que hacer para
corregir el error.