### PR TITLE
Remueve limite de ancho en scoreboard

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -232,7 +232,6 @@ export default class ArenaScoreboard extends Vue {
 <style lang="scss" scoped>
 @import '../../../../sass/main.scss';
 .omegaup-scoreboard {
-  max-width: 900px;
   margin: 0 auto;
 
   a {


### PR DESCRIPTION
# Descripción
Por alguna razón el scoreboard de un contest tiene el límite de ancho de 900px, lo cual en pantallas más anchas se desaprovecha todo el espacio horizontal

## Antes

![Captura de pantalla 2023-09-22 133930](https://github.com/omegaup/omegaup/assets/45462106/64f053a4-d8a1-45c5-89e4-c9e85a5440c3)

## Despues
![Captura de pantalla 2023-09-22 133944](https://github.com/omegaup/omegaup/assets/45462106/08b4fd8d-8874-4402-ab55-42067d2b4fe3)


Fixes: No hay issue abierto al respecto que yo sepa

# Comentarios

En caso de que la solución propuesta no sea la más adecuada, estoy abierto a darle solución al problema con la solución pertinente (hacérmela saber de favor).

# Checklist:

- [ X ] El código sigue la [guía de
      estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de
      omegaUp.
- [ X ] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [ ] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
