### PR TITLE
drop unique key from submission feedback table

### DIFF
--- a/frontend/database/00216_submission_feedback_drop_unique_key.sql
+++ b/frontend/database/00216_submission_feedback_drop_unique_key.sql
@@ -1,0 +1,18 @@
+ALTER TABLE
+    `Submission_Feedback`
+DROP foreign key
+    `fk_sfs_submission_id`;
+
+ALTER TABLE
+    `Submission_Feedback`
+DROP INDEX
+    `submission_id`;
+
+ALTER TABLE
+    `Submission_Feedback`
+ADD CONSTRAINT
+    `fk_sfs_submission_id`
+FOREIGN KEY
+    (`submission_id`)
+REFERENCES
+    `Submissions` (`submission_id`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1003,8 +1003,8 @@ CREATE TABLE `Submission_Feedback` (
   `range_bytes_start` int NOT NULL DEFAULT '0' COMMENT 'Inicio de la subcadena seleccionada (en bytes) para agregarle el comentario',
   `range_bytes_end` int NOT NULL DEFAULT '0' COMMENT 'Fin de la subcadena seleccionada (en bytes) para agregarle el comentario',
   PRIMARY KEY (`submission_feedback_id`),
-  UNIQUE KEY `submission_id` (`submission_id`),
   KEY `fk_sfi_identity_id` (`identity_id`),
+  KEY `fk_sfs_submission_id` (`submission_id`),
   CONSTRAINT `fk_sfi_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_sfs_submission_id` FOREIGN KEY (`submission_id`) REFERENCES `Submissions` (`submission_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Almacena el feedback dejado por los profesores para los envíos de los estudiantes.';


### PR DESCRIPTION
# Descripción

Se elimino el UNIQUE KEY submission_id de la tabla Submission feedback 

Fixes: #6756 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
