### PR TITLE
[DESKTOP] Perfil Escuela y Mi Perfil

### DIFF
--- a/frontend/www/js/omegaup/components/common/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.vue
@@ -29,10 +29,20 @@
       <slot name="table-header"></slot>
       <tbody class="d-table col-12">
         <tr v-for="(group, index) in paginatedItems" :key="index">
-          <th v-if="showPageOffset" scope="row" class="text-center align-middle" :class="bootstrapColumns">
+          <th
+            v-if="showPageOffset"
+            scope="row"
+            class="text-center align-middle"
+            :class="bootstrapColumns"
+          >
             {{ currentPageNumber * rowsPerPage + (index + 1) }}
           </th>
-          <td v-for="(item, itemIndex) in group" :key="itemIndex" class="align-middle" :class="bootstrapColumns">
+          <td
+            v-for="(item, itemIndex) in group"
+            :key="itemIndex"
+            class="align-middle"
+            :class="bootstrapColumns"
+          >
             <slot name="item-data" :item="item">
               <a :href="item.getUrl()">
                 <img
@@ -44,7 +54,11 @@
               </a>
             </slot>
           </td>
-          <td v-if="!group[0].getBadge().isEmpty()" class="text-right align-middle" :class="bootstrapColumns">
+          <td
+            v-if="!group[0].getBadge().isEmpty()"
+            class="text-right align-middle"
+            :class="bootstrapColumns"
+          >
             <strong>{{ group[0].getBadge().get() }}</strong>
           </td>
         </tr>
@@ -118,7 +132,7 @@ export default class GridPaginator extends Vue {
   }
 
   get bootstrapColumns(): string {
-    const cols = 12/this.columns;
+    const cols = 12 / this.columns;
     return `col-${cols}`;
   }
 
@@ -162,7 +176,6 @@ export default class GridPaginator extends Vue {
 }
 
 .table-bordered.table-no-outer-border {
-    border: none;
-  }
-
+  border: none;
+}
 </style>

--- a/frontend/www/js/omegaup/components/common/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card">
+  <div class="card" data-table-grid-paginator>
     <h5 v-if="title" class="card-header">
       {{ title }} <span class="badge badge-secondary">{{ items.length }}</span>
       <slot name="header-link"></slot>
@@ -24,15 +24,15 @@
     </div>
     <table
       v-if="items.length > 0"
-      class="table table-striped mb-0 table-responsive col-12 table-typo"
+      class="table table-striped mb-0 table-responsive col-12 table-typo table-bordered table-no-outer-border"
     >
       <slot name="table-header"></slot>
-      <tbody>
+      <tbody class="d-table col-12">
         <tr v-for="(group, index) in paginatedItems" :key="index">
-          <th v-if="showPageOffset" scope="row" class="text-center">
+          <th v-if="showPageOffset" scope="row" class="text-center align-middle" :class="bootstrapColumns">
             {{ currentPageNumber * rowsPerPage + (index + 1) }}
           </th>
-          <td v-for="(item, itemIndex) in group" :key="itemIndex">
+          <td v-for="(item, itemIndex) in group" :key="itemIndex" class="align-middle" :class="bootstrapColumns">
             <slot name="item-data" :item="item">
               <a :href="item.getUrl()">
                 <img
@@ -44,7 +44,7 @@
               </a>
             </slot>
           </td>
-          <td v-if="!group[0].getBadge().isEmpty()" class="text-right">
+          <td v-if="!group[0].getBadge().isEmpty()" class="text-right align-middle" :class="bootstrapColumns">
             <strong>{{ group[0].getBadge().get() }}</strong>
           </td>
         </tr>
@@ -117,6 +117,11 @@ export default class GridPaginator extends Vue {
     return Math.ceil(totalRows / this.rowsPerPage);
   }
 
+  get bootstrapColumns(): string {
+    const cols = 12/this.columns;
+    return `col-${cols}`;
+  }
+
   private get rowsPerPage(): number {
     return Math.floor(this.itemsPerPage / this.columns);
   }
@@ -151,4 +156,13 @@ export default class GridPaginator extends Vue {
     border: 1px solid #ddd;
   }
 }
