### PR TITLE
Corrección del texto privacy/accept_teacher

### DIFF
--- a/frontend/database/00201_new_accept_teacher_privacy_statements.sql
+++ b/frontend/database/00201_new_accept_teacher_privacy_statements.sql
@@ -1,11 +1,2 @@
 INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
   ('accept_teacher', '5303d4881364e8ff814cfb51badcccc8fb7570bb');
-
--- PrivacyStatements
-INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
-  ('accept_teacher', '4402300fc6f7a45a920edf49c46f8fd0e5c6d189');
-
--- PrivacyStatements
-INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
-  ('accept_teacher', 'a15b0f83e498932d4d7c2f2ed1a91db770c26341');
-  

--- a/frontend/database/00201_new_accept_teacher_privacy_statements.sql
+++ b/frontend/database/00201_new_accept_teacher_privacy_statements.sql
@@ -4,3 +4,8 @@ INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
 -- PrivacyStatements
 INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
   ('accept_teacher', '4402300fc6f7a45a920edf49c46f8fd0e5c6d189');
+
+-- PrivacyStatements
+INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
+  ('accept_teacher', 'a15b0f83e498932d4d7c2f2ed1a91db770c26341');
+  

--- a/frontend/database/00201_new_accept_teacher_privacy_statements.sql
+++ b/frontend/database/00201_new_accept_teacher_privacy_statements.sql
@@ -1,2 +1,6 @@
 INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
   ('accept_teacher', '5303d4881364e8ff814cfb51badcccc8fb7570bb');
+
+-- PrivacyStatements
+INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
+  ('accept_teacher', '4402300fc6f7a45a920edf49c46f8fd0e5c6d189');

--- a/frontend/database/00213_new_accept_teacher_privacy_statements.sql
+++ b/frontend/database/00213_new_accept_teacher_privacy_statements.sql
@@ -1,0 +1,7 @@
+-- PrivacyStatements
+INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
+  ('accept_teacher', '4402300fc6f7a45a920edf49c46f8fd0e5c6d189');
+
+-- PrivacyStatements
+INSERT INTO `PrivacyStatements` (`type`, `git_object_id`) VALUES
+  ('accept_teacher', 'a15b0f83e498932d4d7c2f2ed1a91db770c26341');

--- a/frontend/privacy/accept_teacher/en.md
+++ b/frontend/privacy/accept_teacher/en.md
@@ -1,1 +1,1 @@
- I accept any course admin to see my entire list of problems that I have solved or attempted to solve
+I accept any course admin to see my entire list of problems that I have solved or attempted to solve

--- a/frontend/privacy/accept_teacher/en.md
+++ b/frontend/privacy/accept_teacher/en.md
@@ -1,3 +1,1 @@
-Do you want to accept the admins of the course as your teachers?
-
-If you accept them, they will be able to see the list of problems that you have solved or attempted to solve both inside the course and outside the course.
+ I accept any course admin to see my entire list of problems that I have solved or attempted to solve

--- a/frontend/privacy/accept_teacher/es.md
+++ b/frontend/privacy/accept_teacher/es.md
@@ -1,3 +1,1 @@
-¿Deseas aceptar a las personas administradoras del curso como tus docentes?
-
-Si los aceptas, podrán ver la lista de los problemas que has resuelto y de los que has intentado resolver tanto dentro como fuera del curso.
+Acepto que cualquier admin del curso pueda ver toda mi lista de problemas resueltos y los que he intentado resolver

--- a/frontend/privacy/accept_teacher/pt.md
+++ b/frontend/privacy/accept_teacher/pt.md
@@ -1,3 +1,1 @@
-Você quer adicionar o organizador do curso como seu professor/professora?
-
-Se você aceitar, ele/ela poderá ver uma lista dos problemas que você resolveu e outro dos problemas que você tentou resolver
+Aceito que qualquer admin de curso veja minha lista completa de problemas que resolvi ou tentei resolver


### PR DESCRIPTION
# Descripción

Se hizo la corrección del texto privacy/accept_teacher en sus respectivos idiomas, las correcciones son:

es.md: Acepto que cualquier admin del curso pueda ver toda mi lista de problemas resueltos y los que he intentado resolver
en.md: I accept any course admin to see my entire list of problems that I have solved or attempted to solve
pt.md: Aceito que qualquer admin de curso veja minha lista completa de problemas que resolvi ou tentei resolver

Fixes: #5931 