### PR TITLE
eliminacion omegaup api

### DIFF
--- a/stuff/pipelines/client_contest.py
+++ b/stuff/pipelines/client_contest.py
@@ -12,8 +12,6 @@ import logging
 import os
 import sys
 
-import omegaup.api
-
 import contest_callback
 import rabbitmq_connection
 import rabbitmq_client
@@ -37,12 +35,6 @@ def main() -> None:
     lib.logs.configure_parser(parser)
     rabbitmq_connection.configure_parser(parser)
 
-    parser.add_argument('--api-token', type=str, help='omegaup api token')
-    parser.add_argument('--url',
-                        type=str,
-                        help='omegaup api URL',
-                        default='https://omegaup.com')
-
     args = parser.parse_args()
     lib.logs.init(parser.prog, args)
     logging.info('Started')
@@ -53,11 +45,7 @@ def main() -> None:
                 password=args.rabbitmq_password,
                 host=args.rabbitmq_host
         ) as channel:
-            client = omegaup.api.Client(api_token=args.api_token, url=args.url)
-            callback = contest_callback.ContestsCallback(
-                dbconn=dbconn.conn,
-                client=client,
-            )
+            callback = contest_callback.ContestsCallback(dbconn=dbconn.conn)
             rabbitmq_client.receive_messages(queue='contest',
                                              exchange='certificates',
                                              routing_key='ContestQueue',

--- a/stuff/pipelines/contest_callback.py
+++ b/stuff/pipelines/contest_callback.py
@@ -20,7 +20,7 @@ import verification_code
 class Ranking:
     '''Relevant information for ranking users.'''
     username: str
-    place: int
+    place: Optional[int]
 
 
 @dataclasses.dataclass

--- a/stuff/pipelines/database/contest.py
+++ b/stuff/pipelines/database/contest.py
@@ -61,7 +61,7 @@ def get_contests(
         for position in scoreboard.ranking:
             ranking.append(Ranking(
                 username=position.username,
-                place=position.place))
+                place=position.place)._asdict())
         contest = ContestCertificate(
             certificate_cutoff=row['certificate_cutoff'],
             alias=row['alias'],

--- a/stuff/pipelines/producer_contest.py
+++ b/stuff/pipelines/producer_contest.py
@@ -12,6 +12,7 @@ import sys
 from typing import List
 import mysql.connector
 import mysql.connector.cursor
+import omegaup.api
 import pika
 
 import database.contest
@@ -32,6 +33,7 @@ def send_contest_message_to_client(
         channel: pika.adapters.blocking_connection.BlockingChannel,
         date_lower_limit: datetime.datetime = datetime.datetime(2005, 1, 1),
         date_upper_limit: datetime.datetime = datetime.datetime.now(),
+        client: omegaup.api.Client,
 ) -> None:
     '''Send messages to contest queue.
      date-lower-limit: initial time from which to be taken the finish contests.
@@ -50,6 +52,7 @@ def send_contest_message_to_client(
         cur=cur,
         date_lower_limit=date_lower_limit,
         date_upper_limit=date_upper_limit,
+        client=client
     )
 
     for data in contestants:
@@ -62,18 +65,25 @@ def get_contests_from_db(
     cur: mysql.connector.cursor.MySQLCursorDict,
     date_lower_limit: datetime.datetime,
     date_upper_limit: datetime.datetime,
+    client: omegaup.api.Client
 ) -> List[database.contest.ContestCertificate]:
     ''''A intermediate function in order to mock the original one'''
     return database.contest.get_contests(
         cur=cur,
         date_lower_limit=date_lower_limit,
         date_upper_limit=date_upper_limit,
+        client=client,
     )
 
 
 def main() -> None:
     '''Main entrypoint.'''
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--api-token', type=str, help='omegaup api token')
+    parser.add_argument('--url',
+                        type=str,
+                        help='omegaup api URL',
+                        default='https://omegaup.com')
     parser.add_argument('--date-lower-limit',
                         type=lambda s:
                         datetime.datetime.strptime(s, '%Y-%m-%d'),
@@ -94,6 +104,7 @@ def main() -> None:
 
     logging.info('Started')
     dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
+    client = omegaup.api.Client(api_token=args.api_token, url=args.url)
     try:
         with dbconn.cursor(buffered=True, dictionary=True) as cur, \
             rabbitmq_connection.connect(username=args.rabbitmq_username,
@@ -104,7 +115,8 @@ def main() -> None:
                 cur=cur,
                 channel=channel,
                 date_lower_limit=args.date_lower_limit,
-                date_upper_limit=args.date_upper_limit)
+                date_upper_limit=args.date_upper_limit,
+                client=client)
     finally:
         dbconn.conn.close()
         logging.info('Done')

--- a/stuff/pipelines/test_client_contest.py
+++ b/stuff/pipelines/test_client_contest.py
@@ -6,18 +6,18 @@ import os
 import sys
 
 # pylint indicates pytest_mock should be placed before "import mysql.connector"
-import contest_callback
-import omegaup.api
-import pika
-import producer_contest
 import pytest_mock
-import rabbitmq_client
-import rabbitmq_connection
-import test_constants
-import test_credentials
-
 import mysql.connector
 import mysql.connector.cursor
+import omegaup.api
+import pika
+
+import contest_callback
+import rabbitmq_connection
+import rabbitmq_client
+import producer_contest
+import test_constants
+import test_credentials
 
 sys.path.insert(
     0,
@@ -31,11 +31,9 @@ class ContestsCallbackForTesting:
     '''Contests callback'''
     def __init__(self,
                  *,
-                 dbconn: mysql.connector.MySQLConnection,
-                 client: omegaup.api.Client):
+                 dbconn: mysql.connector.MySQLConnection):
         '''Contructor for contest callback for testing'''
         self.dbconn = dbconn
-        self.client = client
 
     def __call__(self,
                  channel: pika.adapters.blocking_connection.BlockingChannel,
@@ -43,8 +41,7 @@ class ContestsCallbackForTesting:
                  properties: pika.spec.BasicProperties,
                  body: bytes) -> None:
         '''Function to call the original callback'''
-        callback = contest_callback.ContestsCallback(dbconn=self.dbconn,
-                                                     client=self.client)
+        callback = contest_callback.ContestsCallback(dbconn=self.dbconn)
         callback(channel, method, properties, body)
         channel.close()
 
@@ -67,7 +64,7 @@ def test_client_contest() -> None:
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
             host=test_credentials.RABBITMQ_HOST,
-    ) as channel:
+        ) as channel:
         rabbitmq_connection.initialize_rabbitmq(queue='contest',
                                                 exchange='certificates',
                                                 routing_key='ContestQueue',
@@ -77,13 +74,7 @@ def test_client_contest() -> None:
             channel=channel,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
             date_upper_limit=test_constants.DATE_UPPER_LIMIT)
