### PR TITLE
Creando archivo encargado de enviar los mensajes de cursos en RabbitMQ

### DIFF
--- a/stuff/pipelines/producer_course.py
+++ b/stuff/pipelines/producer_course.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+'''Send messages to Course queue in rabbitmq'''
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import sys
+
+from typing import List
+import mysql.connector
+import mysql.connector.cursor
+import pika
+
+import database.course
+import rabbitmq_connection
+import rabbitmq_producer
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "."))
+import lib.db   # pylint: disable=wrong-import-position
+import lib.logs  # pylint: disable=wrong-import-position
+
+
+def send_course_message_to_client(
+        *,
+        cur: mysql.connector.cursor.MySQLCursorDict,
+        channel: pika.adapters.blocking_connection.BlockingChannel,
+        date_lower_limit: datetime.datetime = datetime.datetime(2005, 1, 1),
+        date_upper_limit: datetime.datetime = datetime.datetime.now(),
+) -> None:
+    '''Send messages to course queue.
+     date-lower-limit: initial time from which to be taken the finish courses.
+     By default. the 2005/01/01 date will be taken.
+     date-upper-limit: finish time from which to be taken the finish courses.
+     By default, the current date will be taken.
+    '''
+    course_producer = rabbitmq_producer.RabbitmqProducer(
+        queue='client_course',
+        exchange='certificates',
+        routing_key='CourseQueue',
+        channel=channel
+    )
+
+    courses = get_courses_from_db(
+        cur=cur,
+        date_lower_limit=date_lower_limit,
+        date_upper_limit=date_upper_limit,
+    )
+
+    for data in courses:
+        message = json.dumps(data)
+        course_producer.send_message(message)
+
+
+def get_courses_from_db(
+    *,
+    cur: mysql.connector.cursor.MySQLCursorDict,
+    date_lower_limit: datetime.datetime,
+    date_upper_limit: datetime.datetime,
+) -> List[database.course.CourseCertificate]:
+    ''''A intermediate function in order to mock the original one'''
+    return database.course.get_courses(
+        cur=cur,
+        date_lower_limit=date_lower_limit,
+        date_upper_limit=date_upper_limit,
+    )
+
+
+def main() -> None:
+    '''Main entrypoint.'''
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--date-lower-limit',
+                        type=lambda s:
+                        datetime.datetime.strptime(s, '%Y-%m-%d'),
+                        help='date lower limit',
+                        default=datetime.datetime(2005, 1, 1))
+    parser.add_argument('--date-upper-limit',
+                        type=lambda s:
+                        datetime.datetime.strptime(s, '%Y-%m-%d'),
+                        help='date upper limit',
+                        default=datetime.datetime.today())
+    lib.db.configure_parser(parser)
+    lib.logs.configure_parser(parser)
+
+    rabbitmq_connection.configure_parser(parser)
+
+    args = parser.parse_args()
+    lib.logs.init(parser.prog, args)
+
+    logging.info('Started')
+    dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
+    try:
+        with dbconn.cursor(buffered=True, dictionary=True) as cur, \
+            rabbitmq_connection.connect(username=args.rabbitmq_username,
+                                        password=args.rabbitmq_password,
+                                        host=args.rabbitmq_host,
+                                        ) as channel:
+            send_course_message_to_client(
+                cur=cur,
+                channel=channel,
+                date_lower_limit=args.date_lower_limit,
+                date_upper_limit=args.date_upper_limit)
+    finally:
+        dbconn.conn.close()
+        logging.info('Done')
+
+
+if __name__ == '__main__':
+    main()

--- a/stuff/pipelines/test_producer_course.py
+++ b/stuff/pipelines/test_producer_course.py
@@ -1,0 +1,99 @@
+
+#!/usr/bin/env python3
+
+'''test producer of courses.'''
+
+import json
+import dataclasses
+import os
+import sys
+
+from typing import Optional
+import pytest
+import pika
+import pytest_mock
+import course_callback
+
+import test_credentials
+import rabbitmq_connection
+import producer_course
+import rabbitmq_client
+import rabbitmq_connection
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "."))
+import lib.db   # pylint: disable=wrong-import-position
+
+@dataclasses.dataclass
+class MessageSavingCallback:
+    '''class to save message'''
+    message: Optional[course_callback.CourseCertificate] = None
+
+    def __call__(self,
+                 channel: pika.adapters.blocking_connection.BlockingChannel,
+                 _method: pika.spec.Basic.Deliver,
+                 _properties: pika.spec.BasicProperties,
+                 body: bytes) -> None:
+        '''Callback function to test'''
+        self.message = json.loads(body.decode())
+        channel.close()
+
+
+# mypy has conflict with pytest decorations
+@pytest.mark.parametrize(
+    'params, expected',
+    [
+        (
+            {
+                'minimum_progress_for_certificate': 1,
+                'course_id': 1,
+                'alias': 'course1',
+            },
+            'minimum_progress_for_certificate',
+        ),
+        (
+            {
+                'minimum_progress_for_certificate': 1,
+                'course_id': 2,
+                'alias': 'course2',
+            },
+            'minimum_progress_for_certificate',
+        ),
+    ],
+)  # type: ignore
+def test_course_producer(mocker: pytest_mock.MockerFixture,
+                         params,
+                         expected) -> None:
+    '''Test the message send to the course queue'''
+    mocker.patch('producer_course.get_courses_from_db', return_value=params)
+
+    dbconn = lib.db.connect(
+        lib.db.DatabaseConnectionArguments(
+            user=test_credentials.MYSQL_USER,
+            password=test_credentials.MYSQL_PASSWORD,
+            host=test_credentials.MYSQL_HOST,
+            database=test_credentials.MYSQL_DATABASE,
+            port=test_credentials.MYSQL_PORT,
+            mysql_config_file=lib.db.default_config_file_path() or ''
+        )
+    )
+
+    with dbconn.cursor(buffered=True, dictionary=True) as cur, \
+        rabbitmq_connection.connect(username=test_credentials.OMEGAUP_USERNAME,
+                                     password=test_credentials.OMEGAUP_PASSWORD,
+                                     host=test_credentials.RABBITMQ_HOST) as channel:
+        rabbitmq_connection.initialize_rabbitmq(
+            queue='course',
+            exchange='certificates',
+            routing_key='CourseQueue',
+            channel=channel)
+        producer_course.send_course_message_to_client(cur=cur, channel=channel)
+        callback = MessageSavingCallback()
+        rabbitmq_client.receive_messages(queue='course',
+                                         exchange='certificates',
+                                         routing_key='CourseQueue',
+                                         channel=channel,
+                                         callback=callback)
+        assert expected == callback.message


### PR DESCRIPTION
# Descripción

Se agrega el archivo producer_course.py que se va a encargar de enviar los
mensajes para certificados de cursos en RabbitMQ.

Part of: #5260 

# Comentarios

Este cambio depende de los PRs #6572 y #6581, así que por lo pronto se 
quedará como draft, ya que aún contendrá errores.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
