### PR TITLE
[Project][Plagiarism Detector] Update the contest table to have "plagiarism_threshold" value. 

### DIFF
--- a/frontend/database/00207_plagiarism_threshodl_contest_update.sql
+++ b/frontend/database/00207_plagiarism_threshodl_contest_update.sql
@@ -1,0 +1,4 @@
+-- Adds a new feild "plagiarism_threshold" in Contest table.
+
+ALTER TABLE `Contests`
+    ADD COLUMN `plagiarism_threshold` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'El porcentaje mínimo permitido de similitud entre un par de envíos. Cuando plagio Seleccionado, será 90.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -202,6 +202,7 @@ CREATE TABLE `Contests` (
   `contest_for_teams` tinyint(1) DEFAULT '0' COMMENT 'Bandera que indica si el concurso es para equipos.',
   `default_show_all_contestants_in_scoreboard` tinyint(1) DEFAULT '0' COMMENT 'Bandera que indica si en el scoreboard se mostrarán todos los concursantes por defecto.',
   `score_mode` enum('partial','all_or_nothing','max_per_group') NOT NULL DEFAULT 'partial' COMMENT 'Indica el tipo de evaluación para el concurso',
+  `plagiarism_threshold` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'El porcentaje mínimo permitido de similitud entre un par de envíos. Cuando plagio Seleccionado, será 90.',
   PRIMARY KEY (`contest_id`),
   UNIQUE KEY `contests_alias` (`alias`),
   KEY `rerun_id` (`contest_id`),


### PR DESCRIPTION
# Descripción

added the field `plagiarism_threshold` to store the maximum allowed % similarity when detecting plagiarism. 

Fixes: #6679 

# Comentarios

Please check if the default value should be '0' or '90'(which is what we are going to use if plagiarism is selected). 

@carlosabcs 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
