### PR TITLE
Mejorando la forma de agregar problemas a concursos en las pruebas de Cypress

### DIFF
--- a/cypress/e2e/basic_commands.cy.ts
+++ b/cypress/e2e/basic_commands.cy.ts
@@ -105,7 +105,7 @@ describe('Basic Commands Test', () => {
     const contestOptions = contestPage.generateContestOptions(loginOptions[0]);
     const users = [loginOptions[1].username];
 
-    loginPage.giveAdminPrivilage(
+    loginPage.giveAdminPrivilege(
       'GroupIdentityCreator',
       loginOptions[0].username,
     );

--- a/cypress/e2e/contest.cy.ts
+++ b/cypress/e2e/contest.cy.ts
@@ -70,7 +70,7 @@ describe('Contest Test', () => {
       password: '12345678',
     };
 
-    loginPage.giveAdminPrivilage(
+    loginPage.giveAdminPrivilege(
       'GroupIdentityCreator',
       loginOptions[0].username,
     );
@@ -156,7 +156,7 @@ describe('Contest Test', () => {
       groupDescription: 'group description',
     };
 
-    loginPage.giveAdminPrivilage(
+    loginPage.giveAdminPrivilege(
       'GroupIdentityCreator',
       userLoginOptions[0].username,
     );
@@ -225,7 +225,7 @@ describe('Contest Test', () => {
       groupDescription: 'group description',
     };
 
-    loginPage.giveAdminPrivilage(
+    loginPage.giveAdminPrivilege(
       'GroupIdentityCreator',
       userLoginOptions[4].username,
     );

--- a/cypress/e2e/group.cy.ts
+++ b/cypress/e2e/group.cy.ts
@@ -18,7 +18,7 @@ describe('Group Test', () => {
       groupDescription: 'group description',
     };
 
-    loginPage.giveAdminPrivilage(
+    loginPage.giveAdminPrivilege(
       'GroupIdentityCreator',
       loginOptions[0].username,
     );
@@ -37,7 +37,7 @@ describe('Group Test', () => {
       noOfContestants: '2',
     };
 
-    loginPage.giveAdminPrivilage(
+    loginPage.giveAdminPrivilege(
       'GroupIdentityCreator',
       loginOptions[0].username,
     );

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -267,17 +267,18 @@ Cypress.Commands.add(
     contestAlias,
     problems,
     runs,
+    statusCheck = false,
   }) => {
-    const problem = problems[0];
-    if (!problem) {
-      return;
-    }
-    cy.visit(`/arena/${contestAlias}/#problems`);
-    cy.get(`a[data-problem="${problem.problemAlias}"]`).click();
-
     for (const idx in runs) {
+      const problem = problems[idx];
+      if (!problem) {
+        return;
+      }
+      cy.visit(`/arena/${contestAlias}/#problems`);
+      cy.get(`a[data-problem="${problem.problemAlias}"]`).click();
+
       // Mocking date just a few seconds after to allow create new run
-      cy.clock(new Date(), ['Date']).then((clock) => clock.tick(3000));
+      cy.clock(new Date(), ['Date']).then((clock) => clock.tick(9000));
       cy.get('[data-new-run]').click();
       cy.get('[name="language"]').select(runs[idx].language);
 
@@ -295,6 +296,9 @@ Cypress.Commands.add(
         cy.get('[data-submit-run]').click();
       });
 
+      if (statusCheck) {
+        continue;
+      }
       const expectedStatus: Status = runs[idx].status;
       cy.intercept({ method: 'POST', url: '/api/run/status/' }).as('runStatus');
 
@@ -304,6 +308,7 @@ Cypress.Commands.add(
       cy.get('[data-run-status] > span')
         .first()
         .should('have.text', expectedStatus);
+      statusCheck = true;
     }
   },
 );

--- a/cypress/support/pageObjects/loginPage.ts
+++ b/cypress/support/pageObjects/loginPage.ts
@@ -19,7 +19,7 @@ export class LoginPage {
     return users;
   }
 
-  giveAdminPrivilage(roleName: string, user: string) {
+  giveAdminPrivilege(roleName: string, user: string) {
     cy.loginAdmin();
     const userAdminUrl = '/admin/user/' + user;
     cy.visit(userAdminUrl);

--- a/cypress/support/types.d.ts
+++ b/cypress/support/types.d.ts
@@ -85,6 +85,7 @@ export interface ContestOptions {
   admissionMode: AdmissionModeOptions;
   problems: Array<ProblemOptions>;
   runs: Array<RunOptions>;
+  statusCheck?: boolean;
 }
 
 export interface RunOptions {


### PR DESCRIPTION
# Descripción

En el PR #7359 será necesario crear una prueba en Cypress donde se pueda
realizar la descalificación de envíos en masa, pero actualmente la función que
crea concursos tiene por defecto la creación de un sólo problema.

Así que en este cambio se permite recibir el parámetro con el número de
problemas que se requiren en un concurso, además de los cambios 
necesarios para que se agreguen.

Part of: #7354 

# Comentarios

También se arregló un typo

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.
- [x] Si se está agregando funcionalidad nueva, se agregaron pruebas.
- [x] Si el cambio es grande (> 200 líneas), hay que intentar partirlo en
      varios pull requests. De preferencia uno para los controladores + phpunit
      y luego otro para la interfaz.
