### PR TITLE
Arreglando la fecha de finalización de concurso en prueba de python

### DIFF
--- a/stuff/pipelines/test_contest_queries.py
+++ b/stuff/pipelines/test_contest_queries.py
@@ -29,6 +29,7 @@ def test_get_contests_information() -> None:
     client = omegaup.api.Client(api_token=test_constants.API_TOKEN,
                                 url=test_constants.OMEGAUP_API_ENDPOINT)
     current_time = datetime.datetime.now()
+    past_time = current_time - datetime.timedelta(hours=5)
     future_time = current_time + datetime.timedelta(hours=5)
     alias = ''.join(random.choices(string.digits, k=8))
     client.contest.create(
@@ -49,6 +50,17 @@ def test_get_contests_information() -> None:
         penalty_calc_policy='sum',
         admission_mode='private',
         show_scoreboard_after=True,
+    )
+
+    # Now, we are going to force finishing the contest, so we can generate
+    # certificates for participants
+    client.contest.update(
+        contest_alias=alias,
+        languages='py2,py3',
+        window_length=0,
+        submissions_gap=1200,
+        start_time=past_time,
+        finish_time=int(time.mktime(current_time.timetuple())),
     )
 
     dbconn = lib.db.connect(

--- a/stuff/pipelines/test_contest_queries.py
+++ b/stuff/pipelines/test_contest_queries.py
@@ -30,14 +30,13 @@ def test_get_contests_information() -> None:
                                 url=test_constants.OMEGAUP_API_ENDPOINT)
     current_time = datetime.datetime.now()
     past_time = current_time - datetime.timedelta(hours=5)
-    future_time = current_time + datetime.timedelta(hours=5)
     alias = ''.join(random.choices(string.digits, k=8))
     client.contest.create(
         title=alias,
         alias=alias,
         description='Test contest',
-        start_time=time.mktime(current_time.timetuple()),
-        finish_time=time.mktime(future_time.timetuple()),
+        start_time=time.mktime(past_time.timetuple()),
+        finish_time=time.mktime(current_time.timetuple()),
         window_length=0,
         scoreboard=100,
         points_decay_factor=0,
@@ -50,17 +49,6 @@ def test_get_contests_information() -> None:
         penalty_calc_policy='sum',
         admission_mode='private',
         show_scoreboard_after=True,
-    )
-
-    # Now, we are going to force finishing the contest, so we can generate
-    # certificates for participants
-    client.contest.update(
-        contest_alias=alias,
-        languages='py2,py3',
-        window_length=0,
-        submissions_gap=1200,
-        start_time=past_time,
-        finish_time=int(time.mktime(current_time.timetuple())),
     )
 
     dbconn = lib.db.connect(


### PR DESCRIPTION
# Descripción

Se arregla prueba en python la cual fallaba cuando el reloj se acercaba a 5
horas de que acabara el día.

Resulta que en la prueba se habia olvidado actualizar la fecha de finalización
del concurso del cual se requería obtener los certificados. Y por tal motivo 
había ocasiones en que la prueba no iba a pasar satisfactoriamente porque 
sólo se obtenían los concursos finalizados (este concurso que se creó en las
pruebas efectivamente aún no había concluido, pero las pruebas pasaban 
porque en la consulta se obtienen los concursos que finalizan antes de las 
23:59:59 del día).

Fixes: #6513 

# Comentarios

Temas para resolver en nuevos PR (Hay que crear los issues para que no se
quede en el olvido este comentario):

- Arreglar las declaraciones de tipos en la API, ya que hay elementos que no 
  son necesarios, pero la declaración los requiere (mypy se estará quejando).
- Normalizar la forma en la que recibimos las fechas en las API's. En este caso 
  en específico tuve que usar tres distintos tipos: Timestamp, entero y Date. Eso 
  es muy confuso


# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
