### PR TITLE
Repaired notification menu on mobile devices.

### DIFF
--- a/frontend/www/js/omegaup/components/notification/List.vue
+++ b/frontend/www/js/omegaup/components/notification/List.vue
@@ -88,7 +88,7 @@ export default class NotificationList extends Vue {
 }
 
 .notification-dropdown {
-  width: 35rem;
+  padding: 0.25rem 1.5rem;
   max-height: 600px;
   overflow-y: auto;
 }


### PR DESCRIPTION
# Descripción

The size of the notifications menu container was updated so that when the omegaup.com page is visited on mobile devices, the other containers can also be visible.

![Imagen1](https://user-images.githubusercontent.com/128170939/226278927-86e26419-e145-4d81-932a-fd45b05f61db.png)

Fixes: #6942 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
