### PR TITLE
Modificando la altura del carrusel de testimonios

### DIFF
--- a/frontend/www/js/omegaup/components/homepage/Testimonials.vue
+++ b/frontend/www/js/omegaup/components/homepage/Testimonials.vue
@@ -93,4 +93,9 @@ export default class Testimonials extends Vue {
     }
   }
 }
+@media only screen and (max-width: 720px) {
+  .carousel-inner {
+  min-height: 31rem;
+  }
+}
 </style>

--- a/frontend/www/js/omegaup/components/homepage/Testimonials.vue
+++ b/frontend/www/js/omegaup/components/homepage/Testimonials.vue
@@ -95,7 +95,7 @@ export default class Testimonials extends Vue {
 }
 @media only screen and (max-width: 720px) {
   .carousel-inner {
-  min-height: 31rem;
+    min-height: 31rem;
   }
 }
 </style>

--- a/frontend/www/js/omegaup/components/homepage/Testimonials.vue
+++ b/frontend/www/js/omegaup/components/homepage/Testimonials.vue
@@ -80,7 +80,7 @@ export default class Testimonials extends Vue {
 }
 
 .carousel-inner {
-  min-height: 12rem;
+  min-height: 31rem;
 
   .carousel-item {
     blockquote.blockquote {
@@ -93,9 +93,9 @@ export default class Testimonials extends Vue {
     }
   }
 }
-@media only screen and (max-width: 720px) {
+@media only screen and (min-width: 767px) {
   .carousel-inner {
-    min-height: 31rem;
+    min-height: 12rem;
   }
 }
 </style>


### PR DESCRIPTION
# Descripción

Se definió la altura para el carrusel cuando esté en vista móvil.

![image](https://github.com/omegaup/omegaup/assets/110271913/cdd3c28c-2175-428f-8fc8-55bf365a079f)

# Antes

![image](https://github.com/omegaup/omegaup/assets/110271913/1e869fc2-e50c-4fd6-aa66-4eeb0a586cf3)

Fixes: #7020

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
