### PR TITLE
solving bug disable birthday later than today

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
   mysql:
     image: mysql:8.0
     restart: always
+    platform: linux/amd64
     environment:
       MYSQL_DATABASE: 'omegaup'
       MYSQL_USER: 'omegaup'

--- a/frontend/www/js/omegaup/components/DatePicker.vue
+++ b/frontend/www/js/omegaup/components/DatePicker.vue
@@ -9,6 +9,7 @@
     type="date"
     :disabled="!enabled"
     :readonly="usedFallback"
+    :max="max"
   />
 </template>
 
@@ -27,6 +28,7 @@ export default class DatePicker extends Vue {
   @Prop({ default: true }) enabled!: boolean;
   @Prop({ default: T.datePickerFormat }) format!: string;
   @Prop({ default: false }) isInvalid!: boolean;
+  @Prop({ default: '' }) max!: string;
 
   private usedFallback: boolean = false;
   private stringValue: string = time.formatDateLocal(this.value);

--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
@@ -56,6 +56,7 @@
       <omegaup-datepicker
         v-model="birthDate"
         :required="false"
+        :max="new Date().toISOString().split('T')[0]"
       ></omegaup-datepicker>
     </div>
     <div class="mt-3">


### PR DESCRIPTION
# Descripción

Arreglé el problema de la elección de tu fecha de naciemiento, el cual anteriormente se podía elegir una fecha incluso después del dia de hoy.

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
