### PR TITLE
Uprev de hook_tools

### DIFF
--- a/stuff/lint.sh
+++ b/stuff/lint.sh
@@ -3,7 +3,7 @@
 set -e
 
 OMEGAUP_ROOT="$(git rev-parse --show-toplevel)"
-CONTAINER_VERSION=omegaup/hook_tools:20220404
+CONTAINER_VERSION=omegaup/hook_tools:20220710
 
 if [[ $# != 0 ]]; then
 	# The caller has given us the explicit arguments.


### PR DESCRIPTION
Este cambio hace que sea posible limpiar caracteres extraños que
confunden a los linters automáticamente.