+
+[data-table-grid-paginator] .table td {
+  padding: 0.75rem 1.25rem;
+}
+
+.table-bordered.table-no-outer-border {
+    border: none;
+  }
+
 </style>

--- a/frontend/www/js/omegaup/components/common/TablePaginator.vue
+++ b/frontend/www/js/omegaup/components/common/TablePaginator.vue
@@ -26,17 +26,23 @@
       v-if="items.length > 0"
       class="table table-striped mb-0 table-responsive col-12 table-typo p-0"
     >
-    <thead class="d-table col-12">
-      <tr>
-        <template v-for="column in columnNames"><th :class="column.style"> {{ column.name }} </th></template>
-      </tr>
+      <thead class="d-table col-12">
+        <tr>
+          <template v-for="column in columnNames"
+            ><th :class="column.style">{{ column.name }}</th></template
+          >
+        </tr>
       </thead>
       <tbody class="d-table col-12">
         <tr v-for="(group, index) in paginatedItems" :key="index">
           <th v-if="showPageOffset" scope="row" class="text-left align-middle">
             {{ currentPageNumber * rowsPerPage + (index + 1) }}
           </th>
-          <td v-for="(item, itemIndex) in group" :key="itemIndex" class="align-middle">
+          <td
+            v-for="(item, itemIndex) in group"
+            :key="itemIndex"
+            class="align-middle"
+          >
             <slot name="item-data" :item="item">
               <a :href="item.getUrl()">
                 <img
@@ -48,7 +54,10 @@
               </a>
             </slot>
           </td>
-          <td v-if="!group[0].getBadge().isEmpty()" class="text-right align-middle">
+          <td
+            v-if="!group[0].getBadge().isEmpty()"
+            class="text-right align-middle"
+          >
             <strong>{{ group[0].getBadge().get() }}</strong>
           </td>
         </tr>
