### PR TITLE
Reduciendo el padding en Ranking de Contribuidores

### DIFF
--- a/frontend/www/js/omegaup/components/user/AuthorsRank.vue
+++ b/frontend/www/js/omegaup/components/user/AuthorsRank.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-lg">
+  <div>
     <h5 class="rank-title mb-5">
       {{
         ui.formatString(T.authorRankRangeHeader, {


### PR DESCRIPTION
# Descripción

![image](https://github.com/omegaup/omegaup/assets/110271913/892f05cc-57a5-420d-8cb1-d484a9c8024f)

# Versión desktop

![image](https://github.com/omegaup/omegaup/assets/110271913/48e47a51-9037-491c-9d91-f9015f480537)

Fixes: #7125

# Comentarios

No hice ningún cambio en la tabla como se propuso en el issue, ya que ese problema ya esta solucionado. Lo que hice es reducir mas el padding para que la tabla entre por completo en la pantalla.

# Checklist:

- [x] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
