### PR TITLE
 Temporarily disable `test_client_contest_with_duplicated_codes` 

### DIFF
--- a/stuff/pipelines/test_client_contest.py
+++ b/stuff/pipelines/test_client_contest.py
@@ -102,7 +102,6 @@ def test_client_contest() -> None:
         count = cur.fetchone()
         assert count['count'] > 0
 
-
 @pytest.mark.skip(reason="Disabled temporarily because it's flaky")
 def test_client_contest_with_mocked_codes(
         mocker: pytest_mock.MockerFixture
@@ -157,7 +156,7 @@ def test_client_contest_with_mocked_codes(
             callback=callback)
         assert spy.call_count == 4
 
-
+@pytest.mark.skip(reason="Disabled temporarily because it's flaky")
 def test_client_contest_with_duplicated_codes(
         mocker: pytest_mock.MockerFixture
 ) -> None:

--- a/stuff/pipelines/test_client_contest.py
+++ b/stuff/pipelines/test_client_contest.py
@@ -102,6 +102,7 @@ def test_client_contest() -> None:
         count = cur.fetchone()
         assert count['count'] > 0
 
+
 @pytest.mark.skip(reason="Disabled temporarily because it's flaky")
 def test_client_contest_with_mocked_codes(
         mocker: pytest_mock.MockerFixture
@@ -155,6 +156,7 @@ def test_client_contest_with_mocked_codes(
             routing_key='ContestQueue',
             callback=callback)
         assert spy.call_count == 4
+
 
 @pytest.mark.skip(reason="Disabled temporarily because it's flaky")
 def test_client_contest_with_duplicated_codes(


### PR DESCRIPTION
Because it's flaky and the certificates project hasn't been lunched.