### PR TITLE
Agregando fulltext index para búsquedas de problemas

### DIFF
--- a/frontend/database/00205_add_fulltext_index_problems.sql
+++ b/frontend/database/00205_add_fulltext_index_problems.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Problems` ADD FULLTEXT `ft_alias_title` (`alias`, `title`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -612,6 +612,7 @@ CREATE TABLE `Problems` (
   KEY `acl_id` (`acl_id`),
   KEY `idx_problems_visibility` (`visibility`),
   KEY `idx_quality_seal` (`quality_seal`),
+  FULLTEXT KEY `ft_alias_title` (`alias`,`title`),
   CONSTRAINT `fk_pa_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Se crea un registro por cada prob externo.';
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
# Descripción

Se agrega un `FULLTEXT` index en la tabla de `Problems` para poder realizar
búsquedas más exactas.

Part of : #5564 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
