### PR TITLE
Contestst and Contest Cards now responsive [ARENAV2]

### DIFF
--- a/.my.cnf
+++ b/.my.cnf
@@ -1,0 +1,1 @@
+/home/galovdev/.mysql.docker.cnf

--- a/frontend/www/js/omegaup/components/arena/ContestCard.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestCard.vue
@@ -1,8 +1,8 @@
 <template>
   <b-card class="mb-2">
     <b-container>
-      <b-row class="p-1" align-v="center">
-        <b-col>
+      <b-row class="p-1 flex-column flex-sm-row" align-v="center"> 
+        <b-col class="col-md-5 col-sm-12 p-1 text-center">
           <b-card-text>
             <h5>
               <a :href="getContestURL(contest.alias)">{{ contest.title }}</a>
@@ -15,13 +15,13 @@
             </h5>
           </b-card-text>
         </b-col>
-        <b-col>
+        <b-col class="col-md-3 col-sm-12 p-1 text-center">
           <b-card-text>
             <font-awesome-icon icon="clipboard-list" />
             {{ contest.organizer }}
           </b-card-text>
         </b-col>
-        <b-col cols="3">
+        <b-col class="col-md-4 col-sm-12 p-1 text-center">
           <slot name="contest-button-scoreboard">
             <b-button
               ref="contestButtonScoreboard"
@@ -44,11 +44,11 @@
           </slot>
         </b-col>
       </b-row>
-      <b-row class="p-1" align-v="center">
-        <b-col>
+      <b-row class="p-1 flex-column flex-sm-row" align-v="center">
+        <b-col class="col-md-5 col-sm-12 p-1 text-center">
           <slot name="text-contest-date"></slot>
         </b-col>
-        <b-col>
+        <b-col class="col-md-3 col-sm-12 p-1 text-center">
           <b-card-text>
             <font-awesome-icon icon="stopwatch" />
             {{
@@ -58,13 +58,13 @@
             }}
           </b-card-text>
         </b-col>
-        <b-col>
+        <b-col class="col-md-1 col-sm-12 p-1 text-center">
           <b-card-text>
             <font-awesome-icon icon="users" />
             {{ contest.contestants }}
           </b-card-text>
         </b-col>
-        <b-col>
+        <b-col class="col-md-3 col-sm-12 p-1 text-center">
           <slot name="contest-button-enter">
             <b-button
               v-if="contest.participating"
@@ -173,4 +173,5 @@ export default class ContestCard extends Vue {
 .btn {
   color: $omegaup-white;
 }
+
 </style>

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -9,37 +9,44 @@
         pills
         card
         vertical
-        nav-wrapper-class="contest-list-nav col-sm-4 col-md-2"
+        nav-wrapper-class="contest-list-nav  col-md-2 col-sm-12 test-class"
       >
         <b-card>
           <b-container>
             <b-row class="p-1" align-v="center">
-              <b-col cols="6">
-                <form :action="queryURL" method="GET">
-                  <div class="input-group">
-                    <input
-                      v-model.lazy="currentQuery"
-                      class="form-control"
-                      type="text"
-                      name="query"
-                      autocomplete="off"
-                      autocorrect="off"
-                      autocapitalize="off"
-                      spellcheck="false"
-                      :placeholder="T.wordsKeyword"
-                    />
-                    <button class="btn" type="reset">&times;</button>
-                    <div class="input-group-append">
+              <b-col class="col-md-6 col-sm-12">
+              <form :action="queryURL" method="GET">
+                <div class="row">
+                  <div class="col-12 col-sm-8">
+                    <div class="input-group">
                       <input
-                        class="btn btn-primary btn-md active"
+                        v-model.lazy="currentQuery"
+                        class="form-control"
+                        type="text"
+                        name="query"
+                        autocomplete="off"
+                        autocorrect="off"
+                        autocapitalize="off"
+                        spellcheck="false"
+                        :placeholder="T.wordsKeyword"
+                      />
+                      <button class="btn" type="reset">&times;</button>
+                    </div>
+                  </div>
+                  <div class="px-3 px-sm-0 col-12 col-sm-4 mt-2 mt-sm-0">
+                    <div>
+                      <input
+                        class="btn btn-primary btn-md btn-block active "
                         type="submit"
                         :value="T.wordsSearch"
                       />
                     </div>
                   </div>
-                </form>
-              </b-col>
-              <b-col cols="6" class="d-flex flex-row-reverse">
+                </div>
+              </form>
+            </b-col>
+
+              <b-col sm="12" class="d-flex col-md-6 btns-group mt-1">
                 <b-dropdown ref="dropdownOrderBy" no-caret>
                   <template #button-content>
                     <div>
@@ -566,5 +573,32 @@ export default class ArenaContestList extends Vue {
   font-size: 200%;
   margin: 1em;
   color: var(--arena-contest-list-empty-category-font-color);
+}
+
+.btns-group {
+  justify-content: flex-end;
+  .dropdown {
+    margin-right: 1rem;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .title {
+    font-size: 1.5rem;
+    text-align: center;
+  }
+  .tabs {
+    flex-direction: column;
+  }
+
+  .btns-group {
+    justify-content: flex-start;
+    .dropdown {
+      flex: 1;
+      gap: 1rem;
+      margin-right: 0.8rem;
+    }
+  }
+
 }
 </style>


### PR DESCRIPTION
# Descripción

Limpie un poco las clases repetidas y hice responsive las tarjetas de contest tambien en celular.

Adjunto Imagen de como se veia en celular y como se ve ahora en computadora y en celular :)

Fixes: #6571

![Group 52](https://user-images.githubusercontent.com/107520089/229316366-529c3ced-1802-4394-b1a7-5a79e45f129e.png)



# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
