### PR TITLE
Se arregló el paginador en vista de adminstrador de la nueva tabla de veredictos

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
+++ b/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
@@ -15,6 +15,16 @@
       <div>
         <span class="font-weight-bold">{{ T.wordsSubmissions }}</span>
         <div v-if="showFilters">
+          <b-pagination
+            v-if="showFilters"
+            v-model="currentPage"
+            size="sm"
+            :total-rows="totalRows"
+            :per-page="itemsPerPage"
+            :limit="1"
+            hide-goto-end-buttons
+            @page-click="onPageClick"
+          ></b-pagination>
           <div class="filters row">
             <label
               v-if="!simplifiedView"
@@ -474,6 +484,7 @@
           </tbody>
         </table>
         <b-pagination
+          v-if="!showFilters"
           v-model="currentPage"
           :total-rows="totalRows"
           :per-page="itemsPerPage"
@@ -644,14 +655,33 @@ export default class Runs extends Vue {
   currentRunDetailsData = this.runDetailsData;
   currentPopupDisplayed = this.popupDisplayed;
   currentPage: number = 1;
+  currentDataPage: number = 1;
   newFieldsLaunchDate: Date = new Date('2023-10-22');
 
   get totalRows(): number {
-    return this.filteredRuns.length;
+    if (this.totalRuns === undefined) {
+      return this.filteredRuns.length;
+    }
+    return this.totalRuns;
+  }
+
+  onPageClick(bvEvent: any, page: number): void {
+    if (page == this.currentPage - 1 || page == this.currentPage + 1) {
+      if (this.currentPage + 1 == page) {
+        this.filterOffset++;
+      } else if (this.currentPage - 1 == page) {
+        this.filterOffset--;
+      }
+    } else {
+      bvEvent.preventDefault();
+    }
   }
 
   get paginatedRuns(): types.Run[] {
-    const startIndex = (this.currentPage - 1) * this.itemsPerPage;
+    if (!this.showFilters) {
+      this.currentDataPage = this.currentPage;
+    }
+    const startIndex = (this.currentDataPage - 1) * this.itemsPerPage;
     const endIndex = startIndex + this.itemsPerPage;
     return this.filteredRuns.slice(startIndex, endIndex);
   }
@@ -1045,6 +1075,8 @@ export default class Runs extends Vue {
   }
 
   onRemoveFilter(filter: string): void {
+    this.currentPage = 1;
+    this.currentDataPage = 1;
     if (filter === 'all') {
       this.filterLanguage = '';
       this.filterProblem = null;
@@ -1052,6 +1084,8 @@ export default class Runs extends Vue {
       this.filterUsername = null;
       this.filterVerdict = '';
       this.filterContest = '';
+      this.filterExecution = '';
+      this.filterOutput = '';
       this.filterOffset = 0;
 
       this.filters = [];
@@ -1075,6 +1109,12 @@ export default class Runs extends Vue {
         break;
       case 'contest':
         this.filterContest = '';
+        break;
+      case 'Execution':
+        this.filterExecution = '';
+        break;
+      case 'Output':
+        this.filterOutput = '';
     }
     this.filters = this.filters.filter((item) => item.name !== filter);
   }

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -293,6 +293,7 @@
           :show-filters="true"
           :show-disqualify="true"
           :simplified-view="true"
+          :items-per-page="100"
           :problemset-problems="[]"
           :search-result-users="searchResultUsers"
           :search-result-problems="searchResultProblems"


### PR DESCRIPTION
# Descripción
El paginador ahora carga todos los envíos tal cual lo hacia el paginador anterior en la vista de administrador.
Se arregló un bug donde al dar click en quitar los filtros, los nuevos filtros no se regresaban a "Todos".

Vista de usuario que administra un problema (Cada página es de 100 envíos)
![image](https://github.com/omegaup/omegaup/assets/107278679/cf074c94-4cfe-40d7-8b05-7fd497e4bcc6)

Vista de administrador de un curso (Cada página es de 100 envíos)
![image](https://github.com/omegaup/omegaup/assets/107278679/ca276a41-ec92-480c-adc0-ee0ea894075e)

Todo se mantiene igual en la tabla de envíos a un problema
![image](https://github.com/omegaup/omegaup/assets/107278679/c42e2de4-afab-485d-b29a-9db8cb35cd56)


Fixes: #7304 

# Comentarios
De aprobarse este PR el siguiente paso sería quitar todo lo que no se esté usando del código que se clonó del componente de Runs.vue