-
-        client = omegaup.api.Client(
-            api_token=test_constants.API_TOKEN,
-            url=test_constants.OMEGAUP_API_ENDPOINT,
-        )
-        callback = ContestsCallbackForTesting(dbconn=dbconn.conn,
-                                              client=client)
+        callback = ContestsCallbackForTesting(dbconn=dbconn.conn)
         cur.execute('TRUNCATE TABLE `Certificates`;')
         dbconn.conn.commit()
 
@@ -124,7 +115,7 @@ def test_client_contest_with_mocked_codes(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
             host=test_credentials.RABBITMQ_HOST,
-    ) as channel:
+        ) as channel:
         rabbitmq_connection.initialize_rabbitmq(queue='contest',
                                                 exchange='certificates',
                                                 routing_key='ContestQueue',
@@ -134,12 +125,7 @@ def test_client_contest_with_mocked_codes(
             channel=channel,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
             date_upper_limit=test_constants.DATE_UPPER_LIMIT)
-        client = omegaup.api.Client(
-            api_token=test_constants.API_TOKEN,
-            url=test_constants.OMEGAUP_API_ENDPOINT,
-        )
-        callback = ContestsCallbackForTesting(dbconn=dbconn.conn,
-                                              client=client)
+        callback = ContestsCallbackForTesting(dbconn=dbconn.conn)
         cur.execute('TRUNCATE TABLE `Certificates`;')
         dbconn.conn.commit()
 
@@ -181,7 +167,7 @@ def test_client_contest_with_duplicated_codes(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
             host=test_credentials.RABBITMQ_HOST,
-    ) as channel:
+        ) as channel:
         rabbitmq_connection.initialize_rabbitmq(queue='contest',
                                                 exchange='certificates',
                                                 routing_key='ContestQueue',
@@ -191,12 +177,7 @@ def test_client_contest_with_duplicated_codes(
             channel=channel,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
             date_upper_limit=test_constants.DATE_UPPER_LIMIT)
-        client = omegaup.api.Client(
-            api_token=test_constants.API_TOKEN,
-            url=test_constants.OMEGAUP_API_ENDPOINT,
-        )
-        callback = ContestsCallbackForTesting(dbconn=dbconn.conn,
-                                              client=client)
+        callback = ContestsCallbackForTesting(dbconn=dbconn.conn)
         cur.execute('TRUNCATE TABLE `Certificates`;')
         dbconn.conn.commit()
 

--- a/stuff/pipelines/test_client_contest.py
+++ b/stuff/pipelines/test_client_contest.py
@@ -63,17 +63,21 @@ def test_client_contest() -> None:
         rabbitmq_connection.connect(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
-            host=test_credentials.RABBITMQ_HOST,
-        ) as channel:
+            host=test_credentials.RABBITMQ_HOST,) as channel:
         rabbitmq_connection.initialize_rabbitmq(queue='contest',
                                                 exchange='certificates',
                                                 routing_key='ContestQueue',
                                                 channel=channel)
