### PR TITLE
Added meta tag for better Optimization of site.

### DIFF
--- a/frontend/templates/template.tpl
+++ b/frontend/templates/template.tpl
@@ -2,6 +2,7 @@
 <html lang="{{ LOCALE }}" class="h-100">
   <head data-locale="{{ LOCALE }}">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% if NEW_RELIC_SCRIPT %}
       {{ NEW_RELIC_SCRIPT|raw }}


### PR DESCRIPTION
# Descripción
Using the viewport meta tag to control layout on mobile browsers.
This is result of pagspeedinsight:
![viewport](https://user-images.githubusercontent.com/88332977/162598269-bd23c673-19e0-43b3-89ce-d593112250d8.png)

Articles supporting the need of this PR:
https://developer.chrome.com/blog/300ms-tap-delay-gone-away/
https://web.dev/viewport/

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
