### PR TITLE
Arreglando una falla en los concursos con subtareas que ocasionaba falla en el scoreboard

### DIFF
--- a/frontend/www/js/omegaup/arena/events_socket.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.ts
@@ -118,10 +118,14 @@ export class EventsSocket {
     const data = JSON.parse(message.data);
 
     if (data.message == '/run/update/') {
-      data.run.time = time.remoteTime(data.run.time * 1000);
-      const run = { ...data.run, score_by_group: data.run.score_per_group };
-      delete run.score_per_group;
-      updateRun({ run });
+      const { run } = data;
+      const updatedRun = {
+        ...run,
+        time: time.remoteTime(run.time * 1000),
+        score_by_group: run.score_per_group,
+      };
+      delete updatedRun.score_per_group;
+      updateRun({ run: updatedRun });
     } else if (data.message == '/clarification/update/') {
       data.clarification.time = time.remoteTime(data.clarification.time * 1000);
       clarificationStore.commit('addClarification', data.clarification);

--- a/frontend/www/js/omegaup/arena/events_socket.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.ts
@@ -124,7 +124,6 @@ export class EventsSocket {
         time: time.remoteTime(run.time * 1000),
         score_by_group: run.score_per_group,
       };
-      delete updatedRun.score_per_group;
       updateRun({ run: updatedRun });
     } else if (data.message == '/clarification/update/') {
       data.clarification.time = time.remoteTime(data.clarification.time * 1000);

--- a/frontend/www/js/omegaup/arena/events_socket.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.ts
@@ -119,30 +119,19 @@ export class EventsSocket {
 
     if (data.message == '/run/update/') {
       data.run.time = time.remoteTime(data.run.time * 1000);
-      updateRun({ run: data.run });
+      const run = { ...data.run, score_by_group: data.run.score_per_group };
+      delete run.score_per_group;
+      updateRun({ run });
     } else if (data.message == '/clarification/update/') {
       data.clarification.time = time.remoteTime(data.clarification.time * 1000);
       clarificationStore.commit('addClarification', data.clarification);
     } else if (data.message == '/scoreboard/update/') {
-      if (this.scoreMode === ScoreMode.MaxPerGroup) {
-        api.Contest.scoreboard({ contest_alias: this.problemsetAlias })
-          .then((result: types.Scoreboard) => {
-            this.processRankings({
-              scoreboard: result,
-              currentTime: result.time.getTime(),
-              startTime: result.start_time.getTime(),
-              finishTime: result.finish_time?.getTime() ?? 0,
-            });
-          })
-          .catch(ui.apiError);
-      } else {
-        this.processRankings({
-          scoreboard: data.scoreboard,
-          currentTime: data.scoreboard.time,
-          startTime: data.scoreboard.start_time,
-          finishTime: data.scoreboard.finish_time,
-        });
-      }
+      this.processRankings({
+        scoreboard: data.scoreboard,
+        currentTime: data.scoreboard.time,
+        startTime: data.scoreboard.start_time,
+        finishTime: data.scoreboard.finish_time,
+      });
     }
   }
 

--- a/frontend/www/js/omegaup/arena/navigation.test.ts
+++ b/frontend/www/js/omegaup/arena/navigation.test.ts
@@ -10,6 +10,8 @@ import {
   NavigationType,
   navigateToProblem,
   getScoreModeEnum,
+  getMaxScore,
+  getMaxPerGroupScore,
 } from './navigation';
 import { PopupDisplayed } from '../components/problem/Details.vue';
 import { storeConfig } from './problemStore';
@@ -235,6 +237,96 @@ describe('navigation.ts', () => {
       );
       expect(vueInstance.problem).not.toBeNull();
       expect(vueInstance.problem?.bestScore).toBe(0.8);
+    });
+  });
+
+  describe('getMaxScore', () => {
+    const runs: types.Run[] = [
+      {
+        alias: 'sumas',
+        classname: 'user-rank-unranked',
+        country: 'mx',
+        guid: 'abcdef1212',
+        language: 'py3',
+        memory: 0,
+        penalty: 0,
+        runtime: 0,
+        score: 0.6,
+        contest_score: 60,
+        score_by_group: {
+          sample: 25,
+          easy: 20,
+          medium: 15,
+          hard: 0,
+        },
+        status: 'ready',
+        submit_delay: 0,
+        time: new Date(0),
+        username: 'omegaup',
+        verdict: 'PA',
+      },
+      {
+        alias: 'triangulos',
+        classname: 'user-rank-unranked',
+        country: 'mx',
+        guid: 'fefefe1211',
+        language: 'py3',
+        memory: 0,
+        penalty: 0,
+        runtime: 0,
+        score: 1.0,
+        contest_score: 100,
+        score_by_group: {
+          sample: 25,
+          easy: 25,
+          medium: 25,
+          hard: 25,
+        },
+        status: 'ready',
+        submit_delay: 0,
+        time: new Date(0),
+        username: 'omegaup',
+        verdict: 'AC',
+      },
+      {
+        alias: 'sumas',
+        classname: 'user-rank-unranked',
+        country: 'mx',
+        guid: 'efad3456334',
+        language: 'py3',
+        memory: 0,
+        penalty: 0,
+        runtime: 0,
+        score: 0.9,
+        contest_score: 70,
+        score_by_group: {
+          sample: 15,
+          easy: 25,
+          medium: 10,
+          hard: 20,
+        },
+        status: 'ready',
+        submit_delay: 0,
+        time: new Date(0),
+        username: 'omegaup',
+        verdict: 'PA',
+      },
+    ];
+
+    it('Should get the max score for a problem', () => {
+      const alias = 'sumas';
+      const previousScore = 0.0;
+      const maxScore = getMaxScore(runs, alias, previousScore);
+
+      expect(maxScore).toEqual(70);
+    });
+
+    it('Should get the max score by group for a problem', () => {
+      const alias = 'sumas';
+      const previousScore = 0.0;
+      const maxScore = getMaxPerGroupScore(runs, alias, previousScore);
+
+      expect(maxScore).toEqual(85);
     });
   });
 });

