### PR TITLE
Arreglando la selección de JavaScript en el dropdown

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -103,7 +103,7 @@
                 <option value="lua">Lua (5.3)</option>
                 <option value="go">Go (1.18.beta2)</option>
                 <option value="rs">Rust (1.56.1)</option>
-                <option value="lua">JavaScript (Node.js 16)</option>
+                <option value="js">JavaScript (Node.js 16)</option>
                 <option value="kp">Karel (Pascal)</option>
                 <option value="kj">Karel (Java)</option>
                 <option value="cat">{{ T.wordsJustOutput }}</option>


### PR DESCRIPTION
Este cambio hace que una vez más se pueda seleccionar envíos de JavaScript.