### PR TITLE
Added the number of contests in API and payload

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -16,7 +16,7 @@ rewrite ^/admin/user/([a-zA-Z0-9_+.-]+)/?$ /admin/user.php?username=$1 last;
 rewrite ^/admin/support/?$ /admin/support.php last;
 rewrite ^/arena/?$ /arena/index.php last;
 rewrite ^/arena/admin/?$ /arena/admin.php last;
-rewrite ^/arenav2/?$ /arena/indexv2.php last;
+rewrite ^/arenav2/?$ /arena/indexv2.php?page_size=10 last;
 rewrite ^/arena/problem/([a-zA-Z0-9_+-]+)/?$ /arena/problem.php?problem_alias=$1 last;
 rewrite ^/arena/problem/([a-zA-Z0-9_+-]+)/print/?$ /arena/problemprint.php?problem_alias=$1 last;
 rewrite ^/arena/([a-zA-Z0-9_+-]+)/virtual/?$ /arena/virtual.php?contest_alias=$1  last;

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -33,7 +33,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type ContestListItem=array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: bool, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}
  * @psalm-type ContestList=array{current: list<ContestListItem>, future: list<ContestListItem>, past: list<ContestListItem>}
  * @psalm-type TimeTypeContests=array<string, list<ContestListItem>>
- * @psalm-type ContestListPayload=array{contests: TimeTypeContests, countContests: array<string, int>, isLogged: bool, query: string}
+ * @psalm-type ContestListPayload=array{contests: TimeTypeContests, countContests: array<string, int>, isLogged: bool, query: null|string}
  * @psalm-type ContestListv2Payload=array{contests: ContestList, countContests: array{current: int, future: int, past: int}, query: string | null}
  * @psalm-type ContestNewPayload=array{languages: array<string, string>}
  * @psalm-type Run=array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float|null, time: \OmegaUp\Timestamp, submit_delay: int, type: null|string, username: string, classname: string, alias: string, country: string, contest_alias: null|string}
@@ -1070,7 +1070,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 0,
                 250
             )
-        ) ?? '';
+        );
         $contestsByType = [];
         $countContestsByType = [];
         // tab_name => request settings

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1048,7 +1048,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param int $page
      * @omegaup-request-param int $page_size
