### PR TITLE
Cambiando a dos columnas en insignias

### DIFF
--- a/frontend/www/js/omegaup/components/badge/Badge.vue
+++ b/frontend/www/js/omegaup/components/badge/Badge.vue
@@ -1,5 +1,5 @@
 <template>
-  <figure v-tooltip="description" class="col-md-3 col-sm-3 badge-container">
+  <figure v-tooltip="description" class="col-6 col-sm-3 badge-container">
     <a class="badge-icon" :href="`/badge/${badge.badge_alias}/`"
       ><img
         :class="{ 'badge-gray': !badge.unlocked }"


### PR DESCRIPTION
# Descripción

![image](https://user-images.githubusercontent.com/110271913/229384763-a62ecc78-1ae4-4310-bd82-382d6936928e.png)

# Comentarios

`col-6` funciona para tamaños "Extra small" (https://getbootstrap.com/docs/4.6/layout/overview/), con este cambio ya no necesito el width: 50% que hice durante la entrevista.
También quité el `col-md-3` porque es redundante ya que el `col-sm-3` hace las 3 columnas desde ese tamaño en adelante.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
