### PR TITLE
Arreglando el bestScore por problema para concursos con subtareas

### DIFF
--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -304,7 +304,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
 
     /*
      * Get relevant problems including problemset alias
-     * @return list<\OmegaUp\DAO\VO\Problems>
+     * @return list<array{alias: string, current_version: string, points: int, problem_id: int}>
      */
     final public static function getRelevantProblems(
         int $problemsetId
@@ -312,7 +312,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         // Build SQL statement
         $sql = '
             SELECT
-                p.problem_id, p.alias, pp.version AS current_version
+                p.problem_id, p.alias, pp.version AS current_version, pp.points
             FROM
                 Problemset_Problems pp
             INNER JOIN
@@ -321,17 +321,8 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                 pp.problemset_id = ?
             ORDER BY pp.`order`, `pp`.`problem_id` ASC;';
         $val = [$problemsetId];
-        $result = [];
-        /** @var array{alias: string, current_version: string, problem_id: int} $row */
-        foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $val
-            ) as $row
-        ) {
-            $result[] = new \OmegaUp\DAO\VO\Problems($row);
-        }
-        return $result;
+        /** @var list<array{alias: string, current_version: string, points: int, problem_id: int}> */
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val);
     }
 
     /**

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -321,7 +321,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                 pp.problemset_id = ?
             ORDER BY pp.`order`, `pp`.`problem_id` ASC;';
         $val = [$problemsetId];
-        /** @var list<array{alias: string, current_version: string, points: int, problem_id: int}> */
+        /** @var list<array{alias: string, current_version: string, points: float, problem_id: int}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val);
     }
 

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -115,16 +115,16 @@ class Scoreboard {
             );
         }
 
-        /** @var array<int, array{order: int, alias: string}> */
+        /** @var array<int, array{order: int, alias: string, maxScore: int}> */
         $problemMapping = [];
 
         $order = 0;
