### PR TITLE
Agregando el campo de certificate_id en la tabla de Coder del mes

### DIFF
--- a/frontend/database/00223_add_certificate_id_in_coder_of_the_month_table.sql
+++ b/frontend/database/00223_add_certificate_id_in_coder_of_the_month_table.sql
@@ -4,3 +4,4 @@ ALTER TABLE `Coder_Of_The_Month`
   ADD COLUMN `certificate_id` int DEFAULT NULL COMMENT 'Id del certificado que pertenece al Coder del mes',
   ADD KEY `certificate_id` (`certificate_id`),
   ADD CONSTRAINT `fk_cotmc_certificate_id` FOREIGN KEY (`certificate_id`) REFERENCES `Certificates` (`certificate_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+  

--- a/frontend/database/00223_add_certificate_id_in_coder_of_the_month_table.sql
+++ b/frontend/database/00223_add_certificate_id_in_coder_of_the_month_table.sql
@@ -1,0 +1,6 @@
+
+-- Add certificate_id column
+ALTER TABLE `Coder_Of_The_Month`
+  ADD COLUMN `certificate_id` int DEFAULT NULL COMMENT 'Id del certificado que pertenece al Coder del mes',
+  ADD KEY `certificate_id` (`certificate_id`),
+  ADD CONSTRAINT `fk_cotmc_certificate_id` FOREIGN KEY (`certificate_id`) REFERENCES `Certificates` (`certificate_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/database/00223_add_certificate_id_in_coder_of_the_month_table.sql
+++ b/frontend/database/00223_add_certificate_id_in_coder_of_the_month_table.sql
@@ -1,7 +1,0 @@
-
--- Add certificate_id column
-ALTER TABLE `Coder_Of_The_Month`
-  ADD COLUMN `certificate_id` int DEFAULT NULL COMMENT 'Id del certificado que pertenece al Coder del mes',
-  ADD KEY `certificate_id` (`certificate_id`),
-  ADD CONSTRAINT `fk_cotmc_certificate_id` FOREIGN KEY (`certificate_id`) REFERENCES `Certificates` (`certificate_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
-  

--- a/frontend/database/00223_link_certificates_and_coder_of_the_month.sql
+++ b/frontend/database/00223_link_certificates_and_coder_of_the_month.sql
@@ -1,0 +1,6 @@
+
+-- Add coder_of_the_month_id column in Certificates table
+ALTER TABLE `Certificates`
+  ADD COLUMN `coder_of_the_month_id` int DEFAULT NULL COMMENT 'Id del Coder del mes que obtuvo el certificado' AFTER `contest_id`,
+  ADD KEY `coder_of_the_month_id` (`coder_of_the_month_id`),
+  ADD CONSTRAINT `fk_ccotm_coder_of_the_month_id` FOREIGN KEY (`coder_of_the_month_id`) REFERENCES `Coder_Of_The_Month` (`coder_of_the_month_id`) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -145,13 +145,16 @@ CREATE TABLE `Coder_Of_The_Month` (
   `score` double NOT NULL DEFAULT '0',
   `problems_solved` int NOT NULL DEFAULT '0',
   `certificate_status` enum('uninitiated','queued','generated','retryable_error','fatal_error') NOT NULL DEFAULT 'uninitiated' COMMENT 'Estado de la petición de generar diplomas',
+  `certificate_id` int DEFAULT NULL COMMENT 'Id del certificado que pertenece al Coder del mes',
   PRIMARY KEY (`coder_of_the_month_id`),
   KEY `coder_of_the_month_id` (`coder_of_the_month_id`),
   KEY `fk_cotmu_user_id` (`user_id`),
   KEY `selected_by` (`selected_by`),
   KEY `school_id` (`school_id`),
   KEY `rank_time_category` (`category`,`ranking`,`time`),
+  KEY `certificate_id` (`certificate_id`),
   CONSTRAINT `fk_coms_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`),
+  CONSTRAINT `fk_cotmc_certificate_id` FOREIGN KEY (`certificate_id`) REFERENCES `Certificates` (`certificate_id`),
   CONSTRAINT `fk_cotmi_identity_id` FOREIGN KEY (`selected_by`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_cotmu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Guardar histórico de coders del mes de forma sencilla.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE `Certificates` (
   `certificate_type` enum('course','contest','coder_of_the_month','coder_of_the_month_female') NOT NULL COMMENT 'Tipo de diploma',
   `course_id` int DEFAULT NULL,
   `contest_id` int DEFAULT NULL,
+  `coder_of_the_month_id` int DEFAULT NULL COMMENT 'Id del Coder del mes que obtuvo el certificado',
   `verification_code` varchar(10) NOT NULL COMMENT 'Código de verificación del diploma',
   `contest_place` int DEFAULT NULL COMMENT 'Se guarda el lugar en el que quedo un estudiante si es menor o igual a certificate_cutoff',
   PRIMARY KEY (`certificate_id`),
@@ -102,8 +103,10 @@ CREATE TABLE `Certificates` (
   KEY `identity_id` (`identity_id`),
   KEY `course_id` (`course_id`),
   KEY `contest_id` (`contest_id`),
+  KEY `coder_of_the_month_id` (`coder_of_the_month_id`),
   CONSTRAINT `fk_cc_contest_id` FOREIGN KEY (`contest_id`) REFERENCES `Contests` (`contest_id`),
   CONSTRAINT `fk_cc_course_id` FOREIGN KEY (`course_id`) REFERENCES `Courses` (`course_id`),
+  CONSTRAINT `fk_ccotm_coder_of_the_month_id` FOREIGN KEY (`coder_of_the_month_id`) REFERENCES `Coder_Of_The_Month` (`coder_of_the_month_id`),
   CONSTRAINT `fk_ci_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Diplomas';
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -145,16 +148,13 @@ CREATE TABLE `Coder_Of_The_Month` (
   `score` double NOT NULL DEFAULT '0',
   `problems_solved` int NOT NULL DEFAULT '0',
   `certificate_status` enum('uninitiated','queued','generated','retryable_error','fatal_error') NOT NULL DEFAULT 'uninitiated' COMMENT 'Estado de la petición de generar diplomas',
-  `certificate_id` int DEFAULT NULL COMMENT 'Id del certificado que pertenece al Coder del mes',
   PRIMARY KEY (`coder_of_the_month_id`),
   KEY `coder_of_the_month_id` (`coder_of_the_month_id`),
   KEY `fk_cotmu_user_id` (`user_id`),
   KEY `selected_by` (`selected_by`),
   KEY `school_id` (`school_id`),
   KEY `rank_time_category` (`category`,`ranking`,`time`),
-  KEY `certificate_id` (`certificate_id`),
   CONSTRAINT `fk_coms_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`),
-  CONSTRAINT `fk_cotmc_certificate_id` FOREIGN KEY (`certificate_id`) REFERENCES `Certificates` (`certificate_id`),
   CONSTRAINT `fk_cotmi_identity_id` FOREIGN KEY (`selected_by`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_cotmu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Guardar histórico de coders del mes de forma sencilla.';


### PR DESCRIPTION
# Descripción

Se agrega el campo de `certificate_id` en la tabla de `Coder_Of_The_month`,
este campo servirá para ligar al certificado con el ganador a coder del mes.

Aunque ya existe el campo de `identity_id` en la tabla `Certificates`, esto 
podría llegar a fallar en el momento que el mismo usuario gane dos veces 
este distintivo. Recordemos que puede esperar un año para volver a ganarlo.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
