### PR TITLE
Arreglando el scoreboard para concursos con subtareas al refrescarlo

### DIFF
--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -302,9 +302,6 @@ class Scoreboard {
                 'problemsetNotFound'
             );
         }
-        $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
-            $params->problemset_id
-        );
 
         // Get all distinct contestants participating in the contest
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
@@ -339,6 +336,9 @@ class Scoreboard {
             $params
         );
 
+        $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
+            $params->problemset_id
+        );
         if ($params->score_mode === 'max_per_group') {
             // The way to calculate the score is different in this mode
             $contestRuns = \OmegaUp\DAO\RunsGroups::getProblemsetRunsGroups(
@@ -836,11 +836,13 @@ class Scoreboard {
 
             $identityId = $run['identity_id'];
             $problemId = $run['problem_id'];
-            if (
-                $params->score_mode === 'max_per_group' && isset(
-                    $run['score_by_group']
-                )
-            ) {
+            if ($params->score_mode === 'max_per_group') {
+                if (!isset($run['score_by_group'])) {
+                    throw new \OmegaUp\Exceptions\InvalidParameterException(
+                        'parameterInvalid',
+                        'score_by_group'
+                    );
+                }
                 $contestScore = self::getMaxPerGroupScore(
                     $identityProblemsScoreByGroup,
                     $run['score_by_group'],


### PR DESCRIPTION
# Descripción

Anteriormente ya se habían liberado los cambios para que se calcule correctamente 
el scoreboard y los eventos del scoreboard cuando un concurso es por sub-tareas.

Lo que había faltado arreglar es que esots también se calcularan correctamente
cuando se manda llamar `Scoreboard::apiRefresh`, es importante que eso se realice
en esta api debido a que es la que guarda en caché los últimos cambios al momento
que se realiza un envío. 

De esta forma, ahora si se actualiza correctamente el scoreboard, sin tener que 
recargar la página.

Fixes: #6881

# Comentarios

Hay aún algunos detalles que no corresponden precisamente a este issue, 
pero es bueno tenerlos en cuenta:

- El porcentaje de avance por problema en algunos casos está dando más
  de 100 y esto se debe a que este se calcula con base al score del problema.
  La cuestión aquí es que en la tabla de `Runs_Groups` no existe el campo de 
  `contest_score` y se está guardando solamente el dato de `score`. Quiere 
  decir que este campo puede estar guardando ya sea 1 o 100 para los 
  problemas que hayan obtenido 'AC'.

# Checklist:

- [X] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