-     * @omegaup-request-param string $query
+     * @omegaup-request-param null|string $query
      */
     public static function getContestListDetailsForTypeScript(
         \OmegaUp\Request $r
@@ -1062,14 +1062,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         $page = $r->ensureOptionalInt('page') ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
-        $query = $r->ensureString(
+        $query = $r->ensureOptionalString(
             key: 'query',
+            required: false,
             validator: fn (string $query) => \OmegaUp\Validators::stringOfLengthInRange(
                 $query,
                 0,
                 250
             )
-        );
+        ) ?? '';
         $contestsByType = [];
         $countContestsByType = [];
         // tab_name => request settings

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -214,7 +214,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         bool $public = false,
         ?int $participating = null
     ) {
-        $cacheKey = "{$activeContests}-{$recommended}-{$page}-{$pageSize}";
+        $cacheKey = "0-{$activeContests}-{$recommended}-{$page}-{$pageSize}";
         if (is_null($identity) || is_null($identity->identity_id)) {
             // Get all public contests
             $callback = /** @return array{contests: list<ContestListItem>, count: int} */ fn () => \OmegaUp\DAO\Contests::getAllPublicContests(

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -33,8 +33,8 @@ namespace OmegaUp\Controllers;
  * @psalm-type ContestListItem=array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: bool, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}
  * @psalm-type ContestList=array{current: list<ContestListItem>, future: list<ContestListItem>, past: list<ContestListItem>}
  * @psalm-type TimeTypeContests=array<string, list<ContestListItem>>
- * @psalm-type ContestListPayload=array{contests: TimeTypeContests, isLogged: bool, query: string}
- * @psalm-type ContestListv2Payload=array{contests: ContestList, query: string | null}
+ * @psalm-type ContestListPayload=array{contests: TimeTypeContests, countContests: array<string, int>, isLogged: bool, query: string}
+ * @psalm-type ContestListv2Payload=array{contests: ContestList, countContests: array{current: int, future: int, past: int}, query: string | null}
  * @psalm-type ContestNewPayload=array{languages: array<string, string>}
  * @psalm-type Run=array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float|null, time: \OmegaUp\Timestamp, submit_delay: int, type: null|string, username: string, classname: string, alias: string, country: string, contest_alias: null|string}
  * @psalm-type RunMetadata=array{verdict: string, time: float, sys_time: int, wall_time: float, memory: int}
@@ -75,6 +75,7 @@ namespace OmegaUp\Controllers;
 class Contest extends \OmegaUp\Controllers\Controller {
     const SHOW_INTRO = true;
     const MAX_CONTEST_LENGTH_SECONDS = 2678400; // 31 days
+    const CONTEST_LIST_PAGE_SIZE = 10;
 
     /**
      * Returns a list of contests
@@ -170,16 +171,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'participating'
             );
         }
-        \OmegaUp\Validators::validateStringOfLengthInRange(
-            $r['query'],
-            'query',
-            minLength: null,
-            maxLength: 255,
+        $query = $r->ensureOptionalString(
+            key: 'query',
             required: false,
+            validator: fn (string $query) => \OmegaUp\Validators::stringOfLengthInRange(
+                $query,
+                0,
+                250
+            )
         );
-        $query = $r['query'];
 
-        $contests = self::getContestList(
+        [
+            'contests' => $contests,
+            'count' => $count,
+        ] = self::getContestList(
             $r->identity,
             $query,
             $page,
@@ -191,13 +196,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         return [
-            'number_of_results' => count($contests),
+            'number_of_results' => $count,
             'results' => $contests,
         ];
     }
 
     /**
-     * @return list<ContestListItem>
+     * @return array{contests: list<ContestListItem>, count: int}
      */
     public static function getContestList(
         ?\OmegaUp\DAO\VO\Identities $identity,
@@ -212,7 +217,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $cacheKey = "{$activeContests}-{$recommended}-{$page}-{$pageSize}";
         if (is_null($identity) || is_null($identity->identity_id)) {
             // Get all public contests
-            $callback = /** @return list<ContestListItem> */ fn () => \OmegaUp\DAO\Contests::getAllPublicContests(
+            $callback = /** @return array{contests: list<ContestListItem>, count: int} */ fn () => \OmegaUp\DAO\Contests::getAllPublicContests(
                 $page,
                 $pageSize,
                 $activeContests,
@@ -220,16 +225,25 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $query
             );
             if (empty($query)) {
-                $contests = \OmegaUp\Cache::getFromCacheOrSet(
+                [
+                    'contests' => $contests,
+                    'count' => $count,
+                ] = \OmegaUp\Cache::getFromCacheOrSet(
                     \OmegaUp\Cache::CONTESTS_LIST_PUBLIC,
                     $cacheKey,
                     $callback
                 );
             } else {
-                $contests = $callback();
+                [
+                    'contests' => $contests,
+                    'count' => $count,
+                ] = $callback();
             }
         } elseif ($participating === \OmegaUp\DAO\Enum\ParticipatingStatus::YES) {
-            $contests = \OmegaUp\DAO\Contests::getContestsParticipating(
+            [
+                'contests' => $contests,
+                'count' => $count,
+            ] = \OmegaUp\DAO\Contests::getContestsParticipating(
                 $identity->identity_id,
                 $page,
                 $pageSize,
@@ -237,7 +251,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $query
             );
         } elseif ($public) {
-            $contests = \OmegaUp\DAO\Contests::getRecentPublicContests(
+            [
+                'contests' => $contests,
+                'count' => $count,
+            ] = \OmegaUp\DAO\Contests::getRecentPublicContests(
                 $identity->identity_id,
                 $page,
                 $pageSize,
@@ -245,7 +262,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         } elseif (\OmegaUp\Authorization::isSystemAdmin($identity)) {
             // Get all contests
-            $callback = /** @return list<ContestListItem> */ fn () => \OmegaUp\DAO\Contests::getAllContests(
+            $callback = /** @return array{contests: list<ContestListItem>, count: int} */ fn () => \OmegaUp\DAO\Contests::getAllContests(
                 $page,
                 $pageSize,
                 $activeContests,
@@ -253,17 +270,26 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $query
             );
             if (empty($query)) {
-                $contests = \OmegaUp\Cache::getFromCacheOrSet(
+                [
+                    'contests' => $contests,
+                    'count' => $count,
+                ] = \OmegaUp\Cache::getFromCacheOrSet(
                     \OmegaUp\Cache::CONTESTS_LIST_SYSTEM_ADMIN,
                     $cacheKey,
                     $callback
                 );
             } else {
-                $contests = $callback();
+                [
+                    'contests' => $contests,
+                    'count' => $count,
+                ] = $callback();
             }
         } else {
             // Get all public+private contests
-            $contests = \OmegaUp\DAO\Contests::getAllContestsForIdentity(
+            [
+                'contests' => $contests,
+                'count' => $count,
+            ] = \OmegaUp\DAO\Contests::getAllContestsForIdentity(
                 $identity->identity_id,
                 $page,
                 $pageSize,
@@ -281,7 +307,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
             $addedContests[] = $contestInfo;
         }
-        return $addedContests;
+        return [
+            'contests' => $addedContests,
+            'count' => $count,
+        ];
     }
 
     /**
@@ -328,9 +357,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * Callback to get contests list, depending on a given method
      *
      * @param \OmegaUp\Request $r
-     * @param Closure(int, int, int, bool, null|string):list<Contest> $callbackUserFunction
+     * @param Closure(int, int, int, bool, null|string):array{contests: list<Contest>, count: int} $callbackUserFunction
      *
-     * @return array{contests: list<Contest>}
+     * @return array{contests: list<Contest>, count: int}
      *
      * @omegaup-request-param int|null $page
      * @omegaup-request-param int|null $page_size
@@ -347,7 +376,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
         $query = $r->ensureOptionalString('query');
         $showArchived = $r->ensureOptionalBool('show_archived') ?? false;
-        $contests = $callbackUserFunction(
+        [
+            'contests' => $contests,
+            'count' => $count,
+        ] = $callbackUserFunction(
             $r->identity->identity_id,
             $page,
             $pageSize,
@@ -363,13 +395,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         return [
             'contests' => $contests,
+            'count' => $count,
         ];
     }
 
     /**
      * Returns a list of contests where current user is the director
      *
-     * @return array{contests: list<Contest>}
+     * @return array{contests: list<Contest>, count: int}
      *
      * @omegaup-request-param int|null $page
      * @omegaup-request-param int|null $page_size
@@ -399,7 +432,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a list of contests where current user is participating in
      *
-     * @return array{contests: list<Contest>}
+     * @return array{contests: list<Contest>, count: int}
      *
      * @omegaup-request-param int|null $page
      * @omegaup-request-param int|null $page_size
@@ -1029,14 +1062,16 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         $page = $r->ensureOptionalInt('page') ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
-        \OmegaUp\Validators::validateStringOfLengthInRange(
-            $r['query'],
-            'query',
-            minLength: 0,
-            maxLength: 256,
-            required: false
+        $query = $r->ensureString(
+            key: 'query',
+            validator: fn (string $query) => \OmegaUp\Validators::stringOfLengthInRange(
+                $query,
+                0,
+                250
+            )
         );
-        $contests = [];
+        $contestsByType = [];
+        $countContestsByType = [];
         // tab_name => request settings
         //
         // These same settings should be replicated in the frontend to do
@@ -1093,9 +1128,12 @@ class Contest extends \OmegaUp\Controllers\Controller {
             ) {
                 continue;
             }
-            $contests[$tab_name] = self::getContestList(
+            [
+                'contests' => $contests,
+                'count' => $count,
+            ] = self::getContestList(
                 $r->identity,
-                $r['query'],
+                $query,
                 $page,
                 $pageSize,
                 $settings['active'],
@@ -1103,14 +1141,17 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $settings['public'],
                 $settings['participating']
             );
+            $contestsByType[$tab_name] = $contests;
+            $countContestsByType[$tab_name] = $count;
         }
 
         return [
             'templateProperties' => [
                 'payload' => [
-                    'query' => $r['query'],
+                    'query' => $query,
                     'isLogged' => !is_null($r->identity),
-                    'contests' => $contests,
+                    'contests' => $contestsByType,
+                    'countContests' => $countContestsByType,
                 ],
                 'title' => new \OmegaUp\TranslationString(
                     'omegaupTitleContestList'
@@ -1138,47 +1179,69 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         $page = $r->ensureOptionalInt('page') ?? 1;
-        $pageSize = $r->ensureOptionalInt('page_size') ?? 100;
+        $pageSize = $r->ensureOptionalInt(
+            'page_size'
+        ) ?? \OmegaUp\Controllers\Contest::CONTEST_LIST_PAGE_SIZE;
+        $query = $r->ensureOptionalString(
+            key: 'query',
+            required: false,
+            validator: fn (string $query) => \OmegaUp\Validators::stringOfLengthInRange(
+                $query,
+                0,
+                250
+            )
+        );
 
-        \OmegaUp\Validators::validateStringOfLengthInRange(
-            $r['query'],
-            'query',
-            minLength: 0,
-            maxLength: 256,
-            required: false
+        [
+            'contests' => $currentContests,
+            'count' => $countCurrentContests,
+        ] = self::getContestList(
+            $r->identity,
+            $query,
+            $page,
+            $pageSize,
+            \OmegaUp\DAO\Enum\ActiveStatus::ACTIVE,
+            \OmegaUp\DAO\Enum\RecommendedStatus::ALL
+        );
+        [
+            'contests' => $futureContests,
+            'count' => $countFutureContests,
+        ] = self::getContestList(
+            $r->identity,
+            $query,
+            $page,
+            $pageSize,
+            \OmegaUp\DAO\Enum\ActiveStatus::FUTURE,
+            \OmegaUp\DAO\Enum\RecommendedStatus::ALL
+        );
+        [
+            'contests' => $pastContests,
+            'count' => $countPastContests,
+        ] = self::getContestList(
+            $r->identity,
+            $query,
+            $page,
+            $pageSize,
+            \OmegaUp\DAO\Enum\ActiveStatus::PAST,
+            \OmegaUp\DAO\Enum\RecommendedStatus::ALL
         );
 
         $contests = [
-            'current' => self::getContestList(
-                $r->identity,
-                $r['query'],
-                $page,
-                $pageSize,
-                \OmegaUp\DAO\Enum\ActiveStatus::ACTIVE,
-                \OmegaUp\DAO\Enum\RecommendedStatus::ALL
-            ),
-            'future' => self::getContestList(
-                $r->identity,
-                $r['query'],
-                $page,
-                $pageSize,
-                \OmegaUp\DAO\Enum\ActiveStatus::FUTURE,
-                \OmegaUp\DAO\Enum\RecommendedStatus::ALL
-            ),
-            'past' => self::getContestList(
-                $r->identity,
-                $r['query'],
-                $page,
-                $pageSize,
-                \OmegaUp\DAO\Enum\ActiveStatus::PAST,
-                \OmegaUp\DAO\Enum\RecommendedStatus::ALL
-            )
+            'current' => $currentContests,
+            'future' => $futureContests,
+            'past' => $pastContests,
+        ];
+        $countContests = [
+            'current' => $countCurrentContests,
+            'future' => $countFutureContests,
+            'past' => $countPastContests,
         ];
 
         return [
             'templateProperties' => [
                 'payload' => [
                     'contests' => $contests,
+                    'countContests' => $countContests,
                     'query' => $r->ensureOptionalString('query'),
                 ],
                 'title' => new \OmegaUp\TranslationString(
@@ -5109,7 +5172,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // Get user
         $r->ensureIdentity();
 
-        $contests = self::getContestList(
+        [
+            'contests' => $contests,
+        ] = self::getContestList(
             $r->identity,
             query: null,
             page: 1,

--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -537,18 +537,20 @@ class Group extends \OmegaUp\Controllers\Controller {
             $r->identity,
             $scoreboard
         );
-
+        [
+            'contests' => $availableContests,
+        ] = \OmegaUp\Controllers\Contest::getContestList(
+            $r->identity,
+            query: null,
+            page: 1,
+            pageSize: 20,
+            activeContests: \OmegaUp\DAO\Enum\ActiveStatus::ALL,
+            recommended: \OmegaUp\DAO\Enum\RecommendedStatus::ALL
+        );
         return [
             'templateProperties' => [
                 'payload' => [
-                    'availableContests' => \OmegaUp\Controllers\Contest::getContestList(
-                        $r->identity,
-                        query: null,
-                        page: 1,
-                        pageSize: 20,
-                        activeContests: \OmegaUp\DAO\Enum\ActiveStatus::ALL,
-                        recommended: \OmegaUp\DAO\Enum\RecommendedStatus::ALL
-                    ),
+                    'availableContests' => $availableContests,
                     'contests' => $contests,
                     'scoreboardAlias' => $scoreboard,
                     'groupAlias' => $groupAlias,

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -842,6 +842,7 @@ Returns a list of contests where current user is participating in
 | Name       | Type              |
 | ---------- | ----------------- |
 | `contests` | `types.Contest[]` |
+| `count`    | `number`          |
 
 ## `/api/contest/myList/`
 
@@ -863,6 +864,7 @@ Returns a list of contests where current user is the director
 | Name       | Type              |
 | ---------- | ----------------- |
 | `contests` | `types.Contest[]` |
+| `count`    | `number`          |
 
 ## `/api/contest/open/`
 

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -368,7 +368,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     /**
      * Returns all contests owned by a user.
      *
-     * @return list<Contest>
+     * @return array{contests: list<Contest>, count: int}
      */
     final public static function getAllContestsOwnedByUser(
         int $identityId,
@@ -377,11 +377,17 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         bool $showArchived = false
     ): array {
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
-        $sql = "
-            SELECT
-                $columns,
-                p.scoreboard_url,
-                p.scoreboard_url_admin
+
+        $sqlCount = 'SELECT
+                        COUNT(*)
+                    ';
+
+        $select = "SELECT
+                        $columns,
+                        p.scoreboard_url,
+                        p.scoreboard_url_admin";
+
+        $sql = '
             FROM
                 Contests
             INNER JOIN
@@ -392,19 +398,35 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 Problemsets p ON p.problemset_id = Contests.problemset_id
             WHERE
                 u.main_identity_id = ?
-                AND archived = ?
-            ORDER BY
-                Contests.contest_id DESC
-            LIMIT ?, ?;";
+                AND archived = ?';
+
         $params = [
             $identityId,
             $showArchived,
-            max(0, $page - 1) * $pageSize,
-            intval($pageSize),
         ];
 
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            "{$sqlCount} {$sql}",
+            $params
+        );
+
+        $limits = '
+            ORDER BY
+                Contests.contest_id DESC
+            LIMIT ?, ?;';
+        $params[] = max(0, $page - 1) * $pageSize;
+        $params[] = intval($pageSize);
+
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, problemset_id: int, recommended: bool, rerun_id: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $contests = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$select} {$sql} {$limits}",
+            $params
+        );
+        return [
+            'contests' => $contests,
+            'count' => $count,
+        ];
     }
 
     /**
@@ -446,7 +468,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     /**
      * Returns all contests where a user is participating in.
      *
-     * @return list<Contestv2>
+     * @return array{contests: list<Contestv2>, count: int}
      */
     final public static function getContestsParticipating(
         int $identityId,
@@ -467,13 +489,18 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         );
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
 
+        $sqlCount = 'SELECT
+                        COUNT(*)
+                    ';
+
+        $select = "SELECT
+                        $columns,
+                        p.scoreboard_url,
+                        p.scoreboard_url_admin,
+                        COUNT(contestants.identity_id) AS contestants,
+                        ANY_VALUE(organizer.username) AS organizer";
+
         $sql = "
-            SELECT
-                $columns,
-                p.scoreboard_url,
-                p.scoreboard_url_admin,
-                COUNT(contestants.identity_id) AS contestants,
-                ANY_VALUE(organizer.username) AS organizer
             FROM
                 (SELECT
                     pi.problemset_id
@@ -548,7 +575,13 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
         }
 
-        $sql .= '
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            "{$sqlCount} {$sql}",
+            $params
+        );
+
+        $limits = '
             ORDER BY
                 recommended DESC,
                 finish_time DESC
@@ -558,20 +591,26 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $params[] = intval($pageSize);
 
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, problemset_id: int, recommended: bool, rerun_id: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
-        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$select} {$sql} {$limits}",
+            $params
+        );
 
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = true;
             $contests[] = $row;
         }
-        return $contests;
+        return [
+            'contests' => $contests,
+            'count' => $count,
+        ];
     }
 
     /**
      * Returns all recent public contests.
      *
-     * @return list<ContestListItem>
+     * @return array{contests: list<ContestListItem>, count: int}
      */
     final public static function getRecentPublicContests(
         int $identity_id,
@@ -589,12 +628,17 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $filter = self::formatSearch($query);
         $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
+        $sqlCount = 'SELECT
+                        COUNT(*)
+                    ';
+
+        $select = "SELECT
+                    $columns,
+                    COUNT(contestants.identity_id) AS contestants,
+                    ANY_VALUE(organizer.username) AS organizer,
+                    (participating.identity_id IS NOT NULL) AS `participating`";
+
         $sql = "
-            SELECT
-                $columns,
-                COUNT(contestants.identity_id) AS contestants,
-                ANY_VALUE(organizer.username) AS organizer,
-                (participating.identity_id IS NOT NULL) AS `participating`
             FROM
                 Contests
             LEFT JOIN
@@ -619,13 +663,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 AND `admission_mode` != 'private'
                 AND archived = 0
             GROUP BY
-                Contests.contest_id
-            ORDER BY
-                `last_updated` DESC,
-                `recommended` DESC,
-                `finish_time` DESC,
-                `contest_id` DESC
-            LIMIT ?, ?;";
+                Contests.contest_id";
 
         $params = [$identity_id];
         if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
@@ -634,18 +672,38 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
             $params[] = $filter['query'];
         }
+
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            "{$sqlCount} {$sql}",
+            $params
+        );
+
+        $limits = '
+            ORDER BY
+                `last_updated` DESC,
+                `recommended` DESC,
+                `finish_time` DESC,
+                `contest_id` DESC
+            LIMIT ?, ?;';
         $params[] = max(0, $page - 1) * $pageSize;
         $params[] = intval($pageSize);
 
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
-        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$select} {$sql} {$limits}",
+            $params
+        );
 
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = boolval($row['participating']);
             $contests[] = $row;
         }
