### PR TITLE
Deshabilitando temporalmente la función getNextRegisteredContestForUser (#7286)

### DIFF
--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -210,11 +210,7 @@ class UITools {
                 \OmegaUp\Controllers\User::getUserTypes($user, $identity) :
                 []
             ),
-            'nextRegisteredContestForUser' => (
-                \OmegaUp\DAO\Contests::getNextRegisteredContestForUser(
-                    $identity
-                )
-            ),
+            'nextRegisteredContestForUser' => null,
         ];
     }
 


### PR DESCRIPTION
Se deshabilita temporalmente la función
`getNextRegisteredContestForUser` hasta
arreglar la consulta que está matando la DB en producción

Co-authored-by: lhchavez <lhchavez@lhchavez.com>
(cherry picked from commit f0a9e95985eaa614b01b15b251f94c8581bb7f04)