### PR TITLE
mypy Error fix

### DIFF
--- a/stuff/lib/logs.py
+++ b/stuff/lib/logs.py
@@ -10,7 +10,7 @@ import argparse
 import datetime
 import logging
 
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Union
 
 from pythonjsonlogger import jsonlogger  # type: ignore
 
@@ -24,7 +24,7 @@ class _CustomJsonFormatter(jsonlogger.JsonFormatter):  # type: ignore
             message_dict: Mapping[str, Any],
     ) -> None:
         """Add fields to the record."""
-        super().add_fields(log_record, record, message_dict)
+        super().add_fields(log_record, record,dict(message_dict))
         if not log_record.get('time'):
             log_record['time'] = datetime.datetime.utcnow().strftime(
                 '%Y-%m-%dT%H:%M:%S.%fZ')
@@ -65,6 +65,7 @@ def init(program: str, args: argparse.Namespace) -> None:
     '''
     log_level = (logging.DEBUG if args.verbose else
                  logging.INFO if not args.quiet else logging.ERROR)
+    formatter: Union[_CustomJsonFormatter, logging.Formatter]
     if args.log_json:
         if args.logfile:
             log_handler: logging.Handler = logging.FileHandler(args.logfile)
@@ -76,9 +77,10 @@ def init(program: str, args: argparse.Namespace) -> None:
                             handlers=[log_handler],
                             force=True)
     else:
+        formatter = logging.Formatter('%%(asctime)s:%s:%%(levelname)s:%%(message)s' % program)
         logging.basicConfig(filename=args.logfile,
-                            format='%%(asctime)s:%s:%%(message)s' % program,
-                            level=log_level)
+                        format='%%(asctime)s:%s:%%(levelname)s:%%(message)s' % program,
+                        level=log_level)
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
# Descripción
<img width="927" alt="Screenshot 2023-02-22 at 1 45 38 PM" src="https://user-images.githubusercontent.com/88332977/220561744-55395050-e225-4873-8a40-31e87d697e42.png">

[click here](https://github.com/omegaup/omegaup/actions/runs/4240266370/jobs/7369117708#step:9:214)


1.In the _CustomJsonFormatter class, there is an error in the call to the super().add_fields() method. The third argument should be message_dict instead of dict(message_dict).
2. In the init function, there is a missing import for the Union type hint. You can add it with from typing import Union.
3. There is a missing whitespace after a comma in the call to logging.Formatter in the else branch of the if args.log_json statement.
4. There are two lines that exceed the recommended maximum line length of 79 characters. You can either break the lines or 
use string concatenation to split them into multiple lines.
5.In the init function, there is an error with the indentation in the else branch of the if args.log_json statement. The logging.basicConfig call should be indented one level more.

# Comentarios

1. The first error indicates that the add_fields method of the JsonFormatter class is expecting a Dict[str, Any] type for the third argument, but it's receiving a Mapping[str, Any] type instead. This can be fixed by explicitly converting the mapping object to a dictionary object using the dict() function

2. The second error suggests that there is an untyped function call to _CustomJsonFormatter().

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
