### PR TITLE
Arreglando el login de Google, parte 2

### DIFF
--- a/frontend/www/js/omegaup/components/login/Login.vue
+++ b/frontend/www/js/omegaup/components/login/Login.vue
@@ -13,6 +13,7 @@
               <div
                 id="g_id_onload"
                 :data-client_id="googleClientId"
+                :data-login_uri="loginUri"
                 data-auto_prompt="false"
               ></div>
               <div
@@ -102,6 +103,10 @@ export default class Login extends Vue {
     const script = document.createElement('script');
     script.src = 'https://accounts.google.com/gsi/client';
     document.body.appendChild(script);
+  }
+
+  get loginUri(): string {
+    return document.location.href;
   }
 }
 </script>


### PR DESCRIPTION
Resulta que el `data-login_uri` es requerido.

Este cambio lo regresa.