### PR TITLE
[ DESKTOP ] User profile

### DIFF
--- a/frontend/www/js/omegaup/components/user/Chartsv2.vue
+++ b/frontend/www/js/omegaup/components/user/Chartsv2.vue
@@ -1,31 +1,34 @@
 <template>
   <div class="card-body">
-    <label
-      ><input v-model="type" type="radio" value="delta" />
-      {{ T.profileStatisticsDelta }}</label
+    <div
+      v-if="type != 'total' && type != ''"
+      class="period-group text-center mb-2"
     >
-    <label
-      ><input v-model="type" type="radio" value="cumulative" />
-      {{ T.profileStatisticsCumulative }}</label
-    >
-    <label
-      ><input v-model="type" type="radio" value="total" />
-      {{ T.profileStatisticsTotal }}</label
-    >
-    <div v-if="type != 'total' && type != ''" class="period-group text-center">
-      <label
+      <label class="pr-4"
+        ><input v-model="type" type="radio" value="delta" />
+        {{ T.profileStatisticsDelta }}</label
+      >
+      <label class="pr-4"
+        ><input v-model="type" type="radio" value="cumulative" />
+        {{ T.profileStatisticsCumulative }}</label
+      >
+      <label class="pr-4"
+        ><input v-model="type" type="radio" value="total" />
+        {{ T.profileStatisticsTotal }}</label
+      >
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="day" />
         {{ T.profileStatisticsDay }}</label
       >
-      <label
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="week" />
         {{ T.profileStatisticsWeek }}</label
       >
-      <label
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="month" />
         {{ T.profileStatisticsMonth }}</label
       >
-      <label
+      <label class="pr-4"
         ><input v-model="period" name="period" type="radio" value="year" />
         {{ T.profileStatisticsYear }}</label
       >

--- a/frontend/www/js/omegaup/components/user/Profile.vue
+++ b/frontend/www/js/omegaup/components/user/Profile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-user-profile-edit class="m-5">
+  <div data-user-profile-edit class="mx-auto">
     <omegaup-user-profile-wrapper
       :profile="profile"
       :data="data"
@@ -12,7 +12,7 @@
         </h1>
       </template>
       <template #title>
-        <h3>{{ currentTitle }}</h3>
+        <h3 class="text-center mt-1">{{ currentTitle }}</h3>
       </template>
       <template #content>
         <template v-if="currentSelectedTab === 'view-profile'">
@@ -63,13 +63,6 @@
             @add-identity="(request) => $emit('add-identity', request)"
           ></omegaup-user-manage-identities>
         </template>
-        <template v-else-if="currentSelectedTab === 'manage-api-tokens'">
-          <omegaup-user-manage-api-tokens
-            :api-tokens="apiTokens"
-            @create-api-token="(request) => $emit('create-api-token', request)"
-            @revoke-api-token="(request) => $emit('revoke-api-token', request)"
-          ></omegaup-user-manage-api-tokens>
-        </template>
         <template v-else-if="currentSelectedTab === 'change-password'">
           <omegaup-user-edit-password
             @update-password="(request) => $emit('update-password', request)"
@@ -109,7 +102,6 @@ import user_PasswordAdd from './PasswordAdd.vue';
 import { urlMapping } from './SidebarMainInfo.vue';
 import user_ManageSchools from './ManageSchools.vue';
 import user_ManageIdentities from './ManageIdentities.vue';
