### PR TITLE
Campo para el estado de memory

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -255,7 +255,22 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                     )
                 LIMIT 1
                 ) AS
-                    execution
+                    execution,
+                ( SELECT
+					IF(
+						verdict IN ("JE", "CE"), "MEMORY_NOT_AVAILABLE",
+					IF(
+						verdict IN ("ML", "MLE"), "MEMORY_EXCEEDED", "MEMORY_AVAILABLE"
+					))
+                AS status_memory
+                FROM
+                    Runs_Groups
+                WHERE
+                    run_id = `r`.`run_id`
+                ORDER BY
+                    field(status_memory, "MEMORY_NOT_AVAILABLE", "MEMORY_EXCEEDED", "MEMORY_AVAILABLE")
+                LIMIT 1
+                ) AS status_memory
             FROM
                 Submissions s
             INNER JOIN
@@ -279,7 +294,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         $val[] = $offset * $rowCount;
         $val[] = $rowCount;
 
-        /** @var list<array{alias: string, classname: string, contest_alias: null|string, contest_score: float|null, country: string, execution: null|string, guid: string, language: string, memory: int, output: null|string, penalty: int, run_id: int, runtime: int, score: float, status: string, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, username: string, verdict: string}> */
+        /** @var list<array{alias: string, classname: string, contest_alias: null|string, contest_score: float|null, country: string, execution: null|string, guid: string, language: string, memory: int, output: null|string, penalty: int, run_id: int, runtime: int, score: float, status: string, status_memory: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: null|string, username: string, verdict: string}> */
         $runs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val);
 
         return [

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -257,11 +257,11 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 ) AS
                     execution,
                 ( SELECT
-					IF(
-						verdict IN ("JE", "CE"), "MEMORY_NOT_AVAILABLE",
-					IF(
-						verdict IN ("ML", "MLE"), "MEMORY_EXCEEDED", "MEMORY_AVAILABLE"
-					))
+                    IF(
+                        verdict IN ("JE", "CE"), "MEMORY_NOT_AVAILABLE",
+                    IF(
+                        verdict IN ("ML", "MLE"), "MEMORY_EXCEEDED", "MEMORY_AVAILABLE"
+                    ))
                 AS status_memory
                 FROM
                     Runs_Groups

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -1257,7 +1257,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * A PHPUnit data provider for the contest with max_per_group mode.
      *
-     * @return array{0: int, 1: list<array: {runs: int, score: float, execution: string, output: string}>, 2: list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}>}
+     * @return array{0: int, 1: list<array: {runs: int, score: float, execution: string, output: string, status_memory: string}>, 2: list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}>}
      */
     public function runsMappingProvider(): array {
         $runsMapping = [
@@ -1291,30 +1291,30 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             [
                 100,
                 [
-                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 3, 'score' => 80.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
+                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
+                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
+                    ['runs' => 3, 'score' => 80.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
                 ],
                 $runsMapping
             ],
             [
                 60,
                 [
-                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
+                    ['runs' => 1, 'score' => 40.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
+                    ['runs' => 2, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
                     // Only the number of runs should be updated, because of the
                     // contest's settings
-                    ['runs' => 3, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT'],
+                    ['runs' => 3, 'score' => 73.33, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
                 ],
                 $runsMapping
             ],
             [
                 100,
                 [
-                    ['runs' => 1, 'score' => 0.0, 'execution' => 'EXECUTION_COMPILATION_ERROR', 'output' => 'OUTPUT_INCORRECT'],
-                    ['runs' => 2, 'score' => 50.0, 'execution' => 'EXECUTION_JUDGE_ERROR', 'output' => 'OUTPUT_EXCEEDED'],
-                    ['runs' => 3, 'score' => 83.33, 'execution' => 'EXECUTION_INTERRUPTED', 'output' => 'OUTPUT_INTERRUPTED'],
-                    ['runs' => 4, 'score' => 100.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_CORRECT'],
+                    ['runs' => 1, 'score' => 0.0, 'execution' => 'EXECUTION_COMPILATION_ERROR', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_NOT_AVAILABLE'],
+                    ['runs' => 2, 'score' => 50.0, 'execution' => 'EXECUTION_JUDGE_ERROR', 'output' => 'OUTPUT_EXCEEDED', 'status_memory' => 'MEMORY_NOT_AVAILABLE'],
+                    ['runs' => 3, 'score' => 83.33, 'execution' => 'EXECUTION_INTERRUPTED', 'output' => 'OUTPUT_INTERRUPTED', 'status_memory' => 'MEMORY_AVAILABLE'],
+                    ['runs' => 4, 'score' => 100.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_CORRECT', 'status_memory' => 'MEMORY_AVAILABLE'],
                 ],
                 [
 
@@ -1356,7 +1356,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * @param list<array: {runs: int, score: float, execution: string, output: string}> $expectedResultsInEverySubmission
+     * @param list<array: {runs: int, score: float, execution: string, output: string, status_memory: string}> $expectedResultsInEverySubmission
      * @param list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}> $runsMapping
      *
      * @dataProvider runsMappingProvider
@@ -1446,6 +1446,10 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
             $this->assertSame(
                 $runsList[0]['output'],
                 $expectedResultsInEverySubmission[$index]['output']
+            );
+            $this->assertSame(
+                $runsList[0]['status_memory'],
+                $expectedResultsInEverySubmission[$index]['status_memory']
             );
         }
     }


### PR DESCRIPTION
# Descripción

Se agrego un nuevo campo `status_memory` para verificar el la memoria dependiendo de los veredictos obtenidos por `Runs_Gruops` agrupados de la siguiente manera:

MEMORY_NOT_AVAILABLE
- JE
- CE

MEMORY_EXCEEDED
- ML
- MLE

MEMORY_AVAILABLE
- VE
- FO
- RFE
- RE
- RTE
- TLE
- TO
- WA
- AC


Fixes: #6791 

