### PR TITLE
Arreglando el puerto de mysql en los valores por defecto al realizar la conexión a la DB

### DIFF
--- a/stuff/lib/db.py
+++ b/stuff/lib/db.py
@@ -129,7 +129,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
                          type=str,
                          help='MySQL database',
                          default='omegaup')
-    db_args.add_argument('--port', type=int, help='MySQL port', default=3306)
+    db_args.add_argument('--port', type=int, help='MySQL port', default=13306)
 
 
 def connect(args: DatabaseConnectionArguments) -> Connection:

--- a/stuff/mysql/connector/__init__.pyi
+++ b/stuff/mysql/connector/__init__.pyi
@@ -7,7 +7,7 @@ def connect(
     password: Text,
     database: Text,
     host: Text,
-    port: int = 3306,
+    port: int = 13306,
 ) -> MySQLConnection:
     ...
 


### PR DESCRIPTION
# Descripción

Cuando se realizó el cambio del puerto 3306 a 13306 de mysql, faltó cambiar en
un par de lugares el valor por defecto que recibiría ese argumento.