+        client = omegaup.api.Client(
+            api_token=test_constants.API_TOKEN,
+            url=test_constants.OMEGAUP_API_ENDPOINT,
+        )
         producer_contest.send_contest_message_to_client(
             cur=cur,
             channel=channel,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
-            date_upper_limit=test_constants.DATE_UPPER_LIMIT)
+            date_upper_limit=test_constants.DATE_UPPER_LIMIT,
+            client=client)
         callback = ContestsCallbackForTesting(dbconn=dbconn.conn)
         cur.execute('TRUNCATE TABLE `Certificates`;')
         dbconn.conn.commit()
@@ -114,17 +118,21 @@ def test_client_contest_with_mocked_codes(
         rabbitmq_connection.connect(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
-            host=test_credentials.RABBITMQ_HOST,
-        ) as channel:
+            host=test_credentials.RABBITMQ_HOST,) as channel:
         rabbitmq_connection.initialize_rabbitmq(queue='contest',
                                                 exchange='certificates',
                                                 routing_key='ContestQueue',
                                                 channel=channel)
+        client = omegaup.api.Client(
+            api_token=test_constants.API_TOKEN,
+            url=test_constants.OMEGAUP_API_ENDPOINT,
+        )
         producer_contest.send_contest_message_to_client(
             cur=cur,
             channel=channel,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
-            date_upper_limit=test_constants.DATE_UPPER_LIMIT)
+            date_upper_limit=test_constants.DATE_UPPER_LIMIT,
+            client=client)
         callback = ContestsCallbackForTesting(dbconn=dbconn.conn)
         cur.execute('TRUNCATE TABLE `Certificates`;')
         dbconn.conn.commit()
@@ -166,17 +174,22 @@ def test_client_contest_with_duplicated_codes(
         rabbitmq_connection.connect(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
-            host=test_credentials.RABBITMQ_HOST,
-        ) as channel:
+            host=test_credentials.RABBITMQ_HOST,) as channel:
         rabbitmq_connection.initialize_rabbitmq(queue='contest',
                                                 exchange='certificates',
                                                 routing_key='ContestQueue',
                                                 channel=channel)
+        client = omegaup.api.Client(
+            api_token=test_constants.API_TOKEN,
+            url=test_constants.OMEGAUP_API_ENDPOINT,
+        )
         producer_contest.send_contest_message_to_client(
             cur=cur,
             channel=channel,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
-            date_upper_limit=test_constants.DATE_UPPER_LIMIT)
+            date_upper_limit=test_constants.DATE_UPPER_LIMIT,
+            client=client
+        )
         callback = ContestsCallbackForTesting(dbconn=dbconn.conn)
         cur.execute('TRUNCATE TABLE `Certificates`;')
         dbconn.conn.commit()
@@ -190,6 +203,7 @@ def test_client_contest_with_duplicated_codes(
             exchange='certificates',
             queue='contest',
             routing_key='ContestQueue',
-            callback=callback)
+            callback=callback
+        )
 
         assert spy.call_count > 4

--- a/stuff/pipelines/test_contest_callback.py
+++ b/stuff/pipelines/test_contest_callback.py
@@ -25,7 +25,6 @@ sys.path.insert(
     os.path.join(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "."))
 import lib.db   # pylint: disable=wrong-import-position
-from stuff.pipelines.contest_callback import Ranking
 
 
 def test_insert_contest_certificate() -> None:
@@ -93,7 +92,7 @@ def test_insert_contest_certificate() -> None:
         result = cur.fetchone()
     contest_id = result['contest_id']
     scoreboard_url = result['scoreboard_url']