-        /** @var \OmegaUp\DAO\VO\Problems $problem */
         foreach ($rawProblemsetProblems as $problem) {
-            /** @var int $problem->problem_id */
-            $problemMapping[$problem->problem_id] = [
+            /** @var int $problem['problem_id'] */
+            $problemMapping[$problem['problem_id']] = [
                 'order' => $order++,
-                'alias' => strval($problem->alias),
+                'alias' => strval($problem['alias']),
+                'maxScore' => intval($problem['points']),
             ];
         }
 
@@ -228,12 +228,12 @@ class Scoreboard {
         $problemMapping = [];
 
         $order = 0;
-        /** @var \OmegaUp\DAO\VO\Problems $problem */
         foreach ($rawProblemsetProblems as $problem) {
-            /** @var int $problem->problem_id */
-            $problemMapping[$problem->problem_id] = [
+            /** @var int $problem['problem_id'] */
+            $problemMapping[$problem['problem_id']] = [
                 'order' => $order++,
-                'alias' => strval($problem->alias),
+                'alias' => strval($problem['alias']),
+                'maxScore' => intval($problem['points']),
             ];
         }
 
@@ -244,7 +244,7 @@ class Scoreboard {
             $problemMapping
         );
 
-        $timeout =  is_null($this->params->finish_time) ?
+        $timeout = is_null($this->params->finish_time) ?
             0 :
             max(
                 0,
@@ -323,12 +323,12 @@ class Scoreboard {
         $problemMapping = [];
 
         $order = 0;
-        /** @var \OmegaUp\DAO\VO\Problems $problem */
         foreach ($rawProblemsetProblems as $problem) {
-            /** @var int $problem->problem_id */
-            $problemMapping[$problem->problem_id] = [
+            /** @var int $problem['problem_id'] */
+            $problemMapping[$problem['problem_id']] = [
                 'order' => $order++,
-                'alias' => strval($problem->alias),
+                'alias' => strval($problem['alias']),
+                'maxScore' => intval($problem['points']),
             ];
         }
 
@@ -794,7 +794,7 @@ class Scoreboard {
      * @param \OmegaUp\ScoreboardParams $params
      * @param list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: string}> $contestRuns
      * @param list<array{identity_id: int, username: string, classname: string, name: string|null, country_id: null|string, is_invited: bool}> $rawContestIdentities
-     * @param array<int, array{order: int, alias: string}> $problemMapping
+     * @param array<int, array{order: int, alias: string, maxScore: int}> $problemMapping
      * @return list<ScoreboardEvent>
      */
     private static function calculateEvents(
@@ -847,7 +847,8 @@ class Scoreboard {
                     $identityProblemsScoreByGroup,
                     $run['score_by_group'],
                     $identityId,
-                    $problemId
+                    $problemId,
+                    $problemMapping[$problemId]['maxScore']
                 );
             } else {
                 $contestScore = $run['contest_score'];
@@ -944,7 +945,8 @@ class Scoreboard {
         array &$identityProblemsScoreByGroup,
         ?string $scoreByGroup,
         int $identityId,
-        int $problemId
+        int $problemId,
+        int $maxScore
     ): float {
         if (is_null($scoreByGroup)) {
             return 0.0;
@@ -980,7 +982,7 @@ class Scoreboard {
 
         return array_sum(
             $identityProblemsScoreByGroup[$identityId][$problemId]
-        );
+        ) * $maxScore;
     }
 
     /**

--- a/frontend/tests/controllers/ContestScoreboardTest.php
+++ b/frontend/tests/controllers/ContestScoreboardTest.php
@@ -1525,7 +1525,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                 [
                     [
                         'total' => 0.25,
-                        'expectedScore' => 0.25,
+                        'expectedScore' => 25.0,
                         'points_per_group' => [
                             ['group_name' => 'sample', 'score' => 0.0, 'verdict' => 'WA'],
                             ['group_name' => 'easy', 'score' => 0.25, 'verdict' => 'AC'],
@@ -1535,7 +1535,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                     ],
                     [
                         'total' => 0.25,
-                        'expectedScore' => 0.50,
+                        'expectedScore' => 50.0,
                         'points_per_group' => [
                             ['group_name' => 'sample', 'score' => 0.0, 'verdict' => 'WA'],
                             ['group_name' => 'easy', 'score' => 0.0, 'verdict' => 'TLE'],
@@ -1545,7 +1545,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                     ],
                     [
                         'total' => 0.50,
-                        'expectedScore' => 0.75,
+                        'expectedScore' => 75.0,
                         'points_per_group' => [
                             ['group_name' => 'sample', 'score' => 0.0, 'verdict' => 'WA'],
                             ['group_name' => 'easy', 'score' => 0.25, 'verdict' => 'AC'],
@@ -1560,7 +1560,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                 [
                     [
                         'total' => 0.25,
-                        'expectedScore' => 0.25,
+                        'expectedScore' => 25.0,
                         'points_per_group' => [
                             ['group_name' => 'sample', 'score' => 0.25, 'verdict' => 'AC'],
                             ['group_name' => 'easy', 'score' => 0.0, 'verdict' => 'WA'],
@@ -1570,7 +1570,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                     ],
                     [
                         'total' => 0.75,
-                        'expectedScore' => 0.75,
+                        'expectedScore' => 75.0,
                         'points_per_group' => [
                             ['group_name' => 'sample', 'score' => 0.25, 'verdict' => 'AC'],
                             ['group_name' => 'easy', 'score' => 0.25, 'verdict' => 'AC'],
@@ -1580,7 +1580,7 @@ class ContestScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
                     ],
                     [
                         'total' => 0.5,
-                        'expectedScore' => 1.0,
+                        'expectedScore' => 100.0,
                         'points_per_group' => [
                             ['group_name' => 'sample', 'score' => 0.0, 'verdict' => 'WA'],
                             ['group_name' => 'easy', 'score' => 0.25, 'verdict' => 'AC'],

--- a/frontend/www/js/omegaup/arena/navigation.test.ts
+++ b/frontend/www/js/omegaup/arena/navigation.test.ts
@@ -236,7 +236,7 @@ describe('navigation.ts', () => {
         `#problems/${params.problem.alias}/new-run`,
       );
       expect(vueInstance.problem).not.toBeNull();
-      expect(vueInstance.problem?.bestScore).toBe(0.8);
+      expect(vueInstance.problem?.bestScore).toBe(80);
     });
   });
 
@@ -254,10 +254,10 @@ describe('navigation.ts', () => {
         score: 0.6,
         contest_score: 60,
         score_by_group: {
-          sample: 25,
-          easy: 20,
-          medium: 15,
-          hard: 0,
+          sample: 0.25,
+          easy: 0.2,
+          medium: 0.15,
+          hard: 0.0,
         },
         status: 'ready',
         submit_delay: 0,
@@ -277,10 +277,10 @@ describe('navigation.ts', () => {
         score: 1.0,
         contest_score: 100,
         score_by_group: {
-          sample: 25,
-          easy: 25,
-          medium: 25,
-          hard: 25,
+          sample: 0.25,
+          easy: 0.25,
+          medium: 0.25,
+          hard: 0.25,
         },
         status: 'ready',
         submit_delay: 0,
@@ -300,10 +300,10 @@ describe('navigation.ts', () => {
         score: 0.9,
         contest_score: 70,
         score_by_group: {
-          sample: 15,
-          easy: 25,
-          medium: 10,
-          hard: 20,
+          sample: 0.15,
+          easy: 0.25,
+          medium: 0.1,
+          hard: 0.2,
         },
         status: 'ready',
         submit_delay: 0,
@@ -324,7 +324,7 @@ describe('navigation.ts', () => {
     it('Should get the max score by group for a problem', () => {
       const alias = 'sumas';
       const previousScore = 0.0;
-      const maxScore = 100;
+      const maxScore = 1;
       const maxScoreForProblem = getMaxPerGroupScore(
         runs,
         alias,
@@ -332,7 +332,7 @@ describe('navigation.ts', () => {
         maxScore,
       );
 
-      expect(maxScoreForProblem).toEqual(85);
+      expect(parseFloat(maxScoreForProblem.toFixed(2))).toEqual(0.85);
     });
 
     it('Should get 0 as max score for a problem when score_by_group is not provided', () => {

--- a/frontend/www/js/omegaup/arena/navigation.test.ts
+++ b/frontend/www/js/omegaup/arena/navigation.test.ts
@@ -324,9 +324,82 @@ describe('navigation.ts', () => {
     it('Should get the max score by group for a problem', () => {
       const alias = 'sumas';
       const previousScore = 0.0;
-      const maxScore = getMaxPerGroupScore(runs, alias, previousScore);
+      const maxScore = 100;
+      const maxScoreForProblem = getMaxPerGroupScore(
+        runs,
+        alias,
+        previousScore,
+        maxScore,
+      );
 
-      expect(maxScore).toEqual(85);
+      expect(maxScoreForProblem).toEqual(85);
+    });
+
+    it('Should get 0 as max score for a problem when score_by_group is not provided', () => {
+      const runs: types.Run[] = [
+        {
+          alias: 'sumas',
+          classname: 'user-rank-unranked',
+          country: 'mx',
+          guid: 'abcdef1212',
+          language: 'py3',
+          memory: 0,
+          penalty: 0,
+          runtime: 0,
+          score: 0.6,
+          contest_score: 60,
+          status: 'ready',
+          submit_delay: 0,
+          time: new Date(0),
+          username: 'omegaup',
+          verdict: 'PA',
+        },
+        {
+          alias: 'triangulos',
+          classname: 'user-rank-unranked',
+          country: 'mx',
+          guid: 'fefefe1211',
+          language: 'py3',
+          memory: 0,
+          penalty: 0,
+          runtime: 0,
+          score: 1.0,
+          contest_score: 100,
+          status: 'ready',
+          submit_delay: 0,
+          time: new Date(0),
+          username: 'omegaup',
+          verdict: 'AC',
+        },
+        {
+          alias: 'sumas',
+          classname: 'user-rank-unranked',
+          country: 'mx',
+          guid: 'efad3456334',
+          language: 'py3',
+          memory: 0,
+          penalty: 0,
+          runtime: 0,
+          score: 0.9,
+          contest_score: 70,
+          status: 'ready',
+          submit_delay: 0,
+          time: new Date(0),
+          username: 'omegaup',
+          verdict: 'PA',
+        },
+      ];
+      const alias = 'sumas';
+      const previousScore = 0.0;
+      const maxScore = getMaxScore(runs, alias, previousScore);
+      const maxScoreForProblem = getMaxPerGroupScore(
+        runs,
+        alias,
+        previousScore,
+        maxScore,
+      );
+
+      expect(maxScoreForProblem).toEqual(0);
     });
   });
 });

--- a/frontend/www/js/omegaup/arena/navigation.test.ts
+++ b/frontend/www/js/omegaup/arena/navigation.test.ts
@@ -297,7 +297,7 @@ describe('navigation.ts', () => {
         memory: 0,
         penalty: 0,
         runtime: 0,
-        score: 0.9,
+        score: 0.7,
         contest_score: 70,
         score_by_group: {
           sample: 0.15,
@@ -391,7 +391,7 @@ describe('navigation.ts', () => {
       ];
       const alias = 'sumas';
       const previousScore = 0.0;
-      const maxScore = getMaxScore(runs, alias, previousScore);
+      const maxScore = 100;
       const maxScoreForProblem = getMaxPerGroupScore(
         runs,
         alias,
@@ -400,6 +400,88 @@ describe('navigation.ts', () => {
       );
 
       expect(maxScoreForProblem).toEqual(0);
+    });
+
+    it('Should max score for a problem when submission verdict is CE', () => {
+      const runs: types.Run[] = [
+        {
+          alias: 'sumas',
+          classname: 'user-rank-unranked',
+          country: 'mx',
+          guid: 'abcdef1212',
+          language: 'py3',
+          memory: 0,
+          penalty: 0,
+          runtime: 0,
+          score: 0,
+          status: 'ready',
+          submit_delay: 0,
+          time: new Date(0),
+          username: 'omegaup',
+          verdict: 'CE',
+        },
+        {
+          alias: 'triangulos',
+          classname: 'user-rank-unranked',
+          country: 'mx',
+          guid: 'fefefe1211',
+          language: 'py3',
+          memory: 0,
+          penalty: 0,
+          runtime: 0,
+          score: 0.6,
+          contest_score: 60,
+          score_by_group: {
+            sample: 0.25,
+            easy: 0.0,
+            medium: 0.25,
+            hard: 0.1,
+          },
+          status: 'ready',
+          submit_delay: 0,
+          time: new Date(0),
+          username: 'omegaup',
+          verdict: 'AC',
+        },
+        {
+          alias: 'sumas',
+          classname: 'user-rank-unranked',
+          country: 'mx',
+          guid: 'efad3456334',
+          language: 'py3',
+          memory: 0,
+          penalty: 0,
+          runtime: 0,
+          score: 0.7,
+          contest_score: 70,
+          score_by_group: {
+            sample: 0.15,
+            easy: 0.25,
+            medium: 0.1,
+            hard: 0.2,
+          },
+          status: 'ready',
+          submit_delay: 0,
+          time: new Date(0),
+          username: 'omegaup',
+          verdict: 'PA',
+        },
+      ];
+
+      const alias = 'sumas';
+      const previousScore = 0.0;
+      const maxScore = 100;
+
+      // The function should ignore the submissions where the field
+      // score_by_group is not provided
+      const maxScoreForProblem = getMaxPerGroupScore(
+        runs,
+        alias,
+        previousScore,
+        maxScore,
+      );
+
+      expect(maxScoreForProblem).toEqual(70);
     });
   });
 });

--- a/frontend/www/js/omegaup/arena/navigation.ts
+++ b/frontend/www/js/omegaup/arena/navigation.ts
@@ -102,7 +102,7 @@ export async function navigateToProblem(
       problem.bestScore = getScoreForProblem({
         contestMode,
         problemAlias: problemInfo.alias,
-        problemPoints: 0.0,
+        previousScore: 0.0,
         maxScore: problem.maxScore,
       });
       problemsStore.commit('addProblem', problemInfo);

--- a/frontend/www/js/omegaup/arena/ranking.ts
+++ b/frontend/www/js/omegaup/arena/ranking.ts
@@ -253,7 +253,7 @@ export function onRankingChanged({
         currentProblem.bestScore = getScoreForProblem({
           contestMode: scoreMode,
           problemAlias: problem.alias,
-          problemPoints: problem.points,
+          previousScore: problem.points,
           maxScore: currentProblem.maxScore,
         });
       }

--- a/frontend/www/js/omegaup/arena/ranking.ts
+++ b/frontend/www/js/omegaup/arena/ranking.ts
@@ -254,6 +254,7 @@ export function onRankingChanged({
           contestMode: scoreMode,
           problemAlias: problem.alias,
           problemPoints: problem.points,
+          maxScore: currentProblem.maxScore,
         });
       }
     }


### PR DESCRIPTION
# Descripción

Como sugiere @heduenas en https://github.com/omegaup/omegaup/issues/6878#issuecomment-1596221788, falta agregar el máximo puntaje 
en las funciones de `getMaxPerGroupScore`, tanto en el controlador, como en el
lado del cliente. 

Esto debido a que se ha encontrado con que en los concursos con subtareas no 
se almacena el `contest_score` en la DB, sino que sólo se almacena el 
`score`. Así que en este cambio se realizan dichos cálculos para que se muestre
corectamente el `bestScore` al momento de que se realiza un envío y también 
para que se pinte correctamente la gráfica del `scoreboardEvents`

Fixes: #6878 
Fixes: #6881 
Fixes: #7003 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
