### PR TITLE
Obtener tags públicos y cargar en el payload

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4893,11 +4893,18 @@ class Problem extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r
     ): array {
         $tags = [];
-        $allTags = \OmegaUp\DAO\Tags::getAllPublicTag();
+        $allTags = self::getAllTagsFromCache();
 
         foreach ($allTags as $tag) {
-            $tags[] = ['name' => $tag];
+            if (is_null($tag->name)) {
+                continue;
+            }
+            if ($tag->public == 0) {
+                continue;
+            }
+            $tags[] = ['name' => $tag->name];
         }
+
         return [
             'templateProperties' => [
                 'payload' => [

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4904,7 +4904,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
             }
             $tags[] = ['name' => $tag->name];
         }
-
         return [
             'templateProperties' => [
                 'payload' => [

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4893,13 +4893,10 @@ class Problem extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r
     ): array {
         $tags = [];
-        $allTags = self::getAllTagsFromCache();
+        $allTags = \OmegaUp\DAO\Tags::getAllPublicTag();
 
         foreach ($allTags as $tag) {
-            if (is_null($tag->name)) {
-                continue;
-            }
-            $tags[] = ['name' => $tag->name];
+            $tags[] = ['name' => $tag];
         }
         return [
             'templateProperties' => [

--- a/frontend/server/src/DAO/Tags.php
+++ b/frontend/server/src/DAO/Tags.php
@@ -84,6 +84,33 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
     }
 
     /**
+     * Finds all public tags
+     *
+     * @return list<string>
+     */
+    public static function getAllPublicTag() {
+        $sql = '
+            SELECT
+                name
+            FROM
+                Tags
+            WHERE
+                public = true;';
+
+        $results = [];
+        /** @var array{name: string} $row */
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll(
+                $sql
+            ) as $row
+        ) {
+            $results[] = $row['name'];
+        }
+
+        return $results;
+    }
+
+    /**
      * @return list<TagWithProblemCount>
      */
     public static function getPublicQualityTagsByLevel(

--- a/frontend/server/src/DAO/Tags.php
+++ b/frontend/server/src/DAO/Tags.php
@@ -84,33 +84,6 @@ class Tags extends \OmegaUp\DAO\Base\Tags {
     }
 
     /**
-     * Finds all public tags
-     *
-     * @return list<string>
-     */
-    public static function getAllPublicTag() {
-        $sql = '
-            SELECT
-                name
-            FROM
-                Tags
-            WHERE
-                public = true;';
-
-        $results = [];
-        /** @var array{name: string} $row */
-        foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql
-            ) as $row
-        ) {
-            $results[] = $row['name'];
-        }
-
-        return $results;
-    }
-
-    /**
      * @return list<TagWithProblemCount>
      */
     public static function getPublicQualityTagsByLevel(


### PR DESCRIPTION
# Descripción

Se cambió el payload para sólo desplegar los tags públicos.

Fixes: #6747 
