### PR TITLE
Aligned the navigation bar buttons on the right side for mobile users…

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <header>
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top p-0">
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top p-0 text-right">
       <div class="container-xl pl-0 pl-xl-3">
         <a class="navbar-brand p-3" href="/">
           <img
@@ -390,7 +390,6 @@ export default class Navbar extends Vue {
 @import '../../../../sass/main.scss';
 
 nav.navbar {
-  text-align: end;
   background-color: var(--header-primary-color);
   .navbar-brand {
     background-color: var(--header-navbar-brand-background-color);

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -392,9 +392,6 @@ export default class Navbar extends Vue {
 nav.navbar {
   text-align: end;
   background-color: var(--header-primary-color);
-  .navbar-nav .dropdown-menu {
-    position: absolute;
-  }
   .navbar-brand {
     background-color: var(--header-navbar-brand-background-color);
   }

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -105,7 +105,7 @@
               >
             </li>
           </ul>
-          <ul v-else class="navbar-nav navbar-right">
+          <ul v-else class="navbar-nav navbar-right align-items-end">
             <omegaup-notifications-clarifications
               v-if="inContest"
               :clarifications="clarifications"
@@ -383,8 +383,11 @@ export default class Navbar extends Vue {
 @import '../../../../sass/main.scss';
 
 nav.navbar {
+  text-align: end;
   background-color: var(--header-primary-color);
-
+  .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
   .navbar-brand {
     background-color: var(--header-navbar-brand-background-color);
   }

--- a/frontend/www/js/omegaup/components/common/NavbarItems.vue
+++ b/frontend/www/js/omegaup/components/common/NavbarItems.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="mr-auto">
-    <ul v-if="!omegaUpLockDown && (!inContest || isAdmin)" class="navbar-nav">
+    <ul
+      v-if="!omegaUpLockDown && (!inContest || isAdmin)"
+      class="navbar-nav align-items-end"
+    >
       <li
         v-if="isLoggedIn"
         class="nav-item dropdown nav-contests"


### PR DESCRIPTION
# Descripción
For mobile users, the navigation bar buttons appeared on the left side while the navbar button was on the right which causes problem to many. 

In this pull request, I moved the navigation bar buttons on the right side for mobile users. It doesn't affect the  web view. 

I have used `align-items` tag instead of `float` as stated in the previous Pull Request. 

In the video below you can see the the PR doesn't affect the web view and make the mobile view much better. 
![Screenshot from 2022-04-14 23-09-24](https://user-images.githubusercontent.com/63846699/163443840-f5a06c5f-a102-474f-b945-06a64c33c052.png)



https://user-images.githubusercontent.com/63846699/162439035-35c1022d-0e38-4741-a9e3-997e08fab14e.mp4




Fixes:#5934 

# Comentarios

If any improvements are needed please let me know. Thank You. 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
