### PR TITLE
Reemplazando funciones de selenium que ya están por deprecar

### DIFF
--- a/frontend/tests/ui/conftest.py
+++ b/frontend/tests/ui/conftest.py
@@ -17,6 +17,9 @@ import pytest
 
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException, TimeoutException
+from selenium.webdriver import Firefox
+from selenium.webdriver.firefox.service import Service
+from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
@@ -614,15 +617,13 @@ def _get_browser(request, browser_name):
             options=chrome_options)
         chrome_browser.set_window_size(*_WINDOW_SIZE)
         return chrome_browser
-    firefox_options = webdriver.firefox.options.Options()
+    firefox_options = Options()
     firefox_options.set_capability('marionette', True)
     firefox_options.set_capability('loggingPrefs', {'browser': 'ALL'})
-    firefox_options.profile = webdriver.FirefoxProfile()
-    firefox_options.profile.set_preference(
+    firefox_options.set_preference(
         'webdriver.log.file', '/tmp/firefox_console')
     firefox_options.headless = request.config.option.headless
-    firefox_browser = webdriver.Firefox(
-        options=firefox_options)
+    firefox_browser = Firefox(options=firefox_options)
     firefox_browser.set_window_size(*_WINDOW_SIZE)
     return firefox_browser
 

--- a/frontend/tests/ui/test_contest.py
+++ b/frontend/tests/ui/test_contest.py
@@ -256,7 +256,8 @@ def check_ranking(driver, problem, user, *, scores):
         EC.visibility_of_element_located(
             (By.CSS_SELECTOR, '.omegaup-scoreboard')))
 
-    ranking_problem = driver.browser.find_element_by_xpath(
+    ranking_problem = driver.browser.find_element(
+        By.XPATH,
         '//tr[@class = "%s"]/td[contains(@class, "%s")]/div[@class = "points"]'
         % (user, problem))
 
@@ -318,14 +319,16 @@ def create_contest_admin(driver, contest_alias, problem, users, user,
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, 'input[data-title]'))).send_keys('(Updated)')
 
-        driver.browser.find_element_by_css_selector(
+        driver.browser.find_element(
+            By.CSS_SELECTOR,
             'form.contest-form').submit()
 
         message_link = driver.wait.until(
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '#status span.message a')))
 
-        contest_title = driver.browser.find_element_by_css_selector(
+        contest_title = driver.browser.find_element(
+            By.CSS_SELECTOR,
             '.page-header h1')
 
         assert '(Updated)' in contest_title.text, 'Update contest failed'
@@ -402,10 +405,12 @@ def create_clarification_user(driver, problem, question):
             (By.CSS_SELECTOR,
              '[data-new-clarification-message]'))).send_keys(question)
 
-    driver.browser.find_element_by_css_selector(
+    driver.browser.find_element(
+        By.CSS_SELECTOR,
         '[data-new-clarification]').submit()
 
-    clarifications = driver.browser.find_elements_by_css_selector(
+    clarifications = driver.browser.find_elements(
+        By.CSS_SELECTOR,
         '[data-tab-clarifications] table tbody tr')
 
     assert len(clarifications) == 1, len(clarifications)
@@ -427,7 +432,8 @@ def answer_clarification_admin(driver, answer):
             (By.CSS_SELECTOR,
              '[data-select-answer]')))).select_by_value(answer)
 
