### PR TITLE
Regresando un JOIN que se había quitado para arreglar los rankings de escuelas

### DIFF
--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -332,12 +332,15 @@ def update_schools_solved_problems(
         FROM
             `Submissions` AS `su`
         INNER JOIN
+            `Runs` AS `r` ON `r`.run_id = `su`.current_run_id
+        INNER JOIN
             `Schools` AS `sc` ON `sc`.`school_id` = `su`.`school_id`
         INNER JOIN
             `Problems` AS `p` ON `p`.`problem_id` = `su`.`problem_id`
         WHERE
             `su`.`time` >= CURDATE() - INTERVAL %(months)s MONTH
-            AND `su`.`verdict` = "AC" AND `p`.`visibility` >= 1
+            AND `r`.`verdict` = "AC"
+            AND `p`.`visibility` >= 1
             AND NOT EXISTS (
                 SELECT
                     *


### PR DESCRIPTION
# Descripción

De acuerdo a los hallazgos encontrados en los logs de New Relic, desde el día
1° de Noviembre de 2022 comenzó a fallar el cronjob de ranking de escuelas.

Al revisar que cambios se realizaron en la consulta en días cercanos al momento
en que comenzó a fallar, existe un PR en el cual se quitó un JOIN innecesario para 
hacer más ligera la ejecución de dicha consulta.

https://github.com/omegaup/omegaup/pull/6817

El problema que está ocurriendo es que por algún motivo que no he logrado
identificar los escuelas no se están agrupando correctamente, esto ocasiona que
existan dos registros con la misma información (id de la escuela y fecha) y la consulta 
falle al existir información duplicada.

Fixes: #6900 

# Comentarios

Revirtiendo el cambio funciona correctamente, pero habrá que revisar si esta es 
la mejor forma de solucionar el issue.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
