### PR TITLE
Agregando información del envío en la url de la notificación

### DIFF
--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -123,7 +123,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
                                 'problemAlias' => $courseSubmissionInfo['problem_alias'],
                                 'courseName' => $course->name,
                             ],
-                            'url' => "/course/{$courseAlias}/assignment/{$assignmentAlias}/#problems/{$problemAlias}/show-run-from-notification:{$guid}",
+                            'url' => "/course/{$courseAlias}/assignment/{$assignmentAlias}/#problems/{$problemAlias}/show-run:{$guid}",
                             'iconUrl' => '/media/info.png',
                         ]
                     ]),

--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -131,14 +131,12 @@ OmegaUp.on('ready', async () => {
           }: {
             problem: types.NavbarProblemsetProblem;
           }) => {
-            const [, guid] = window.location.hash.split(':');
             navigateToProblem({
               type: NavigationType.ForSingleProblemOrCourse,
               problem,
               target: arenaCourse,
               problems: this.problems,
               problemsetId: payload.currentAssignment.problemset_id,
-              guid,
             });
           },
           'update-search-result-users-assignment': ({
@@ -484,14 +482,4 @@ OmegaUp.on('ready', async () => {
       courseAlias: payload.courseDetails.alias,
     });
   }, 5 * 60 * 1000);
-
-  window.addEventListener('hashchange', function () {
-    if (this.location.hash.includes('show-run-from-notification')) {
-      const [, problemAlias] = this.location.hash.split('/');
-      const problemSelector = document.querySelector(
-        `[data-problem="${problemAlias}"]`,
-      ) as HTMLAnchorElement;
-      problemSelector.click();
-    }
-  });
 });

--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -28,7 +28,6 @@ interface BaseNavigation {
   };
   problem: types.NavbarProblemsetProblem;
   problems: types.NavbarProblemsetProblem[];
-  guid?: string;
 }
 
 type NavigationForContest = BaseNavigation & {
@@ -74,10 +73,6 @@ export async function navigateToProblem(
       setLocationHash(`#problems/${problem.alias}/new-run`);
       return;
     }
-    if (request.guid) {
-      setLocationHash(`#problems/${problem.alias}/show-run:${request.guid}`);
-      return;
-    }
     setLocationHash(`#problems/${problem.alias}`);
     return;
   }
@@ -107,10 +102,6 @@ export async function navigateToProblem(
       target.problem = problem;
       if (target.popupDisplayed === PopupDisplayed.RunSubmit) {
         setLocationHash(`#problems/${problem.alias}/new-run`);
-        return;
-      }
-      if (request.guid) {
-        setLocationHash(`#problems/${problem.alias}/show-run:${request.guid}`);
         return;
       }
       setLocationHash(`#problems/${problem.alias}`);


### PR DESCRIPTION
# Descripción

Se incluye en la url de la notificación de feedback el guid para que se muestre 
el detalle del envío cuando se da click.

![FixRedirectNotification](https://user-images.githubusercontent.com/3230352/234525178-1cac8021-ef83-4de0-906d-752a750aae5d.gif)


Fixes: #6993 

# Comentarios

Hasta el momento este cambio funciona bien cuando el usuario se encuentra
fuera del curso al que pertenece la notificación. Si se encuentra dentro del
curso, no se abre el pop up con los detalles del envío.

Estoy revisando como poder solucionarlo.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