-        return $contests;
+        return [
+            'contests' => $contests,
+            'count' => $count,
+        ];
     }
 
     /**
@@ -668,7 +726,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
      * UNION
      * Todos los concursos públicos.
      *
-     * @return list<ContestListItem>
+     * @return array{contests: list<ContestListItem>, count: int}
      */
     final public static function getAllContestsForIdentity(
         int $identityId,
@@ -771,11 +829,16 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         )
         ";
 
-        $sql = "SELECT
-            $columns,
-            COUNT(pi.identity_id) AS contestants,
-            ANY_VALUE(organizer.username) AS organizer,
-            BIT_OR(rc.participating) AS participating
+        $sqlCount = 'SELECT
+                        COUNT(*) AS number_of_rows
+                    ';
+
+        $select = "SELECT
+                        $columns,
+                        COUNT(pi.identity_id) AS contestants,
+                        ANY_VALUE(organizer.username) AS organizer,
+                        BIT_OR(rc.participating) AS participating";
+        $sql = "
         FROM
             ($sql_relevant_contests) rc
         INNER JOIN
@@ -791,11 +854,6 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             AND archived = 0
         GROUP BY
             Contests.contest_id
-        ORDER BY
-            CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
-            recommended DESC,
-            original_finish_time DESC
-        LIMIT ?, ?
         ";
 
         $params = [
@@ -816,22 +874,41 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
             $params[] = $filter['query'];
         }