-import user_ManageApiTokens from './ManageApiTokens.vue';
 import userDeleteAccount from './DeleteAccount.vue';
 
 @Component({
@@ -121,7 +113,6 @@ import userDeleteAccount from './DeleteAccount.vue';
     'omegaup-user-edit-password': user_PasswordEdit,
     'omegaup-user-add-password': user_PasswordAdd,
     'omegaup-user-manage-identities': user_ManageIdentities,
-    'omegaup-user-manage-api-tokens': user_ManageApiTokens,
     'omegaup-user-manage-schools': user_ManageSchools,
     'omegaup-user-delete-account': userDeleteAccount,
   },
@@ -132,7 +123,6 @@ export default class Profile extends Vue {
   @Prop({ default: 'view-profile' }) selectedTab!: string;
   @Prop({ default: null }) viewProfileSelectedTab!: string | null;
   @Prop() identities!: types.Identity[];
-  @Prop() apiTokens!: types.ApiToken[];
   @Prop() profileBadges!: Set<string>;
   @Prop() visitorBadges!: Set<string>;
   @Prop() countries!: dao.Countries[];
@@ -161,3 +151,10 @@ export default class Profile extends Vue {
   }
 }
 </script>
+
+<style scoped>
+[data-user-profile-edit] {
+  max-width: 69rem;
+  margin: 3rem 0;
+}
+</style>

--- a/frontend/www/js/omegaup/components/user/ProfileWrapper.vue
+++ b/frontend/www/js/omegaup/components/user/ProfileWrapper.vue
@@ -2,7 +2,7 @@
   <div class="container-fluid p-0 mt-0">
     <slot name="message"></slot>
     <div class="row">
-      <div class="col-md-3 col-lg-2">
+      <div class="col-md-3 col-lg-3">
         <omegaup-user-maininfo
           :profile="profile"
           :data="data"
@@ -11,7 +11,7 @@
         >
         </omegaup-user-maininfo>
       </div>
-      <div class="col-md-9 col-lg-10 sticky-top">
+      <div class="col-md-9 col-lg-9 sticky-top">
         <div class="card">
           <div class="card-header">
             <slot name="title"></slot>

--- a/frontend/www/js/omegaup/components/user/SidebarMainInfo.vue
+++ b/frontend/www/js/omegaup/components/user/SidebarMainInfo.vue
@@ -1,16 +1,14 @@
 <template>
   <div class="card">
     <div class="card-header">
-      <omegaup-countryflag
-        v-if="profile.country_id"
-        class="m-1"
-        :country="profile.country_id"
-      />
-      <div class="text-center rounded-circle bottom-margin">
+      <div class="text-center rounded-circle bottom-margin mt-3">
         <img class="rounded-circle" :src="profile.gravatar_92" />
       </div>
-
-      <div class="mb-3 text-center">
+      <div class="mb-3 text-center mt-2">
+        <omegaup-countryflag
+          v-if="profile.country_id"
+          :country="profile.country_id"
+        />
         <omegaup-user-username
           :classname="profile.classname"
           :username="profile.username"
@@ -93,7 +91,6 @@ export const urlMapping: { key: string; title: string; visible: boolean }[] = [
   { key: 'edit-preferences', title: T.userEditPreferences, visible: true },
   { key: 'manage-schools', title: T.userEditManageSchools, visible: true },
   { key: 'manage-identities', title: T.profileManageIdentities, visible: true },
-  { key: 'manage-api-tokens', title: T.profileManageApiTokens, visible: true },
   { key: 'change-password', title: T.userEditChangePassword, visible: false },
   { key: 'add-password', title: T.userEditAddPassword, visible: false },
   { key: 'change-email', title: T.userEditChangeEmail, visible: false },

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card">
-          <div class="card-header">
+          <div class="card-header" data-profile-tabs>
             <nav class="nav nav-tabs" role="tablist" data-profile-navtabs>
               <a
                 v-if="profile.is_own_profile || !profile.is_private"
@@ -119,22 +119,12 @@
                 role="tab"
                 aria-labelledby="nav-contests-tab"
               >
-                <omegaup-grid-paginator
-                  :columns="1"
+                <omegaup-table-paginator
+                  :column-names="columnNames"
                   :items="contests"
                   :items-per-page="15"
                 >
-                  <template #table-header>
-                    <thead>
-                      <tr>
-                        <th>{{ T.profileContestsTableContest }}</th>
-                        <th class="text-right">
-                          {{ T.profileContestsTablePlace }}
-                        </th>
-                      </tr>
-                    </thead>
-                  </template>
-                </omegaup-grid-paginator>
+                </omegaup-table-paginator>
               </div>
               <div
                 v-if="currentSelectedTab == ViewProfileTabs.CreatedContent"
@@ -150,9 +140,11 @@
                   class="mb-3"
                 >
                   <template v-if="profile.is_own_profile" #header-link
-                    ><a href="/problem/mine/" class="float-right">{{
-                      T.profileCreatedContentSeeAll
-                    }}</a></template
+                    ><a
+                      href="/problem/mine/"
+                      class="float-right align-self-center"
+                      >{{ T.profileCreatedContentSeeAll }}</a
+                    ></template
                   >
                 </omegaup-grid-paginator>
                 <omegaup-grid-paginator
@@ -163,9 +155,11 @@
                   class="mb-3"
                 >
                   <template v-if="profile.is_own_profile" #header-link
-                    ><a href="/contest/mine/" class="float-right">{{
-                      T.profileCreatedContentSeeAll
-                    }}</a></template
+                    ><a
+                      href="/contest/mine/"
+                      class="float-right align-self-center"
+                      >{{ T.profileCreatedContentSeeAll }}</a
+                    ></template
                   >
                 </omegaup-grid-paginator>
                 <omegaup-grid-paginator
@@ -176,9 +170,11 @@
                   class="mb-3"
                 >
                   <template v-if="profile.is_own_profile" #header-link
-                    ><a href="/course/mine/" class="float-right">{{
-                      T.profileCreatedContentSeeAll
-                    }}</a></template
+                    ><a
+                      href="/course/mine/"
+                      class="float-right align-self-center"
+                      >{{ T.profileCreatedContentSeeAll }}</a
+                    ></template
                   >
                 </omegaup-grid-paginator>
               </div>
@@ -223,6 +219,7 @@ import user_Charts from './Chartsv2.vue';
 import user_MainInfo from './MainInfo.vue';
 import badge_List from '../badge/List.vue';
 import common_GridPaginator from '../common/GridPaginator.vue';
+import common_TablePaginator from '../common/TablePaginator.vue';
 import { types } from '../../api_types';
 import * as Highcharts from 'highcharts/highstock';
 import * as ui from '../../ui';
@@ -260,6 +257,7 @@ function getInitialSelectedTab(
     'omegaup-user-maininfo': user_MainInfo,
     'omegaup-badge-list': badge_List,
     'omegaup-grid-paginator': common_GridPaginator,
+    'omegaup-table-paginator': common_TablePaginator,
     'omegaup-countryflag': country_Flag,
   },
 })
