### PR TITLE
Corrigiendo version de problema al ver un curso

### DIFF
--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -55,6 +55,7 @@ OmegaUp.on('ready', async () => {
     ({ runDetails, problemDetails } = await getProblemAndRunDetails({
       problems: payload.currentAssignment.problems,
       location: window.location.hash,
+      problemsetId: payload.currentAssignment.problemset_id,
     }));
   } catch (e: any) {
     ui.apiError(e);

--- a/frontend/www/js/omegaup/arena/location.ts
+++ b/frontend/www/js/omegaup/arena/location.ts
@@ -79,10 +79,12 @@ export async function getProblemAndRunDetails({
   location,
   contestAlias,
   problems,
+  problemsetId,
 }: {
   location: string;
   contestAlias?: string;
   problems?: types.NavbarProblemsetProblem[];
+  problemsetId?: number;
 }): Promise<{
   runDetails: null | types.RunDetails;
   problemDetails: null | types.ProblemDetails;
@@ -98,6 +100,7 @@ export async function getProblemAndRunDetails({
       problem_alias: problemAlias,
       prevent_problemset_open: false,
       contest_alias: contestAlias || undefined,
+      problemset_id: problemsetId || undefined,
     });
   }
   if (guid) {


### PR DESCRIPTION
# Descripción

Hay un bug en cursos en el que si un problema se actualiza (redacción o casos) después de haberlo agregado a un assignment, se ven versiones diferentes al entrar a ver el problema en un flujo normal (ver abajo) y al recargar esa página una vez que se está viendo el problema.

En el flujo normal uno entraría al curso, ya sea desde la lista de "mis cursos" o del link "ir al curso" después de editarlo. Y aquí es donde se nota claramente el problema, después de editar el assignment para que utilice la versión más reciente del problema, no se veía la versión actualizada. Pero al estar *viendo el problema dentro del assignment* y recargar la página, sí se veía la versión actualizada.

Resulta que hay dos maneras de llegar al contenido de un problema:
* vía `navigation.ts`.`navigateToProblem`: https://cs.github.com/omegaup/omegaup/blob/075610fad087768505dad500cd4d588f133d0dc1/frontend/www/js/omegaup/arena/navigation.ts?q=navigatetoProblem#L40
* vía `location.ts`.`getProblemAndRunDetails`: https://cs.github.com/omegaup/omegaup/blob/075610fad087768505dad500cd4d588f133d0dc1/frontend/www/js/omegaup/arena/location.ts#L78

En una de ellas sí se incluía el `problemsetId` para el cual se está solicitando el problema y en la otra no. Con este cambio, el `problemsetId` se incluye en ambas llamadas.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.