### PR TITLE
Agregando el campo de timestamp en la tabla de Problemset_Identities

### DIFF
--- a/frontend/database/00220_add_timestamp_problemset_identities.sql
+++ b/frontend/database/00220_add_timestamp_problemset_identities.sql
@@ -1,0 +1,3 @@
+-- Problemset_Identities table
+ALTER TABLE `Problemset_Identities`
+ADD COLUMN `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Almacena la hora y fecha en que se creó la invitación del usuario a un concurso';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -700,6 +700,7 @@ CREATE TABLE `Problemset_Identities` (
   `share_user_information` tinyint(1) DEFAULT NULL COMMENT 'Almacena la respuesta del participante de un concurso si está de acuerdo en divulgar su información.',
   `privacystatement_consent_id` int DEFAULT NULL COMMENT 'Id del documento con el consentimiento de privacidad',
   `is_invited` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si la identidad ingresará al concurso por invitación o lo encontró en el listado de concursos públicos',
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Almacena la hora y fecha en que se creó la invitación del usuario a un concurso',
   PRIMARY KEY (`identity_id`,`problemset_id`),
   KEY `problemset_id` (`problemset_id`),
   KEY `identity_id` (`identity_id`),


### PR DESCRIPTION
# Descripción

Se agrega el campo de timestamp en la tabla de `Problemset_Identities` para 
poder determinar cual fue el último concurso al cual fue invitado un usuario.

Part of: #6910 

# Comentarios

Hasta que se apruebe este PR se podrá continuar con el PR https://github.com/omegaup/omegaup/pull/7182 ya que la consulta 
que se requerirá tendrá que consultar este campo. 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
