### PR TITLE
Agregando prueba en jest para el componente de GridPaginator

### DIFF
--- a/frontend/www/js/omegaup/components/common/GridPaginator.test.ts
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.test.ts
@@ -1,0 +1,94 @@
+import { shallowMount } from '@vue/test-utils';
+
+import common_GridPaginator from './GridPaginator.vue';
+import { LinkableResource, Problem } from '../../linkable_resource';
+
+describe('GridPaginator.vue', () => {
+  const title = 'Coder of the month';
+  const items: LinkableResource[] = [
+    new Problem({
+      accepted: 1,
+      difficulty: 2,
+      submissions: 3,
+      alias: 'colas',
+      quality_seal: true,
+      title: 'Colas',
+    }),
+    new Problem({
+      accepted: 1,
+      difficulty: 2,
+      submissions: 4,
+      alias: 'filas',
+      quality_seal: true,
+      title: 'Filas',
+    }),
+    new Problem({
+      accepted: 1,
+      difficulty: 2,
+      submissions: 5,
+      alias: 'divisiones',
+      quality_seal: false,
+      title: 'Divisiones',
+    }),
+  ];
+  const columns = 2;
+  const itemsPerPage = 2;
+
+  it('Should handle an empty grid', () => {
+    const wrapper = shallowMount(common_GridPaginator, {
+      propsData: {
+        items: [],
+        itemsPerPage,
+        columns,
+        title,
+      },
+    });
+
+    expect(wrapper.find('h5.card-header').text()).toContain(title);
+    expect(wrapper.find('table').exists()).toBeFalsy();
+  });
+
+  it('Should handle a grid with information', async () => {
+    const title = 'Coder of the month';
+    const wrapper = shallowMount(common_GridPaginator, {
+      propsData: {
+        items,
+        itemsPerPage: 4,
+        columns,
+        title,
+      },
+    });
+
+    expect(wrapper.find('table').exists()).toBeTruthy();
+    // Only one page is shown
+    expect(
+      wrapper.find('button[data-button-previous]').attributes('disabled'),
+    ).toBe('disabled');
+    expect(
+      wrapper.find('button[data-button-next]').attributes('disabled'),
+    ).toBe('disabled');
+  });
+
+  it('Should handle a grid with information divided in multiple pages', async () => {
+    const title = 'Coder of the month';
+    const wrapper = shallowMount(common_GridPaginator, {
+      propsData: {
+        items,
+        itemsPerPage,
+        columns,
+        title,
+      },
+    });
+
+    expect(wrapper.find('table').exists()).toBeTruthy();
+
+    // There are more than one page, so the button "Next" in the paginator
+    // should be enabled
+    expect(
+      wrapper.find('button[data-button-previous]').attributes('disabled'),
+    ).toBe('disabled');
+    expect(
+      wrapper.find('button[data-button-next]').attributes('disabled'),
+    ).toBeUndefined();
+  });
+});

--- a/frontend/www/js/omegaup/components/common/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.vue
@@ -55,6 +55,7 @@
         <button
           class="btn btn-primary"
           type="button"
+          data-button-previous
           :disabled="totalPagesCount === 1 || currentPageNumber === 0"
           @click="previousPage"
         >
@@ -63,6 +64,7 @@
         <button
           class="btn btn-primary"
           type="button"
+          data-button-next
           :disabled="
             totalPagesCount === 1 || currentPageNumber >= totalPagesCount - 1
           "


### PR DESCRIPTION
# Descripción

Se agregan las siguientes prueba en jest para el componente de GridPaginator:
- Validar que un grid está vacío.
- Validar que un grid muestra información en una página
- Validar que un grid muestra información en múltiples páginas

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
