### PR TITLE
se seleccionan los campos del objeto submission feedback

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -411,17 +411,25 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
     public static function getFeedbackBySubmission(
         \OmegaUp\DAO\VO\Submissions $submission
     ): ?\OmegaUp\DAO\VO\SubmissionFeedback {
-        $sql = '
-            SELECT
-                sf.*
-            FROM
-                Submission_Feedback sf
-            INNER JOIN
-                Submissions s ON s.submission_id = sf.submission_id
-            WHERE
-                s.submission_id = ?
-            FOR UPDATE;
-        ';
+        $fields = join(
+            ', ',
+            array_map(
+                fn (string $field): string => "sf.{$field}",
+                array_keys(
+                    \OmegaUp\DAO\VO\SubmissionFeedback::FIELD_NAMES
+                )
+            )
+        );
+        $sql = "SELECT
+                    {$fields}
+                FROM
+                    Submission_Feedback sf
+                INNER JOIN
+                    Submissions s ON s.submission_id = sf.submission_id
+                WHERE
+                    s.submission_id = ?
+                FOR UPDATE;
+        ";
 
         /** @var array{date: \OmegaUp\Timestamp, feedback: string, identity_id: int, submission_feedback_id: int, submission_id: int}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow(


### PR DESCRIPTION
# Descripción

Para poder agregar mas campos en la tabla de submission_feedback sin que esto afecte a pruebas ya existentes se deja de utilizar el patron `SELECT *`

Part of: #6686 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
