### PR TITLE
Default scoreboard

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -120,6 +120,9 @@
       <div v-if="showTab === 'new_form'" class="tab-pane active">
         <omegaup-contest-new-form
           :admission-mode="details.admission_mode"
+          :default-show-all-contestants-in-scoreboard="
+            details.default_show_all_contestants_in_scoreboard
+          "
           :initial-alias="details.alias"
           :initial-title="details.title"
           :initial-description="details.description"

--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -384,6 +384,7 @@ export default class NewForm extends Vue {
   @Prop() update!: boolean;
   @Prop() allLanguages!: string[];
   @Prop({ default: 'private' }) admissionMode!: string;
+  @Prop({ default: false }) defaultShowAllContestantsInScoreboard!: boolean;
   @Prop({ default: '' }) initialAlias!: string;
   @Prop({ default: '' }) initialDescription!: string;
   @Prop({ default: 'none' }) initialFeedback!: string;
@@ -532,7 +533,8 @@ export default class NewForm extends Vue {
       penalty: this.penalty,
       scoreboard: this.scoreboard,
       penalty_type: this.penaltyType,
-      default_show_all_contestants_in_scoreboard: false,
+      default_show_all_contestants_in_scoreboard: this
+        .defaultShowAllContestantsInScoreboard,
       show_scoreboard_after: this.showScoreboardAfter,
       score_mode: this.currentScoreMode,
       needs_basic_information: this.needsBasicInformation,

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -386,6 +386,7 @@ OmegaUp.on('ready', () => {
             })
               .then(() => {
                 contestEdit.details.admission_mode = admissionMode;
+                contestEdit.details.default_show_all_contestants_in_scoreboard = defaultShowAllContestantsInScoreboard;
                 ui.success(`
                   ${T.contestEditContestEdited} <a href="/arena/${payload.details.alias}/">${T.contestEditGoToContest}</a>
                 `);


### PR DESCRIPTION
# Description

Fix "default-show-all-contestants-in-scoreboard" bug

![image](https://user-images.githubusercontent.com/77215230/225317585-3b7c2a82-8693-49e4-b4f0-b867b5834e25.png)


Fix: #6398 

# Check list:

- [ ] The code follows the [guide of
      style](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) from
      omegaUp.
- [ ] All tests were run and passed.
- [ ] If new functionality is being added, tests have been added.
- [ ] If the change is large (> 200 lines), try to split it into
      several pull requests. Preferably one for controllers + phpunit
      and then another for the interface.