### PR TITLE
Agregando input para filtrar problemas en perfil de usuario

### DIFF
--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -1638,6 +1638,7 @@ userObjectivesUpdateSuccess = "Thanks for helping us. Your answers have been sav
 userOrMailNotFound = "Account name or email not found."
 userPasswordMustBeSame = "The new passwords must be the same."
 userProfileIsPrivate = "This account's profile is marked private; some information will not be displayed"
+userProfileProblemsFilter = "Filter"
 userRankEmptyList = "There is not data to show in the ranking"
 userRankOfTheMonthHeader = "%(count) coders with the most points in the month"
 userRankSolvedProblemsHelp = "The number of solved problems is updated once a day."

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -1638,6 +1638,7 @@ userObjectivesUpdateSuccess = "Gracias por ayudarnos. Tus respuestas han sido gu
 userOrMailNotFound = "Nombre de cuenta o correo electrónico no encontrado"
 userPasswordMustBeSame = "Los passwords nuevos deben ser iguales."
 userProfileIsPrivate = "El perfil de esta cuenta está marcado como privado; alguna información no se mostrará"
+userProfileProblemsFilter = "Filtrar"
 userRankEmptyList = "No hay datos que mostrar en el ranking"
 userRankOfTheMonthHeader = "%(count) coders con mayor puntaje del mes"
 userRankSolvedProblemsHelp = "El número de problemas resueltos se actualiza una vez al día."

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -1638,6 +1638,7 @@ userObjectivesUpdateSuccess = "(Thank5 f0r h31ping u5. Y0ur an5w3r5 hav3 b33n 5a
 userOrMailNotFound = "(Acc0un7 nam3 0r 3mai1 n07 f0und.)"
 userPasswordMustBeSame = "(Th3 n3w pa55w0rd5 mu57 b3 7h3 5am3.)"
 userProfileIsPrivate = "(Thi5 acc0un7'5 pr0fi13 i5 mark3d priva73; 50m3 inf0rma7i0n wi11 n07 b3 di5p1ay3d)"
+userProfileProblemsFilter = "(Fi173r)"
 userRankEmptyList = "(Th3r3 i5 n07 da7a 70 5h0w in 7h3 ranking)"
 userRankOfTheMonthHeader = "(%(count) c0d3r5 wi7h 7h3 m057 p0in75 in 7h3 m0n7h)"
 userRankSolvedProblemsHelp = "(Th3 numb3r 0f 501v3d pr0b13m5 i5 upda73d 0nc3 a day.)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -1638,6 +1638,7 @@ userObjectivesUpdateSuccess = "Obrigado por nos ajudar. Suas respostas foram sal
 userOrMailNotFound = "Nome da conta ou e-mail não encontrado"
 userPasswordMustBeSame = "As novas senhas devem ser as mesmas."
 userProfileIsPrivate = "O perfil desta conta é marcado como privado; algumas informações não serão exibidas"
+userProfileProblemsFilter = "Filtrar"
 userRankEmptyList = "Não há dados para mostrar no ranking"
 userRankOfTheMonthHeader = "%(count) coders com maior pontuação do mês"
 userRankSolvedProblemsHelp = "O número de problemas resolvidos é atualizado uma vez por dia."

--- a/frontend/www/js/omegaup/components/common/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="card">
     <h6 v-if="title" class="card-header">
-      {{ title }} <span class="badge badge-secondary">{{ items.length }}</span>
+      {{ title }}
+      <span class="badge badge-secondary">{{ filteredItems.length }}</span>
       <slot name="header-link"></slot>
     </h6>
     <div v-if="sortOptions.length > 0" class="card-body text-center">
@@ -23,7 +24,7 @@
       </div>
     </div>
     <table
-      v-if="items.length > 0"
+      v-if="filteredItems.length > 0"
       class="table table-striped mb-0 table-responsive col-12 table-typo"
     >
       <slot name="table-header"></slot>
@@ -50,7 +51,19 @@
         </tr>
       </tbody>
     </table>
-    <div v-if="items.length > 0" class="card-footer text-center">
+    <form
+      v-if="shouldShowFilterInput"
+      class="form-inline m-3"
+      @submit.prevent=""
+    >
+      <input
+        v-model="filter"
+        class="form-control mr-sm-2 mb-2"
+        type="search"
+        :placeholder="filterByProblemText"
+      />
+    </form>
+    <div v-if="filteredItems.length > 0" class="card-footer text-center">
       <div class="btn-group" role="group">
         <button
           class="btn btn-primary"
