### PR TITLE
Quitando temporalmente la consulta del FULLTEXT index que está fallando en producción

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1438,8 +1438,6 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                         p.{$searchType} = ?";
         } else {
             $args = array_fill(0, 5, $query);
-            $args[] = preg_replace('/[\W]/', ' ', $query);
-            $args[] = preg_replace('/[\W]/', ' ', $query);
             $select .= ' IFNULL(SUM(relevance), 0.0) AS relevance
             ';
             $sql = "FROM
@@ -1471,18 +1469,6 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                                 alias LIKE CONCAT('%', ?, '%') OR
                                 problem_id = ?
                             )
-                        UNION ALL
-                        SELECT
-                            {$fields},
-                            IFNULL(
-                                MATCH(alias, title)
-                                AGAINST (? IN BOOLEAN MODE), 0.0
-                            ) AS relevance
-                        FROM
-                            Problems p
-                        WHERE
-                            MATCH(alias, title)
-                            AGAINST (? IN BOOLEAN MODE)
                     ) AS p";
             $groupByClause = "
                         GROUP BY {$fields}


### PR DESCRIPTION
# Descripción

Se quita la consulta donde se utiliza el FULLTEXT index de Problems en lo que 
descubrimos que es lo que falló en el deploy de la migreación de DB

Fixes: #6616 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
