### PR TITLE
Arreglando la consulta que obtiene los datos de las identidades de un grupo

### DIFF
--- a/frontend/server/src/DAO/GroupsIdentities.php
+++ b/frontend/server/src/DAO/GroupsIdentities.php
@@ -21,8 +21,8 @@ class GroupsIdentities extends \OmegaUp\DAO\Base\GroupsIdentities {
                 i.username,
                 i.name,
                 i.gender,
-                c.name as country,
-                c.country_id,
+                IFNULL(c.name, ci.name) as country,
+                IFNULL(c.country_id, ci.country_id) as country_id,
                 s.name as state,
                 s.state_id,
                 sc.name as school,
@@ -38,6 +38,8 @@ class GroupsIdentities extends \OmegaUp\DAO\Base\GroupsIdentities {
                 States s ON s.state_id = i.state_id AND s.country_id = i.country_id
             LEFT JOIN
                 Countries c ON c.country_id = s.country_id
+            LEFT JOIN
+                Countries ci ON ci.country_id = i.country_id
             LEFT JOIN
                 Identities_Schools isc ON isc.identity_school_id = i.current_identity_school_id
             LEFT JOIN

--- a/frontend/server/src/DAO/GroupsIdentities.php
+++ b/frontend/server/src/DAO/GroupsIdentities.php
@@ -21,8 +21,8 @@ class GroupsIdentities extends \OmegaUp\DAO\Base\GroupsIdentities {
                 i.username,
                 i.name,
                 i.gender,
-                IFNULL(c.name, ci.name) as country,
-                IFNULL(c.country_id, ci.country_id) as country_id,
+                c.name as country,
+                c.country_id,
                 s.name as state,
                 s.state_id,
                 sc.name as school,
@@ -37,9 +37,7 @@ class GroupsIdentities extends \OmegaUp\DAO\Base\GroupsIdentities {
             LEFT JOIN
                 States s ON s.state_id = i.state_id AND s.country_id = i.country_id
             LEFT JOIN
-                Countries c ON c.country_id = s.country_id
-            LEFT JOIN
-                Countries ci ON ci.country_id = i.country_id
+                Countries c ON c.country_id = i.country_id
             LEFT JOIN
                 Identities_Schools isc ON isc.identity_school_id = i.current_identity_school_id
             LEFT JOIN

--- a/frontend/tests/controllers/IdentityCreateTest.php
+++ b/frontend/tests/controllers/IdentityCreateTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * Tests for apiCreate and apiBulkCreate in IdentityController
  */
@@ -11,11 +9,9 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testIdentityHasContestOrganizerRole() {
         [
-            'user' => $creator,
             'identity' => $creatorIdentity
         ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         [
-            'user' => $mentorUser,
             'identity' => $mentorIdentity
         ] = \OmegaUp\Test\Factories\User::createMentorIdentity();
 
@@ -37,7 +33,9 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testCreateSingleIdentity() {
         // Identity creator group member will create the identity
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -86,7 +84,9 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testCreateIdentityWithWrongGroup() {
         // Identity creator group member will upload csv file
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -99,7 +99,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $identityName = substr(\OmegaUp\Test\Utils::createRandomString(), - 10);
         // Call api using identity creator group member
         try {
-            $response = \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,
                 'username' => "{$wrongGroupAlias}:{$identityName}",
                 'name' => $identityName,
@@ -123,7 +123,9 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testCreateIdentityWithoutGroup() {
         // Identity creator group member will upload csv file
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -135,7 +137,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $identityName = substr(\OmegaUp\Test\Utils::createRandomString(), - 10);
         // Call api using identity creator group member
         try {
-            $response = \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,
                 'username' => $identityName,
                 'name' => $identityName,
@@ -159,7 +161,9 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testCreateIdentityWithWrongUsername() {
         // Identity creator group member will upload csv file
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -171,7 +175,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $wrongIdentityName = 'username:with:wrong:char';
         // Call api using identity creator group member
         try {
-            $response = \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,
                 'username' => "{$group['group']->alias}:{$wrongIdentityName}",
                 'name' => $wrongIdentityName,
@@ -190,7 +194,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
         }
         $wrongIdentityName = 'wrongUsername';
         try {
-            $response = \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\Identity::apiCreate(new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,
                 'username' => $wrongIdentityName,
                 'name' => $wrongIdentityName,
@@ -215,7 +219,6 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testUploadCsvFile() {
         // Identity creator group member will upload csv file
         [
-            'user' => $creator,
             'identity' => $creatorIdentity,
         ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
@@ -269,7 +272,6 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testRemoveIdentitiesFromGroupAndAddThemAgain() {
         // Identity creator group member will upload csv file
         [
-           'user' => $creator,
            'identity' => $creatorIdentity,
         ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
@@ -360,7 +362,6 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
     public function testUploadCsvFileWithDuplicatedUsernames() {
         // Identity creator group member will upload csv file
         [
-            'user' => $creator,
             'identity' => $creatorIdentity,
         ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
@@ -374,7 +375,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         try {
             // Call api using identity creator group member
-            $response = \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,
                 'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
                     'duplicated_identities.csv',
@@ -393,7 +394,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testUploadCsvFileWithWrongCountryId() {
         // Identity creator group member will upload csv file
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        ['identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -405,7 +406,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         try {
             // Call api using identity creator group team member
-            $response = \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
+            \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
                 'auth_token' => $creatorLogin->auth_token,
                 'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
                     'identities_wrong_country_id.csv',
@@ -438,7 +439,7 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
 
         try {
             // Call api using identity creator group team member
-            $response = \OmegaUp\Controllers\Identity::apiBulkCreate(
+            \OmegaUp\Controllers\Identity::apiBulkCreate(
                 new \OmegaUp\Request([
                     'auth_token' => $creatorLogin->auth_token,
                     'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
@@ -457,11 +458,87 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
         }
     }
 
+    public function testUploadCsvFileWithEmptyStateAndSelectedCountry() {
+        // Identity creator group member will upload csv file
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        $creatorLogin = self::login($creatorIdentity);
+        $group = \OmegaUp\Test\Factories\Groups::createGroup(
+            $creatorIdentity,
+            null,
+            null,
+            null,
+            $creatorLogin
+        );
+
+        // Call api using identity creator group team member
+        \OmegaUp\Controllers\Identity::apiBulkCreate(
+            new \OmegaUp\Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                    'identities_no_states.csv',
+                    $group['group']->alias
+                ),
+                'group_alias' => $group['group']->alias,
+            ])
+        );
+
+        [
+            'identities' => $identities,
+        ] = \OmegaUp\Controllers\Group::apiMembers(new \OmegaUp\Request([
+            'auth_token' => $creatorLogin->auth_token,
+            'group_alias' => $group['group']->alias,
+        ]));
+
+        $membersMapping = [
+            [
+                'name' => 'Identity One',
+                'country_id' => 'MX',
+                'state_id' => 'AGU',
+            ],
+            [
+                'name' => 'Identity Two',
+                'country_id' => 'MX',
+                'state_id' => '',
+            ],
+            [
+                'name' => 'Identity Three',
+                'country_id' => 'MX',
+                'state_id' => 'BCS',
+            ],
+            [
+                'name' => 'Identity Four',
+                'country_id' => 'MX',
+                'state_id' => '',
+            ],
+            [
+                'name' => 'Identity Five',
+                'country_id' => 'US',
+                'state_id' => '',
+            ],
+        ];
+
+        foreach ($membersMapping as $key => $member) {
+            $this->assertEquals($member['name'], $identities[$key]['name']);
+            $this->assertEquals(
+                $member['country_id'],
+                $identities[$key]['country_id']
+            );
+            $this->assertEquals(
+                $member['state_id'],
+                $identities[$key]['state_id']
+            );
+        }
+    }
+
     /**
      * Basic test for login an identity
      */
     public function testLoginIdentity() {
-        ['user' => $creator, 'identity' => $creatorIdentity] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
         $creatorLogin = self::login($creatorIdentity);
         $group = \OmegaUp\Test\Factories\Groups::createGroup(
             $creatorIdentity,
@@ -483,11 +560,6 @@ class IdentityCreateTest extends \OmegaUp\Test\ControllerTestCase {
             'state_id' => 'QUE',
             'gender' => 'male',
             'school_name' => \OmegaUp\Test\Utils::createRandomString(),
-            'group_alias' => $group['group']->alias,
-        ]));
-
-        $response = \OmegaUp\Controllers\Group::apiMembers(new \OmegaUp\Request([
-            'auth_token' => $creatorLogin->auth_token,
             'group_alias' => $group['group']->alias,
         ]));
 

--- a/frontend/tests/resources/identities_no_states.csv
+++ b/frontend/tests/resources/identities_no_states.csv
@@ -1,0 +1,6 @@
+username,name,country_id,state_id,gender,school_name
+identity_1,Identity One,MX,AGU,male,School Group
+identity_2,Identity Two,MX,,male,School Group
+identity_3,Identity Three,MX,BCS,female,School Group
+identity_4,Identity Four,MX,,male,School Group
+identity_5,Identity Five,US,,female,School Group


### PR DESCRIPTION
# Descripción

Se arregla la consulta que obtiene la lista de identidades que pertenecen a un 
grupo. 

Resulta que al obtener los paises se consultaba el id que al que corresponda el
estado que se almacenó. Pero hay ocasiones en las que no se proporciona dicho
estado, pero el pais sí. Así que para obtener este dato se muestra como valor
por defecto el id del pais ligado al estado, si el estado no fue proporcionado, se
obtiene el id del pais que se guardó en la identidad.

Antes:
![image](https://user-images.githubusercontent.com/3230352/159818124-a44da81c-7c3b-4c15-9482-75d72cf27eb7.png)

Ahora:
![image](https://user-images.githubusercontent.com/3230352/159818165-d97e4280-6527-4fae-9bcb-bcadfa6fbc8f.png)

Fixes: #6463 

# Comentarios

Posiblemente sea necesario en un futuro normalizar los datos de esos campos
para evitar estar consultando en dos lugares distintos que en ocasiones pueden
mostrar información distinta en cada una de las tablas

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.