### PR TITLE
Campo para verificar estado runtime

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -254,8 +254,22 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                         "EXECUTION_FINISHED"
                     )
                 LIMIT 1
-                ) AS
-                    execution
+                ) AS execution,
+                ( SELECT
+                    IF(
+                        verdict IN ("JE", "CE"), "RUNTIME_NOT_AVAILABLE",
+                    IF(
+                        verdict IN ("TLE", "TO"), "RUNTIME_EXCEEDED", "RUNTIME_AVAILABLE"
+                    ))
+				    AS status_runtime
+				FROM
+					Runs_Groups
+				WHERE
+					run_id = `r`.`run_id`
+				ORDER BY
+                    field(status_runtime, "RUNTIME_NOT_AVAILABLE", "RUNTIME_EXCEEDED", "RUNTIME_AVAILABLE")
+				LIMIT 1
+                ) AS status_runtime
             FROM
                 Submissions s
             INNER JOIN
@@ -279,7 +293,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         $val[] = $offset * $rowCount;
         $val[] = $rowCount;
 
-        /** @var list<array{alias: string, classname: string, contest_alias: null|string, contest_score: float|null, country: string, execution: null|string, guid: string, language: string, memory: int, output: null|string, penalty: int, run_id: int, runtime: int, score: float, status: string, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, username: string, verdict: string}> */
+        /** @var list<array{alias: string, classname: string, contest_alias: null|string, contest_score: float|null, country: string, execution: null|string, guid: string, language: string, memory: int, output: null|string, penalty: int, run_id: int, runtime: int, score: float, status: string, status_runtime: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, username: string, verdict: string}> */
         $runs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val);
 
         return [

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -1257,7 +1257,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * A PHPUnit data provider for the contest with max_per_group mode.
      *
-     * @return array{0: int, 1: list<array: {runs: int, score: float, execution: string, output: string}>, 2: list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}>}
+     * @return array{0: int, 1: list<array: {runs: int, score: float, execution: string, output: string, status_runtime: string}>, 2: list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}>}
      */
     public function runsMappingProvider(): array {
         $runsMapping = [
@@ -1291,30 +1291,30 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             [
                 100,
                 [
-                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 3, 'score' => 80.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
+                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
+                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
+                    ['runs' => 3, 'score' => 80.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                 ],
                 $runsMapping
             ],
             [
                 60,
                 [
-                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
+                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
+                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                     // Only the number of runs should be updated, because of the
                     // contest's settings
-                    ['runs' => 3, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
+                    ['runs' => 3, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                 ],
                 $runsMapping
             ],
             [
                 100,
                 [
-                    ['runs' => 1, 'score' => 0.0, 'execution' => 'EXECUTION_COMPILATION_ERROR', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 2, 'score' => 50.0, 'execution' => 'EXECUTION_JUDGE_ERROR', 'output' => 'OUTPUT_EXCEEDED'],
-                    ['runs' => 3, 'score' => 83.33, 'execution' => 'EXECUTION_INTERRUPTED', 'output' => 'OUTPUT_INTERRUPTED'],
-                    ['runs' => 4, 'score' => 100.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_CORRECT'],
+                    ['runs' => 1, 'score' => 0.0, 'execution' => 'EXECUTION_COMPILATION_ERROR', 'output' => 'OUTPUT_INCORRECT', 'status_runtime' => 'RUNTIME_NOT_AVAILABLE'],
+                    ['runs' => 2, 'score' => 50.0, 'execution' => 'EXECUTION_JUDGE_ERROR', 'output' => 'OUTPUT_EXCEEDED', 'status_runtime' => 'RUNTIME_NOT_AVAILABLE'],
+                    ['runs' => 3, 'score' => 83.33, 'execution' => 'EXECUTION_INTERRUPTED', 'output' => 'OUTPUT_INTERRUPTED', 'status_runtime' => 'RUNTIME_EXCEEDED'],
+                    ['runs' => 4, 'score' => 100.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_CORRECT', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                 ],
                 [
 
@@ -1356,7 +1356,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * @param list<array: {runs: int, score: float, execution: string, output: string}> $expectedResultsInEverySubmission
+     * @param list<array: {runs: int, score: float, execution: string, output: string, status_runtime: string}> $expectedResultsInEverySubmission
      * @param list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}> $runsMapping
      *
      * @dataProvider runsMappingProvider
@@ -1446,6 +1446,10 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             $this->assertSame(
                 $runsList[0]['output'],
                 $expectedResultsInEverySubmission[$index]['output']
+            );
+            $this->assertSame(
+                $runsList[0]['status_runtime'],
+                $expectedResultsInEverySubmission[$index]['status_runtime']
             );
         }
     }


### PR DESCRIPTION
# Descripción

Se agrego un nuevo campo `status_runtime` para verificar el runtime dependiendo de los veredictos obtenidos por `Runs_Groups` agrupados de la siguiente manera:

RUNTIME_NOT_AVAILABLE
- JE
- CE

RUNTIME_EXCEEDED
- TLE
- TO

RUNTIME_AVAILABLE
- VE
- FO
- RFE
- RE
- RTE
- ML
- MLE
- WA
- AC


Fixes: #6790 


