### PR TITLE
Agregando el estilo de ancho fijo al menú de notificaciones en tamaño para desktop

### DIFF
--- a/frontend/www/js/omegaup/components/notification/List.vue
+++ b/frontend/www/js/omegaup/components/notification/List.vue
@@ -87,6 +87,10 @@ export default class NotificationList extends Vue {
   display: block;
 }
 
+.navbar-expand-lg .navbar-nav .dropdown-menu {
+  width: 35rem;
+}
+
 .notification-dropdown {
   max-width: 100vw;
   max-height: 600px;

--- a/frontend/www/js/omegaup/components/notification/List.vue
+++ b/frontend/www/js/omegaup/components/notification/List.vue
@@ -73,7 +73,7 @@ export default class NotificationList extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 .notification-toggle {
   font-size: 1.4rem;
   position: relative;

--- a/frontend/www/js/omegaup/components/notification/Notification.vue
+++ b/frontend/www/js/omegaup/components/notification/Notification.vue
@@ -17,7 +17,7 @@
       :class="{ 'notification-link': url }"
       @click="handleClick"
     >
-      <img class="d-block" width="80" :src="iconUrl" />
+      <img class="d-block" width="50" :src="iconUrl" />
       <template v-if="notificationMarkdown">
         <omegaup-markdown :markdown="notificationMarkdown"></omegaup-markdown>
       </template>


### PR DESCRIPTION
# Descripción

Para la vista de desktop se ajusta un ancho fijo al menú de notificaciones 
para que no se muestre tan encimado el texto. 

Antes se mostraba así:

![Screenshot from 2023-04-25 11-22-16](https://user-images.githubusercontent.com/3230352/234356192-004d450d-2982-4606-8bad-05eaaeb17ce1.png)


Y ahora se muestra así:

![Screenshot from 2023-04-25 11-22-45](https://user-images.githubusercontent.com/3230352/234356211-bac7a7bf-c3c9-41c3-85c6-2d63b88889f3.png)

En la vista para mobile se sigue mostrando correctamente:

![image](https://user-images.githubusercontent.com/3230352/236023299-9caa4630-622e-495e-9637-2cea311d89f9.png)

![image](https://user-images.githubusercontent.com/3230352/236023492-b9edbc54-484f-4943-a3a8-b293d4e8e465.png)

Fixes: #6992 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.