### PR TITLE
Haciendo opcional el campo de Escuela al agregar identidades en bulk

### DIFF
--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -237,33 +237,37 @@ class Identity extends \OmegaUp\Controllers\Controller {
                     $group->alias
                 );
 
-                $state = null;
-                if (!is_null($countryId) && !is_null($stateId)) {
-                    $state = \OmegaUp\DAO\States::getByPK(
-                        $countryId,
-                        $stateId
+                if (isset($identity['school_name'])) {
+                    $state = null;
+                    if (!is_null($countryId) && !is_null($stateId)) {
+                        $state = \OmegaUp\DAO\States::getByPK(
+                            $countryId,
+                            $stateId
+                        );
+                    }
+
+                    $schoolId = \OmegaUp\Controllers\School::createSchool(
+                        trim($identity['school_name']),
+                        $state
                     );
+
+                    // Create IdentitySchool
+                    $identitySchool = new \OmegaUp\DAO\VO\IdentitiesSchools([
+                        'identity_id' => $newIdentity->identity_id,
+                        'school_id' => $schoolId,
+                    ]);
+
+                    \OmegaUp\DAO\IdentitiesSchools::create($identitySchool);
+
+                    // Save current_identity_school_id on Identity
+                    $newIdentity->current_identity_school_id = $identitySchool->identity_school_id;
                 }
-                $schoolId = \OmegaUp\Controllers\School::createSchool(
-                    trim($identity['school_name']),
-                    $state
-                );
 
                 self::saveIdentityGroupInsideTransaction(
                     $newIdentity,
                     $group
                 );
 
-                // Create IdentitySchool
-                $identitySchool = new \OmegaUp\DAO\VO\IdentitiesSchools([
-                    'identity_id' => $newIdentity->identity_id,
-                    'school_id' => $schoolId,
-                ]);
-
-                \OmegaUp\DAO\IdentitiesSchools::create($identitySchool);
-
-                // Save current_identity_school_id on Identity
-                $newIdentity->current_identity_school_id = $identitySchool->identity_school_id;
                 \OmegaUp\DAO\Identities::update($newIdentity);
             }
 

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -237,7 +237,12 @@ class Identity extends \OmegaUp\Controllers\Controller {
                     $group->alias
                 );
 
+                $school = null;
+                $schoolId = null;
                 if (isset($identity['school_name'])) {
+                    $school = trim($identity['school_name']);
+                }
+                if (!empty($school)) {
                     $state = null;
                     if (!is_null($countryId) && !is_null($stateId)) {
                         $state = \OmegaUp\DAO\States::getByPK(
@@ -245,12 +250,18 @@ class Identity extends \OmegaUp\Controllers\Controller {
                             $stateId
                         );
                     }
-
                     $schoolId = \OmegaUp\Controllers\School::createSchool(
-                        trim($identity['school_name']),
+                        $school,
                         $state
                     );
+                }
 
+                self::saveIdentityGroupInsideTransaction(
+                    $newIdentity,
+                    $group
+                );
+
+                if (!is_null($schoolId)) {
                     // Create IdentitySchool
                     $identitySchool = new \OmegaUp\DAO\VO\IdentitiesSchools([
                         'identity_id' => $newIdentity->identity_id,
@@ -262,11 +273,6 @@ class Identity extends \OmegaUp\Controllers\Controller {
                     // Save current_identity_school_id on Identity
                     $newIdentity->current_identity_school_id = $identitySchool->identity_school_id;
                 }
-
-                self::saveIdentityGroupInsideTransaction(
-                    $newIdentity,
-                    $group
-                );
 
                 \OmegaUp\DAO\Identities::update($newIdentity);
             }

--- a/frontend/tests/Factories/Identity.php
+++ b/frontend/tests/Factories/Identity.php
@@ -49,18 +49,21 @@ class Identity {
                     )
                 );
             }
-            array_push($identities, [
+            $identity = [
                 'username' => $username,
                 'name' => strval($data[1]),
                 'country_id' => strval($data[2]),
                 'state_id' => strval($data[3]),
                 'gender' => strval($data[4]),
-                'school_name' => strval($data[5]),
                 'password' => is_null(
                     $password
                 ) ? \OmegaUp\Test\Utils::createRandomString() : $password,
                 'usernames' => $members,
-            ]);
+            ];
+            if (isset($data[5])) {
+                $identity['school_name'] = strval($data[5]);
+            }
+            array_push($identities, $identity);
         }
         fclose($handle);
 
@@ -104,7 +107,7 @@ class Identity {
         \OmegaUp\Controllers\Identity::apiBulkCreate(new \OmegaUp\Request([
             'auth_token' => $adminLogin->auth_token,
             'identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
-                'identities.csv',
+                'identities_no_school_name.csv',
                 strval($group->alias),
                 $password
             ),

--- a/frontend/tests/resources/identities_no_school_name.csv
+++ b/frontend/tests/resources/identities_no_school_name.csv
@@ -1,0 +1,6 @@
+﻿username,name,country_id,state_id,gender
+identity_1,Identity One,MX,AGU,male
+identity_2,Identity Two,MX,BCN,male
+identity_3,Identity Three,MX,BCS,female
+identity_4,Identity Four,MX,CHH,male
+identity_5,Identity Five,MX,CHP,female


### PR DESCRIPTION
# Descripción

Como parte del issue en el que no se pueden cargar ciertos archivos .csv como
identidades de un grupo, se agrega este primer cambio el cual permite que el
archivo se suba aún cuando no se haya pasado nada en el campo de escuela

Part of: #6587 

# Comentarios

Faltará en otro cambio arregla la llave duplicada que está haciendo que falle 
la carga de archivos, y un cambio más (o posiblemente en este cambio) para 
arreglar el bug en el que se guardan todas las identidades con la misma 
escuela.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
