### PR TITLE
Agregando el event listener de hashchange para detectar las notificaciones del feedback

### DIFF
--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -39,6 +39,7 @@ type NavigationForContest = BaseNavigation & {
 type NavigationForSingleProblemOrCourse = BaseNavigation & {
   type: NavigationType.ForSingleProblemOrCourse;
   problemsetId: number;
+  guid?: string;
 };
 
 export type NavigationRequest =
@@ -54,12 +55,13 @@ export function getScoreModeEnum(scoreMode: string): ScoreMode {
 export async function navigateToProblem(
   request: NavigationRequest,
 ): Promise<void> {
-  let contestAlias, problemsetId, contestMode: ScoreMode;
+  let contestAlias, problemsetId, guid, contestMode: ScoreMode;
   if (request.type === NavigationType.ForContest) {
     contestAlias = request.contestAlias;
     contestMode = request.contestMode;
   } else if (request.type === NavigationType.ForSingleProblemOrCourse) {
     problemsetId = request.problemsetId;
+    guid = request.guid;
   }
   const { target, problem, problems } = request;
   if (
@@ -71,6 +73,10 @@ export async function navigateToProblem(
     target.problemInfo = problemsStore.state.problems[problem.alias];
     if (target.popupDisplayed === PopupDisplayed.RunSubmit) {
       setLocationHash(`#problems/${problem.alias}/new-run`);
+      return;
+    }
+    if (guid) {
+      setLocationHash(`#problems/${problem.alias}/show-run:${guid}`);
       return;
     }
     setLocationHash(`#problems/${problem.alias}`);


### PR DESCRIPTION
# Descripción

En el cambio del PR #6999 se agregó la información del envío en la url de
la notificación para que al dar clic en cada elemento de la lista mandara al
usuario al detalle de dicho envío. 

Pero había faltado arreglar que cuando el usaurio ya estaba en el curso 
no se mostraba el detalle. Esto se debía a que ya no había un cambio de
URL, así que el navegador ya no realizaba ninguna acción.

En este cambio se agrega el event listener del cambio de hash para que 
cuando eso suceda, ahora se manden llamar las funciones necesarias 
para llevar al usuario al problema y el detalle del envío que corresponden 
a la notificación.

![FixLinkNotificationWhenHashChange](https://github.com/omegaup/omegaup/assets/3230352/9f1363f5-f15d-4ebb-a4b0-115a4a0e43b3)


Fixes: #6993 

# Comentarios

Quizás faltaría ocultar el dropdown de las notificaciones, per como este queda 
atrás del popUp de los detalles del envío puede que no sea tan necesario

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
