### PR TITLE
Permitiendo agregar problemas con nombres cortos (2 letras) a cursos y concursos

### DIFF
--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -357,8 +357,7 @@ def add_assignment_with_problem(driver, assignment_alias, problem_alias):
             (By.CSS_SELECTOR,
              '[data-course-problemlist] .card-footer')))
 
-    driver.typeahead_helper(
-        '*[contains(@class, "card-footer")]', problem_alias)
+    driver.typeahead_helper_v2('.problems-container', problem_alias)
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR, 'button[data-add-problem]'))).click()

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -357,7 +357,7 @@ def add_assignment_with_problem(driver, assignment_alias, problem_alias):
             (By.CSS_SELECTOR,
              '[data-course-problemlist] .card-footer')))
 
-    driver.typeahead_helper_v2('.problems-container', problem_alias)
+    driver.typeahead_helper_v2('div[data-course-add-problem]', problem_alias)
     driver.wait.until(
         EC.element_to_be_clickable(
             (By.CSS_SELECTOR, 'button[data-add-problem]'))).click()

--- a/frontend/www/js/omegaup/components/contest/AddProblem.vue
+++ b/frontend/www/js/omegaup/components/contest/AddProblem.vue
@@ -14,6 +14,7 @@
             <omegaup-common-typeahead
               v-else
               :existing-options="searchResultProblems"
+              :activation-threshold="2"
               :value.sync="alias"
               @update-existing-options="
                 (query) => $emit('update-search-result-problems', query)

--- a/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
+++ b/frontend/www/js/omegaup/components/course/AssignmentDetails.vue
@@ -162,7 +162,11 @@
             :assignment-problems="assignmentProblems"
             :tagged-problems="taggedProblems"
             :selected-assignment="assignment"
+            :search-result-problems="searchResultProblems"
             @emit-tags="(tags) => $emit('tags-problems', tags)"
+            @update-search-result-problems="
+              (query) => $emit('update-search-result-problems', query)
+            "
           ></omegaup-course-scheduled-problem-list>
           <omegaup-course-problem-list
             v-else
@@ -291,6 +295,7 @@ export default class CourseAssignmentDetails extends Vue {
   @Prop() finishTimeCourse!: Date;
   @Prop() startTimeCourse!: Date;
   @Prop() courseAlias!: string;
+  @Prop() scheduledAssignmentProblems!: types.ProblemsetProblem[];
   @Prop() assignmentProblems!: types.ProblemsetProblem[];
   @Prop() taggedProblems!: omegaup.Problem[];
   @Prop({ default: true }) shouldAddProblems!: boolean;

--- a/frontend/www/js/omegaup/components/course/ProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ProblemList.vue
@@ -84,6 +84,7 @@
                 <span class="faux-label">{{ problemCardFooterLabel }}</span>
                 <omegaup-common-typeahead
                   :existing-options="searchResultProblems"
+                  :activation-threshold="2"
                   :value.sync="problemAlias"
                   @update-existing-options="
                     (query) => $emit('update-search-result-problems', query)

--- a/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
@@ -41,7 +41,7 @@
         </table>
       </div>
     </div>
-    <div class="card-footer">
+    <div class="card-footer" data-course-add-problem>
       <form>
         <div class="row">
           <div class="col-md-12">

--- a/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
+++ b/frontend/www/js/omegaup/components/course/ScheduledProblemList.vue
@@ -20,7 +20,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="problem in problems">
+            <tr v-for="problem in problems" :key="problem.alias">
               <td class="align-middle">
                 <a :href="`/arena/problem/${problem.alias}/`">{{
                   problem.alias
@@ -49,12 +49,15 @@
               <div class="form-group col-md-8">
                 <label
                   >{{ problemCardFooterLabel }}
-                  <omegaup-autocomplete
-                    v-model="problemAlias"
-                    class="form-control"
-                    :init="(el) => typeahead.problemTypeahead(el)"
-                  ></omegaup-autocomplete
-                ></label>
+                  <omegaup-common-typeahead
+                    :existing-options="searchResultProblems"
+                    :activation-threshold="2"
+                    :value.sync="problemAlias"
+                    @update-existing-options="
+                      (query) => $emit('update-search-result-problems', query)
+                    "
+                  ></omegaup-common-typeahead>
+                </label>
                 <p class="help-block">
                   {{ addCardFooterDescLabel }}
                 </p>
@@ -93,8 +96,7 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import { types } from '../../api_types';
 import T from '../../lang';
-import * as typeahead from '../../typeahead';
-import Autocomplete from '../Autocomplete.vue';
+import common_Typeahead from '../common/Typeahead.vue';
 
 import {
   FontAwesomeIcon,
@@ -107,7 +109,7 @@ library.add(fas);
 
 @Component({
   components: {
-    'omegaup-autocomplete': Autocomplete,
+    'omegaup-common-typeahead': common_Typeahead,
     'font-awesome-icon': FontAwesomeIcon,
     'font-awesome-layers': FontAwesomeLayers,
     'font-awesome-layers-text': FontAwesomeLayersText,
@@ -118,8 +120,8 @@ export default class CourseScheduledProblemList extends Vue {
   @Prop() assignmentProblems!: types.ProblemsetProblem[];
   @Prop() taggedProblems!: omegaup.Problem[];
   @Prop() selectedAssignment!: types.CourseAssignment;
+  @Prop() searchResultProblems!: types.ListItem[];
 
-  typeahead = typeahead;
   T = T;
   assignment: Partial<types.CourseAssignment> = this.selectedAssignment;
   problems: types.AddedProblem[] = this.assignmentProblems;


### PR DESCRIPTION
# Descripción

Se ajusta el valor del parámetro `activation-threshold` a 2 en los problemas 
para que estos se puedan agregar tanto a cursos como a concursos.

![ProblemsWithShortName](https://user-images.githubusercontent.com/3230352/167257523-80a17d09-cd54-4c34-9195-35dcfe2b277f.gif)

Fixes: #6553 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
