### PR TITLE
Agregando el botón de logout al dropdown menú en móvil.

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -19,7 +19,7 @@
           />
         </a>
 
-        <div class="d-inline-flex d-flex-row order-md-1">
+        <div class="d-inline-flex d-flex-row order-lg-1">
           <ul v-if="!isLoggedIn" class="navbar-nav navbar-right d-lg-flex">
             <li class="nav-item">
               <a

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -20,14 +20,7 @@
         </a>
 
         <div class="d-inline-flex d-flex-row order-md-1">
-          <a
-            v-if="isLoggedIn"
-            class="navbar justify-content-end mr-2 d-lg-none"
-            href="/logout/"
-          >
-            <font-awesome-icon :icon="['fas', 'power-off']" />
-          </a>
-          <ul v-else class="navbar-nav navbar-right d-lg-flex">
+          <ul v-if="!isLoggedIn" class="navbar-nav navbar-right d-lg-flex">
             <li class="nav-item">
               <a
                 class="nav-link px-2"
@@ -306,6 +299,14 @@
               </div>
             </li>
           </ul>
+
+          <a
+            v-if="isLoggedIn"
+            class="navbar justify-content-end mb-2 d-lg-none"
+            href="/logout/"
+          >
+            <font-awesome-icon :icon="['fas', 'power-off']" />
+          </a>
         </div>
 
         <a


### PR DESCRIPTION
# Descripción

En la versión móvil, se quitó el botón de logout del navbar y se agregó al dropdown menu.

![image](https://github.com/omegaup/omegaup/assets/110271913/f66765d2-2b3b-4aa4-b42e-d5744dafc975)

# Versión desktop

![image](https://github.com/omegaup/omegaup/assets/110271913/786d3007-8d42-4e2f-8dc9-833ba78ae867)

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