-    driver.browser.find_element_by_css_selector(
+    driver.browser.find_element(
+        By.CSS_SELECTOR,
         '[data-form-clarification-answer]').submit()
 
     resolved = driver.wait.until(
@@ -474,15 +480,16 @@ def create_contest(driver, alias, scoreboard_time_percent=100):
     driver.wait.until(
         EC.visibility_of_element_located(
             (By.CSS_SELECTOR, 'input[data-title]'))).send_keys(alias)
-    driver.browser.find_element_by_name('alias').send_keys(alias)
-    driver.browser.find_element_by_name('description').send_keys(
+    driver.browser.find_element(By.NAME, 'alias').send_keys(alias)
+    driver.browser.find_element(By.NAME, 'description').send_keys(
         'contest description')
-    scoreboard_element = driver.browser.find_element_by_name('scoreboard')
+    scoreboard_element = driver.browser.find_element(By.NAME, 'scoreboard')
     scoreboard_element.clear()
     scoreboard_element.send_keys(scoreboard_time_percent)
 
     with driver.page_transition():
-        driver.browser.find_element_by_css_selector(
+        driver.browser.find_element(
+            By.CSS_SELECTOR,
             'form.contest-form').submit()
 
 
@@ -632,7 +639,7 @@ def change_contest_admission_mode(driver, contest_admission_mode):
 def compare_contestants_list(driver, users_set):
     ''' Compares list of contestants toggle scoreboard filter.'''
 
-    contestants_list = driver.browser.find_elements_by_xpath(
+    contestants_list = driver.browser.find_elements(By.XPATH,
         '//*[@data-table-scoreboard]/tbody/tr/td[@class="user"]')
     # Considering only the username. All unassociated identities are created
     # with a name, which is appended after the username, like:
@@ -648,7 +655,8 @@ def compare_contestants_list(driver, users_set):
 def assert_run_verdict(driver, user, problem, *, classname):
     ''' Asserts that run verdict matches with expected classname. '''
 
-    run_verdict = driver.browser.find_element_by_xpath(
+    run_verdict = driver.browser.find_element(
+        By.XPATH,
         '//tr[contains(concat(" ", normalize-space(@class), " "), " %s ")]'
         '/td[contains(concat(" ", normalize-space(@class), " "), " %s ")]'
         % (user, problem))

--- a/frontend/tests/ui/test_course.py
+++ b/frontend/tests/ui/test_course.py
@@ -107,7 +107,8 @@ def test_user_ranking_course(driver):
         else:
             logging.error('Failed to toggle contestants')
 
-        run_user = driver.browser.find_element_by_xpath(
+        run_user = driver.browser.find_element(
+            By.XPATH,
             '//td[contains(@class, "accepted")]/preceding-sibling::td[@class='
             '"user"]')
         assert run_user.text == driver.user_username, run_user
@@ -131,7 +132,7 @@ def test_user_ranking_course(driver):
                 (By.XPATH,
                  '//input[@name = "show-scoreboard"][@value="true"]'))).click()
 
-        driver.browser.find_element_by_css_selector(
+        driver.browser.find_element(By.CSS_SELECTOR,
             'form[data-course-form]').submit()
         assert (('/course/%s/edit/' % course_alias) in
                 driver.browser.current_url), driver.browser.current_url
@@ -163,7 +164,7 @@ def show_run_details_course(driver: conftest.Driver, course_alias: str,
 
     util.show_run_details(driver, code='#include <iostream>')
 
-    driver.browser.find_element_by_css_selector('div[data-overlay]').click()
+    driver.browser.find_element(By.CSS_SELECTOR,'div[data-overlay]').click()
 
 
 def test_create_identities_for_course(driver):
@@ -254,7 +255,8 @@ def test_create_identities_for_course(driver):
                  '//form[contains(concat(" ", normalize-space(@class), " "), '
                  '" add-identity-form ")]/div/button'))).click()
 
-        associated_identities = driver.browser.find_element_by_xpath(
+        associated_identities = driver.browser.find_element(
+            By.XPATH,
             '//tr/td[text() = "%s"]' % (associated.username))
         assert associated_identities is not None, 'No identity matches'
 
@@ -309,12 +311,12 @@ def create_course(driver, course_alias: str, school_name: str) -> None:
     driver.typeahead_helper('*[contains(@class, "omegaup-course-details")]',
                             school_name,
                             select_suggestion=False)
-    driver.browser.find_element_by_css_selector(
+    driver.browser.find_element(By.CSS_SELECTOR,
         'textarea[data-course-new-description]'
     ).send_keys('course description')
 
     with driver.page_transition():
-        driver.browser.find_element_by_css_selector(
+        driver.browser.find_element(By.CSS_SELECTOR,
             'form[data-course-form]').submit()
     assert (f'/course/{course_alias}/edit/' in driver.browser.current_url
             ), driver.browser.current_url
@@ -343,13 +345,13 @@ def add_assignment_with_problem(driver, assignment_alias, problem_alias):
         EC.visibility_of_element_located(
             (By.CSS_SELECTOR, ('.schedule .name')))).send_keys(
                 assignment_alias)
-    assignments_tab = driver.browser.find_element_by_css_selector(
+    assignments_tab = driver.browser.find_element(By.CSS_SELECTOR,
         '.tab-pane.active')
-    new_assignment_form = assignments_tab.find_element_by_css_selector(
+    new_assignment_form = assignments_tab.find_element(By.CSS_SELECTOR,
         '.schedule')
-    new_assignment_form.find_element_by_css_selector('.alias').send_keys(
+    new_assignment_form.find_element(By.CSS_SELECTOR,'.alias').send_keys(
         assignment_alias)
-    new_assignment_form.find_element_by_css_selector('textarea').send_keys(
+    new_assignment_form.find_element(By.CSS_SELECTOR,'textarea').send_keys(
         'homework description')
 
     driver.wait.until(
@@ -367,7 +369,7 @@ def add_assignment_with_problem(driver, assignment_alias, problem_alias):
              '[data-course-problemlist] table.table-striped')))
 
     with util.dismiss_status(driver):
-        new_assignment_form.find_element_by_css_selector(
+        new_assignment_form.find_element(By.CSS_SELECTOR,
             'button[data-schedule-assignment]').click()
     driver.wait.until(
         EC.invisibility_of_element_located(

--- a/frontend/tests/ui/test_group.py
+++ b/frontend/tests/ui/test_group.py
@@ -26,21 +26,21 @@ def test_create_group_with_identities_and_restrictions(driver):
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '.navbar-nav:first-child')))
 
-        navbar.find_element_by_css_selector(
+        navbar.find_element(By.CSS_SELECTOR,
             'li.nav-problems a.dropdown-toggle').click()
         problems_dropdown = driver.wait.until(
             EC.visibility_of(
-                navbar.find_element_by_css_selector(
+                navbar.find_element(By.CSS_SELECTOR,
                     'li.nav-problems .dropdown-menu')))
         # Problems menu
         for present_href in ['/problem/collection/', '/submissions/',
                              '/problem/new/']:
-            assert problems_dropdown.find_elements_by_css_selector(
+            assert problems_dropdown.find_elements(By.CSS_SELECTOR,
                 'a[href="%s"]' % present_href), (
                     '%s item is not present!' % present_href)
 
         # Contests menu
-        assert navbar.find_elements_by_css_selector('li.nav-contests a')
+        assert navbar.find_elements(By.CSS_SELECTOR,'li.nav-contests a')
 
         group_alias = util.create_group(driver, group_title, description)
         identity, *_ = util.add_identities_group(driver, group_alias)
@@ -53,33 +53,33 @@ def test_create_group_with_identities_and_restrictions(driver):
                 (By.CSS_SELECTOR, '.navbar-nav:first-child')))
 
         # Problems menu
-        navbar.find_element_by_css_selector(
+        navbar.find_element(By.CSS_SELECTOR,
             'li.nav-problems a.dropdown-toggle').click()
         problems_dropdown = driver.wait.until(
             EC.visibility_of(
-                navbar.find_element_by_css_selector(
+                navbar.find_element(By.CSS_SELECTOR,
                     'li.nav-problems .dropdown-menu')))
         for present_href in ['/problem/collection/', '/submissions/']:
-            assert problems_dropdown.find_elements_by_css_selector(
+            assert problems_dropdown.find_elements(By.CSS_SELECTOR,
                 'a[href="%s"]' % present_href), (
                     '%s item is not present!' % present_href)
         for absent_href in ['/problem/new/']:
-            assert not problems_dropdown.find_elements_by_css_selector(
+            assert not problems_dropdown.find_elements(By.CSS_SELECTOR,
                 'a[href="%s"]' % absent_href), (
                     '%s item is visible!' % absent_href)
 
-        navbar.find_element_by_css_selector(
+        navbar.find_element(By.CSS_SELECTOR,
             'li.nav-contests a.dropdown-toggle').click()
         contests_dropdown = driver.wait.until(
             EC.visibility_of(
-                navbar.find_element_by_css_selector(
+                navbar.find_element(By.CSS_SELECTOR,
                     'li.nav-contests .dropdown-menu')))
         for present_href in ['/arena/']:
-            assert contests_dropdown.find_elements_by_css_selector(
+            assert contests_dropdown.find_elements(By.CSS_SELECTOR,
                 'a[href="%s"]' % present_href), (
                     '%s item is not present!' % present_href)
         for absent_href in ['/contest/new/', '/scoreboardmerge/']:
-            assert not contests_dropdown.find_elements_by_css_selector(
+            assert not contests_dropdown.find_elements(By.CSS_SELECTOR,
                 'a[href="%s"]' % absent_href), (
                     '%s item is visible!' % absent_href)
 
@@ -91,7 +91,7 @@ def test_create_group_with_identities_and_restrictions(driver):
             driver.wait.until(
                 EC.element_to_be_clickable(
                     (By.CSS_SELECTOR, 'a[data-nav-courses-all]'))).click()
-        assert not driver.browser.find_elements_by_css_selector(
+        assert not driver.browser.find_elements(By.CSS_SELECTOR,
             'a[href="/course/new/"]')
 
         inaccessible_paths = ['/problem/new/', '/contest/new/',


### PR DESCRIPTION
# Descripción

Se actualizan algunas funciones que están por ser deprecadas de selenium.

Al parecer en GitHub ya estaban marcando errores las pruebas debido a esas
fallas

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.