### PR TITLE
Agregando `lastrowid` a `mysq.connector.cursor.BaseCursor`

### DIFF
--- a/stuff/mysql/connector/cursor.pyi
+++ b/stuff/mysql/connector/cursor.pyi
@@ -3,6 +3,8 @@ from typing import Any, Iterator, Iterable, Mapping, Optional, Sequence, Text, T
 
 
 class BaseCursor:
+    lastrowid: int
+
     def close(self) -> None:
         ...
 


### PR DESCRIPTION
Esto es necesario para obtener el último ID insertado en MySQL.