### PR TITLE
Agregando link a cursos públicos cuando el usuario no está logueado

### DIFF
--- a/frontend/www/js/omegaup/components/course/CardPublic.test.ts
+++ b/frontend/www/js/omegaup/components/course/CardPublic.test.ts
@@ -33,4 +33,23 @@ describe('CardPublic.vue', () => {
     );
     expect(wrapper.text()).toContain(T.courseCardPublicLevelIntroductory);
   });
+
+  it('Should click on the course name even when a user is not logged in', async () => {
+    const wrapper = shallowMount(course_CardPublic, {
+      propsData: {
+        course: publicCourse,
+      },
+    });
+
+    expect(
+      wrapper.find(`a[href="/course/${publicCourse.alias}/"]`).text(),
+    ).toBe(publicCourse.name);
+
+    // Now, with the user logged in, the result should remain the same.
+    await wrapper.setProps({ loggedIn: true });
+
+    expect(
+      wrapper.find(`a[href="/course/${publicCourse.alias}/"]`).text(),
+    ).toBe(publicCourse.name);
+  });
 });

--- a/frontend/www/js/omegaup/components/course/CardPublic.vue
+++ b/frontend/www/js/omegaup/components/course/CardPublic.vue
@@ -9,10 +9,7 @@
           >
             <div>
               <h5 class="card-title mb-0">
-                <a v-if="loggedIn" :href="`/course/${course.alias}/`">{{
-                  course.name
-                }}</a>
-                <template v-else>{{ course.name }}</template>
+                <a :href="`/course/${course.alias}/`">{{ course.name }}</a>
               </h5>
               <p class="card-text">
                 <small>{{ course.school_name }}</small>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@babel/cli": "^7.14",
     "@babel/core": "^7.14",
     "@babel/helper-environment-visitor": "^7.16.7",
+    "@babel/helper-string-parser": "^7.22.5",
     "@babel/parser": "^7.14",
     "@babel/plugin-proposal-class-properties": "^7.14",
     "@babel/plugin-transform-async-to-generator": "^7.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,6 +632,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"


### PR DESCRIPTION
# Descripción

Se agrega la funcionalidad de poder dar clic  la lista de cursos públicos aún cuando
el usaurio no está logueado.

![Screenshot from 2023-10-23 10-38-17](https://github.com/omegaup/omegaup/assets/3230352/47eee63e-569f-48d2-a0ac-38c51d0f583d)


Fixes: #7301 

# Comentarios

También se aprovechó a agregar una librería que estaba faltando al ejecutar las 
pruebas de jest

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
