### PR TITLE
Dándole al contenedor de MySQL la capabilidad `SYS_NICE`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,8 @@ services:
         published: 13306
         protocol: tcp
         mode: host
+    cap_add:
+      - SYS_NICE
 
   rabbitmq:
     image: rabbitmq:3-management-alpine


### PR DESCRIPTION
Este cambio hace que ya no se muestre la advertencia:

    mbind: operation not permitted