### PR TITLE
User ranking overflow fix

### DIFF
--- a/frontend/www/js/omegaup/components/user/Rank.vue
+++ b/frontend/www/js/omegaup/components/user/Rank.vue
@@ -60,7 +60,7 @@
         {{ T.searchUser }}
       </button>
     </div>
-    <table class="table mb-0">
+    <table class="table mb-0 table-responsive-sm">
       <thead>
         <tr>
           <th scope="col">#</th>


### PR DESCRIPTION
# Descripción
Fixed user ranking table overflow
Fixes: #6960 
<img src="https://user-images.githubusercontent.com/38367679/228629953-5489f778-e8a5-498b-90cb-ce85e844541d.png" width="300px">


# Checklist:
- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
