### PR TITLE
[Plagiarism Detector] Delete plagiarism threshold

### DIFF
--- a/frontend/database/00212_remove_plagiarism_threshold.sql
+++ b/frontend/database/00212_remove_plagiarism_threshold.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `Contests`
+    DROP COLUMN `plagiarism_threshold`,

--- a/frontend/database/00212_remove_plagiarism_threshold.sql
+++ b/frontend/database/00212_remove_plagiarism_threshold.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `Contests`
-    DROP COLUMN `plagiarism_threshold`,
+    DROP COLUMN `plagiarism_threshold`;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -202,7 +202,6 @@ CREATE TABLE `Contests` (
   `contest_for_teams` tinyint(1) DEFAULT '0' COMMENT 'Bandera que indica si el concurso es para equipos.',
   `default_show_all_contestants_in_scoreboard` tinyint(1) DEFAULT '0' COMMENT 'Bandera que indica si en el scoreboard se mostrarán todos los concursantes por defecto.',
   `score_mode` enum('partial','all_or_nothing','max_per_group') NOT NULL DEFAULT 'partial' COMMENT 'Indica el tipo de evaluación para el concurso',
-  `plagiarism_threshold` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'El porcentaje mínimo permitido de similitud entre un par de envíos. Cuando plagio Seleccionado, será 90.',
   PRIMARY KEY (`contest_id`),
   UNIQUE KEY `contests_alias` (`alias`),
   KEY `rerun_id` (`contest_id`),


### PR DESCRIPTION
# Descripción

Support PR to delete `plagiarism_threshold` and replace it with `check_plagiarism`. 


Fixes: #6704 
Related PR : #6705 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
