### PR TITLE
Agregando test a Contest para nuevo campo score_mode

### DIFF
--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -27,6 +27,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                                 Contests.finish_time,
                                 Contests.admission_mode,
                                 Contests.partial_score,
+                                Contests.score_mode,
                                 Contests.alias,
                                 Contests.recommended,
                                 Contests.window_length,

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -27,7 +27,6 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                                 Contests.finish_time,
                                 Contests.admission_mode,
                                 Contests.partial_score,
-                                Contests.score_mode,
                                 Contests.alias,
                                 Contests.recommended,
                                 Contests.window_length,

--- a/frontend/tests/Factories/Contest.php
+++ b/frontend/tests/Factories/Contest.php
@@ -99,7 +99,13 @@ class ContestParams {
     public $teamsGroupAlias;
 
     /**
-     * @param array{title?: string, admissionMode?: string, basicInformation?: bool, contestForTeams?: bool, teamsGroupAlias?: string, requestsUserInformation?: string, contestDirector?: \OmegaUp\DAO\VO\Identities, contestDirectorUser?: \OmegaUp\DAO\VO\Users, partialScore?: bool, windowLength?: ?int, languages?: ?list<string>, startTime?: \OmegaUp\Timestamp, finishTime?: \OmegaUp\Timestamp, lastUpdated?: \OmegaUp\Timestamp, penaltyCalcPolicy?: string, feedback?: string} $params
+     * @readonly
+     * @var null|string
+     */
+    public $scoreMode;
+
+    /**
+     * @param array{title?: string, admissionMode?: string, basicInformation?: bool, contestForTeams?: bool, teamsGroupAlias?: string, requestsUserInformation?: string, contestDirector?: \OmegaUp\DAO\VO\Identities, contestDirectorUser?: \OmegaUp\DAO\VO\Users, partialScore?: bool, windowLength?: ?int, languages?: ?list<string>, startTime?: \OmegaUp\Timestamp, finishTime?: \OmegaUp\Timestamp, lastUpdated?: \OmegaUp\Timestamp, penaltyCalcPolicy?: string, feedback?: string, scoreMode?: string} $params
      */
     public function __construct($params = []) {
         $this->title = $params['title'] ?? \OmegaUp\Test\Utils::createRandomString();
@@ -139,6 +145,7 @@ class ContestParams {
         $this->partialScore = $params['partialScore'] ?? true;
         $this->contestForTeams = $params['contestForTeams'] ?? false;
         $this->teamsGroupAlias = $params['teamsGroupAlias'] ?? null;
+        $this->scoreMode = $params['scoreMode'] ?? 'partial';
     }
 }
 
@@ -189,6 +196,7 @@ class Contest {
             'requests_user_information' => $params->requestsUserInformation,
             'penalty_calc_policy' => $params->penaltyCalcPolicy,
             'contest_for_teams' => $params->contestForTeams,
+            'score_mode' => $params->scoreMode,
         ]);
 
         if (!is_null($params->teamsGroupAlias)) {

--- a/frontend/tests/controllers/ContestCreateTest.php
+++ b/frontend/tests/controllers/ContestCreateTest.php
@@ -351,4 +351,47 @@ class ContestCreateTest extends \OmegaUp\Test\ControllerTestCase {
             'name' =>  $teamGroup->name,
         ], $response['teams_group']);
     }
+
+    /**
+     * A PHPUnit data provider for all the score mode to get profile details.
+     *
+     * @return list<array{0:string}>
+     */
+    public function scoreModeProvider(): array {
+        return [
+            ['partial'],
+            ['all_or_nothing'],
+            ['max_per_group'],
+        ];
+    }
+
+    /**
+     * @dataProvider scoreModeProvider
+     */
+    public function testCreateContestWithScoreMode(string $scoreMode) {
+        // Get a problem
+        $problem = \OmegaUp\Test\Factories\Problem::createProblem();
+
+        // Create contest with 2 hours and a window length 30 of minutes
+        $contest = \OmegaUp\Test\Factories\Contest::createContest(
+            new \OmegaUp\Test\Factories\ContestParams([
+                'scoreMode' => $scoreMode,])
+        );
+
+        // Add the problem to the contest
+        \OmegaUp\Test\Factories\Contest::addProblemToContest(
+            $problem,
+            $contest
+        );
+
+        // Create a contestant
+        $login = self::login($contest['director']);
+
+        // Create a contest request
+        $response = \OmegaUp\DAO\Contests::getByAlias(
+            $contest['request']['alias']
+        );
+
+        $this->assertEquals($response->score_mode, $scoreMode);
+    }
 }


### PR DESCRIPTION
# Descripción
Se agrego prueba unitaria para la creacion de Concursos con el campo score_mode

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
