### PR TITLE
Mostrando los concursos para equipos a identidades en el nuevo listado de concursos

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -1165,9 +1165,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * @return array{templateProperties: array{payload: ContestListv2Payload, title: \OmegaUp\TranslationString}, entrypoint: string}
      *
-     * @omegaup-request-param int $page
-     * @omegaup-request-param int $page_size
-     * @omegaup-request-param string $query
+     * @omegaup-request-param int|null $page
+     * @omegaup-request-param int|null $page_size
+     * @omegaup-request-param null|string $query
      */
     public static function getContestListDetailsv2ForTypeScript(
         \OmegaUp\Request $r

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -10,7 +10,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type AuthorRankTablePayload=array{length: int, page: int, ranking: AuthorsRank, pagerItems: list<PageItem>}
  * @psalm-type Badge=array{assignation_time: \OmegaUp\Timestamp|null, badge_alias: string, first_assignation: \OmegaUp\Timestamp|null, owners_count: int, total_users: int}
  * @psalm-type AssociatedIdentity=array{username: string, default: bool}
- * @psalm-type CommonPayload=array{associatedIdentities: list<AssociatedIdentity>, omegaUpLockDown: bool, inContest: bool, isLoggedIn: bool, isReviewer: bool, gravatarURL128: string, gravatarURL51: string, currentEmail: string, currentName: null|string, currentUsername: string, userClassname: string, userCountry: string, profileProgress: float, isMainUserIdentity: bool, isAdmin: bool, lockDownImage: string, navbarSection: string, userTypes: list<string>}
+ * @psalm-type CommonPayload=array{associatedIdentities: list<AssociatedIdentity>, currentEmail: string, currentName: null|string, currentUsername: string, gravatarURL128: string, gravatarURL51: string, isAdmin: bool, inContest: bool, isLoggedIn: bool, isMainUserIdentity: bool, isReviewer: bool, lockDownImage: string, navbarSection: string, omegaUpLockDown: bool, profileProgress: float, userClassname: string, userCountry: string, userTypes: list<string>}
  * @psalm-type UserRankInfo=array{name: string, problems_solved: int, rank: int, author_ranking: int|null}
  * @psalm-type UserRank=array{rank: list<array{classname: string, country_id: null|string, name: null|string, problems_solved: int, ranking: null|int, score: float, user_id: int, username: string}>, total: int}
  * @psalm-type Problem=array{title: string, alias: string, submissions: int, accepted: int, difficulty: float, quality_seal: bool}

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -648,15 +648,15 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         int $pageSize = 1000,
         ?string $query = null
     ) {
-        $end_check = \OmegaUp\DAO\Enum\ActiveStatus::sql(
+        $endCheck = \OmegaUp\DAO\Enum\ActiveStatus::sql(
             \OmegaUp\DAO\Enum\ActiveStatus::ACTIVE
         );
-        $recommended_check = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
+        $recommendedCheck = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
             \OmegaUp\DAO\Enum\ActiveStatus::ALL
         );
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
         $filter = self::formatSearch($query);
-        $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
+        $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
         $sqlCount = 'SELECT
                         COUNT(*)
@@ -689,7 +689,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 Contests.problemset_id = participating.problemset_id AND
                 participating.identity_id = ?
             WHERE
-                $recommended_check  AND $end_check AND $query_check
+                $recommendedCheck  AND $endCheck AND $queryCheck
                 AND `admission_mode` != 'private'
                 AND archived = 0
             GROUP BY
@@ -760,19 +760,19 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
      */
     final public static function getAllContestsForIdentity(
         int $identityId,
-        int $pagina = 1,
-        int $renglones_por_pagina = 1000,
-        int $activos = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
-        int $recomendados = \OmegaUp\DAO\Enum\RecommendedStatus::ALL,
+        int $page = 1,
+        int $rowsPerPage = 1000,
+        int $activeContests = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
+        int $recommendedContests = \OmegaUp\DAO\Enum\RecommendedStatus::ALL,
         ?string $query = null
     ): array {
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
-        $end_check = \OmegaUp\DAO\Enum\ActiveStatus::sql($activos);
-        $recommended_check = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
-            $recomendados
+        $endCheck = \OmegaUp\DAO\Enum\ActiveStatus::sql($activeContests);
+        $recommendedCheck = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
+            $recommendedContests
         );
         $filter = self::formatSearch($query);
-        $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
+        $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
         $sqlRelevantContests = "
         -- Organizer
@@ -894,7 +894,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         INNER JOIN
             Identities organizer ON organizer.user_id = a.owner_id
         WHERE
-            $recommended_check AND $end_check AND $query_check
+            $recommendedCheck AND $endCheck AND $queryCheck
             AND archived = 0
         GROUP BY
             Contests.contest_id
@@ -934,8 +934,8 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 original_finish_time DESC
             LIMIT ?, ?';
 
-        $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
-        $params[] = intval($renglones_por_pagina);
+        $params[] = max(0, $page - 1) * $rowsPerPage;
+        $params[] = intval($rowsPerPage);
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             "{$select} {$sql} {$limits}",
@@ -957,18 +957,18 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
      * @return array{contests: list<ContestListItem>, count: int}
      */
     final public static function getAllPublicContests(
-        int $pagina = 1,
-        int $renglones_por_pagina = 1000,
-        int $activos = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
-        int $recomendados = \OmegaUp\DAO\Enum\RecommendedStatus::ALL,
+        int $page = 1,
+        int $rowsPerPage = 1000,
+        int $activeContests = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
+        int $recommendedContests = \OmegaUp\DAO\Enum\RecommendedStatus::ALL,
         ?string $query = null
     ): array {
-        $end_check = \OmegaUp\DAO\Enum\ActiveStatus::sql($activos);
-        $recommended_check = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
-            $recomendados
+        $endCheck = \OmegaUp\DAO\Enum\ActiveStatus::sql($activeContests);
+        $recommendedCheck = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
+            $recommendedContests
         );
         $filter = self::formatSearch($query);
-        $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
+        $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
 
@@ -999,9 +999,9 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                     a.owner_id = organizer.user_id
                 WHERE
                     `admission_mode` <> 'private'
-                    AND $recommended_check
-                    AND $end_check
-                    AND $query_check
+                    AND $recommendedCheck
+                    AND $endCheck
+                    AND $queryCheck
                     AND archived = 0
                 GROUP BY
                     Contests.contest_id
@@ -1027,8 +1027,8 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 `recommended` DESC,
                 `original_finish_time` DESC
             LIMIT ?, ?';
-        $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
-        $params[] = intval($renglones_por_pagina);
+        $params[] = max(0, $page - 1) * $rowsPerPage;
+        $params[] = intval($rowsPerPage);
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             "{$select} {$sql} {$limits}",
@@ -1049,19 +1049,19 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     /** @return array{contests: list<ContestListItem>, count: int}
      */
     final public static function getAllContests(
-        int $pagina = 1,
-        int $renglones_por_pagina = 1000,
-        int $activos = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
-        int $recomendados = \OmegaUp\DAO\Enum\RecommendedStatus::ALL,
+        int $page = 1,
+        int $rowsPerPage = 1000,
+        int $activeContests = \OmegaUp\DAO\Enum\ActiveStatus::ALL,
+        int $recommendedContests = \OmegaUp\DAO\Enum\RecommendedStatus::ALL,
         ?string $query = null
     ) {
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
-        $end_check = \OmegaUp\DAO\Enum\ActiveStatus::sql($activos);
-        $recommended_check = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
-            $recomendados
+        $endCheck = \OmegaUp\DAO\Enum\ActiveStatus::sql($activeContests);
+        $recommendedCheck = \OmegaUp\DAO\Enum\RecommendedStatus::sql(
+            $recommendedContests
         );
         $filter = self::formatSearch($query);
-        $query_check = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
+        $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
 
         $sqlCount = 'SELECT
                         COUNT(*)
@@ -1087,7 +1087,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                     Identities AS organizer
                 ON
                     a.owner_id = organizer.user_id
-                WHERE $recommended_check AND $end_check AND $query_check AND archived = 0
+                WHERE $recommendedCheck AND $endCheck AND $queryCheck AND archived = 0
                 GROUP BY
                     Contests.contest_id
                 ";
@@ -1113,8 +1113,8 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 `original_finish_time` DESC
             LIMIT ?, ?;';
 
-        $params[] = max(0, $pagina - 1) * $renglones_por_pagina;
-        $params[] = intval($renglones_por_pagina);
+        $params[] = max(0, $page - 1) * $rowsPerPage;
+        $params[] = intval($rowsPerPage);
         /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, partial_score: bool, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             "{$select} {$sql} {$limits}",

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -3,8 +3,8 @@
 namespace OmegaUp;
 
 /**
- * @psalm-type CommonPayload=array{associatedIdentities: list<array{default: bool, username: string}>, currentEmail: string, currentName: null|string, currentUsername: string, gravatarURL128: string, gravatarURL51: string, inContest: bool, isAdmin: bool, isLoggedIn: bool, isMainUserIdentity: bool, isReviewer: bool, lockDownImage: string, navbarSection: string, omegaUpLockDown: bool, profileProgress: float, userClassname: null|string, userCountry: string, userTypes: list<string>}
- * @psalm-type AssociatedIdentity=array{username: string, default: bool}
+ * @psalm-type AssociatedIdentity=array{default: bool, username: string}
+ * @psalm-type CommonPayload=array{associatedIdentities: list<AssociatedIdentity>, currentEmail: string, currentName: null|string, currentUsername: string, gravatarURL128: string, gravatarURL51: string, isAdmin: bool, inContest: bool, isLoggedIn: bool, isMainUserIdentity: bool, isReviewer: bool, lockDownImage: string, navbarSection: string, omegaUpLockDown: bool, profileProgress: float, userClassname: string, userCountry: string, userTypes: list<string>}
  * @psalm-type CurrentSession=array{associated_identities: list<AssociatedIdentity>, valid: bool, email: string|null, user: \OmegaUp\DAO\VO\Users|null, identity: \OmegaUp\DAO\VO\Identities|null, classname: string, auth_token: string|null, is_admin: bool}
  * @psalm-type RenderCallbackPayload=array{templateProperties: array{fullWidth?: bool, hideFooterAndHeader?: bool, payload: array<string, mixed>, scripts?: list<string>, title: \OmegaUp\TranslationString}, entrypoint: string, inContest?: bool, navbarSection?: string}
  */

--- a/frontend/tests/controllers/TeamGroupsTest.php
+++ b/frontend/tests/controllers/TeamGroupsTest.php
@@ -4,6 +4,106 @@
  * TeamGroupsTest
  */
 class TeamGroupsTest extends \OmegaUp\Test\ControllerTestCase {
+    public function testShowContestForTeamsInArena() {
+        // Identity creator group member will upload csv file
+        [
+            'identity' => $creatorIdentity,
+        ] = \OmegaUp\Test\Factories\User::createGroupIdentityCreator();
+        $creatorLogin = self::login($creatorIdentity);
+        [
+            'teamGroup' => $teamGroup,
+        ] = \OmegaUp\Test\Factories\Groups::createTeamsGroup(
+            $creatorIdentity,
+            login: $creatorLogin,
+        );
+        $numberOfUsers = 2;
+
+        $usernameAndPasswordIdentities = [];
+        foreach (range(0, $numberOfUsers - 1) as $id) {
+            $usernameAndPasswordIdentities[] = [
+                'username' => "new_user_{$id}",
+                'password' => "new_user_password_{$id}",
+            ];
+        }
+
+        $teamUsernames = \OmegaUp\Test\Factories\Identity::getUsernamesInCsvFile(
+            'team_identities.csv',
+            $teamGroup->alias,
+        );
+
+        // Call api using identity creator group member
+        \OmegaUp\Controllers\Identity::apiBulkCreateForTeams(
+            new \OmegaUp\Request([
+                'auth_token' => $creatorLogin->auth_token,
+                'team_identities' => \OmegaUp\Test\Factories\Identity::getCsvData(
+                    'team_identities.csv',
+                    $teamGroup->alias,
+                    forTeams: true,
+                ),
+                'team_group_alias' => $teamGroup->alias,
+            ])
+        );
+
+        // Users to associate
+        foreach ($usernameAndPasswordIdentities as $id => $usernameIdentity) {
+            [
+                'identity' => $identities[$id],
+            ] = \OmegaUp\Test\Factories\User::createUser(
+                new \OmegaUp\Test\Factories\UserParams($usernameIdentity)
+            );
+
+            $teamAlias = "teams:{$teamGroup->alias}:{$teamUsernames[$id]}";
+            \OmegaUp\Controllers\TeamsGroup::apiAddMembers(
+                new \OmegaUp\Request([
+                    'auth_token' => $creatorLogin->auth_token,
+                    'team_group_alias' => $teamAlias,
+                    'usernames' => $usernameIdentity['username'],
+                ])
+            );
+        }
+
+        // Create contest for teams
+        \OmegaUp\Test\Factories\Contest::createContest(
+            new \OmegaUp\Test\Factories\ContestParams([
+                'title' => 'Contest_For_Teams',
+                'contestForTeams' => true,
+                'teamsGroupAlias' => $teamGroup->alias,
+            ])
+        );
+
+        foreach ($identities as $index => $identity) {
+            $identity->password = $usernameAndPasswordIdentities[$index]['password'];
+            $login = self::login($identity);
+
+            [
+                'identities' => $associatedIdentities,
+            ] = \OmegaUp\Controllers\User::apiListAssociatedIdentities(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                ])
+            );
+
+            // User switch the account
+            \OmegaUp\Controllers\Identity::apiSelectIdentity(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'usernameOrEmail' => $associatedIdentities[1]['username'],
+                ])
+            );
+
+            $contestListPayload = \OmegaUp\Controllers\Contest::getContestListDetailsv2ForTypeScript(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                ])
+            )['templateProperties']['payload'];
+
+            $this->assertEquals(
+                1,
+                $contestListPayload['countContests']['current']
+            );
+        }
+    }
+
     public function testTeamGroupEditDetailsPayload() {
         [
             'owner' => $owner,

--- a/frontend/tests/resources/team_identities_local.csv
+++ b/frontend/tests/resources/team_identities_local.csv
@@ -1,0 +1,6 @@
+﻿username,name,country_id,state_id,gender,school_name,usernames
+team_1,Team One,MX,AGU,decline,School Group,test_user_0;test_user_1
+team_2,Team Two,MX,BCN,other,School Group,test_user_2;test_user_3
+team_3,Team Three,MX,BCS,female,School Group,test_user_4;test_user_5
+team_4,Team Four,MX,CHH,male,School Group,test_user_6;test_user_7
+team_5,Team Five,MX,CHP,decline,School Group,test_user_8;test_user_9


### PR DESCRIPTION
# Descripción

Se arregla el nuevo listado de concursos para que en este se muestren también 
los concursos para equipos a los cuales ha sido asignado el usuario logueado.

Se muestra una animación de como se puede ingresar:

![TeamGroupContest](https://user-images.githubusercontent.com/3230352/170290529-d7b6bc6c-cd94-4651-9754-7524de4de5ae.gif)

Fixes: #6576 

# Comentarios

También se revisa el caso en el que un usuario que asocia una identidad que 
fue creada con el objetivo de ingresar a un concurso para equipos, pueda 
efectivamente ingresar a dicho concurso. El tema aquí es de que es un poco
complejo el proceso, así que habrá que refinarlo, de manera que no cause 
más confusiones.

![TeamGroupContestAssociatedIdentity](https://user-images.githubusercontent.com/3230352/170291358-db6355e0-e15f-4f4b-810f-1e14fa583bd3.gif)

También faltaría agregar una prueba para evitar regresiones.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
