### PR TITLE
Arreglando errores en la implementación del nuevo método de SignUp de Google

### DIFF
--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -510,8 +510,9 @@ class Session extends \OmegaUp\Controllers\Controller {
         // https://developers.google.com/identity/gsi/web/guides/verify-google-id-token?hl=en
         $gCsrfToken = $r->ensureString('g_csrf_token');
         $idToken = $r->ensureString('credential');
+        $csrfTokenCookie = $_COOKIE['g_csrf_token'];
 
-        if ($gCsrfToken !== $_COOKIE['g_csrf_token']) {
+        if (is_null($csrfTokenCookie) || $gCsrfToken !== $csrfTokenCookie) {
             self::$log->error('Invalid CSRF token');
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'loginGoogleInvalidCSRFToken',

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -510,6 +510,7 @@ class Session extends \OmegaUp\Controllers\Controller {
         // https://developers.google.com/identity/gsi/web/guides/verify-google-id-token?hl=en
         $gCsrfToken = $r->ensureString('g_csrf_token');
         $idToken = $r->ensureString('credential');
+        /** @var null|string*/
         $csrfTokenCookie = $_COOKIE['g_csrf_token'];
 
         if (is_null($csrfTokenCookie) || $gCsrfToken !== $csrfTokenCookie) {

--- a/frontend/www/js/omegaup/components/login/Login.vue
+++ b/frontend/www/js/omegaup/components/login/Login.vue
@@ -13,7 +13,7 @@
               <div
                 id="g_id_onload"
                 :data-client_id="googleClientId"
-                data-login_uri="http://localhost:8001/api/session/googleLogin/"
+                :data-login_uri="`${omegaupUrl}/api/session/googleLogin/`"
                 data-auto_prompt="false"
               ></div>
               <div
@@ -91,6 +91,8 @@ import T from '../../lang';
 export default class Login extends Vue {
   @Prop() facebookUrl!: string;
   @Prop() googleClientId!: string;
+  @Prop() omegaupUrl!: string;
+
   usernameOrEmail: string = '';
   password: string = '';
   T = T;

--- a/frontend/www/js/omegaup/components/login/Signin.vue
+++ b/frontend/www/js/omegaup/components/login/Signin.vue
@@ -3,6 +3,7 @@
     <omegaup-login
       :facebook-url="facebookUrl"
       :google-client-id="googleClientId"
+      :omegaup-url="omegaupUrl"
       @login="(username, password) => $emit('login', username, password)"
     >
     </omegaup-login>
@@ -42,6 +43,7 @@ export default class Signin extends Vue {
   @Prop() validateRecaptcha!: boolean;
   @Prop() facebookUrl!: string;
   @Prop() googleClientId!: string;
+  @Prop() omegaupUrl!: string;
 
   T = T;
 }

--- a/frontend/www/js/omegaup/login/signin.ts
+++ b/frontend/www/js/omegaup/login/signin.ts
@@ -65,6 +65,7 @@ OmegaUp.on('ready', () => {
           validateRecaptcha: payload.validateRecaptcha,
           facebookUrl: payload.facebookUrl,
           googleClientId,
+          omegaupUrl: document.location.origin,
         },
         on: {
           'register-and-login': (


### PR DESCRIPTION
# Descripción

Al subir los cambios al sandbox con el nuevo método para login de google
nos percatamos que ocurrían un par de errores:

- La cookie con el csrfToken no estaba envuelta en un `try / catch` así que 
  si no existe, arrojaba un error si formato en la plataforma.
- el `data-login_uri` que utiliza google para identificar la página de redirección
  estaba hardcodeado con localhost, por tal motivo no se podía loguear el usuario

Part of: #6915 

# Comentarios

Hasta el momento, sólo se detectaron esos dos errores porque ellos ocasionaban
que no se pudiera continuar probando.

En caso de salir más fallas después de hacer merge de este PR, se seguirán 
arreglando en nuevos PRs hasta que garanticemos que todo funciona correcto

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
