### PR TITLE
Corregir la generacion de valores en .ods

### DIFF
--- a/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
@@ -154,9 +154,9 @@ office:value-type="string"><text:p>${assignment.name} ${formatString(
       student.name
     }\
 </text:p></table:table-cell><table:table-cell office:value-type="percentage" \
-office:value="${new Percentage(
-      student.courseProgress / 100,
-    ).toString()}"><text:p>${new Percentage(
+office:value="${new Percentage(student.courseProgress / 100).value.toFixed(
+      4,
+    )}"><text:p>${new Percentage(
       student.courseProgress / 100,
     ).toString()}</text:p>\
 </table:table-cell><table:table-cell office:value-type="percentage" office:value="\

--- a/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.test.ts
@@ -162,7 +162,7 @@ office:value="${new Percentage(
 </table:table-cell><table:table-cell office:value-type="percentage" office:value="\
 ${new Percentage(
   student.assignments[assignment.alias].progress / 100,
-).toString()}"><text:p>${new Percentage(
+).value.toFixed(4)}"><text:p>${new Percentage(
       student.assignments[assignment.alias].progress / 100,
     ).toString()}</text:p></table:table-cell></table:table-row>
 </table:table>`);

--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -182,7 +182,9 @@ export function toOds(courseName: string, table: TableCell[][] | null): string {
     result += '<table:table-row>\n';
     for (const cell of row) {
       if (cell instanceof Percentage) {
-        result += `<table:table-cell office:value-type="percentage" office:value="${cell.toString()}"><text:p>${cell.toString()}</text:p></table:table-cell>`;
+        result += `<table:table-cell office:value-type="percentage" office:value="${cell.value.toFixed(
+          4,
+        )}"><text:p>${cell.toString()}</text:p></table:table-cell>`;
       } else if (typeof cell === 'number') {
         const num: number = cell;
         result += `<table:table-cell office:value-type="float" office:value="${num}"><text:p>${num.toPrecision(


### PR DESCRIPTION
# Descripción

Corrige la exportación de valores porcentuales en el generador de archivos `.ods`. Resulta que el valor exportado tiene que ser el valor real y no el valor porcentual.

Referencia: http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part1.html#__RefHeading__1417678_253892949

Verifiqué el cambio descargando localmente con el curso de prueba de `bootstrap-environment.py`

Fixes: #5865

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
