### PR TITLE
Agregando timeouts de MySQL en el ambiente de pruebas

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,10 @@ services:
       MYSQL_PASSWORD: 'omegaup'
       MYSQL_ROOT_PASSWORD: 'omegaup'
       MYSQL_TCP_PORT: 13306
+    command:
+      - --max_execution_time=30000
+      - --lock_wait_timeout=10
+      - --wait_timeout=20
     expose:
       - '13306'
     volumes:


### PR DESCRIPTION
Este cambio hace que MySQL eventualmente termine las consultas si toman más de cierto tiempo para evitar timeouts en GitHub.