### PR TITLE
Se arreglo bug que mostraba 0 paginas cuando no habia envíos

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunsForCourses.test.ts
+++ b/frontend/www/js/omegaup/components/arena/RunsForCourses.test.ts
@@ -230,10 +230,29 @@ describe('RunsForCourses.vue', () => {
     });
 
     const paginationComponent = wrapper.findComponent({ name: 'BPagination' });
+
     expect(paginationComponent.exists()).toBe(true);
 
     expect(paginationComponent.vm.$data.localNumberOfPages).toBe(10);
     expect(paginationComponent.vm.$data.currentPage).toBe(1);
+
+    const pageSlotContent = wrapper.find('[data-page]').text();
+
+    expect(pageSlotContent).toContain('1 - 10');
+  });
+
+  it('Should handle paginator in admin view with no runs', async () => {
+    const wrapper = mount(arena_RunsForCourses, {
+      propsData: {
+        contestAlias: 'contest',
+        showFilters: true,
+        showUser: true,
+        itemsPerPage: 1,
+      },
+    });
+
+    const pageSlotContent = wrapper.find('[data-page]').text();
+    expect(pageSlotContent).toContain('1 - 1');
   });
 
   it('Should handle username filter', async () => {

--- a/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
+++ b/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
@@ -26,9 +26,7 @@
             @page-click="onPageClick"
           >
             <template #page="{ page, active }">
-              <b v-if="active"
-                >{{ page }} - {{ Math.ceil(totalRows / itemsPerPage) }}</b
-              >
+              <b v-if="active">{{ page }} - {{ totalPages }}</b>
               <i v-else>{{ page }}</i>
             </template>
           </b-pagination>
@@ -602,6 +600,13 @@ export default class Runs extends Vue {
       return this.filteredRuns.length;
     }
     return this.totalRuns;
+  }
+
+  get totalPages(): number {
+    if (this.totalRows > 0) {
+      return Math.ceil(this.totalRows / this.itemsPerPage);
+    }
+    return 1;
   }
 
   onPageClick(bvEvent: any, page: number): void {

--- a/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
+++ b/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
@@ -26,7 +26,7 @@
             @page-click="onPageClick"
           >
             <template #page="{ page, active }">
-              <b v-if="active">{{ page }} - {{ totalPages }}</b>
+              <b v-if="active" data-page>{{ page }} - {{ totalPages }}</b>
               <i v-else>{{ page }}</i>
             </template>
           </b-pagination>


### PR DESCRIPTION
# Descripción

Se arregló un bug donde se mostraba en el paginador "1-0 " cuando no habia envios. Ahora muestra 1-1.
![image](https://github.com/omegaup/omegaup/assets/107278679/912a1a6d-ca50-44f2-9160-0f825d23e805)


Fixes: #7367 
