### PR TITLE
Redirigir a la pagina correcta

### DIFF
--- a/frontend/www/js/omegaup/carousel.config.ts
+++ b/frontend/www/js/omegaup/carousel.config.ts
@@ -40,7 +40,7 @@ const carouselConfig: {
         es: 'Ve el tutorial',
         pt: 'Veja o tutorial',
       },
-      href: 'https://blog.omegaup.com/category/omegaup/omegaup-101/',
+      href: 'https://blog.omegaup.com/introduccion-a-omegaup-parte-0/',
     },
   },
   {


### PR DESCRIPTION
# Descripción

Se corrigió el link para ver el tutorial 

** Ahora: **
![CorrectPage](https://user-images.githubusercontent.com/60702547/193141617-deec9505-cc60-453a-9227-a101e40a0ac6.png)


Fixes: #6770 
