### PR TITLE
Evitando que el generador de DAOs se queje cuando faltan archivos

### DIFF
--- a/stuff/dao_linter.py
+++ b/stuff/dao_linter.py
@@ -46,7 +46,10 @@ class DaoLinter(linters.Linter):
                 path = os.path.join('frontend/server/src/DAO/Base', filename)
             else:
                 path = os.path.join('frontend/server/src/DAO/VO', filename)
-            original_contents[path] = contents_callback(path)
+            try:
+                original_contents[path] = contents_callback(path)
+            except FileNotFoundError:
+                original_contents[path] = b''
             new_contents[path] = contents.encode('utf-8')
 
         return linters.MultipleResults(new_contents, original_contents,


### PR DESCRIPTION
Antes esto causaba una excepción: idealmente el generador de DAOs
debería poder proceder y crear los archivos necesarios cuando se agrega
un nuevo DAO.