-        $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
 
+        /** @var list<array{number_of_rows: int}> */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$sqlCount} {$sql}",
+            $params
+        );
+
+        $limits = '
+            ORDER BY
+                CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
+                recommended DESC,
+                original_finish_time DESC
+            LIMIT ?, ?';
+
+        $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
         $params[] = intval($renglones_por_pagina);
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
-        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$select} {$sql} {$limits}",
+            $params
+        );
 
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = boolval($row['participating']);
             $contests[] = $row;
         }
-        return $contests;
+        return [
+            'contests' => $contests,
+            'count' => count($count),
+        ];
     }
 
     /**
-     * @return list<ContestListItem>
+     * @return array{contests: list<ContestListItem>, count: int}
      */
     final public static function getAllPublicContests(
         int $pagina = 1,
@@ -849,12 +926,17 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
 
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
 
+        $sqlCount = 'SELECT
+                        COUNT(*)
+                    ';
+
+        $select = "SELECT
+                        $columns,
+                        COUNT(contestants.identity_id) AS `contestants`,
+                        ANY_VALUE(organizer.username) AS organizer,
+                        FALSE AS `participating`
+                        ";
         $sql = "
-               SELECT
-                    $columns,
-                    COUNT(contestants.identity_id) AS `contestants`,
-                    ANY_VALUE(organizer.username) AS organizer,
-                    FALSE AS `participating`
                 FROM
                     `Contests`
                 LEFT JOIN
@@ -877,11 +959,6 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                     AND archived = 0
                 GROUP BY
                     Contests.contest_id
-                ORDER BY
-                    CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
-                    `recommended` DESC,
-                    `original_finish_time` DESC
-                LIMIT ?, ?
                 ";
 
         $params = [];
@@ -891,20 +968,39 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
             $params[] = $filter['query'];
         }
