### PR TITLE
Mostrar etiquetas públicas en Problem Finder

### DIFF
--- a/frontend/www/js/omegaup/components/problem/FinderWizard.vue
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.vue
@@ -139,14 +139,13 @@ export default class ProblemFinderWizard extends Vue {
   get tagObjects(): TagObject[] {
     const tagObjects: TagObject[] = [];
     this.possibleTags.forEach((tagObject) => {
-      if (T[tagObject.name]) {
-        tagObjects.push({
-          key: tagObject.name,
-          value: Object.prototype.hasOwnProperty.call(T, tagObject.name)
-            ? T[tagObject.name]
-            : tagObject.name,
-        });
+      if (!Object.prototype.hasOwnProperty.call(T, tagObject.name)) {
+        return;
       }
+      tagObjects.push({
+        key: tagObject.name,
+        value: T[tagObject.name],
+      });
     });
     return tagObjects;
   }

--- a/frontend/www/js/omegaup/components/problem/FinderWizard.vue
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.vue
@@ -139,12 +139,14 @@ export default class ProblemFinderWizard extends Vue {
   get tagObjects(): TagObject[] {
     const tagObjects: TagObject[] = [];
     this.possibleTags.forEach((tagObject) => {
-      tagObjects.push({
-        key: tagObject.name,
-        value: Object.prototype.hasOwnProperty.call(T, tagObject.name)
-          ? T[tagObject.name]
-          : tagObject.name,
-      });
+      if (T[tagObject.name]) {
+        tagObjects.push({
+          key: tagObject.name,
+          value: Object.prototype.hasOwnProperty.call(T, tagObject.name)
+            ? T[tagObject.name]
+            : tagObject.name,
+        });
+      }
     });
     return tagObjects;
   }


### PR DESCRIPTION
# Descripción

Se modifico el `tagObject` del problem finder para filtrar solo las etiquetas que sean públicas y esten dentro de `lang`

Fixes: #6747 

** Antes: **
![problemFinder](https://user-images.githubusercontent.com/60702547/190828043-01a827f7-1e2f-4ecf-a258-ca4ffc5628b2.png)

** Ahora: **
![problemFinderNow](https://user-images.githubusercontent.com/60702547/190828099-abd1de45-fe69-4564-9366-7111463805f0.png)
