### PR TITLE
Actualizando la versión de Java y Golang en los Dockerfiles

### DIFF
--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -24,7 +24,7 @@ RUN add-apt-repository ppa:ondrej/php && \
         mysql-client-core-8.0 \
         nginx \
         nodejs \
-        openjdk-16-jre-headless \
+        openjdk-11-jre-headless \
         php8.0 \
         php8.0-apcu \
         php8.0-curl \

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -94,7 +94,7 @@ RUN apt-get update -y && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
         newrelic-php5 \
-        openjdk-16-jre-headless \
+        openjdk-11-jre-headless \
         php8.0-apcu \
         php8.0-curl \
         php8.0-fpm \

--- a/stuff/docker/Dockerfile.local-backend
+++ b/stuff/docker/Dockerfile.local-backend
@@ -4,7 +4,7 @@ RUN apt update && \
     apt install -y --no-install-recommends \
         pkg-config cmake curl ca-certificates git gcc libc-dev zlib1g-dev && \
     /usr/sbin/update-ca-certificates && \
-    curl --location https://dl.google.com/go/go1.14.7.linux-amd64.tar.gz | \
+    curl --location https://dl.google.com/go/go1.17.9.linux-amd64.tar.gz | \
         tar -xz -C /usr/local && \
     apt autoremove -y && \
     apt clean
@@ -67,7 +67,7 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-      curl ca-certificates openjdk-16-jre-headless wait-for-it && \
+      curl ca-certificates openjdk-11-jre-headless wait-for-it && \
     /usr/sbin/update-ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean

--- a/stuff/docker/Dockerfile.local-backend-test
+++ b/stuff/docker/Dockerfile.local-backend-test
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 USER root
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        curl ca-certificates openjdk-16-jre-headless && \
+        curl ca-certificates openjdk-11-jre-headless && \
     /usr/sbin/update-ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean


### PR DESCRIPTION
# Descripción

Para poder realizar las pruebas en el PR https://github.com/omegaup/quark/pull/83 se requiere 
actualizar la versión de Java y de Golang. Intenté actualizarlos, pero aún 
no logro que funcione correctamente el entrondo de desarrollo de quark.

Part of: #6449

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