+
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            "{$sqlCount} {$sql}",
+            $params
+        );
+
+        $limits = '
+                ORDER BY
+                CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
+                `recommended` DESC,
+                `original_finish_time` DESC
+            LIMIT ?, ?';
         $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
         $params[] = intval($renglones_por_pagina);
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
-        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$select} {$sql} {$limits}",
+            $params
+        );
 
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = boolval($row['participating']);
             $contests[] = $row;
         }
-        return $contests;
+        return [
+            'contests' => $contests,
+            'count' => $count,
+        ];
     }
 
-    /** @return list<ContestListItem>
+    /** @return array{contests: list<ContestListItem>, count: int}
      */
     final public static function getAllContests(
         int $pagina = 1,
@@ -921,12 +1017,16 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $filter = self::formatSearch($query);
         $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
+        $sqlCount = 'SELECT
+                        COUNT(*)
+                    ';
+
+        $select = "SELECT
+                        $columns,
+                        COUNT(contestants.identity_id) AS contestants,
+                        ANY_VALUE(organizer.username) AS organizer,
+                        TRUE AS participating";
         $sql = "
-                SELECT
-                    $columns,
-                    COUNT(contestants.identity_id) AS contestants,
-                    ANY_VALUE(organizer.username) AS organizer,
-                    TRUE AS participating
                 FROM
                     Contests
                 LEFT JOIN
@@ -944,11 +1044,6 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 WHERE $recommended_check AND $end_check AND $query_check AND archived = 0
                 GROUP BY
                     Contests.contest_id
-                ORDER BY
-                    CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
-                    `recommended` DESC,
-                    `original_finish_time` DESC
-                LIMIT ?, ?
                 ";
 
         $params = [];
@@ -958,17 +1053,37 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
             $params[] = $filter['query'];
         }
