### PR TITLE
Fix Clipboard style in example input table

### DIFF
--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -243,10 +243,13 @@ export default class Markdown extends Vue {
   }
 
   td > button.clipboard {
+    float: right;
     border-color: var(--markdown-button-clipboard-border-color);
+    margin-left: 0.5em;
+    margin-right: -6px;
+    margin-top: -6px;
     padding: 3px;
     font-size: 90%;
-    margin-bottom: 6px;
   }
 
   figure {
@@ -319,7 +322,7 @@ export default class Markdown extends Vue {
     }
 
     tr td:first-child pre {
-      margin-right: 20px;
+      margin-right: 31px;
     }
   }
 

--- a/frontend/www/js/omegaup/components/Markdown.vue
+++ b/frontend/www/js/omegaup/components/Markdown.vue
@@ -243,13 +243,10 @@ export default class Markdown extends Vue {
   }
 
   td > button.clipboard {
-    float: right;
     border-color: var(--markdown-button-clipboard-border-color);
-    margin-left: 0.5em;
-    margin-right: -6px;
-    margin-top: -6px;
     padding: 3px;
     font-size: 90%;
+    margin-bottom: 6px;
   }
 
   figure {


### PR DESCRIPTION
# Descripción

Antes:
<img width="43" alt="image" src="https://user-images.githubusercontent.com/5838427/173201979-46237aac-cc89-44cd-8a8d-dd60ca2881f7.png">

<img width="91" alt="image" src="https://user-images.githubusercontent.com/5838427/173202006-602607e9-777d-4b69-8d2f-fa497cb2c5c3.png">


Ahora:
<img width="87" alt="image" src="https://user-images.githubusercontent.com/5838427/173209132-65cd0872-9d12-4339-8c9f-65b408846c07.png">

<img width="75" alt="image" src="https://user-images.githubusercontent.com/5838427/173209146-8dcca6a3-a966-4d49-a5b9-1b663f7f9488.png">

Fixes: #6547 