@@ -314,6 +312,14 @@ export default class ViewProfile extends Vue {
     if (!this.data?.unsolvedProblems) return [];
     return this.data.unsolvedProblems.map((problem) => new Problem(problem));
   }
+
+  get columnNames(): Array<{ name: string; style: string }> {
+    return [
+      { name: T.profileContestsTableContest, style: 'text-left' },
+      { name: T.profileContestsTablePlace, style: 'text-right' },
+    ];
+  }
+
   get solvedProblems(): Problem[] {
     if (!this.data?.solvedProblems) return [];
     return this.data.solvedProblems.map((problem) => new Problem(problem));
@@ -342,7 +348,19 @@ export default class ViewProfile extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+.float-right {
+  font-size: 1rem;
+}
+
+[data-profile-tabs] h5 {
+  font-size: 1rem;
+}
+
+[data-profile-tabs] .table {
+  padding: 0;
+}
+
 a:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
**Cambios User Profile: **

- Width container se ajusta al de la nav
- Bandera de pais se pone al lado del perfil, ya no vuela
- Titulo ahora esta centrado y con tamano correcto
- GridPaginator de secciones ahora ocupa todo el width entre 2 columnas, tambien quite el padding que habia entre ellas
- Ahora tienen lineas entre cada celda para que el problema se diferencie y no parezca que es el mismo
- El sidebar tiene un poco mas de width porque con 2 columnas se veia mal la seccion de las secciones en mi perfil
- Filtros estadisticas estan en el mismo renglon y tienn mas espaciado entre si
- Problemas resueltos, creados y ver todo tienen tamaño de font acorde 

Fixes: #7030

* Parte del PR #7097 que dividi en tres secciones, Paginators, User Profile y School Profile

# Checklist:

- [ ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.

![MI PERFIL](https://github.com/omegaup/omegaup/assets/107520089/c6856db1-76f8-413f-a88d-2f3faa0affc3)
