### PR TITLE
Refactor: Aplica patrón de stringOfLengthInRange y mejora el mensaje

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -5914,12 +5914,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
             ];
             return $response;
         }
-        if (!\OmegaUp\Validators::alias($name)) {
+        try {
+            \OmegaUp\Validators::alias($name);
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
             $response['templateProperties']['payload']['error'] = [
-                'description' => \OmegaUp\Translations::getInstance()->get(
-                    'parameterInvalidAlias'
-                ),
-                'field' => 'name',
+                'description' => $e->getErrorMessage(),
+                'field' => $e->parameter,
             ];
             return $response;
         }

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -215,17 +215,32 @@ class Validators {
     /**
      * Returns whether the alias is valid.
      *
-     * @return boolean
+     * @param string $alias the alias to validate
+     * @param int $maxLength the maximum length of the alias
+     *
+     * @return boolean true if the alias is valid, false otherwise
+     * @throws \OmegaUp\Exceptions\InvalidParameterException if the alias is invalid
      */
     public static function alias(
         string $alias,
         int $maxLength = Validators::ALIAS_MAX_LENGTH
     ): bool {
-        return (
-            preg_match('/^[a-zA-Z0-9_-]+$/', $alias) === 1
-            && !self::isRestrictedAlias($alias)
-            && strlen($alias) <= $maxLength
-        );
+        if (!preg_match('/^[a-zA-Z0-9_-]+$/', $alias)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'alias'
+            );
+        }
+
+        if (strlen($alias) > $maxLength) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterStringTooLong',
+                'alias',
+                ['max_length' => strval($maxLength)]
+            );
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
# Descripción

Se mantuvo el mensaje de error para mantener la claridad, pero se implementó la función `alias` de manera diferente en **Validators.php**, siguiendo el patrón de la función `stringOfLengthInRange` y utilizando `throw error` en lugar de simplemente devolver False. Además, se modificó el bloque de código en **Problem.php** para que maneje correctamente la respuesta de `alias`.

Fixes: [#1113](https://github.com/omegaup/omegaup/issues/1113)

![OmegaUp Contest](https://cdn.discordapp.com/attachments/1160427026839257133/1206113301558333531/Screenshot_2024-02-10_at_9.33.08_PM.png?ex=65dad38b&is=65c85e8b&hm=d9dd91eb9feabb6906e84d56c3e3a75445c7bd6a00bec1457858488b28c1681f&)


# Comentarios

Se realizaron cambios en los siguientes archivos:

- **omegaup/frontend/server/src/Validators.php**
- **omegaup/frontend/server/src/Controllers/Problem.php**


# Checklist:

- [x] El código sigue la [guía de estilo](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) de omegaUp.
- [x] Se corrieron todas las pruebas y pasaron.