### PR TITLE
Mejorando la manera en la que se hacen los rewrites

### DIFF
--- a/frontend/server/nginx.rewrites
+++ b/frontend/server/nginx.rewrites
@@ -108,66 +108,23 @@ rewrite ^/user/emailedit/([a-zA-Z0-9_]+)/?$ /users/emailedit.php?username=$1 las
 rewrite ^/user/emailedit/?$ /users/emailedit.php last;
 rewrite ^/user/verifyemail/([a-zA-Z0-9_]+)/?$ /userverifyemail.php?id=$1 last;
 
-# Cache control
-location ~ (/dist/|^/third_party/|^/media/|^/css|^/js/|^/img/) {
-  add_header  Cache-Control "max-age=31557600";
-}
-
 # libinteractive templates
 location ~ '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/([a-zA-Z0-9_.-]+)$' {
-  if (-f $request_filename) {
-    # Normal case: file is found and nginx can handle it natively.
-    break;
-  }
-  if (-d $document_root/templates/$1/$2) {
-    # Directory was found, but file was not. That means that the
-    # re-generation process was already run, so we will never be
-    # able to find that file.
-    return 404;
-  }
-  if ($args != '') {
-    # The re-generation process was already run, and we still
-    # could not find that file. Give up to avoid infinitely
-    # redirecting.
-    return 404;
-  }
-  # Try re-generating the template. Once this is done, it will cause a redirect to nginx.
-  rewrite '^/templates/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/(.*)$' /problems/template.php?problem_alias=$1&commit=$2&filename=$3? last;
+  try_files $uri /problems/template.php?problem_alias=$1&commit=$2&filename=$3;
 }
 
 # output-only inputs.
 location ~ '^/probleminput/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/([a-zA-Z0-9_.-]+)$' {
-  if (-f $request_filename) {
-    # Normal case: file is found and nginx can handle it natively.
-    break;
-  }
-  if (-d $document_root/probleminput/$1/$2) {
-    # Directory was found, but file was not. That means that the
-    # re-generation process was already run, so we will never be
-    # able to find that file.
-    return 404;
-  }
-  if ($args != '') {
-    # The re-generation process was already run, and we still
-    # could not find that file. Give up to avoid infinitely
-    # redirecting.
-    return 404;
-  }
-  # Try re-generating the template. Once this is done, it will cause a redirect to nginx.
-  rewrite '^/probleminput/([a-zA-Z0-9_-]+)/([0-9a-f]{40})/(.*)$' /problems/input.php?problem_alias=$1&commit=$2&filename=$3 last;
+  try_files $uri /problems/input.php?problem_alias=$1&commit=$2&filename=$3;
 }
 
 # problem images
 location ~ '^/img/([a-zA-Z0-9_-]+)/([0-9a-f]{40})\.([a-zA-Z0-9._-]+)$' {
-  if (-f $request_filename) {
-    break;
-  }
-  if ($args != '') {
-    # The re-generation process was already run, and we still
-    # could not find that file. Give up to avoid infinitely
-    # redirecting.
-    return 404;
-  }
-  # Try re-generating the image. Once this is done, it will cause a redirect to nginx.
-  rewrite /problems/image.php?problem_alias=$1&object_id=$2&extension=$3? last;
+  add_header  Cache-Control "max-age=31557600";
+  try_files $uri /problems/image.php?problem_alias=$1&object_id=$2&extension=$3;
+}
+
+# Cache control. This should go last.
+location ~ (/dist/|^/third_party/|^/media/|^/css|^/js/|^/img/) {
+  add_header  Cache-Control "max-age=31557600";
 }

--- a/frontend/server/src/FileHandler.php
+++ b/frontend/server/src/FileHandler.php
@@ -33,7 +33,7 @@ class FileHandler {
 
         do {
             $path = $dir . $prefix . mt_rand(0, 9999999);
-        } while (!@mkdir($path, $mode));
+        } while (!@mkdir($path, $mode, true));
 
         return $path;
     }

--- a/frontend/server/src/ProblemDeployer.php
+++ b/frontend/server/src/ProblemDeployer.php
@@ -192,7 +192,7 @@ class ProblemDeployer {
             return;
         }
         $tmpDir = \OmegaUp\FileHandler::tempDir(
-            '/tmp',
+            TEMPLATES_PATH,
             'ProblemDeployer',
             0755
         );
@@ -219,13 +219,16 @@ class ProblemDeployer {
                     $problemArtifacts->get("examples/{$filename}.in")
                 );
             }
-            $target = TEMPLATES_PATH . "/{$this->alias}/{$publishedCommit}";
-            @mkdir($target, 0755, true);
+            $tmpTarget = "{$tmpDir}/target";
+            @mkdir($tmpTarget, 0755, true);
             $args = ['/usr/bin/java', '-Xmx64M', '-jar',
                 '/usr/share/java/libinteractive.jar', 'generate-all', $idlPath,
-                '--package-directory', $target, '--package-prefix',
+                '--package-directory', $tmpTarget, '--package-prefix',
                 "{$this->alias}_", '--shift-time-for-zip'];
-            $this->executeRaw($args, $target);
+            $this->executeRaw($args, $tmpTarget);
+            $target = TEMPLATES_PATH . "/{$this->alias}/{$publishedCommit}";
+            @mkdir(dirname($target), 0755, true);
+            rename($tmpTarget, $target);
         } catch (\Exception $e) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'problemDeployerLibinteractiveValidationError',

--- a/frontend/www/problems/image.php
+++ b/frontend/www/problems/image.php
@@ -6,6 +6,8 @@ try {
     \OmegaUp\Controllers\Problem::getImage(
         new \OmegaUp\Request($_REQUEST)
     );
+} catch (\OmegaUp\Exceptions\ExitException $e) {
+    exit;
 } catch (\Exception $e) {
     \OmegaUp\ApiCaller::handleException($e);
 }

--- a/frontend/www/problems/input.php
+++ b/frontend/www/problems/input.php
@@ -3,7 +3,7 @@ namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
 
 try {
-    \OmegaUp\Controllers\Problem::apiInput(
+    \OmegaUp\Controllers\Problem::getInput(
         new \OmegaUp\Request($_REQUEST)
     );
 } catch (\OmegaUp\Exceptions\ExitException $e) {

--- a/stuff/docker/etc/nginx/mime.types
+++ b/stuff/docker/etc/nginx/mime.types
@@ -1,0 +1,92 @@
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/font-woff                 woff;
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-fontobject         eot;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+    application/tar+bzip2                 tar.bz2;
+    application/tar+gzip                  tar.gz;
+    application/x-bzip2                   bz2;
+    application/x-gzip                    gz;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}


### PR DESCRIPTION
Resulta que debido a varias complicaciones (configuración de nginx
principalmente), las imágenes no se estaban desplegando correctamente en
algunas ocasiones. También, la cabecera de `Cache-Control` no se estaba
estableciendo correctamente y las imágenes no se estaban cacheando bien.

Este cambio hace que eso ocurra más confiablemente, así que Selenium ya
no debería fallar tanto.

Fixes: #6406