### PR TITLE
Arreglando `stuff/docker/go/test.sh`

### DIFF
--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -24,7 +24,7 @@ RUN add-apt-repository ppa:ondrej/php && \
         mysql-client-core-8.0 \
         nginx \
         nodejs \
-        openjdk-11-jre-headless \
+        openjdk-16-jre-headless \
         php8.0 \
         php8.0-apcu \
         php8.0-curl \

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -94,7 +94,7 @@ RUN apt-get update -y && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
         newrelic-php5 \
-        openjdk-11-jre-headless \
+        openjdk-16-jre-headless \
         php8.0-apcu \
         php8.0-curl \
         php8.0-fpm \

--- a/stuff/docker/Dockerfile.local-backend
+++ b/stuff/docker/Dockerfile.local-backend
@@ -1,8 +1,18 @@
-FROM ubuntu:bionic AS base-builder
+FROM ubuntu:focal AS base-builder
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
     apt install -y --no-install-recommends \
-        pkg-config cmake curl ca-certificates git gcc libc-dev zlib1g-dev && \
+        ca-certificates \
+        cmake \
+        curl \
+        gcc \
+        git \
+        libc-dev \
+        make \
+        pkg-config \
+        zlib1g-dev \
+        && \
     /usr/sbin/update-ca-certificates && \
     curl --location https://dl.google.com/go/go1.17.9.linux-amd64.tar.gz | \
         tar -xz -C /usr/local && \
@@ -11,21 +21,17 @@ RUN apt update && \
 ENV PATH $PATH:/usr/local/go/bin
 RUN useradd --create-home --uid 1000 --shell /bin/bash --user-group ubuntu
 
+# Build system libgit2
+RUN git clone --recurse-submodules https://github.com/libgit2/git2go -b v33.0.4 --depth=1 /tmp/git2go && \
+    (cd /tmp/git2go && \
+     git submodule update --init && \
+     sudo ./script/build-libgit2.sh --system --static) && \
+    rm -rf /tmp/git2go
+
 RUN mkdir -p /home/ubuntu/go/omegaup/bin
 WORKDIR /home/ubuntu/go/omegaup
 
-ADD go/go.mod /home/ubuntu/go/omegaup/
-RUN chown -R ubuntu:ubuntu /home/ubuntu/go/
 USER ubuntu
-
-# Get dependencies.
-RUN git clone --recurse-submodules https://github.com/lhchavez/git2go
-
-RUN go get -d -tags=static github.com/lhchavez/git2go/v29@v29.0.0
-
-RUN (cd git2go && \
-     git submodule update --init && \
-     ./script/build-libgit2-static.sh)
 
 
 FROM base-builder AS quark-builder
@@ -67,7 +73,11 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-      curl ca-certificates openjdk-11-jre-headless wait-for-it && \
+      ca-certificates \
+      curl \
+      openjdk-16-jre-headless \
+      wait-for-it \
+      && \
     /usr/sbin/update-ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean

--- a/stuff/docker/Dockerfile.local-backend-test
+++ b/stuff/docker/Dockerfile.local-backend-test
@@ -4,7 +4,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 USER root
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        curl ca-certificates openjdk-11-jre-headless && \
+        ca-certificates \
+        curl \
+        openjdk-16-jre-headless \
+        && \
     /usr/sbin/update-ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean
@@ -12,7 +15,9 @@ RUN apt-get update -y && \
 RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.27/libinteractive.jar \
         -o /usr/share/java/libinteractive.jar
 
-USER ubuntu
+ADD go/go.mod /home/ubuntu/go/omegaup/
 ADD go/Makefile /home/ubuntu/go/omegaup/
+RUN chown -R ubuntu:ubuntu /home/ubuntu/go/
+USER ubuntu
 
 CMD ["/bin/bash"]

--- a/stuff/docker/go/Makefile
+++ b/stuff/docker/go/Makefile
@@ -3,19 +3,18 @@ test: test-quark test-gitserver
 
 .PHONY: test-quark
 test-quark: .get-stamp
-	go test -tags=static \
+	go test \
 		github.com/omegaup/quark/...
 
 .PHONY: test-gitserver
 test-gitserver: .get-stamp
-	go test -tags=static \
-		github.com/omegaup/gitserver/...
+	go test \
+		github.com/omegaup/gitserver
 
 .get-stamp:
-	go get -t -tags=static \
-		github.com/omegaup/go-base \
-		github.com/omegaup/quark \
-		github.com/omegaup/githttp \
-		github.com/omegaup/gitserver
+	go get -t \
+		github.com/omegaup/go-base/... \
+		github.com/omegaup/githttp/... \
+		github.com/omegaup/gitserver \
+		github.com/omegaup/quark/...
 	touch $@
-

--- a/stuff/docker/go/go.mod
+++ b/stuff/docker/go/go.mod
@@ -1,8 +1,6 @@
 module github.com/omegaup
 
-go 1.13
-
-replace github.com/lhchavez/git2go/v29 => ./git2go
+go 1.17
 
 replace github.com/omegaup/githttp => ./githttp
 

--- a/stuff/docker/go/test.sh
+++ b/stuff/docker/go/test.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Running this will open a shell where the sources for quark is
+# installed. Useful to develop quark in a jiffy. Run all tests with:
+#
+#   make
+#
+# Or only the quark tests with
+#
+#   make test-quark
+
 DIR="$(realpath "$(dirname "$(dirname "${0}")")")"
 
 if [[ ! -d "${DIR}/go/go-base" ]]; then


### PR DESCRIPTION
Este cambio hace que se puedan volver a ejecutar las pruebas de quark desde este repositorio (cortesía de Docker).
