### PR TITLE
Ajustando el login para pantallas móviles 

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -427,7 +427,7 @@ nav.navbar {
 }
 @media only screen and (min-width: 385px) {
   .text-navLogIn {
-    font-size: inherit; 
+    font-size: inherit;
   }
 }
 @media only screen and (max-width: 992px) {

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -30,7 +30,7 @@
           <ul v-else class="navbar-nav navbar-right d-lg-flex">
             <li class="nav-item">
               <a
-                class="nav-link px-2 text-navLogIn"
+                class="nav-link text-navLogIn"
                 :href="formattedLoginURL"
                 data-login-button
                 >{{ T.navLogIn }}</a
@@ -424,10 +424,12 @@ nav.navbar {
 }
 .text-navLogIn {
   font-size: 14px;
+  padding: auto;
 }
 @media only screen and (min-width: 385px) {
   .text-navLogIn {
     font-size: inherit;
+    padding: 0.5rem;
   }
 }
 @media only screen and (max-width: 992px) {

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -2,7 +2,7 @@
   <header>
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top p-0 text-right">
       <div class="container-xl pl-0 pl-xl-3">
-        <a class="navbar-brand p-3" href="/">
+        <a class="navbar-brand p-3 mr-0 mr-sm-3" href="/">
           <img
             alt="omegaUp"
             src="/media/omegaup_curves.png"
@@ -30,7 +30,7 @@
           <ul v-else class="navbar-nav navbar-right d-lg-flex">
             <li class="nav-item">
               <a
-                class="nav-link px-2"
+                class="nav-link px-2 text-navLogIn"
                 :href="formattedLoginURL"
                 data-login-button
                 >{{ T.navLogIn }}</a
@@ -421,6 +421,14 @@ nav.navbar {
   overflow-y: scroll;
   height: 65vh;
   max-width: 40vw;
+}
+.text-navLogIn {
+  font-size: 14px;
+}
+@media only screen and (min-width: 385px) {
+  .text-navLogIn {
+    font-size: inherit; 
+  }
 }
 @media only screen and (max-width: 992px) {
   .allow-overflow {

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -30,7 +30,7 @@
           <ul v-else class="navbar-nav navbar-right d-lg-flex">
             <li class="nav-item">
               <a
-                class="nav-link text-navLogIn"
+                class="nav-link nav-login-text"
                 :href="formattedLoginURL"
                 data-login-button
                 >{{ T.navLogIn }}</a
@@ -422,12 +422,12 @@ nav.navbar {
   height: 65vh;
   max-width: 40vw;
 }
-.text-navLogIn {
+.nav-login-text {
   font-size: 14px;
   padding: auto;
 }
 @media only screen and (min-width: 385px) {
-  .text-navLogIn {
+  .nav-login-text {
     font-size: inherit;
     padding: 0.5rem;
   }


### PR DESCRIPTION
# Descripción

Para pantallas más pequeñas de 385px, se redujo el tamaño de la letra de "Iniciar sesión / Registrarse" de 16px a 14px. Se eliminaron los paddings para aprovechar mejor el espacio, y ahora se puede ver correctamente incluso en pantallas de 345px.

Vista en iPhone SE:
![image](https://github.com/omegaup/omegaup/assets/110271913/702875e2-3656-42c3-869c-e8ee102ec802)

Vista Samsung Galaxy A51/71
![image](https://github.com/omegaup/omegaup/assets/110271913/240c70bd-5fd6-4b92-a1ca-e8262db06fc6)

Vista en pantallas de 345px:
![image](https://github.com/omegaup/omegaup/assets/110271913/83251c61-41e6-4b78-9b8a-29f02253216a)

# Antes
Así se veía antes de los cambios en iPhone SE
![image](https://github.com/omegaup/omegaup/assets/110271913/621f6ccc-bde8-4c9f-826a-ca26f90a2995)

# Checklist:

- [X] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [X] Se corrieron todas las pruebas y pasaron.
- [X] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [X] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
