### PR TITLE
Arreglar la conexión del valor de `validator` al editar problemas

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -231,8 +231,8 @@
                 :memory-limit="memoryLimit"
                 :output-limit="outputLimit"
                 :input-limit="inputLimit"
-                :initial-validator="validator"
                 :overall-wall-time-limit="overallWallTimeLimit"
+                :validator="validator"
                 :validator-time-limit="validatorTimeLimit"
               ></omegaup-problem-settings>
             </div>


### PR DESCRIPTION
# Descripción

Se corrige la conexión entre el tipo de validador en el modelo de editar problema y el validador que conocer el componente `Settings`. Por algún motivo se estaba pasando como un prop `initial-validator` que no existe en el componente `Settings`.

Fixes: #6812

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.