### PR TITLE
Arreglando el error con el contador de tiempo de envíos cuando está mal configurado el reloj

### DIFF
--- a/cypress/integration/basic_commands.spec.ts
+++ b/cypress/integration/basic_commands.spec.ts
@@ -20,7 +20,7 @@ describe('Basic Commands Test', () => {
     cy.visit('/');
   });
 
-  /*it('Should create a course with unlimited duration', () => {
+  it('Should create a course with unlimited duration', () => {
     const loginOptions: LoginOptions = {
       username: uuid(),
       password: uuid(),
@@ -261,7 +261,7 @@ describe('Basic Commands Test', () => {
     cy.get('[data-run-status] > span')
       .first()
       .should('have.text', expectedStatus);
-  });*/
+  });
 
   it('Should create a contest', () => {
     const loginOptions: LoginOptions = {

--- a/cypress/integration/basic_commands.spec.ts
+++ b/cypress/integration/basic_commands.spec.ts
@@ -263,50 +263,49 @@ describe('Basic Commands Test', () => {
       .should('have.text', expectedStatus);
   });
 
+  const now = new Date();
+
+  const problemAlias = 'problem-' + uuid().slice(0, 8);
+  const contestOptions: ContestOptions = {
+    contestAlias: 'contest' + uuid().slice(0, 5),
+    description: 'Test Description',
+    startDate: addSubstractDaysToDate(now, {days: -1}),
+    endDate: addSubstractDaysToDate(now, {days: 2}),
+    showScoreboard: true,
+    basicInformation: false,
+    partialPoints: true,
+    requestParticipantInformation: 'no',
+    admissionMode: 'public',
+    problems: [
+      {
+        problemAlias: 'sumas',
+        tag: 'Recursion',
+        autoCompleteTextTag: 'Recur',
+        problemLevelIndex: 1,
+      },
+    ],
+    runs: [
+      {
+        problemAlias: 'sumas',
+        fixturePath: 'main.cpp',
+        language: 'cpp11-gcc',
+        valid: true,
+      },
+      {
+        problemAlias: 'sumas',
+        fixturePath: 'main.cpp',
+        language: 'cpp11-gcc',
+        valid: false,
+      },
+    ]
+  };
+  const loginOptions: LoginOptions = {
+    username: 'omegaup',
+    password: 'omegaup',
+  };
+
   it('Should create a contest', () => {
-    const loginOptions: LoginOptions = {
-      username: 'omegaup',
-      password: 'omegaup',
-    };
-
     cy.login(loginOptions);
-
-    const now = new Date();
-
-    const problemAlias = 'problem-' + uuid().slice(0, 8);
-    const contestOptions: ContestOptions = {
-      contestAlias: 'contest' + uuid().slice(0, 5),
-      description: 'Test Description',
-      startDate: addSubstractDaysToDate(now, {days: -1}),
-      endDate: addSubstractDaysToDate(now, {days: 2}),
-      showScoreboard: true,
-      basicInformation: false,
-      partialPoints: true,
-      requestParticipantInformation: 'no',
-      admissionMode: 'public',
-      problems: [
-        {
-          problemAlias: 'sumas',
-          tag: 'Recursion',
-          autoCompleteTextTag: 'Recur',
-          problemLevelIndex: 1,
-        },
-      ],
-      runs: [
-        {
-          problemAlias: 'sumas',
-          fixturePath: 'main.cpp',
-          language: 'cpp11-gcc',
-          valid: true,
-        },
-        {
-          problemAlias: 'sumas',
-          fixturePath: 'main.cpp',
-          language: 'cpp11-gcc',
-          valid: false,
-        },
-      ]
-    };
 
     cy.createContest(contestOptions);
     cy.location('href').should('include', contestOptions.contestAlias); // Url
@@ -340,7 +339,10 @@ describe('Basic Commands Test', () => {
       'have.value',
       contestOptions.requestParticipantInformation,
     );
+  });
 
+  it('Should create runs inside contest', () => {
+    cy.login(loginOptions);
     cy.addProblemsToContest(contestOptions);
     cy.changeAdmissionModeContest(contestOptions);
 
@@ -349,7 +351,7 @@ describe('Basic Commands Test', () => {
       cy.url().should('eq', 'http://127.0.0.1:8001/'),
     );
 
-    // Mocking date 1 hour before to test timeRemote is working correctly.
+    // Mocking date 2 hours before to test timeRemote is working correctly.
     cy.clock(new Date(
       now.getFullYear(),
       now.getMonth(),
@@ -366,7 +368,7 @@ describe('Basic Commands Test', () => {
       cy.get('header .username').should('have.text', 'user'),
     );
 
-    cy.enterToContest(contestOptions);
+    cy.enterContest(contestOptions);
     cy.createRunsInsideContest(contestOptions);
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -192,7 +192,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  'enterToContest',
+  'enterContest',
   ({
     contestAlias,
   }) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -7,6 +7,7 @@ import {
   LoginOptions,
   ProblemOptions,
   RunOptions,
+  Status,
 } from './types';
 
 // Logins the user given a username and password
@@ -156,6 +157,101 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  'addProblemsToContest',
+  ({
+    contestAlias,
+    problems,
+  }) => {
+    cy.visit(`contest/${contestAlias}/edit/`);
+    cy.get('a[data-nav-contest-edit]').click();
+    cy.get('a.dropdown-item.problems').click();
+
+    for (const idx in problems) {
+      cy.get('input[type="text"]').type(problems[idx].problemAlias)
+      cy.get('.typeahead-dropdown').click();
+      cy.get('.add-problem').click();
+    }
+  },
+);
+
+Cypress.Commands.add(
+  'changeAdmissionModeContest',
+  ({
+    contestAlias,
+    admissionMode,
+  }) => {
+    cy.visit(`contest/${contestAlias}/edit/`);
+    cy.get('a[data-nav-contest-edit]').click();
+    cy.get('a.dropdown-item.admission-mode').click();
+    cy.get('select[name="admission-mode"]').select(
+      admissionMode,
+    ); // private | registration | public
+    cy.get('.change-admission-mode').click();
+  },
+);
+
+Cypress.Commands.add(
+  'enterToContest',
+  ({
+    contestAlias,
+  }) => {
+    cy.visit('arena/');
+    cy.get('a[data-contests]').click();
+    cy.get('a[data-list-current]').click();
+    cy.get(`a[href="/arena/${contestAlias}/"]`).click();
+    cy.get('button[data-start-contest]').click();
+  },
+);
+
+Cypress.Commands.add(
+  'createRunsInsideContest',
+  ({
+    contestAlias,
+    problems,
+    runs,
+  }) => {
+    const problem = problems[0];
+    if (!problem) {
+      return;
+    }
+    cy.visit(`/arena/${contestAlias}/#problems`);
+    cy.get(`a[data-problem="${problem.problemAlias}"]`).click();
+
+    for (const idx in runs) {
+      // Mocking date just a few seconds after to allow create new run
+      cy.clock(new Date(), ['Date']).then((clock) => clock.tick(3000));
+      cy.get('[data-new-run]').click();
+      cy.get('[name="language"]').select(runs[idx].language);
+
+      // Only the first submission is created because of server validations
+      if (!runs[idx].valid) {
+        cy.fixture(runs[idx].fixturePath).then((fileContent) => {
+          cy.get('.CodeMirror-line').type(fileContent);
+          cy.get('[data-submit-run]').should('be.disabled');
+        });
+        break;
+      }
+
+      cy.fixture(runs[idx].fixturePath).then((fileContent) => {
+        cy.get('.CodeMirror-line').type(fileContent);
+        cy.get('[data-submit-run]').click();
+      });
+
+      const expectedStatus: Status = 'AC';
+      cy.get('[data-run-status] > span').first().should('have.text', 'new');
+      cy.intercept({ method: 'POST', url: '/api/run/status/' }).as('runStatus');
+
+      cy.wait(['@runStatus'], { timeout: 10000 }).its(
+        'response.statusCode',
+      ).should('eq', 200);
+      cy.get('[data-run-status] > span')
+        .first()
+        .should('have.text', expectedStatus);
+    }
+  },
+);
+
 /**
  *
  * @param date Date object to convert
@@ -180,8 +276,11 @@ export const getISODateTime = (date: Date) => {
  * @param days number of days to add to the date
  * @returns Date Relative Date Object
  */
-export const addDaysToDate = (date: Date, { days }: { days: number }): Date => {
+export const addSubstractDaysToDate = (date: Date, { days }: { days: number }): Date => {
   if (days == 0) return date;
+  if (days < 0) {
+    return new Date(date.getTime() - 24 * 3600 * 1000);
+  }
 
   return new Date(date.getTime() + 24 * 3600 * 1000);
 };

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -30,7 +30,7 @@ declare global {
       ): void;
       addProblemsToContest(contestOptions: ContestOptions): void;
       changeAdmissionModeContest(contestOptions: ContestOptions): void;
-      enterToContest(contestOptions: ContestOptions): void;
+      enterContest(contestOptions: ContestOptions): void;
       createRunsInsideContest(contestOptions: ContestOptions): void;
     }
   }

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -28,6 +28,10 @@ declare global {
         contestOptions: Partial<ContestOptions> &
           Pick<ContestOptions, 'contestAlias'>,
       ): void;
+      addProblemsToContest(contestOptions: ContestOptions): void;
+      changeAdmissionModeContest(contestOptions: ContestOptions): void;
+      enterToContest(contestOptions: ContestOptions): void;
+      createRunsInsideContest(contestOptions: ContestOptions): void;
     }
   }
 }

--- a/cypress/support/types.d.ts
+++ b/cypress/support/types.d.ts
@@ -33,14 +33,19 @@ export interface ContestOptions {
   partialPoints?: boolean;
   basicInformation?: boolean;
   requestParticipantInformation?: RequestParticipantInformation;
+  admissionMode: AdmissionModeOptions;
+  problems: Array<ProblemOptions>;
+  runs: Array<RunOptions>;
 }
 
 export interface RunOptions {
   problemAlias: string;
   fixturePath: string;
   language: Language;
+  valid: boolean;
 }
 
+export type AdmissionModeOptions = 'private' | 'registration' | 'public';
 export type RequestParticipantInformation = 'no' | 'optional' | 'required';
 export type ProblemLevel = 'introductory' | 'intermediate' | 'advanced';
 export type Language =

--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -103,6 +103,13 @@ OmegaUp.on('ready', async () => {
     }
   }
 
+  let nextSubmissionTimestamp: null | Date = null;
+  if (problemDetails?.nextSubmissionTimestamp != null) {
+    nextSubmissionTimestamp = time.remoteTime(
+      problemDetails?.nextSubmissionTimestamp.getTime(),
+    );
+  }
+
   const contestContestant = new Vue({
     el: '#main-container',
     components: { 'omegaup-arena-contest': arena_Contest },
@@ -117,7 +124,7 @@ OmegaUp.on('ready', async () => {
       digitsAfterDecimalPoint: 2,
       showPenalty: true,
       searchResultUsers: [] as types.ListItem[],
-      nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
+      nextSubmissionTimestamp,
       runDetailsData: runDetails,
       shouldShowFirstAssociatedIdentityRunWarning:
         payload.shouldShowFirstAssociatedIdentityRunWarning,

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -51,6 +51,13 @@ OmegaUp.on('ready', async () => {
   }
   trackClarifications(payload.clarifications);
 
+  let nextSubmissionTimestamp: null | Date = null;
+  if (problemDetails?.nextSubmissionTimestamp != null) {
+    nextSubmissionTimestamp = time.remoteTime(
+      problemDetails?.nextSubmissionTimestamp.getTime(),
+    );
+  }
+
   const contestPractice = new Vue({
     el: '#main-container',
     components: { 'omegaup-arena-contest-practice': arena_ContestPractice },
@@ -62,7 +69,7 @@ OmegaUp.on('ready', async () => {
       showNewClarificationPopup,
       guid,
       problemAlias,
-      nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
+      nextSubmissionTimestamp,
       runDetailsData: runDetails,
       shouldShowFirstAssociatedIdentityRunWarning:
         payload.shouldShowFirstAssociatedIdentityRunWarning,

--- a/frontend/www/js/omegaup/arena/contest_virtual.ts
+++ b/frontend/www/js/omegaup/arena/contest_virtual.ts
@@ -119,6 +119,13 @@ OmegaUp.on('ready', async () => {
     }, refreshTime);
   }
 
+  let nextSubmissionTimestamp: null | Date = null;
+  if (problemDetails?.nextSubmissionTimestamp != null) {
+    nextSubmissionTimestamp = time.remoteTime(
+      problemDetails?.nextSubmissionTimestamp.getTime(),
+    );
+  }
+
   const contestContestant = new Vue({
     el: '#main-container',
     components: { 'omegaup-arena-contest': arena_Contest },
@@ -132,7 +139,7 @@ OmegaUp.on('ready', async () => {
       problemAlias,
       digitsAfterDecimalPoint: 2,
       showPenalty: true,
-      nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
+      nextSubmissionTimestamp,
       runDetailsData: runDetails,
     }),
     render: function (createElement) {

--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -63,6 +63,13 @@ OmegaUp.on('ready', async () => {
 
   trackClarifications(payload.courseDetails.clarifications);
 
+  let nextSubmissionTimestamp: null | Date = null;
+  if (problemDetails?.nextSubmissionTimestamp != null) {
+    nextSubmissionTimestamp = time.remoteTime(
+      problemDetails?.nextSubmissionTimestamp.getTime(),
+    );
+  }
+
   const arenaCourse = new Vue({
     el: '#main-container',
     components: {
@@ -78,7 +85,7 @@ OmegaUp.on('ready', async () => {
       problemAlias,
       searchResultUsers: [] as types.ListItem[],
       runDetailsData: runDetails,
-      nextSubmissionTimestamp: problemDetails?.nextSubmissionTimestamp,
+      nextSubmissionTimestamp,
       shouldShowFirstAssociatedIdentityRunWarning:
         payload.shouldShowFirstAssociatedIdentityRunWarning,
     }),

--- a/frontend/www/js/omegaup/arena/location.ts
+++ b/frontend/www/js/omegaup/arena/location.ts
@@ -2,6 +2,7 @@ import { types } from '../api_types';
 import { PopupDisplayed } from '../components/problem/Details.vue';
 import clarificationsStore from './clarificationsStore';
 import * as api from '../api';
+import * as time from '../time';
 import { trackRun } from './submissions';
 import problemsStore from './problemStore';
 
@@ -110,7 +111,7 @@ export async function getProblemAndRunDetails({
   const [problemDetails, runDetails] = await Promise.all([
     problemPromise,
     runPromise,
-  ]);
+  ]).then(time.remoteTimeAdapter);
 
   if (problemDetails != null) {
     for (const run of problemDetails.runs ?? []) {

--- a/frontend/www/js/omegaup/arena/location.ts
+++ b/frontend/www/js/omegaup/arena/location.ts
@@ -102,16 +102,18 @@ export async function getProblemAndRunDetails({
       prevent_problemset_open: false,
       contest_alias: contestAlias || undefined,
       problemset_id: problemsetId || undefined,
-    });
+    }).then(time.remoteTimeAdapter);
   }
   if (guid) {
-    runPromise = api.Run.details({ run_alias: guid });
+    runPromise = api.Run.details({ run_alias: guid }).then(
+      time.remoteTimeAdapter,
+    );
   }
 
   const [problemDetails, runDetails] = await Promise.all([
     problemPromise,
     runPromise,
-  ]).then(time.remoteTimeAdapter);
+  ]);
 
   if (problemDetails != null) {
     for (const run of problemDetails.runs ?? []) {

--- a/frontend/www/js/omegaup/arena/location.ts
+++ b/frontend/www/js/omegaup/arena/location.ts
@@ -102,17 +102,15 @@ export async function getProblemAndRunDetails({
       prevent_problemset_open: false,
       contest_alias: contestAlias || undefined,
       problemset_id: problemsetId || undefined,
-    }).then(time.remoteTimeAdapter);
+    });
   }
   if (guid) {
-    runPromise = api.Run.details({ run_alias: guid }).then(
-      time.remoteTimeAdapter,
-    );
+    runPromise = api.Run.details({ run_alias: guid });
   }
 
   const [problemDetails, runDetails] = await Promise.all([
-    problemPromise,
-    runPromise,
+    problemPromise.then(time.remoteTimeAdapter),
+    runPromise.then(time.remoteTimeAdapter),
   ]);
 
   if (problemDetails != null) {

--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import * as api from '../api';
 import * as ui from '../ui';
+import * as time from '../time';
 import { setLocationHash } from '../location';
 import { types } from '../api_types';
 import { myRunsStore } from './runsStore';
@@ -68,6 +69,7 @@ export async function navigateToProblem(
     contest_alias: contestAlias,
     problemset_id: problemsetId,
   })
+    .then(time.remoteTimeAdapter)
     .then((problemInfo) => {
       for (const run of problemInfo.runs ?? []) {
         trackRun({ run });

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -51,6 +51,13 @@ OmegaUp.on('ready', async () => {
 
   trackClarifications(payload.clarifications ?? []);
 
+  let nextSubmissionTimestamp: null | Date = null;
+  if (payload.problem.nextSubmissionTimestamp != null) {
+    nextSubmissionTimestamp = time.remoteTime(
+      payload.problem.nextSubmissionTimestamp.getTime(),
+    );
+  }
+
   const problemDetailsView = new Vue({
     el: '#main-container',
     components: {
@@ -70,7 +77,7 @@ OmegaUp.on('ready', async () => {
         (payload.nominationStatus?.nominatedBeforeAc &&
           !payload.nominationStatus?.solved),
       guid,
-      nextSubmissionTimestamp: payload.problem.nextSubmissionTimestamp,
+      nextSubmissionTimestamp,
       searchResultUsers: [] as types.ListItem[],
     }),
     render: function (createElement) {
@@ -155,6 +162,7 @@ OmegaUp.on('ready', async () => {
               language: language,
               source: code,
             })
+              .then(time.remoteTimeAdapter)
               .then((response) => {
                 problemDetailsView.nextSubmissionTimestamp =
                   response.nextSubmissionTimestamp;
@@ -393,6 +401,7 @@ OmegaUp.on('ready', async () => {
       switch (e.data.method) {
         case 'submitRun':
           api.Run.create(e.data.params)
+            .then(time.remoteTimeAdapter)
             .then((response) => {
               problemDetailsView.nextSubmissionTimestamp =
                 response.nextSubmissionTimestamp;


### PR DESCRIPTION
# Descripción

Se arregla el error que está ocurriendo en el tiempo de espera entre envíos
cuando el reloj de la computadora está mal configurado.

Hay distintos lugares donde se recibe `nextSubissionTimestamp`, y para que
se calcule correctamente en el lado del cliente, es necesario convertir esta fecha
en fecha remota (del servidor). Cosa que no estaba ocurriendo en la mayoría
de lugares.

Con este cambio, se realiza una búsqueda de todos las APIs donde se
puede obtener, y se agrega la función que se encarga de convertir las fechas
en fechas remotas.

Además de eso, se revisan los lugares donde se obtiene este dato, pero que
en lugar de obtenerse vía API, se obtiene por medio del payload. En estos
casos se le aplica la conversión directamente a la propiedad.

Fixes: #6462 

# Comentarios

Pareciera que el problema original que se reporta en el issue se soluciona.

Aunque hay ciertos casos que aún hay que analizar. En los concursos por ejemplo:

- Cuando el reloj está atrasado, hay ocasiones que se recarga la página y aunque
aún falte tiempo para realizar envíos de un problema, el botón está habilitado,
cosa que deja de suceder si se comienza a navegar entre problemas.

- Cuando el reloj está adelantado, el botón aparece habilitado aunque se acabe
de realizar un envío. Y cuando se reinicia la página, hay ocasiones en las que
aparece el contador con un número muy grande de segundos para poder realizar
envíos. También si se navega entre problemas deja de aparecer ese problema.

Pareciera que en los dos casos mencionados hay un punto en el que se intenta
obtener el tiempo remoto, cuando algún otro proceso ya lo convirtió. Sigo sin
encontrar el punto exacto en el que esto sucede.

Para los cursos lo único que noté es que el botón siempre está habilitado, quiere
decir que no hay contadores entre envíos. Habrá que agrega la funcionalidad
(aunque sea en otro cambio).

Cabe destacar que en ninguno de los casos donde se muestra habilitado el botón
y no debería,  se pueden realizar envíos,  así que las validaciones del servidor 
están funcionando correctamente.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