-    ranking = List[Ranking]
+    ranking = []
     with rabbitmq_connection.connect(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
@@ -106,7 +105,7 @@ def test_insert_contest_certificate() -> None:
             certificate_cutoff=3,
             alias=alias,
             scoreboard_url=scoreboard_url,
-            ranking=ranking
+            ranking=ranking,
         )
         callback(
             _channel=channel,

--- a/stuff/pipelines/test_contest_callback.py
+++ b/stuff/pipelines/test_contest_callback.py
@@ -12,12 +12,12 @@ import sys
 import time
 
 from typing import List
+import omegaup.api
 
 import contest_callback
 import test_credentials
 import rabbitmq_connection
 import test_constants
-import omegaup.api
 
 
 sys.path.insert(
@@ -90,7 +90,6 @@ def test_insert_contest_certificate() -> None:
                 alias = %s;
             ''', (alias,))
         result = cur.fetchone()
-
     contest_id = result['contest_id']
     scoreboard_url = result['scoreboard_url']
     with rabbitmq_connection.connect(
@@ -98,13 +97,10 @@ def test_insert_contest_certificate() -> None:
             password=test_credentials.OMEGAUP_PASSWORD,
             host=test_credentials.RABBITMQ_HOST
     ) as channel:
-        callback = contest_callback.ContestsCallback(
-            dbconn=dbconn.conn,
-            client=client,
-        )
+        callback = contest_callback.ContestsCallback(dbconn=dbconn.conn)
         body = contest_callback.ContestCertificate(
             contest_id=contest_id,
-            certificate_cutoff=3,  # setting a default value
+            certificate_cutoff=3, # setting a default value
             alias=alias,
             scoreboard_url=scoreboard_url,
         )

--- a/stuff/pipelines/test_contest_callback.py
+++ b/stuff/pipelines/test_contest_callback.py
@@ -25,6 +25,7 @@ sys.path.insert(
     os.path.join(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "."))
 import lib.db   # pylint: disable=wrong-import-position
+from stuff.pipelines.contest_callback import Ranking
 
 
 def test_insert_contest_certificate() -> None:
@@ -92,6 +93,7 @@ def test_insert_contest_certificate() -> None:
         result = cur.fetchone()
     contest_id = result['contest_id']
     scoreboard_url = result['scoreboard_url']
+    ranking = List[Ranking]
     with rabbitmq_connection.connect(
             username=test_credentials.OMEGAUP_USERNAME,
             password=test_credentials.OMEGAUP_PASSWORD,
@@ -100,9 +102,11 @@ def test_insert_contest_certificate() -> None:
         callback = contest_callback.ContestsCallback(dbconn=dbconn.conn)
         body = contest_callback.ContestCertificate(
             contest_id=contest_id,
-            certificate_cutoff=3, # setting a default value
+            # setting a default value
+            certificate_cutoff=3,
             alias=alias,
             scoreboard_url=scoreboard_url,
+            ranking=ranking
         )
         callback(
             _channel=channel,

--- a/stuff/pipelines/test_contest_queries.py
+++ b/stuff/pipelines/test_contest_queries.py
@@ -67,6 +67,7 @@ def test_get_contests_information() -> None:
             cur=cur,
             date_lower_limit=test_constants.DATE_LOWER_LIMIT,
             date_upper_limit=test_constants.DATE_UPPER_LIMIT,
+            client=client,
         )
 
         assert alias in [contest.alias for contest in contests]

--- a/stuff/pipelines/test_producer_contest.py
+++ b/stuff/pipelines/test_producer_contest.py
@@ -18,6 +18,8 @@ import producer_contest
 import rabbitmq_connection
 import rabbitmq_client
 import test_credentials
+import test_constants
+import omegaup.api
 
 sys.path.insert(
     0,
@@ -52,6 +54,9 @@ class MessageSavingCallback:
                     alias='contest1',
                     scoreboard_url='abcdef',
                     contest_id=1,
+                    ranking=[
+                        database.contest.Ranking(username='user_1', place=1),
+                    ],
                 ),
             ],
             database.contest.ContestCertificate(
@@ -59,6 +64,9 @@ class MessageSavingCallback:
                 alias='contest1',
                 scoreboard_url='abcdef',
                 contest_id=1,
+                ranking=[
+                    database.contest.Ranking(username='user_1', place=1),
+                ],
             )._asdict(),
         ),
         (
@@ -68,6 +76,10 @@ class MessageSavingCallback:
                     alias='contest2',
                     scoreboard_url='123456',
                     contest_id=2,
+                    ranking=[
+                        database.contest.Ranking(username='user_1', place=1),
+                    ],
+
                 ),
             ],
             database.contest.ContestCertificate(
@@ -75,6 +87,9 @@ class MessageSavingCallback:
                 alias='contest2',
                 scoreboard_url='123456',
                 contest_id=2,
+                ranking=[
+                    database.contest.Ranking(username='user_1', place=1),
+                ],
             )._asdict(),
         ),
     ],
@@ -107,8 +122,13 @@ def test_contest_producer(mocker: pytest_mock.MockerFixture,
             exchange='certificates',
             routing_key='ContestQueue',
             channel=channel)
+        client = omegaup.api.Client(
+            api_token=test_constants.API_TOKEN,
+            url=test_constants.OMEGAUP_API_ENDPOINT,
+        )
         producer_contest.send_contest_message_to_client(cur=cur,
-                                                        channel=channel)
+                                                        channel=channel,
+                                                        client=client)
         callback = MessageSavingCallback()
         rabbitmq_client.receive_messages(queue='contest',
                                          exchange='certificates',


### PR DESCRIPTION
# Descripción

Se modificaron archivos de python para eliminar omegaup.api, y agregar nueva informacion sobre el scoreboard

Fixes: #6863 


# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