+
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            "{$sqlCount} {$sql}",
+            $params
+        );
+
+        $limits = '
+            ORDER BY
+                CASE WHEN original_finish_time > NOW() THEN 1 ELSE 0 END DESC,
+                `recommended` DESC,
+                `original_finish_time` DESC
+            LIMIT ?, ?;';
+
         $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
         $params[] = intval($renglones_por_pagina);
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
-        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            "{$select} {$sql} {$limits}",
+            $params
+        );
 
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = boolval($row['participating']);
             $contests[] = $row;
         }
-        return $contests;
+        return [
+            'contests' => $contests,
+            'count' => $count,
+        ];
     }
 
     public static function getContestForProblemset(?int $problemsetId): ?\OmegaUp\DAO\VO\Contests {

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2845,12 +2845,14 @@ export namespace types {
 
   export interface ContestListPayload {
     contests: types.TimeTypeContests;
+    countContests: { [key: string]: number };
     isLogged: boolean;
     query: string;
   }
 
   export interface ContestListv2Payload {
     contests: types.ContestList;
+    countContests: { current: number; future: number; past: number };
     query?: string;
   }
 
@@ -4699,10 +4701,16 @@ export namespace messages {
   };
   export type ContestListParticipatingRequest = { [key: string]: any };
   export type _ContestListParticipatingServerResponse = any;
-  export type ContestListParticipatingResponse = { contests: types.Contest[] };
+  export type ContestListParticipatingResponse = {
+    contests: types.Contest[];
+    count: number;
+  };
   export type ContestMyListRequest = { [key: string]: any };
   export type _ContestMyListServerResponse = any;
-  export type ContestMyListResponse = { contests: types.Contest[] };
+  export type ContestMyListResponse = {
+    contests: types.Contest[];
+    count: number;
+  };
   export type ContestOpenRequest = { [key: string]: any };
   export type ContestOpenResponse = {};
   export type ContestProblemClarificationsRequest = { [key: string]: any };

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2847,7 +2847,7 @@ export namespace types {
     contests: types.TimeTypeContests;
     countContests: { [key: string]: number };
     isLogged: boolean;
-    query: string;
+    query?: string;
   }
 
   export interface ContestListv2Payload {

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -252,7 +252,7 @@ export enum ContestsTab {
   },
 })
 export default class ArenaContestList extends Vue {
-  @Prop() initialQuery!: string;
+  @Prop({ default: null }) initialQuery!: null | string;
   @Prop() contests!: types.TimeTypeContests;
   @Prop() isLogged!: boolean;
   @Prop({ default: null }) selectedTab!: ContestsTab | null;


### PR DESCRIPTION
# Descripción

In the issue #6490, it's gonna be necessary get the number of the contests by 
every period in order to enable only the needed buttons in the pagination.

This PR has all the changes in the server side to achieve the expected result.

Part of: #6490

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
