### PR TITLE
css change to fix footer to bottom of page

### DIFF
--- a/frontend/templates/template.tpl
+++ b/frontend/templates/template.tpl
@@ -53,7 +53,7 @@
       <div id="common-navbar"></div>
       {% jsInclude 'common_navbar' omitRuntime %}
     {% endif %}
-    <main role="main" {% if not fullWidth %}class="container-lg p-5"{% endif %}>
+    <main role="main" {% if not fullWidth %}class="container-lg p-5"{% endif %} style="flex-grow: 1;">
       <div class="alert mt-0" id="status" style="display: none;">
         <button type="button" class="close" id="alert-close">&times;</button>
         <span class="message"></span>

--- a/frontend/www/js/omegaup/components/common/Footer.vue
+++ b/frontend/www/js/omegaup/components/common/Footer.vue
@@ -216,6 +216,9 @@ export default class Footer extends Vue {
 .common-footer {
   background-color: $omegaup-primary--darker;
   color: $omegaup-white;
+  position: fixed;
+  bottom: 0px;
+  width: 100%;
 
   .footer-navigation {
     .footer-brand {

--- a/frontend/www/js/omegaup/components/common/Footer.vue
+++ b/frontend/www/js/omegaup/components/common/Footer.vue
@@ -216,9 +216,6 @@ export default class Footer extends Vue {
 .common-footer {
   background-color: $omegaup-primary--darker;
   color: $omegaup-white;
-  position: fixed;
-  bottom: 0px;
-  width: 100%;
 
   .footer-navigation {
     .footer-brand {


### PR DESCRIPTION
# Description

Fixes:  #6539 

# Comments

Added:

position: fixed;
bottom: 0px;
width: 100%;

to .common-footer 

It now looks like:
![image](https://user-images.githubusercontent.com/63517269/163653053-104a478d-f52a-48ad-be25-10fbb6c202e0.png)


# Checklist:

- [ x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x ] Se corrieron todas las pruebas y pasaron.
- [x ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
