### PR TITLE
Evitando el error de NaN en el mejor puntaje por problema

### DIFF
--- a/frontend/server/src/DAO/RunsGroups.php
+++ b/frontend/server/src/DAO/RunsGroups.php
@@ -56,7 +56,7 @@ class RunsGroups extends \OmegaUp\DAO\Base\RunsGroups {
                         s.type = 'normal'
                 )
                 SELECT
-                    IFNULL(ROUND(SUM(mspg_limit.score), 2), 0.00) AS score,
+                    IFNULL(ROUND((SUM(mspg_limit.score) / pp.points), 2), 0.00) AS score,
                     IFNULL(ROUND(SUM(mspg_limit.score), 2), 0.00) AS contest_score,
                     IFNULL(SUM(mspg_limit.penalty), 0) AS penalty,
                     mspg_all.problem_id,

--- a/frontend/server/src/DAO/RunsGroups.php
+++ b/frontend/server/src/DAO/RunsGroups.php
@@ -56,8 +56,8 @@ class RunsGroups extends \OmegaUp\DAO\Base\RunsGroups {
                         s.type = 'normal'
                 )
                 SELECT
-                    IFNULL(ROUND((SUM(mspg_limit.score) / pp.points), 2), 0.00) AS score,
-                    IFNULL(ROUND(SUM(mspg_limit.score), 2), 0.00) AS contest_score,
+                    IFNULL(ROUND((SUM(mspg_limit.score)), 2), 0.00) AS score,
+                    IFNULL(ROUND(SUM(mspg_limit.score) * pp.points, 2), 0.00) AS contest_score,
                     IFNULL(SUM(mspg_limit.penalty), 0) AS penalty,
                     mspg_all.problem_id,
                     mspg_all.identity_id,

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -1307,7 +1307,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * A PHPUnit data provider for the contest with max_per_group mode.
      *
