### PR TITLE
Quitando form que evitaba cerrar el dropdown de notificaciones al dar click

### DIFF
--- a/frontend/www/js/omegaup/components/notification/List.vue
+++ b/frontend/www/js/omegaup/components/notification/List.vue
@@ -16,32 +16,25 @@
       ></a
     >
     <div class="dropdown-menu dropdown-menu-right notification-dropdown">
-      <!--
-        Trick to avoid closing on click
-        The form element makes click events work inside dropdown on items that are not nav-link.
-        TODO: Try another way to allow this behaviour.
-      -->
-      <form>
-        <div v-if="notifications.length === 0" class="text-center">
-          {{ T.notificationsNoNewNotifications }}
-        </div>
-        <a
-          v-else
-          class="dropdown-item"
-          href="#"
-          @click="$emit('read', notifications, null)"
-        >
-          {{ T.notificationsMarkAllAsRead }} ✔️
-        </a>
-        <transition-group name="list"
-          ><omegaup-notification
-            v-for="notification in notifications"
-            :key="notification.notification_id"
-            :notification="notification"
-            @remove="readSingleNotification"
-          ></omegaup-notification
-        ></transition-group>
-      </form>
+      <div v-if="notifications.length === 0" class="text-center">
+        {{ T.notificationsNoNewNotifications }}
+      </div>
+      <a
+        v-else
+        class="dropdown-item"
+        href="#"
+        @click="$emit('read', notifications, null)"
+      >
+        {{ T.notificationsMarkAllAsRead }} ✔️
+      </a>
+      <transition-group name="list"
+        ><omegaup-notification
+          v-for="notification in notifications"
+          :key="notification.notification_id"
+          :notification="notification"
+          @remove="readSingleNotification"
+        ></omegaup-notification
+      ></transition-group>
     </div>
   </li>
 </template>


### PR DESCRIPTION
# Descripción

Se quita un elemento `form` que se había agregado en el dropdown de notificaiones
en el navbar. Este form lo que evitaba era cerrar el el dropdown cuando se daba click
en algún elemento que no tiene la clase `nav-link`.

![CloseNotficationDropdownOnClick](https://github.com/omegaup/omegaup/assets/3230352/f182f221-992e-4681-be75-20e85cb7d28d)


Fixes: #7043 

# Comentarios

Habrá que revisar a qué elementos le afecta este cambio y ver como se puede resolver


# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