--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -151,7 +151,7 @@ export function getMaxScore(
   return maxScore;
 }
 
-function getMaxPerGroupScore(
+export function getMaxPerGroupScore(
   runs: types.Run[],
   alias: string,
   previousScore: number,

--- a/stuff/bootstrap.json
+++ b/stuff/bootstrap.json
@@ -474,6 +474,70 @@
 				}
 			},
 			{
+				"api": "/contest/create/",
+				"params": {
+					"visibility": 1,
+					"title": "Subtasks",
+					"alias": "subtasks",
+					"description": "Concurso con subtareas",
+					"start_time": "$NOW$",
+					"finish_time": "$NOW$+86400",
+					"window_length": "0",
+					"scoreboard": 100,
+					"score_mode" : "max_per_group",
+					"points_decay_factor": 0,
+					"submissions_gap": 1200,
+					"penalty": 0,
+					"feedback": "detailed",
+					"penalty_type": "contest_start",
+					"languages": "c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,cpp20-gcc,cpp20-clang,java,kt,py2,py3,rb,cs,pas,hs,lua,go,rs,js",
+					"penalty_calc_policy": "sum",
+					"admission_mode": "private",
+					"show_scoreboard_after": "true",
+					"certificate_cutoff": 2
+				}
+			},
+			{
+				"api": "/contest/addProblem/",
+				"params": {
+					"contest_alias": "subtasks",
+					"problem_alias": "triangulos",
+					"points": 100
+				}
+			},
+			{
+				"api": "/contest/addProblem/",
+				"params": {
+					"contest_alias": "subtasks",
+					"problem_alias": "sumas",
+					"points": 100
+				}
+			},
+			{
+				"api": "/contest/addProblem/",
+				"params": {
+					"contest_alias": "subtasks",
+					"problem_alias": "triangulos-interactive",
+					"points": 100
+				}
+			},
+			{
+				"api": "/contest/addProblem/",
+				"params": {
+					"contest_alias": "subtasks",
+					"problem_alias": "colas",
+					"points": 100
+				}
+			},
+			{
+				"api": "/contest/update/",
+				"params": {
+					"contest_alias": "subtasks",
+					"admission_mode": "public",
+					"languages": "c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,cpp20-gcc,cpp20-clang,java,kt,py2,py3,rb,cs,pas,hs,lua,go,rs,js"
+				}
+			},
+			{
 				"api": "/school/create/",
 				"params": {
 					"name": "Escuela curso",
@@ -1616,7 +1680,7 @@
 				"fail_ok": true,
 				"params": {
 					"problem_alias": "sumas",
-					"problemset_id": 3,
+					"problemset_id": 4,
 					"language": "py3",
 					"source": "print(1)"
 				}
@@ -1638,7 +1702,7 @@
 				"fail_ok": true,
 				"params": {
 					"problem_alias": "sumas",
-					"problemset_id": 5,
+					"problemset_id": 6,
 					"language": "py3",
 					"source": "print(1)"
 				}


### PR DESCRIPTION
# Descripción

Una vez aplicados los cambios en quark donde se mandan los scores en el mensaje
del broadcaster, ya debería ser posible calcular el máximo puntaje por sub-grupos
desde el front-end. 

Esto no estaba sucediendo debido a que desde el broadcaster se está mandando 
la información en una llave que no corresponde a la del que se utiliza en la UI.

En este cambio se arregla dicha llave para que ahora si se calcule correctamente 
la calificación

Fixes: #6878

# Comentarios

Si hay comentarios para los reviewers (por ejemplo, dónde hay que empezar a
revisar, algo a lo que hay que poner atención adicional, etc.), todo eso se
puede poner en esta sección.

También si faltan cosas por hacer, se puede hacer un checklist en esta sección.

Si no se utiliza, esta sección se puede eliminar.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
