### PR TITLE
Reduciendo el padding en horizontal en Crear Concurso para móvil

### DIFF
--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -3,7 +3,7 @@
     <div v-if="!update" class="card-header bg-primary text-white panel-heading">
       <h3 class="card-title mb-0">{{ T.contestNew }}</h3>
     </div>
-    <div class="card-body">
+    <div class="card-body px-2 px-sm-4">
       <div class="btn-group d-block mb-3 text-center">
         <button class="btn btn-secondary" data-contest-omi @click="fillOmi">
           {{ T.contestNewFormOmiStyle }}


### PR DESCRIPTION
# Descripción

![image](https://github.com/omegaup/omegaup/assets/110271913/afbe0187-1a12-4a91-9982-25a6173ab8fe)

# Versión desktop

![image](https://github.com/omegaup/omegaup/assets/110271913/b82ab19d-208f-4e5b-88f3-86e919337f17)

Fixes: #7092 

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
