### PR TITLE
Dejando de mostrar envíos no-listos en la lista de envíos

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -282,6 +282,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 Contests c ON c.contest_id = ps.contest_id
             WHERE
                 TIMESTAMPDIFF(SECOND, s.time, NOW()) <= 24 * 3600
+                AND s.status = 'ready'
                 AND u.is_private = 0
                 AND p.visibility >= ?
                 AND (

--- a/frontend/tests/controllers/SubmissionsFeedTest.php
+++ b/frontend/tests/controllers/SubmissionsFeedTest.php
@@ -104,6 +104,12 @@ class SubmissionsFeedTest extends \OmegaUp\Test\ControllerTestCase {
             new \OmegaUp\Timestamp(strtotime($runCreationDate))
         );
 
+        // Also add a submissing in the 30-day interval but that hasn't been graded yet.
+        $runData = \OmegaUp\Test\Factories\Run::createRunToProblem(
+            $problems[0],
+            $identities[0]
+        );
+
         $submissions = \OmegaUp\DAO\Submissions::getLatestSubmissions();
         $this->assertCount(1, $submissions);
         $this->assertEquals(


### PR DESCRIPTION
Este cambio hace que la gente no se espante.

Fixes: #6484