### PR TITLE
Arreglando el linter de Python

### DIFF
--- a/stuff/lib/logs.py
+++ b/stuff/lib/logs.py
@@ -10,21 +10,26 @@ import argparse
 import datetime
 import logging
 
-from typing import Any, Dict, Mapping
+from typing import Any, Dict
 
-from pythonjsonlogger import jsonlogger  # type: ignore
+from pythonjsonlogger import jsonlogger
 
 
-class _CustomJsonFormatter(jsonlogger.JsonFormatter):  # type: ignore
+class _CustomJsonFormatter(jsonlogger.JsonFormatter):
     """A JSON formatter that adds the level."""
+
+    def __init__(self) -> None:
+        # TODO(https://github.com/madzak/python-json-logger/pull/170): Remove
+        # the type: ignore annotation when v2.0.8 is released.
+        super().__init__()  # type: ignore
+
     def add_fields(
             self,
             log_record: Dict[str, str],
             record: logging.LogRecord,
-            message_dict: Mapping[str, Any],
+            message_dict: Dict[str, Any],
     ) -> None:
         """Add fields to the record."""
-        message_dict = dict(message_dict)  # convert Mapping to Dict
         super().add_fields(log_record, record, message_dict)
         if not log_record.get('time'):
             log_record['time'] = datetime.datetime.utcnow().strftime(
@@ -71,7 +76,7 @@ def init(program: str, args: argparse.Namespace) -> None:
             log_handler: logging.Handler = logging.FileHandler(args.logfile)
         else:
             log_handler = logging.StreamHandler()
-        formatter = _CustomJsonFormatter()  # type: ignore
+        formatter = _CustomJsonFormatter()
         log_handler.setFormatter(formatter)
         logging.basicConfig(level=log_level,
                             handlers=[log_handler],

--- a/stuff/requirements.txt
+++ b/stuff/requirements.txt
@@ -11,7 +11,7 @@ pyparsing==3.0.7
 pytest-mock>=3.7.0
 pytest-stub==1.1.0
 pytest==6.2.5
-python-json-logger>=2.0.2
+python-json-logger>=2.0.7
 pytest-shutil>=1.7.0
 pytest-timeout==2.1.0
 types-requests==2.27.8


### PR DESCRIPTION
En un cambio anterior, se arreglaron los lints de Python porque se publicó una actualización de `pythonjsonlogger` que ahora incluye tipos. Esos arreglos se hicieron mediante agregar más `type: ignore`, pero eso es subóptimo.

Este cambio actualiza a la última versión de esta librería para garantizar que todos vamos a tener esos tipos instalados, y se eliminan todos los `type: ignore` que se pueden, excepto uno que necesita que se publique una nueva versión.