### PR TITLE
Actualizando a node 18

### DIFF
--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: ./Dockerfile.frontend
       context: ./stuff/docker/
       target: frontend
-    image: omegaup/frontend:${TAG:-latest}
+    image: omegaup/frontend:${TAG:-20231008}
 
   php:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       dockerfile: ./Dockerfile.dev-php
       context: ./stuff/docker/
-    image: omegaup/dev-php:20221023
+    image: omegaup/dev-php:20231008
     user: "${UID_GID}"
     restart: always
     volumes:

--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -12,23 +12,14 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    NODE_MAJOR=18 && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install nodejs -y && \
-    apt-get update && \
-    apt-get install -y build-essential && \
-    apt-get install -y python3 && \
-    yarn global add node-gyp && \
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
+        build-essential \
         git \
         mysql-client-core-8.0 \
         nginx \

--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -7,33 +7,24 @@ RUN apt-get update -y && \
         && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        git \
+        build-essential \
         ca-certificates \
-        gnupg2 \
         curl \
+        git \
+        gnupg2 \
         php8.1-cli \
         php8.1-curl \
         php8.1-gmp \
         php8.1-mbstring \
-        php8.1-zip \
         php8.1-xml \
+        php8.1-zip \
         && \
     /usr/sbin/update-ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    NODE_MAJOR=18 && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install nodejs -y && \
-    apt-get update && \
-    apt-get install -y build-essential && \
-    apt-get install -y python3 && \
-    yarn global add node-gyp && \
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 


### PR DESCRIPTION
Estábamos usando node 14 y ya se terminó el soporte. Eso está causando que varias dependencias ya no estén compilando correctamente.

Este cambio actualiza node a la versión 18 para poder compilar los contenedores correctamente.