### PR TITLE
Usando la base de datos readonly para evitar carga

### DIFF
--- a/stuff/cron/build_problem_rec_model.py
+++ b/stuff/cron/build_problem_rec_model.py
@@ -22,10 +22,9 @@ from typing import (cast, DefaultDict, Dict, List, Mapping, Optional, Sequence,
 import numpy as np  # type: ignore
 import pandas as pd  # type: ignore
 
-sys.path.insert(
-    0,
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-import lib.db   # pylint: disable=wrong-import-position
+sys.path.insert(0,
+                os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+import lib.db  # pylint: disable=wrong-import-position
 import lib.logs  # pylint: disable=wrong-import-position
 
 # Default training parameters.
@@ -38,9 +37,11 @@ ProblemList = List[int]
 ProblemSet = Set[int]
 
 
-def mean_average_precision(predicted: ProblemList,
-                           expected: ProblemList,
-                           k: int) -> Optional[float]:
+def mean_average_precision(
+    predicted: ProblemList,
+    expected: ProblemList,
+    k: int,
+) -> Optional[float]:
     '''Compute MAP@k - https://goo.gl/KMghXR'''
     if not predicted or not expected:
         return None
@@ -78,7 +79,11 @@ def load_mysql(args: argparse.Namespace) -> pd.DataFrame:
     Ignoring problem sets helps remove bias in recommendations
     introduced by problem ordering in contests and tests.
     '''
-    dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
+    dbconn = lib.db.connect_readonly(
+        lib.db.DatabaseConnectionArguments.from_args_readonly(args))
+    if not dbconn:
+        dbconn = lib.db.connect(
+            lib.db.DatabaseConnectionArguments.from_args(args))
     try:
         logging.info('Reading runs from MySQL')
         runs: pd.DataFrame = pd.read_sql_query(
@@ -125,10 +130,11 @@ def load_mysql(args: argparse.Namespace) -> pd.DataFrame:
         dbconn.conn.close()
 
 
-def train_test_split(runs: pd.DataFrame,
-                     train_fraction: float = _TRAIN_FRACTION,
-                     random_seed: Optional[int] = None
-                     ) -> Tuple[pd.Series, pd.Series]:
+def train_test_split(
+    runs: pd.DataFrame,
+    train_fraction: float = _TRAIN_FRACTION,
+    random_seed: Optional[int] = None,
+) -> Tuple[pd.Series, pd.Series]:
     '''Splits runs into test/train sets by user.
 
     The split is done based on `train_fraction`.
@@ -142,10 +148,11 @@ def train_test_split(runs: pd.DataFrame,
     return train_users, test_users
 
 
-def generate_model(train_ac: Mapping[int, Sequence[int]],
-                   num_followups: int = _NUM_FOLLOWUPS,
-                   followup_decay: float = _FOLLOWUP_DECAY
-                   ) -> Mapping[int, Sequence[Tuple[int, float]]]:
+def generate_model(
+    train_ac: Mapping[int, Sequence[int]],
+    num_followups: int = _NUM_FOLLOWUPS,
+    followup_decay: float = _FOLLOWUP_DECAY
+) -> Mapping[int, Sequence[Tuple[int, float]]]:
     '''Assumes runs are sorted by submission time'''
     tuples: List[Tuple[int, int, float]] = []
     for problems in train_ac.values():
@@ -157,8 +164,8 @@ def generate_model(train_ac: Mapping[int, Sequence[int]],
     weighted_pairs = pd.DataFrame(tuples,
                                   columns=('source', 'target', 'weight'))
     logging.info('Weighted pairs: %d', len(tuples))
-    model: DefaultDict[int, List[Tuple[int, float]]] = collections.defaultdict(
-        list)
+    model: DefaultDict[int, List[Tuple[int,
+                                       float]]] = collections.defaultdict(list)
     for (recommended_problem_id,
          solved_problem_id), score in weighted_pairs.groupby(
              ['source', 'target']).aggregate(sum).itertuples():
@@ -171,11 +178,14 @@ def generate_model(train_ac: Mapping[int, Sequence[int]],
 
 class TrainingConfig:
     '''A class to store the configuration for training a model.'''
-    def __init__(self,
-                 train_fraction: float = _TRAIN_FRACTION,
-                 rng_seed: int = 0,
-                 num_followups: int = _NUM_FOLLOWUPS,
-                 followup_decay: float = _FOLLOWUP_DECAY):
+
+    def __init__(
+        self,
+        train_fraction: float = _TRAIN_FRACTION,
+        rng_seed: int = 0,
+        num_followups: int = _NUM_FOLLOWUPS,
+        followup_decay: float = _FOLLOWUP_DECAY,
+    ):
         self.train_fraction: float = train_fraction
         assert 0 < self.train_fraction < 1
         self.rng_seed: Optional[int] = rng_seed
@@ -186,6 +196,7 @@ class TrainingConfig:
 class Model:
     '''A class that represents a prediction model.
     '''
+
     def __init__(self, config: TrainingConfig, runs: pd.DataFrame):
         self.config = config
 
@@ -251,8 +262,12 @@ class Model:
             finally:
                 conn.commit()
 
-    def recommend(self, latest_problem: int, banned_problems: ProblemSet,
-                  k: int) -> Optional[ProblemList]:
+    def recommend(
+        self,
+        latest_problem: int,
+        banned_problems: ProblemSet,
+        k: int,
+    ) -> Optional[ProblemList]:
         '''Recommends the a problem given that a user just solved last_problem.
 
         Args:

--- a/stuff/lib/db.py
+++ b/stuff/lib/db.py
@@ -35,58 +35,72 @@ class DatabaseConnectionArguments(NamedTuple):
             password=args.password,
             mysql_config_file=args.mysql_config_file,
             database=args.database,
-            port=args.port
+            port=args.port,
+        )
+
+    @staticmethod
+    def from_args_readonly(
+            args: argparse.Namespace) -> 'DatabaseConnectionArguments':
+        '''Converts arguments to a named tuple for the database connection'''
+        return DatabaseConnectionArguments(
+            host=args.readonly_host,
+            user=args.readonly_user,
+            password=args.readonly_password,
+            mysql_config_file=args.mysql_config_file,
+            database=args.readonly_database,
+            port=args.readonly_port,
         )
 
 
 class Connection:
     '''A MySQL connection.'''
+
     def __init__(self, dbconn: mysql.connector.MySQLConnection) -> None:
         self.conn = dbconn
 
     @overload
     def cursor(
-            self,
-            *,
-            buffered: Literal[True],
-            dictionary: Literal[False] = ...,
+        self,
+        *,
+        buffered: Literal[True],
+        dictionary: Literal[False] = ...,
     ) -> ContextManager[mysql.connector.cursor.MySQLCursorBuffered]:
         ...
 
     @overload
     def cursor(
-            self,
-            *,
-            buffered: Literal[False] = ...,
-            dictionary: Literal[True],
+        self,
+        *,
+        buffered: Literal[False] = ...,
+        dictionary: Literal[True],
     ) -> ContextManager[mysql.connector.cursor.MySQLCursorDict]:
         ...
 
     @overload
     def cursor(
-            self,
-            *,
-            buffered: Literal[True],
-            dictionary: Literal[True],
+        self,
+        *,
+        buffered: Literal[True],
+        dictionary: Literal[True],
     ) -> ContextManager[mysql.connector.cursor.MySQLCursorBufferedDict]:
         ...
 
     @overload
     def cursor(
-            self,
-            *,
-            buffered: Literal[False] = ...,
-            dictionary: Literal[False] = ...,
+        self,
+        *,
+        buffered: Literal[False] = ...,
+        dictionary: Literal[False] = ...,
     ) -> ContextManager[mysql.connector.cursor.MySQLCursor]:
         ...
 
     # mypy and contextmanagers have an outstanding bad relationship :/
     @contextlib.contextmanager  # type: ignore
     def cursor(
-            self,
-            *,
-            buffered: bool = False,
-            dictionary: bool = False,
+        self,
+        *,
+        buffered: bool = False,
+        dictionary: bool = False,
     ) -> Union[
         Generator[mysql.connector.cursor.MySQLCursorBuffered, None, None],
         Generator[mysql.connector.cursor.MySQLCursorDict, None, None],
@@ -105,8 +119,7 @@ def default_config_file_path() -> Optional[str]:
     '''Try to autodetect the config file path.'''
     for candidate_path in (
             # ~/.my.cnf
-            os.path.join(os.getenv('HOME') or '.', '.my.cnf'),
-    ):
+            os.path.join(os.getenv('HOME') or '.', '.my.cnf'), ):
         if os.path.isfile(candidate_path):
             return candidate_path
     return None
@@ -119,6 +132,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
                          type=str,
                          default=default_config_file_path(),
                          help='.my.cnf file that stores credentials')
+
     db_args.add_argument('--host',
                          type=str,
                          help='MySQL host',
@@ -131,19 +145,41 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
                          default='omegaup')
     db_args.add_argument('--port', type=int, help='MySQL port', default=13306)
 
+    db_args.add_argument('--readonly-host',
+                         type=str,
+                         help='Read-only MySQL host')
+    db_args.add_argument('--readonly-user',
+                         type=str,
+                         help='Read-only MySQL username')
+    db_args.add_argument('--readonly-password',
+                         type=str,
+                         help='MySQL password')
+    db_args.add_argument('--readonly-database',
+                         type=str,
+                         help='Read-only MySQL database',
+                         default='omegaup')
+    db_args.add_argument('--readonly-port',
+                         type=int,
+                         help='Read-only MySQL port',
+                         default=3306)
+
 
 def connect(args: DatabaseConnectionArguments) -> Connection:
     '''Connects to MySQL with the arguments provided.
 
     Returns a MySQL connection.
     '''
+    port = args.port
     host = args.host
     user = args.user
     password = args.password
-    if user is None and os.path.isfile(args.mysql_config_file):
+    database = args.database
+    if (user is None and args.mysql_config_file
+            and os.path.isfile(args.mysql_config_file)):
         config = configparser.ConfigParser()
         config.read(args.mysql_config_file)
         # Puppet quotes some configuration entries.
+        port = int(config['client']['port'].strip("'"))
         host = config['client']['host'].strip("'")
         user = config['client']['user'].strip("'")
         password = config['client']['password'].strip("'")
@@ -153,14 +189,52 @@ def connect(args: DatabaseConnectionArguments) -> Connection:
     assert user is not None, 'Missing --user parameter'
     assert host is not None, 'Missing --host parameter'
     assert password is not None, 'Missing --password parameter'
+    assert database is not None, 'Missing --database parameter'
 
     return Connection(
         mysql.connector.connect(
             host=host,
             user=user,
             password=password,
-            database=args.database,
-            port=args.port,
+            database=database,
+            port=port,
+        ))
+
+
+def connect_readonly(
+        args: DatabaseConnectionArguments) -> Optional[Connection]:
+    '''Connects to the read-only MySQL replica with the arguments provided.
+
+    Returns a MySQL connection, or None if the read-only replica is not
+    configured. The caller can use the regular MySQL connection instead.
+    '''
+    port = args.port
+    host = args.host
+    user = args.user
+    password = args.password
+    database = args.database
+    if (user is None and args.mysql_config_file
+            and os.path.isfile(args.mysql_config_file)):
+        config = configparser.ConfigParser()
+        config.read(args.mysql_config_file)
+        # Puppet quotes some configuration entries.
+        if 'clientreadonly' in config:
+            port = int(config['clientreadonly']['port'].strip("'"))
+            host = config['clientreadonly']['host'].strip("'")
+            user = config['clientreadonly']['user'].strip("'")
+            password = config['clientreadonly']['password'].strip("'")
+            database = config['clientreadonly']['database'].strip("'")
+
+    if not port or not host or not user or not password or not database:
+        return None
+
+    return Connection(
+        mysql.connector.connect(
+            host=host,
+            user=user,
+            password=password,
+            database=database,
+            port=port,
         ))
 
 


### PR DESCRIPTION
Este cambio hace que todos los cronjobs se conecten usando la base de datos readonly para evitar que la base de datos primaria esté demasiado ocupada durante las madrugadas y tire la página.