### PR TITLE
Mostrar (accepted/submissions) en la columna ratio en la lista de problemas

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -21,7 +21,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type RunMetadata=array{verdict: string, time: float, sys_time: int, wall_time: float, memory: int}
  * @psalm-type CaseResult=array{contest_score: float, max_score: float, meta: RunMetadata, name: string, out_diff?: string, score: float, verdict: string}
  * @psalm-type ListItem=array{key: string, value: string}
- * @psalm-type ProblemListItem=array{alias: string, difficulty: float|null, difficulty_histogram: list<int>, points: float, problem_id: int, quality: float|null, quality_histogram: list<int>, quality_seal: bool, ratio: float, score: float, tags: list<array{name: string, source: string}>, title: string, visibility: int}
+ * @psalm-type ProblemListItem=array{accepted: int, alias: string, difficulty: float|null, difficulty_histogram: list<int>, points: float, problem_id: int, quality: float|null, quality_histogram: list<int>, quality_seal: bool, ratio: float, score: float, submissions: int, tags: list<array{name: string, source: string}>, title: string, visibility: int}
  * @psalm-type Statements=array<string, string>
  * @psalm-type Run=array{guid: string, language: string, status: string, verdict: string, runtime: int, penalty: int, memory: int, score: float, contest_score: float|null, time: \OmegaUp\Timestamp, submit_delay: int, type: null|string, username: string, classname: string, alias: string, country: string, contest_alias: null|string}
  * @psalm-type ArenaProblemDetails=array{accepts_submissions: bool, alias: string, commit: string, input_limit: int, languages: list<string>, letter?: string, points: float, problem_id?: int, problemsetter?: ProblemsetterInfo, quality_seal: bool, runs?: list<Run>,  settings?: ProblemSettingsDistrib, source?: string, statement?: ProblemStatement, title: string, visibility: int}
@@ -4142,21 +4142,23 @@ class Problem extends \OmegaUp\Controllers\Controller {
         foreach ($problems as $problem) {
             /** @var ProblemListItem */
             $problemArray = $problem->asFilteredArray([
+                'accepted',
                 'alias',
                 'difficulty',
                 'difficulty_histogram',
-                'problem_id',
                 'points',
+                'problem_id',
                 'quality',
                 'quality_histogram',
                 'ratio',
                 'score',
+                'submissions',
                 'tags',
                 'title',
                 'visibility',
                 'quality_seal',
             ]);
-            $problemArray['tags'] = $hiddenTags ? []  : \OmegaUp\DAO\Problems::getTagsForProblem(
+            $problemArray['tags'] = $hiddenTags ? [] : \OmegaUp\DAO\Problems::getTagsForProblem(
                 $problem,
                 public: false,
                 showUserTags: $problem->allow_user_add_tags
@@ -4220,6 +4222,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         foreach ($problems as $problem) {
             /** @var ProblemListItem */
             $problemArray = $problem->asFilteredArray([
+                'accepted',
                 'alias',
                 'difficulty',
                 'difficulty_histogram',
@@ -4229,6 +4232,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'quality_histogram',
                 'ratio',
                 'score',
+                'submissions',
                 'tags',
                 'title',
                 'visibility',

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -82,7 +82,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
      * @param list<string> $programmingLanguages
      * @param list<string> $tags
      * @param list<string> $authors
-     * @return array{count: int, problems: list<array{alias: string, difficulty: float|null, difficulty_histogram: list<int>, points: float, problem_id: int, quality: float|null, quality_histogram: list<int>, quality_seal: bool, ratio: float, score: float, tags: list<array{name: string, source: string}>, title: string, visibility: int}>}
+     * @return array{count: int, problems: list<array{accepted: int, alias: string, difficulty: float|null, difficulty_histogram: list<int>, points: float, problem_id: int, quality: float|null, quality_histogram: list<int>, quality_seal: bool, ratio: float, score: float, submissions: int, tags: list<array{name: string, source: string}>, title: string, visibility: int}>}
      */
     final public static function byIdentityType(
         string $identityType,
@@ -456,8 +456,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
 
         // Only these fields (plus score, points and ratio) will be returned.
         $filters = [
-            'title', 'quality', 'difficulty', 'alias', 'visibility', 'problem_id',
-            'quality_histogram', 'difficulty_histogram', 'quality_seal',
+            'accepted', 'title', 'quality', 'difficulty', 'alias', 'visibility', 'problem_id',
+            'quality_histogram', 'difficulty_histogram', 'submissions', 'quality_seal',
         ];
         $problems = [];
         $hiddenTags = $identityType !== IDENTITY_ANONYMOUS ? \OmegaUp\DAO\Users::getHideTags(

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -470,7 +470,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                     \OmegaUp\DAO\VO\Problems::FIELD_NAMES
                 )
             );
-            /** @var array{title: string, quality: null|float, difficulty: null|float, alias: string, visibility: int,quality_histogram: list<int>, difficulty_histogram: list<int>, quality_seal: bool, problem_id: int} */
+            /** @var array{title: string, quality: null|float, difficulty: null|float, alias: string, accepted: int, visibility: int,quality_histogram: list<int>, difficulty_histogram: list<int>, quality_seal: bool, submissions: int, problem_id: int} */
             $problem = $problemObject->asFilteredArray($filters);
 
             // score, points and ratio are not actually fields of a Problems object.

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -3828,6 +3828,7 @@ export namespace types {
   }
 
   export interface ProblemListItem {
+    accepted: number;
     alias: string;
     difficulty?: number;
     difficulty_histogram: number[];
@@ -3838,6 +3839,7 @@ export namespace types {
     quality_seal: boolean;
     ratio: number;
     score: number;
+    submissions: number;
     tags: { name: string; source: string }[];
     title: string;
     visibility: number;

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -204,7 +204,10 @@
             </td>
             <td v-else class="text-center align-middle">—</td>
             <td class="text-right align-middle">
-              {{ (100.0 * problem.ratio).toFixed(2) }}%
+              {{ (100.0 * problem.ratio).toFixed(2) }}% ({{
+                problem.accepted
+              }}
+              / {{ problem.submissions }})
             </td>
             <td v-if="loggedIn" class="text-right align-middle">
               {{ problem.score.toFixed(2) }}

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -204,7 +204,7 @@
             </td>
             <td v-else class="text-center align-middle">—</td>
             <td class="text-right align-middle">
-              {{ (100.0 * problem.ratio).toFixed(2) }}% <br />({{
+              {{ (100.0 * problem.ratio).toFixed(2) }}%<br />({{
                 problem.accepted
               }}/{{ problem.submissions }})
             </td>

--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -204,10 +204,9 @@
             </td>
             <td v-else class="text-center align-middle">—</td>
             <td class="text-right align-middle">
-              {{ (100.0 * problem.ratio).toFixed(2) }}% ({{
+              {{ (100.0 * problem.ratio).toFixed(2) }}% <br />({{
                 problem.accepted
-              }}
-              / {{ problem.submissions }})
+              }}/{{ problem.submissions }})
             </td>
             <td v-if="loggedIn" class="text-right align-middle">
               {{ problem.score.toFixed(2) }}


### PR DESCRIPTION
# Descripción

Muestra el numerador y denominador en la columna `ratio`

Fixes: #1892

# Comentarios

`accepted` es precalculado al actualizar ranks, pero submissions se calcula sobre la marcha, entonces ratio no se ve enteramente consistente.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