@@ -99,12 +112,15 @@ export default class GridPaginator extends Vue {
   @Prop({ default: 3 }) columns!: number;
   @Prop() title!: string;
   @Prop({ default: false }) showPageOffset!: boolean;
+  @Prop({ default: false }) shouldShowFilterInput!: boolean;
   @Prop({ default: () => [] }) sortOptions!: SortOption[];
 
   private T = T;
   private currentPageNumber = 0;
   private currentSortOption =
     this.sortOptions.length > 0 ? this.sortOptions[0].value : '';
+  filter: null | string = null;
+  filteredItems: LinkableResource[] = this.items;
 
   private nextPage(): void {
     this.currentPageNumber++;
@@ -115,7 +131,7 @@ export default class GridPaginator extends Vue {
   }
 
   private get totalPagesCount(): number {
-    const totalRows = Math.ceil(this.items.length / this.columns);
+    const totalRows = Math.ceil(this.filteredItems.length / this.columns);
     return Math.ceil(totalRows / this.rowsPerPage);
   }
 
@@ -125,8 +141,8 @@ export default class GridPaginator extends Vue {
 
   private get itemsRows(): LinkableResource[][] {
     const groups = [];
-    for (let i = 0; i < this.items.length; i += this.columns) {
-      groups.push(this.items.slice(i, i + this.columns));
+    for (let i = 0; i < this.filteredItems.length; i += this.columns) {
+      groups.push(this.filteredItems.slice(i, i + this.columns));
     }
     return groups;
   }
@@ -135,6 +151,17 @@ export default class GridPaginator extends Vue {
     const start = this.currentPageNumber * this.rowsPerPage;
     const end = start + this.rowsPerPage;
     return this.itemsRows.slice(start, end);
+  }
+
+  get filterByProblemText(): string {
+    return T.userProfileProblemsFilter;
+  }
+
+  @Watch('filter')
+  onFilterChange(newFilter: string) {
+    this.filteredItems = this.items.filter((item: LinkableResource) =>
+      item.toString().toLowerCase().includes(newFilter.toLowerCase()),
+    );
   }
 
   @Watch('currentSortOption')

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -96,6 +96,7 @@
                   :items="solvedProblems"
                   :items-per-page="30"
                   :title="T.profileSolvedProblems"
+                  :should-show-filter-input="true"
                   class="mb-3"
                 ></omegaup-grid-paginator>
                 <omegaup-grid-paginator

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -1639,6 +1639,7 @@
 	"userOrMailNotFound": "Account name or email not found.",
 	"userPasswordMustBeSame": "The new passwords must be the same.",
 	"userProfileIsPrivate": "This account's profile is marked private; some information will not be displayed",
+	"userProfileProblemsFilter": "Filter",
 	"userRankEmptyList": "There is not data to show in the ranking",
 	"userRankOfTheMonthHeader": "%(count) coders with the most points in the month",
 	"userRankSolvedProblemsHelp": "The number of solved problems is updated once a day.",

--- a/frontend/www/js/omegaup/lang.en.ts
+++ b/frontend/www/js/omegaup/lang.en.ts
@@ -1640,6 +1640,7 @@ const translations: { [key: string]: string; } = {
   userOrMailNotFound: "Account name or email not found.",
   userPasswordMustBeSame: "The new passwords must be the same.",
   userProfileIsPrivate: "This account's profile is marked private; some information will not be displayed",
+  userProfileProblemsFilter: "Filter",
   userRankEmptyList: "There is not data to show in the ranking",
   userRankOfTheMonthHeader: "%(count) coders with the most points in the month",
   userRankSolvedProblemsHelp: "The number of solved problems is updated once a day.",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -1639,6 +1639,7 @@
 	"userOrMailNotFound": "Nombre de cuenta o correo electr\u00f3nico no encontrado",
 	"userPasswordMustBeSame": "Los passwords nuevos deben ser iguales.",
 	"userProfileIsPrivate": "El perfil de esta cuenta est\u00e1 marcado como privado; alguna informaci\u00f3n no se mostrar\u00e1",
+	"userProfileProblemsFilter": "Filtrar",
 	"userRankEmptyList": "No hay datos que mostrar en el ranking",
 	"userRankOfTheMonthHeader": "%(count) coders con mayor puntaje del mes",
 	"userRankSolvedProblemsHelp": "El n\u00famero de problemas resueltos se actualiza una vez al d\u00eda.",

--- a/frontend/www/js/omegaup/lang.es.ts
+++ b/frontend/www/js/omegaup/lang.es.ts
@@ -1640,6 +1640,7 @@ const translations: { [key: string]: string; } = {
   userOrMailNotFound: "Nombre de cuenta o correo electr\u00f3nico no encontrado",
   userPasswordMustBeSame: "Los passwords nuevos deben ser iguales.",
   userProfileIsPrivate: "El perfil de esta cuenta est\u00e1 marcado como privado; alguna informaci\u00f3n no se mostrar\u00e1",
+  userProfileProblemsFilter: "Filtrar",
   userRankEmptyList: "No hay datos que mostrar en el ranking",
   userRankOfTheMonthHeader: "%(count) coders con mayor puntaje del mes",
   userRankSolvedProblemsHelp: "El n\u00famero de problemas resueltos se actualiza una vez al d\u00eda.",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -1639,6 +1639,7 @@
 	"userOrMailNotFound": "(Acc0un7 nam3 0r 3mai1 n07 f0und.)",
 	"userPasswordMustBeSame": "(Th3 n3w pa55w0rd5 mu57 b3 7h3 5am3.)",
 	"userProfileIsPrivate": "(Thi5 acc0un7'5 pr0fi13 i5 mark3d priva73; 50m3 inf0rma7i0n wi11 n07 b3 di5p1ay3d)",
+	"userProfileProblemsFilter": "(Fi173r)",
 	"userRankEmptyList": "(Th3r3 i5 n07 da7a 70 5h0w in 7h3 ranking)",
 	"userRankOfTheMonthHeader": "(%(count) c0d3r5 wi7h 7h3 m057 p0in75 in 7h3 m0n7h)",
 	"userRankSolvedProblemsHelp": "(Th3 numb3r 0f 501v3d pr0b13m5 i5 upda73d 0nc3 a day.)",

--- a/frontend/www/js/omegaup/lang.pseudo.ts
+++ b/frontend/www/js/omegaup/lang.pseudo.ts
@@ -1640,6 +1640,7 @@ const translations: { [key: string]: string; } = {
   userOrMailNotFound: "(Acc0un7 nam3 0r 3mai1 n07 f0und.)",
   userPasswordMustBeSame: "(Th3 n3w pa55w0rd5 mu57 b3 7h3 5am3.)",
   userProfileIsPrivate: "(Thi5 acc0un7'5 pr0fi13 i5 mark3d priva73; 50m3 inf0rma7i0n wi11 n07 b3 di5p1ay3d)",
+  userProfileProblemsFilter: "(Fi173r)",
   userRankEmptyList: "(Th3r3 i5 n07 da7a 70 5h0w in 7h3 ranking)",
   userRankOfTheMonthHeader: "(%(count) c0d3r5 wi7h 7h3 m057 p0in75 in 7h3 m0n7h)",
   userRankSolvedProblemsHelp: "(Th3 numb3r 0f 501v3d pr0b13m5 i5 upda73d 0nc3 a day.)",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -1639,6 +1639,7 @@
 	"userOrMailNotFound": "Nome da conta ou e-mail n\u00e3o encontrado",
 	"userPasswordMustBeSame": "As novas senhas devem ser as mesmas.",
 	"userProfileIsPrivate": "O perfil desta conta \u00e9 marcado como privado; algumas informa\u00e7\u00f5es n\u00e3o ser\u00e3o exibidas",
+	"userProfileProblemsFilter": "Filtrar",
 	"userRankEmptyList": "N\u00e3o h\u00e1 dados para mostrar no ranking",
 	"userRankOfTheMonthHeader": "%(count) coders com maior pontua\u00e7\u00e3o do m\u00eas",
 	"userRankSolvedProblemsHelp": "O n\u00famero de problemas resolvidos \u00e9 atualizado uma vez por dia.",

--- a/frontend/www/js/omegaup/lang.pt.ts
+++ b/frontend/www/js/omegaup/lang.pt.ts
@@ -1640,6 +1640,7 @@ const translations: { [key: string]: string; } = {
   userOrMailNotFound: "Nome da conta ou e-mail n\u00e3o encontrado",
   userPasswordMustBeSame: "As novas senhas devem ser as mesmas.",
   userProfileIsPrivate: "O perfil desta conta \u00e9 marcado como privado; algumas informa\u00e7\u00f5es n\u00e3o ser\u00e3o exibidas",
+  userProfileProblemsFilter: "Filtrar",
   userRankEmptyList: "N\u00e3o h\u00e1 dados para mostrar no ranking",
   userRankOfTheMonthHeader: "%(count) coders com maior pontua\u00e7\u00e3o do m\u00eas",
   userRankSolvedProblemsHelp: "O n\u00famero de problemas resolvidos \u00e9 atualizado uma vez por dia.",


### PR DESCRIPTION
# Descripción

Se agrega un campo de búsqueda para filtrar problemas en la vista de perfil de
usuario. Esto permitirá a los creadores de concursos saber si un usuario ya 
resolvió los problemas que se agregarán en dicho concurso.

![SearchProblemsInUserProfile](https://github.com/omegaup/omegaup/assets/3230352/0a471132-8b3e-4414-8669-23273cf6007f)


Fixes: #3397 

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [ ] Si se está agregando funcionalidad nueva, se agregaron pruebas.