### PR TITLE
Dejando de calcular el scoreboard en los cursos públicos

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -55,7 +55,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type IntroDetailsPayload=array{course: CourseDetails, isFirstTimeAccess: bool, needsBasicInformation: bool, shouldShowAcceptTeacher: bool, shouldShowResults: bool, statements: array{acceptTeacher?: PrivacyStatement, privacy?: PrivacyStatement}, userRegistrationAccepted?: bool|null, userRegistrationAnswered?: bool, userRegistrationRequested?: bool}
  * @psalm-type NavbarProblemsetProblem=array{acceptsSubmissions: bool, alias: string, bestScore: int, hasRuns: bool, maxScore: float|int, text: string}
  * @psalm-type ArenaAssignment=array{alias: string|null, assignment_type: string, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string|null, problems: list<NavbarProblemsetProblem>, problemset_id: int, runs: list<Run>, start_time: \OmegaUp\Timestamp, totalRuns: int|null}
- * @psalm-type AssignmentDetailsPayload=array{showRanking: bool, scoreboard: Scoreboard, courseDetails: CourseDetails, currentAssignment: ArenaAssignment, shouldShowFirstAssociatedIdentityRunWarning: bool}
+ * @psalm-type AssignmentDetailsPayload=array{showRanking: bool, scoreboard?: Scoreboard, courseDetails: CourseDetails, currentAssignment: ArenaAssignment, shouldShowFirstAssociatedIdentityRunWarning: bool}
  * @psalm-type AssignmentDetails=array{admin: bool, alias: string, assignmentType: string, courseAssignments: list<CourseAssignment>, description: string, director: string, finishTime: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetProblem>, problemsetId: int, startTime: \OmegaUp\Timestamp}
  * @psalm-type CourseScoreboardPayload=array{assignment: AssignmentDetails, problems: list<NavbarProblemsetProblem>, scoreboard: Scoreboard, scoreboardToken:null|string}
  * @psalm-type AddedProblem=array{alias: string, commit?: string, points: float, is_extra_problem?: bool}
@@ -4224,7 +4224,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             ] = self::getAllRuns($assignment->problemset_id);
         }
 
-        return [
+        $response = [
             'templateProperties' => [
                 'payload' => [
                     'shouldShowFirstAssociatedIdentityRunWarning' => (
@@ -4259,10 +4259,6 @@ class Course extends \OmegaUp\Controllers\Controller {
                         'runs' => $runs,
                         'totalRuns' => $totalRuns,
                     ],
-                    'scoreboard' => $scoreboard->generate(
-                        withRunDetails: false,
-                        sortByName: false
-                    ),
                 ],
                 'fullWidth' => true,
                 'title' => new \OmegaUp\TranslationString(
@@ -4277,6 +4273,13 @@ class Course extends \OmegaUp\Controllers\Controller {
             'inContest' => $assignment->assignment_type === 'test',
             'entrypoint' => 'arena_course',
         ];
+        if ($course->admission_mode !== self::ADMISSION_MODE_PUBLIC) {
+            $response['templateProperties']['payload']['scoreboard'] = $scoreboard->generate(
+                withRunDetails: false,
+                sortByName: false
+            );
+        }
+        return $response;
     }
 
     /**

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -272,13 +272,16 @@ export namespace types {
           x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
           return x;
         })(x.currentAssignment);
-        x.scoreboard = ((x) => {
-          if (typeof x.finish_time !== 'undefined' && x.finish_time !== null)
-            x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
-          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
-          x.time = ((x: number) => new Date(x * 1000))(x.time);
-          return x;
-        })(x.scoreboard);
+        if (typeof x.scoreboard !== 'undefined' && x.scoreboard !== null)
+          x.scoreboard = ((x) => {
+            if (typeof x.finish_time !== 'undefined' && x.finish_time !== null)
+              x.finish_time = ((x: number) => new Date(x * 1000))(
+                x.finish_time,
+              );
+            x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+            x.time = ((x: number) => new Date(x * 1000))(x.time);
+            return x;
+          })(x.scoreboard);
         return x;
       })(
         JSON.parse(
@@ -2418,7 +2421,7 @@ export namespace types {
   export interface AssignmentDetailsPayload {
     courseDetails: types.CourseDetails;
     currentAssignment: types.ArenaAssignment;
-    scoreboard: types.Scoreboard;
+    scoreboard?: types.Scoreboard;
     shouldShowFirstAssociatedIdentityRunWarning: boolean;
     showRanking: boolean;
   }

--- a/frontend/www/js/omegaup/components/arena/Arena.vue
+++ b/frontend/www/js/omegaup/components/arena/Arena.vue
@@ -73,6 +73,7 @@ import { Tab } from '../problem/Details.vue';
 @Component
 export default class Arena extends Vue {
   @Prop({ default: false }) shouldShowRuns!: boolean;
+  @Prop({ default: true }) shouldShowRanking!: boolean;
   @Prop({ default: () => [] }) clarifications!: types.Clarification[];
   @Prop() title!: string;
   @Prop() activeTab!: string;
@@ -98,7 +99,7 @@ export default class Arena extends Vue {
       {
         name: 'ranking',
         text: T.wordsRanking,
-        visible: true,
+        visible: this.shouldShowRanking,
       },
       {
         name: 'runs',

--- a/frontend/www/js/omegaup/components/arena/Course.vue
+++ b/frontend/www/js/omegaup/components/arena/Course.vue
@@ -3,6 +3,7 @@
     :active-tab="activeTab"
     :title="currentAssignment.name"
     :should-show-runs="isAdmin"
+    :should-show-ranking="course.admission_mode !== 'public'"
     @update:activeTab="(selectedTab) => $emit('update:activeTab', selectedTab)"
   >
     <template #socket-status>
@@ -125,7 +126,7 @@
         </div>
       </div>
     </template>
-    <template #arena-scoreboard>
+    <template v-if="scoreboard" #arena-scoreboard>
       <omegaup-arena-scoreboard
         :show-invited-users-filter="false"
         :problems="scoreboard.problems"
@@ -263,7 +264,7 @@ export default class ArenaCourse extends Vue {
   @Prop({ default: null }) problemAlias!: null | string;
   @Prop({ default: SocketStatus.Waiting }) socketStatus!: SocketStatus;
   @Prop({ default: false }) showNewClarificationPopup!: boolean;
-  @Prop() scoreboard!: types.Scoreboard;
+  @Prop() scoreboard!: null | types.Scoreboard;
   @Prop({ default: PopupDisplayed.None }) popupDisplayed!: PopupDisplayed;
   @Prop({ default: () => [] }) runs!: types.Run[];
   @Prop({ default: null }) allRuns!: null | types.Run[];


### PR DESCRIPTION
# Descripción

Se omite la generación del scoreboard en los cursos públicos. Esto debido a 
la gran cantidad de usuarios que pueden estar registrandose a dichos cursos
lo cual está ocasionando que el scoreboard deborde la memoria del servidor 
y evite que se muestren algunas tareas.

![HideScoreboardPublicCourse](https://user-images.githubusercontent.com/3230352/169972971-6c03d24a-8891-478c-8e4e-16cccf8f13d9.gif)

Fixes: #6592

# Comentarios

Falta agregar las pruebas.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
