### PR TITLE
Fix bug "Endless redirects"

### DIFF
--- a/frontend/www/libinteractive/index.php
+++ b/frontend/www/libinteractive/index.php
@@ -61,4 +61,5 @@ if ($location[strlen($location) - 1] != '/') {
     $location .= '/';
 }
 
-header("Location: {$location}{$preferred}/");
+header("Location: /libinteractive/{$preferred}/");
+


### PR DESCRIPTION
This line of code made the following bug:

When a user visits /libinteractive/index.php the intended redirection should be /libinteractive/en

But because there was an error in this line of code "header("Location: {$location}{$preferred}/");"

This code redirects the user to the URL {$location}{$preferred}/. However, the value of {$location} is the current request URI, which is /libinteractive/index.php. This means that the user is being redirected to the URL /libinteractive/index.php/{$preferred}/. However, this URL is the same as the original URL, so the user is redirected back to /libinteractive/index.php, which then redirects the user back to /libinteractive/index.php/{$preferred}/, and so on.

Thus creating a infinite loop and recursive function.

The new code:
"header("Location: /libinteractive/{$preferred}/");"

This should take the user to the desired language page.

# Descripción

Por favor incluye la descripción de lo que cambiaste. Lo que pongas en esta
sección se va a utilizar como commit message cuando se haga merge.

Si tu cambio toca la interfaz, hay que incluir una captura de pantalla.

Fixes: #(issue)

# Comentarios

Si hay comentarios para los reviewers (por ejemplo, dónde hay que empezar a
revisar, algo a lo que hay que poner atención adicional, etc.), todo eso se
puede poner en esta sección.

También si faltan cosas por hacer, se puede hacer un checklist en esta sección.

Si no se utiliza, esta sección se puede eliminar.

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