-     * @return array{0: int, 1: list<array: {runs: int, score: float, execution: string, output: string, status_memory: string, status_runtime: string}>, 2: list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}>}
+     * @return array{0: int, 1: list<array: {runs: int, score: float, execution: string, output: string, status_memory: string, status_runtime: string}>, 2: list<array{total: float, points_per_group:array{group_name: string, score: float, verdict: string}}>, 3: int}
      */
     public function runsMappingProvider(): array {
         $runsMapping = [
@@ -1342,10 +1342,11 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                 100,
                 [
                     ['runs' => 1, 'score' => 0.4, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_AVAILABLE'],
-                    ['runs' => 2, 'score' => 0.73, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_AVAILABLE'],
+                    ['runs' => 2, 'score' => 0.7333, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                     ['runs' => 3, 'score' => 0.8, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                 ],
-                $runsMapping
+                $runsMapping,
+                100,
             ],
             [
                 60,
@@ -1356,14 +1357,15 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                     // contest's settings
                     ['runs' => 3, 'score' => 0.73, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                 ],
-                $runsMapping
+                $runsMapping,
+                1
             ],
             [
                 100,
                 [
                     ['runs' => 1, 'score' => 0.0, 'execution' => 'EXECUTION_COMPILATION_ERROR', 'output' => 'OUTPUT_INCORRECT', 'status_memory' => 'MEMORY_NOT_AVAILABLE', 'status_runtime' => 'RUNTIME_NOT_AVAILABLE'],
                     ['runs' => 2, 'score' => 0.5, 'execution' => 'EXECUTION_JUDGE_ERROR', 'output' => 'OUTPUT_EXCEEDED', 'status_memory' => 'MEMORY_NOT_AVAILABLE', 'status_runtime' => 'RUNTIME_NOT_AVAILABLE'],
-                    ['runs' => 3, 'score' => 0.83, 'execution' => 'EXECUTION_INTERRUPTED', 'output' => 'OUTPUT_INTERRUPTED', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_EXCEEDED'],
+                    ['runs' => 3, 'score' => 0.8333, 'execution' => 'EXECUTION_INTERRUPTED', 'output' => 'OUTPUT_INTERRUPTED', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_EXCEEDED'],
                     ['runs' => 4, 'score' => 1.0, 'execution' => 'EXECUTION_FINISHED', 'output' => 'OUTPUT_CORRECT', 'status_memory' => 'MEMORY_AVAILABLE', 'status_runtime' => 'RUNTIME_AVAILABLE'],
                 ],
                 [
@@ -1401,6 +1403,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                         ],
                     ],
                 ],
+                100,
             ],
         ];
     }
@@ -1414,7 +1417,8 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     public function testScoreboardForContestInMaxPerGroupMode(
         int $scoreboardPercentage,
         array $expectedResultsInEverySubmission,
-        array $runsMapping
+        array $runsMapping,
+        int $pointsPerProblem
     ) {
         // Get a problem
         $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
@@ -1430,7 +1434,8 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
         // Add the problem to the contest
         \OmegaUp\Test\Factories\Contest::addProblemToContest(
             $problemData,
-            $contestData
+            $contestData,
+            $pointsPerProblem
         );
 
         // Create our contestant
@@ -1483,7 +1488,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
 
             $this->assertSame(
                 $response[0]['problems'][0]['points'],
-                $expectedResultsInEverySubmission[$index]['score']
+                $expectedResultsInEverySubmission[$index]['score'] * $pointsPerProblem
             );
             $this->assertSame(
                 $response[0]['problems'][0]['runs'],

--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -180,7 +180,7 @@ export function getMaxPerGroupScore(
 
   const values = Object.values(scoreByGroup);
 
-  // Avoiding show NaN in bestScore value
+  // Avoid showing NaN in bestScore value
   for (const value of values) {
     if (typeof value === 'undefined') {
       return 0;

--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -179,5 +179,13 @@ export function getMaxPerGroupScore(
   );
 
   const values = Object.values(scoreByGroup);
+
+  // Avoiding show NaN in bestScore value
+  for (const value of values) {
+    if (typeof value === 'undefined') {
+      return 0;
+    }
+  }
+
   return values.reduce((acc, value) => acc + value, 0);
 }

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -45,7 +45,9 @@
               :active-problem="activeProblemAlias"
               :in-assignment="false"
               :digits-after-decimal-point="
-                contest.score_mode == 'partial' ? digitsAfterDecimalPoint : 0
+                contest.score_mode == 'all_or_nothing'
+                  ? 0
+                  : digitsAfterDecimalPoint
               "
               @disable-active-problem="activeProblem = null"
               @navigate-to-problem="onNavigateToProblem"

--- a/frontend/www/js/omegaup/components/arena/NavbarProblems.vue
+++ b/frontend/www/js/omegaup/components/arena/NavbarProblems.vue
@@ -33,15 +33,7 @@
           v-if="problem.acceptsSubmissions"
           class="col-xs-7 solved text-right w-50 pr-3"
         >
-          <span class="mr-1"
-            >({{
-              parseFloat(problem.bestScore).toFixed(digitsAfterDecimalPoint)
-            }}
-            /
-            {{
-              parseFloat(problem.maxScore).toFixed(digitsAfterDecimalPoint)
-            }})</span
-          >
+          <span class="mr-1">{{ getMaxScoreForProblem(problem) }}</span>
           <font-awesome-icon
             v-if="problem.bestScore == problem.maxScore"
             icon="check"
@@ -103,6 +95,12 @@ export default class ArenaNavbarProblems extends Vue {
 
   getProblemTypeTitle(acceptsSubmissions: boolean): string {
     return acceptsSubmissions ? T.wordsProblem : T.wordsLecture;
+  }
+
+  getMaxScoreForProblem(problem: types.NavbarProblemsetProblem): string {
+    return `(${problem.bestScore.toFixed(
+      this.digitsAfterDecimalPoint,
+    )} / ${problem.maxScore.toFixed(this.digitsAfterDecimalPoint)})`;
   }
 
   get urlAssignment(): string {


### PR DESCRIPTION
# Descripción

Por lo reportado en el issue #6878 hay ocasiones en las que se muestra`NaN` en 
el mayor puntaje del problema. La razón es porque no se está recibiendo 
correctamente el valor en el campo `score_by_group`. 

Aunque ya debería obtenerse correctamente ese dato después del cambio en #7049 
esto se puede evitar con una validación extra que se agrega en este PR.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
