### PR TITLE
 Modificando la altura del carrusel de presentación

### DIFF
--- a/frontend/www/js/omegaup/components/homepage/Slide.vue
+++ b/frontend/www/js/omegaup/components/homepage/Slide.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-lg p-4">
+  <div class="container-lg p-4 bg-danger">
     <div
       class="slide d-flex align-items-center justify-content-around flex-wrap flex-lg-nowrap"
     >
@@ -50,6 +50,10 @@ export default class Slide extends Vue {
 .slide {
   @media only screen and (min-width: 767px) {
     height: 500px;
+  }
+
+  @media only screen and (max-width: 767px) {
+    height: 700px;
   }
 
   h2 {

--- a/frontend/www/js/omegaup/components/homepage/Slide.vue
+++ b/frontend/www/js/omegaup/components/homepage/Slide.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-lg p-4 bg-danger">
+  <div class="container-lg p-4">
     <div
       class="slide d-flex align-items-center justify-content-around flex-wrap flex-lg-nowrap"
     >


### PR DESCRIPTION
# Descripción

Se definió la altura para el carrusel cuando esté en vista móvil.

Fixes: #7019

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