@@ -97,7 +106,7 @@ interface SortOption {
 export default class TablePaginator extends Vue {
   @Prop() items!: LinkableResource[];
   @Prop() itemsPerPage!: number;
-  @Prop() columnNames!: Array<{name: string, style: string}>;
+  @Prop() columnNames!: Array<{ name: string; style: string }>;
   @Prop() title!: string;
   @Prop({ default: false }) showPageOffset!: boolean;
   @Prop({ default: () => [] }) sortOptions!: SortOption[];
@@ -159,7 +168,6 @@ export default class TablePaginator extends Vue {
 }
 
 .table-bordered.table-no-outer-border {
-    border: none;
-  }
-
+  border: none;
+}
 </style>

--- a/frontend/www/js/omegaup/components/common/TablePaginator.vue
+++ b/frontend/www/js/omegaup/components/common/TablePaginator.vue
@@ -1,15 +1,19 @@
 <template>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h2 class="panel-title">
-        {{ title }} <span class="badge">{{ items.length }}</span>
-      </h2>
-    </div>
-    <div v-if="sortOptions.length > 0" class="panel-body text-center">
+  <div class="card" data-table-grid-paginator>
+    <h5 v-if="title" class="card-header">
+      {{ title }} <span class="badge badge-secondary">{{ items.length }}</span>
+      <slot name="header-link"></slot>
+    </h5>
+    <div v-if="sortOptions.length > 0" class="card-body text-center">
       <div class="form-check form-check-inline">
-        <label v-for="sortOption in sortOptions" class="radio-inline">
+        <label
+          v-for="(sortOption, index) in sortOptions"
+          :key="index"
+          class="form-check-label mr-4"
+        >
           <input
             v-model="currentSortOption"
+            class="form-check-input m-0"
             name="sort-selector"
             type="radio"
             :value="sortOption.value"
@@ -18,27 +22,39 @@
         </label>
       </div>
     </div>
-    <table v-if="items.length > 0" class="table table-striped">
-      <slot name="table-header"></slot>
-      <tbody>
-        <tr v-for="(group, index) in paginatedItems">
-          <td v-if="showPageOffset" class="text-center">
+    <table
+      v-if="items.length > 0"
+      class="table table-striped mb-0 table-responsive col-12 table-typo p-0"
+    >
+    <thead class="d-table col-12">
+      <tr>
+        <template v-for="column in columnNames"><th :class="column.style"> {{ column.name }} </th></template>
+      </tr>
+      </thead>
+      <tbody class="d-table col-12">
+        <tr v-for="(group, index) in paginatedItems" :key="index">
+          <th v-if="showPageOffset" scope="row" class="text-left align-middle">
             {{ currentPageNumber * rowsPerPage + (index + 1) }}
-          </td>
-          <td v-for="item in group">
+          </th>
+          <td v-for="(item, itemIndex) in group" :key="itemIndex" class="align-middle">
             <slot name="item-data" :item="item">
               <a :href="item.getUrl()">
+                <img
+                  v-if="item.getLogo()"
+                  :src="item.getLogo().url"
+                  :title="item.getLogo().title"
+                />
                 {{ item.toString() }}
               </a>
             </slot>
           </td>
-          <td v-if="!group[0].getBadge().isEmpty()" class="numericColumn">
+          <td v-if="!group[0].getBadge().isEmpty()" class="text-right align-middle">
             <strong>{{ group[0].getBadge().get() }}</strong>
           </td>
         </tr>
       </tbody>
     </table>
-    <div v-if="items.length > 0" class="panel-footer text-center">
+    <div v-if="items.length > 0" class="card-footer text-center">
       <div class="btn-group" role="group">
         <button
           class="btn btn-primary"
@@ -65,8 +81,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import T from '../lang';
-import { LinkableResource } from '../linkable_resource';
+import T from '../../lang';
+import { LinkableResource } from '../../linkable_resource';
 
 interface SortOption {
   value: string;
@@ -74,21 +90,20 @@ interface SortOption {
 }
 
 /**
-  Creates a two-dimensional paginated table, with the number of columns passed
-  as a prop and the number of rows being calculated taking into account the number
-  of items per page, total items and the number of columns.
+ * Creates a two-dimensional paginated table, with the number of rows being
+ * calculated taking into account the number of items per page, total items.
  */
 @Component
-export default class GridPaginator extends Vue {
+export default class TablePaginator extends Vue {
   @Prop() items!: LinkableResource[];
   @Prop() itemsPerPage!: number;
-  @Prop({ default: 3 }) columns!: number;
+  @Prop() columnNames!: Array<{name: string, style: string}>;
   @Prop() title!: string;
   @Prop({ default: false }) showPageOffset!: boolean;
   @Prop({ default: () => [] }) sortOptions!: SortOption[];
 
   private T = T;
-  private currentPageNumber: number = 0;
+  private currentPageNumber = 0;
   private currentSortOption =
     this.sortOptions.length > 0 ? this.sortOptions[0].value : '';
 
@@ -101,18 +116,17 @@ export default class GridPaginator extends Vue {
   }
 
   private get totalPagesCount(): number {
-    const totalRows = Math.ceil(this.items.length / this.columns);
-    return Math.ceil(totalRows / this.rowsPerPage);
+    return Math.ceil(this.items.length / this.rowsPerPage);
   }
 
   private get rowsPerPage(): number {
-    return Math.floor(this.itemsPerPage / this.columns);
+    return Math.floor(this.itemsPerPage);
   }
 
   private get itemsRows(): LinkableResource[][] {
     const groups = [];
-    for (let i = 0; i < this.items.length; i += this.columns) {
-      groups.push(this.items.slice(i, i + this.columns));
+    for (let i = 0; i < this.items.length; i++) {
+      groups.push(this.items.slice(i, i + 1));
     }
     return groups;
   }
@@ -129,3 +143,23 @@ export default class GridPaginator extends Vue {
   }
 }
 </script>
+
+<style>
+@media (max-width: 550px) {
+  .table-typo td,
+  .table-typo th {
+    display: block;
+    background-color: #fff;
+    border: 1px solid #ddd;
+  }
+}
+
+[data-table-grid-paginator] .table td {
+  padding: 0.75rem 1.25rem;
+}
+
+.table-bordered.table-no-outer-border {
+    border: none;
+  }
+
+</style>

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -17,7 +17,7 @@
           </li>
         </ul>
         <omegaup-table-paginator
-          :columnNames="columnNames"
+          :column-names="columnNames"
           :items="codersOfTheMonth"
           :items-per-page="3"
           :title="T.codersOfTheMonth"
@@ -35,7 +35,7 @@
     <div class="row">
       <div class="col-md-12">
         <omegaup-table-paginator
-          :columnNames="userColumnNames"
+          :column-names="userColumnNames"
           :show-page-offset="true"
           :items="schoolUsers"
           :items-per-page="30"
@@ -106,18 +106,18 @@ export default class SchoolProfile extends Vue {
     },
   ];
 
-  get columnNames(): Array<{name: string, style: string}> {
+  get columnNames(): Array<{ name: string; style: string }> {
     return [
-    { name: T.codersOfTheMonthUser, style: '' },
-    { name: T.codersOfTheMonthDate, style: 'text-right' },
+      { name: T.codersOfTheMonthUser, style: '' },
+      { name: T.codersOfTheMonthDate, style: 'text-right' },
     ];
   }
 
-  get userColumnNames(): Array<{name: string, style: string}> {
+  get userColumnNames(): Array<{ name: string; style: string }> {
     return [
-    { name: T.profileContestsTablePlace, style: 'col-1 text-left' },
-    { name: T.username, style: 'text-center' },
-    { name: this.sortByTableTitle, style: 'text-right' },
+      { name: T.profileContestsTablePlace, style: 'col-1 text-left' },
+      { name: T.username, style: 'text-center' },
+      { name: this.sortByTableTitle, style: 'text-right' },
     ];
   }
 
@@ -163,5 +163,4 @@ h2 {
   font-size: 1.8rem;
   letter-spacing: 0.01rem;
 }
-
 </style>

--- a/frontend/www/js/omegaup/components/schools/Profile.vue
+++ b/frontend/www/js/omegaup/components/schools/Profile.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="container-lg p-5">
+  <div class="py-0 px-0 mx-auto my-0">
     <h2 class="text-center mb-4">
       <span v-if="rank !== 0" class="rank-number">#{{ rank }} </span>
       {{ name }}
     </h2>
-    <div class="row mb-4">
+    <div class="row mb-3">
       <div class="col-md-4">
         <ul v-if="country" class="list-group mb-3">
           <li class="list-group-item">
@@ -16,24 +16,16 @@
             <strong>{{ T.profileState }}:</strong> {{ stateName }}
           </li>
         </ul>
-        <omegaup-grid-paginator
-          :columns="1"
+        <omegaup-table-paginator
+          :columnNames="columnNames"
           :items="codersOfTheMonth"
-          :items-per-page="5"
+          :items-per-page="3"
           :title="T.codersOfTheMonth"
         >
-          <template #table-header>
-            <thead>
-              <tr>
-                <th>{{ T.codersOfTheMonthUser }}</th>
-                <th class="numericColumn">{{ T.codersOfTheMonthDate }}</th>
-              </tr>
-            </thead>
-          </template>
-        </omegaup-grid-paginator>
+        </omegaup-table-paginator>
       </div>
-      <div class="col-md-8">
-        <div class="card">
+      <div class="col-md-8 pl-0">
+        <div class="card h-100">
           <div class="card-body">
             <highcharts :options="chartOptions"></highcharts>
           </div>
@@ -42,8 +34,8 @@
     </div>
     <div class="row">
       <div class="col-md-12">
-        <omegaup-grid-paginator
-          :columns="1"
+        <omegaup-table-paginator
+          :columnNames="userColumnNames"
           :show-page-offset="true"
           :items="schoolUsers"
           :items-per-page="30"
@@ -51,17 +43,6 @@
           :sort-options="sortOptions"
           @sort-option-change="updateUsers"
         >
-          <template #table-header>
-            <thead>
-              <tr>
-                <th scope="col" class="text-center">
-                  {{ T.profileContestsTablePlace }}
-                </th>
-                <th scope="col">{{ T.username }}</th>
-                <th scope="col" class="text-right">{{ sortByTableTitle }}</th>
-              </tr>
-            </thead>
-          </template>
           <template #item-data="slotProps">
             <omegaup-username
               :username="slotProps.item.toString()"
@@ -69,7 +50,7 @@
               :linkify="true"
             ></omegaup-username>
           </template>
-        </omegaup-grid-paginator>
+        </omegaup-table-paginator>
       </div>
     </div>
   </div>
@@ -80,9 +61,9 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { omegaup } from '../../omegaup';
 import T from '../../lang';
 import * as ui from '../../ui';
-
 import CountryFlag from '../CountryFlag.vue';
 import GridPaginator from '../common/GridPaginator.vue';
+import TablePaginator from '../common/TablePaginator.vue';
 import UserName from '../user/Username.vue';
 import { types } from '../../api_types';
 import { SchoolCoderOfTheMonth, SchoolUser } from '../../linkable_resource';
@@ -92,6 +73,7 @@ import { Chart } from 'highcharts-vue';
   components: {
     'omegaup-country-flag': CountryFlag,
     'omegaup-grid-paginator': GridPaginator,
+    'omegaup-table-paginator': TablePaginator,
     'omegaup-username': UserName,
     highcharts: Chart,
   },
@@ -123,6 +105,21 @@ export default class SchoolProfile extends Vue {
       value: 'organized_contests',
     },
   ];
+
+  get columnNames(): Array<{name: string, style: string}> {
+    return [
+    { name: T.codersOfTheMonthUser, style: '' },
+    { name: T.codersOfTheMonthDate, style: 'text-right' },
+    ];
+  }
+
+  get userColumnNames(): Array<{name: string, style: string}> {
+    return [
+    { name: T.profileContestsTablePlace, style: 'col-1 text-left' },
+    { name: T.username, style: 'text-center' },
+    { name: this.sortByTableTitle, style: 'text-right' },
+    ];
+  }
 
   get schoolUsers(): SchoolUser[] {
     return this.users.sort((userA, userB) => {
@@ -161,4 +158,10 @@ export default class SchoolProfile extends Vue {
 .rank-number {
   color: gray;
 }
+
+h2 {
+  font-size: 1.8rem;
+  letter-spacing: 0.01rem;
+}
+
 </style>

--- a/frontend/www/js/omegaup/components/user/Chartsv2.vue
+++ b/frontend/www/js/omegaup/components/user/Chartsv2.vue
@@ -1,31 +1,34 @@
 <template>
   <div class="card-body">
-    <label
-      ><input v-model="type" type="radio" value="delta" />
-      {{ T.profileStatisticsDelta }}</label
+    <div
+      v-if="type != 'total' && type != ''"
+      class="period-group text-center mb-2"
     >
-    <label
-      ><input v-model="type" type="radio" value="cumulative" />
-      {{ T.profileStatisticsCumulative }}</label
-    >
-    <label
-      ><input v-model="type" type="radio" value="total" />
-      {{ T.profileStatisticsTotal }}</label
-    >
-    <div v-if="type != 'total' && type != ''" class="period-group text-center">
-      <label
+      <label class="pr-4"
+        ><input v-model="type" type="radio" value="delta" />
+        {{ T.profileStatisticsDelta }}</label
+      >
+      <label class="pr-4"
+        ><input v-model="type" type="radio" value="cumulative" />
+        {{ T.profileStatisticsCumulative }}</label
+      >
+      <label class="pr-4"
+        ><input v-model="type" type="radio" value="total" />
+        {{ T.profileStatisticsTotal }}</label
+      >
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="day" />
         {{ T.profileStatisticsDay }}</label
       >
-      <label
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="week" />
         {{ T.profileStatisticsWeek }}</label
       >
-      <label
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="month" />
         {{ T.profileStatisticsMonth }}</label
       >
-      <label
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="year" />
         {{ T.profileStatisticsYear }}</label
       >

--- a/frontend/www/js/omegaup/components/user/Profile.vue
+++ b/frontend/www/js/omegaup/components/user/Profile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-user-profile-edit class="m-5">
+  <div data-user-profile-edit class="mx-auto">
     <omegaup-user-profile-wrapper
       :profile="profile"
       :data="data"
@@ -12,7 +12,7 @@
         </h1>
       </template>
       <template #title>
-        <h3>{{ currentTitle }}</h3>
+        <h3 class="text-center mt-1">{{ currentTitle }}</h3>
       </template>
       <template #content>
         <template v-if="currentSelectedTab === 'view-profile'">
@@ -151,3 +151,10 @@ export default class Profile extends Vue {
   }
 }
 </script>
+
+<style scoped>
+[data-user-profile-edit] {
+  max-width: 69rem;
+  margin: 3rem 0;
+}
+</style>

--- a/frontend/www/js/omegaup/components/user/ProfileWrapper.vue
+++ b/frontend/www/js/omegaup/components/user/ProfileWrapper.vue
@@ -2,7 +2,7 @@
   <div class="container-fluid p-0 mt-0">
     <slot name="message"></slot>
     <div class="row">
-      <div class="col-md-3 col-lg-2">
+      <div class="col-md-3 col-lg-3">
         <omegaup-user-maininfo
           :profile="profile"
           :data="data"
@@ -11,7 +11,7 @@
         >
         </omegaup-user-maininfo>
       </div>
-      <div class="col-md-9 col-lg-10 sticky-top">
+      <div class="col-md-9 col-lg-9 sticky-top">
         <div class="card">
           <div class="card-header">
             <slot name="title"></slot>

--- a/frontend/www/js/omegaup/components/user/SidebarMainInfo.vue
+++ b/frontend/www/js/omegaup/components/user/SidebarMainInfo.vue
@@ -1,16 +1,14 @@
 <template>
   <div class="card">
     <div class="card-header">
-      <omegaup-countryflag
-        v-if="profile.country_id"
-        class="m-1"
-        :country="profile.country_id"
-      />
-      <div class="text-center rounded-circle bottom-margin">
+      <div class="text-center rounded-circle bottom-margin mt-3">
         <img class="rounded-circle" :src="profile.gravatar_92" />
       </div>
-
-      <div class="mb-3 text-center">
+      <div class="mb-3 text-center mt-2">
+        <omegaup-countryflag
+          v-if="profile.country_id"
+          :country="profile.country_id"
+        />
         <omegaup-user-username
           :classname="profile.classname"
           :username="profile.username"

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card">
-          <div class="card-header">
+          <div class="card-header" data-profile-tabs>
             <nav class="nav nav-tabs" role="tablist" data-profile-navtabs>
               <a
                 v-if="profile.is_own_profile || !profile.is_private"
@@ -119,22 +119,12 @@
                 role="tab"
                 aria-labelledby="nav-contests-tab"
               >
-                <omegaup-grid-paginator
-                  :columns="1"
+                <omegaup-table-paginator
+                  :column-names="columnNames"
                   :items="contests"
                   :items-per-page="15"
                 >
-                  <template #table-header>
-                    <thead>
-                      <tr>
-                        <th>{{ T.profileContestsTableContest }}</th>
-                        <th class="text-right">
-                          {{ T.profileContestsTablePlace }}
-                        </th>
-                      </tr>
-                    </thead>
-                  </template>
-                </omegaup-grid-paginator>
+                </omegaup-table-paginator>
               </div>
               <div
                 v-if="currentSelectedTab == ViewProfileTabs.CreatedContent"
@@ -150,9 +140,11 @@
                   class="mb-3"
                 >
                   <template v-if="profile.is_own_profile" #header-link
-                    ><a href="/problem/mine/" class="float-right">{{
-                      T.profileCreatedContentSeeAll
-                    }}</a></template
+                    ><a
+                      href="/problem/mine/"
+                      class="float-right align-self-center"
+                      >{{ T.profileCreatedContentSeeAll }}</a
+                    ></template
                   >
                 </omegaup-grid-paginator>
                 <omegaup-grid-paginator
@@ -163,9 +155,11 @@
                   class="mb-3"
                 >
                   <template v-if="profile.is_own_profile" #header-link
-                    ><a href="/contest/mine/" class="float-right">{{
-                      T.profileCreatedContentSeeAll
-                    }}</a></template
+                    ><a
+                      href="/contest/mine/"
+                      class="float-right align-self-center"
+                      >{{ T.profileCreatedContentSeeAll }}</a
+                    ></template
                   >
                 </omegaup-grid-paginator>
                 <omegaup-grid-paginator
@@ -176,9 +170,11 @@
                   class="mb-3"
                 >
                   <template v-if="profile.is_own_profile" #header-link
-                    ><a href="/course/mine/" class="float-right">{{
-                      T.profileCreatedContentSeeAll
-                    }}</a></template
+                    ><a
+                      href="/course/mine/"
+                      class="float-right align-self-center"
+                      >{{ T.profileCreatedContentSeeAll }}</a
+                    ></template
                   >
                 </omegaup-grid-paginator>
               </div>
@@ -223,6 +219,7 @@ import user_Charts from './Chartsv2.vue';
 import user_MainInfo from './MainInfo.vue';
 import badge_List from '../badge/List.vue';
 import common_GridPaginator from '../common/GridPaginator.vue';
+import common_TablePaginator from '../common/TablePaginator.vue';
 import { types } from '../../api_types';
 import * as Highcharts from 'highcharts/highstock';
 import * as ui from '../../ui';
@@ -260,6 +257,7 @@ function getInitialSelectedTab(
     'omegaup-user-maininfo': user_MainInfo,
     'omegaup-badge-list': badge_List,
     'omegaup-grid-paginator': common_GridPaginator,
+    'omegaup-table-paginator': common_TablePaginator,
     'omegaup-countryflag': country_Flag,
   },
 })
@@ -314,6 +312,14 @@ export default class ViewProfile extends Vue {
     if (!this.data?.unsolvedProblems) return [];
     return this.data.unsolvedProblems.map((problem) => new Problem(problem));
   }
+
+  get columnNames(): Array<{name: string, style: string}> {
+    return [
+    { name: T.profileContestsTableContest, style: 'text-left' },
+    { name: T.profileContestsTablePlace, style: 'text-right' },
+    ];
+  }
+  
   get solvedProblems(): Problem[] {
     if (!this.data?.solvedProblems) return [];
     return this.data.solvedProblems.map((problem) => new Problem(problem));
@@ -342,7 +348,19 @@ export default class ViewProfile extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+.float-right {
+  font-size: 1rem;
+}
+
+[data-profile-tabs] h5 {
+  font-size: 1rem;
+}
+
+[data-profile-tabs] .table {
+  padding: 0;
+}
+
 a:hover {
   cursor: pointer;
 }

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -313,13 +313,13 @@ export default class ViewProfile extends Vue {
     return this.data.unsolvedProblems.map((problem) => new Problem(problem));
   }
 
-  get columnNames(): Array<{name: string, style: string}> {
+  get columnNames(): Array<{ name: string; style: string }> {
     return [
-    { name: T.profileContestsTableContest, style: 'text-left' },
-    { name: T.profileContestsTablePlace, style: 'text-right' },
+      { name: T.profileContestsTableContest, style: 'text-left' },
+      { name: T.profileContestsTablePlace, style: 'text-right' },
     ];
   }
-  
+
   get solvedProblems(): Problem[] {
     if (!this.data?.solvedProblems) return [];
     return this.data.solvedProblems.map((problem) => new Problem(problem));


### PR DESCRIPTION
**Cambios School Profile: **

- Width container
- Espaciado entre elementos ahora es igual
- Ahora los elementos de la izquierda y la grafica tienen el mismo height
- Tamano y espaciado letra titulo
- TablePaginator de Coder del Mes y Coders que pertenecen a esta escuela ocupa todo el width del container y tienen lineas entre si.
- Margin de arriba del titulo arreglado.

**Cambios User Profile: **

- Width container se ajusta al de la nav
- Bandera de pais se pone al lado del perfil, ya no vuela
- Titulo ahora esta centrado y con tamano correcto
- GridPaginator de secciones ahora ocupa todo el width entre 2 columnas, tambien quite el padding que habia entre ellas
- Ahora tienen lineas entre cada celda para que el problema se diferencie y no parezca que es el mismo
- El sidebar tiene un poco mas de width porque con 2 columnas se veia mal la seccion de las secciones en mi perfil
- Filtros estadisticas estan en el mismo renglon y tienn mas espaciado entre si
- Problemas resueltos, creados y ver todo tienen tamano de font acorde 

![MI PERFIL](https://github.com/omegaup/omegaup/assets/107520089/f6b4aee6-8729-4e29-a3ab-258a5fd30408)
![PERFIL_ESCUELA](https://github.com/omegaup/omegaup/assets/107520089/d4144917-f2c5-41f1-bb68-96c5d54fb7ac)

Fixes: #7029, #7030

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
