### PR TITLE
Haciendo que psalm pueda re-ejecutarse correctamente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ node_modules/
 # Ignore composer files
 vendor/
 
+# Ignore psalm cache
+/.psalm/
+
 # Ignore JavaScript build files.
 frontend/www/js/dist/
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     autoloader="frontend/server/bootstrap.php"
-    cacheDirectory="/tmp/psalm"
+    cacheDirectory="./.psalm"
     hoistConstants="true"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
En la última versión de Psalm ahora se está evitando ejecutar el análisis de los métodos si no se han modificado. Eso implica que la fase de análisis que determina si se necesita modificar las firmas de las funciones ahora ya no necesariamente tiene el contenido correcto.

Este cambio hace que ahora se guarden los resultados intermedios en un cache para asegurarnos que siempre se tengan resultados correctos en el análisis.