### PR TITLE
Actualizando el archivo dao_schema con el campo nuevo de cotm_id en certificados

### DIFF
--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE `Certificates` (
   `certificate_type` enum('course','contest','coder_of_the_month','coder_of_the_month_female') NOT NULL COMMENT 'Tipo de diploma',
   `course_id` int DEFAULT NULL,
   `contest_id` int DEFAULT NULL,
+  `coder_of_the_month_id` int DEFAULT NULL COMMENT 'Id del Coder del mes que obtuvo el certificado',
   `verification_code` varchar(10) NOT NULL COMMENT 'Código de verificación del diploma',
   `contest_place` int DEFAULT NULL COMMENT 'Se guarda el lugar en el que quedo un estudiante si es menor o igual a certificate_cutoff',
   PRIMARY KEY (`certificate_id`),
@@ -102,8 +103,10 @@ CREATE TABLE `Certificates` (
   KEY `identity_id` (`identity_id`),
   KEY `course_id` (`course_id`),
   KEY `contest_id` (`contest_id`),
+  KEY `coder_of_the_month_id` (`coder_of_the_month_id`),
   CONSTRAINT `fk_cc_contest_id` FOREIGN KEY (`contest_id`) REFERENCES `Contests` (`contest_id`),
   CONSTRAINT `fk_cc_course_id` FOREIGN KEY (`course_id`) REFERENCES `Courses` (`course_id`),
+  CONSTRAINT `fk_ccotm_coder_of_the_month_id` FOREIGN KEY (`coder_of_the_month_id`) REFERENCES `Coder_Of_The_Month` (`coder_of_the_month_id`),
   CONSTRAINT `fk_ci_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Diplomas';
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/frontend/server/src/DAO/Base/Certificates.php
+++ b/frontend/server/src/DAO/Base/Certificates.php
@@ -37,6 +37,7 @@ abstract class Certificates {
                 `certificate_type` = ?,
                 `course_id` = ?,
                 `contest_id` = ?,
+                `coder_of_the_month_id` = ?,
                 `verification_code` = ?,
                 `contest_place` = ?
             WHERE
@@ -62,6 +63,11 @@ abstract class Certificates {
                 is_null($Certificates->contest_id) ?
                 null :
                 intval($Certificates->contest_id)
+            ),
+            (
+                is_null($Certificates->coder_of_the_month_id) ?
+                null :
+                intval($Certificates->coder_of_the_month_id)
             ),
             $Certificates->verification_code,
             (
@@ -96,6 +102,7 @@ abstract class Certificates {
                 `Certificates`.`certificate_type`,
                 `Certificates`.`course_id`,
                 `Certificates`.`contest_id`,
+                `Certificates`.`coder_of_the_month_id`,
                 `Certificates`.`verification_code`,
                 `Certificates`.`contest_place`
             FROM
@@ -214,6 +221,7 @@ abstract class Certificates {
                 `Certificates`.`certificate_type`,
                 `Certificates`.`course_id`,
                 `Certificates`.`contest_id`,
+                `Certificates`.`coder_of_the_month_id`,
                 `Certificates`.`verification_code`,
                 `Certificates`.`contest_place`
             FROM
@@ -271,9 +279,11 @@ abstract class Certificates {
                     `certificate_type`,
                     `course_id`,
                     `contest_id`,
+                    `coder_of_the_month_id`,
                     `verification_code`,
                     `contest_place`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -301,6 +311,11 @@ abstract class Certificates {
                 is_null($Certificates->contest_id) ?
                 null :
                 intval($Certificates->contest_id)
+            ),
+            (
+                is_null($Certificates->coder_of_the_month_id) ?
+                null :
+                intval($Certificates->coder_of_the_month_id)
             ),
             $Certificates->verification_code,
             (

--- a/frontend/server/src/DAO/VO/Certificates.php
+++ b/frontend/server/src/DAO/VO/Certificates.php
@@ -22,6 +22,7 @@ class Certificates extends \OmegaUp\DAO\VO\VO {
         'certificate_type' => true,
         'course_id' => true,
         'contest_id' => true,
+        'coder_of_the_month_id' => true,
         'verification_code' => true,
         'contest_place' => true,
     ];
@@ -74,6 +75,11 @@ class Certificates extends \OmegaUp\DAO\VO\VO {
         if (isset($data['contest_id'])) {
             $this->contest_id = intval(
                 $data['contest_id']
+            );
+        }
+        if (isset($data['coder_of_the_month_id'])) {
+            $this->coder_of_the_month_id = intval(
+                $data['coder_of_the_month_id']
             );
         }
         if (isset($data['verification_code'])) {
@@ -131,6 +137,13 @@ class Certificates extends \OmegaUp\DAO\VO\VO {
      * @var int|null
      */
     public $contest_id = null;
+
+    /**
+     * Id del Coder del mes que obtuvo el certificado
+     *
+     * @var int|null
+     */
+    public $coder_of_the_month_id = null;
 
     /**
      * Código de verificación del diploma


### PR DESCRIPTION
# Descripción

Se actualiza el archivo `dao_schema.sql` con los últimos cambios en la base de 
datos.

# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.