### PR TITLE
Arreglando el login via Google

### DIFF
--- a/frontend/server/src/SessionManager.php
+++ b/frontend/server/src/SessionManager.php
@@ -49,6 +49,12 @@ class SessionManager {
             foreach ($cookies as $cookie) {
                 $parts = explode('=', $cookie);
                 $oldName = trim($parts[0]);
+                if ($oldName !== $name) {
+                    // If there are a lot of cookies set, this could make the
+                    // response header section balloon in size and make nginx
+                    // unhappy.
+                    continue;
+                }
                 setcookie($oldName, '', $oldExpire);
                 setcookie($oldName, '', $oldExpire, '/');
                 // This should clear the cookies with the old pre-RFC 6265

--- a/frontend/tests/controllers/UserRegistrationTest.php
+++ b/frontend/tests/controllers/UserRegistrationTest.php
@@ -22,17 +22,23 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         ob_start();
         try {
             // Create collision
-            \OmegaUp\Controllers\Session::LoginViaGoogle("A{$salt}@isp1.com");
+            \OmegaUp\Controllers\Session::loginViaGoogleEmail(
+                "A{$salt}@isp1.com"
+            );
         } catch (\OmegaUp\Exceptions\ExitException $e) {
             // This is expected.
         }
         try {
-            \OmegaUp\Controllers\Session::LoginViaGoogle("A{$salt}@isp2.com");
+            \OmegaUp\Controllers\Session::loginViaGoogleEmail(
+                "A{$salt}@isp2.com"
+            );
         } catch (\OmegaUp\Exceptions\ExitException $e) {
             // This is expected.
         }
         try {
-            \OmegaUp\Controllers\Session::LoginViaGoogle("A{$salt}@isp3.com");
+            \OmegaUp\Controllers\Session::loginViaGoogleEmail(
+                "A{$salt}@isp3.com"
+            );
         } catch (\OmegaUp\Exceptions\ExitException $e) {
             // This is expected.
         }
@@ -52,7 +58,9 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         $password = \OmegaUp\Test\Utils::createRandomString();
 
         try {
-            \OmegaUp\Controllers\Session::LoginViaGoogle("{$username}@isp.com");
+            \OmegaUp\Controllers\Session::loginViaGoogleEmail(
+                "{$username}@isp.com"
+            );
         } catch (\OmegaUp\Exceptions\ExitException $e) {
             // This is expected.
         }
@@ -91,7 +99,7 @@ class UserRegistrationTest extends \OmegaUp\Test\ControllerTestCase {
         $email = "{$username}@isp.com";
 
         try {
-            \OmegaUp\Controllers\Session::LoginViaGoogle($email);
+            \OmegaUp\Controllers\Session::loginViaGoogleEmail($email);
         } catch (\OmegaUp\Exceptions\ExitException $e) {
             // This is expected.
         }

--- a/frontend/www/js/omegaup/components/login/Login.vue
+++ b/frontend/www/js/omegaup/components/login/Login.vue
@@ -13,7 +13,6 @@
               <div
                 id="g_id_onload"
                 :data-client_id="googleClientId"
-                :data-login_uri="`${omegaupUrl}/api/session/googleLogin/`"
                 data-auto_prompt="false"
               ></div>
               <div
@@ -91,7 +90,6 @@ import T from '../../lang';
 export default class Login extends Vue {
   @Prop() facebookUrl!: string;
   @Prop() googleClientId!: string;
-  @Prop() omegaupUrl!: string;
 
   usernameOrEmail: string = '';
   password: string = '';

--- a/frontend/www/js/omegaup/components/login/Signin.vue
+++ b/frontend/www/js/omegaup/components/login/Signin.vue
@@ -3,7 +3,6 @@
     <omegaup-login
       :facebook-url="facebookUrl"
       :google-client-id="googleClientId"
-      :omegaup-url="omegaupUrl"
       @login="(username, password) => $emit('login', username, password)"
     >
     </omegaup-login>
@@ -43,7 +42,6 @@ export default class Signin extends Vue {
   @Prop() validateRecaptcha!: boolean;
   @Prop() facebookUrl!: string;
   @Prop() googleClientId!: string;
-  @Prop() omegaupUrl!: string;
 
   T = T;
 }

--- a/frontend/www/js/omegaup/login/signin.ts
+++ b/frontend/www/js/omegaup/login/signin.ts
@@ -65,7 +65,6 @@ OmegaUp.on('ready', () => {
           validateRecaptcha: payload.validateRecaptcha,
           facebookUrl: payload.facebookUrl,
           googleClientId,
-          omegaupUrl: document.location.origin,
         },
         on: {
           'register-and-login': (

--- a/stuff/docker/etc/nginx/nginx.conf
+++ b/stuff/docker/etc/nginx/nginx.conf
@@ -16,6 +16,10 @@ http {
   uwsgi_temp_path /tmp/uwsgi_temp;
   access_log /dev/stderr;
 
+  proxy_busy_buffers_size 512k;
+  proxy_buffers 4 512k;
+  proxy_buffer_size 256k;
+
   include /etc/nginx/mime.types;
 
   upstream php {
@@ -36,6 +40,10 @@ http {
     location ~* "\.php(/|$)" {
       fastcgi_index index.php;
       fastcgi_keep_conn on;
+
+      fastcgi_buffer_size 64k;
+      fastcgi_buffers 16 32k;
+      fastcgi_busy_buffers_size 64k;
 
       fastcgi_param QUERY_STRING $query_string;
       fastcgi_param REQUEST_METHOD $request_method;


### PR DESCRIPTION
Resulta que pedirle al OAuth que hiciera un redirect a un API no fue buena idea, porque era fácil entrar en una situación donde los errores se muestran al usuario, y no hay manera de indicarles _qué_ salió mal.

Este cambio hace que el flujo OAuth termine en el mismo lugar donde empezó. Eso también preserva el redirect.
