### PR TITLE
Dejando de usar score_per_group que ya se eliminó en quark

### DIFF
--- a/frontend/www/js/omegaup/arena/events_socket.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.ts
@@ -122,7 +122,6 @@ export class EventsSocket {
       const updatedRun = {
         ...run,
         time: time.remoteTime(run.time * 1000),
-        score_by_group: run.score_per_group,
       };
       updateRun({ run: updatedRun });
     } else if (data.message == '/clarification/update/') {


### PR DESCRIPTION
# Descripción

Ahora que ya se quitó todo registro del campo `score_per_group` en  quark 
es momento de dejarlo también podemos eliminarlo en el frontend

Fixes: #(issue)

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
