### PR TITLE
Permitiendo que las identidades creadas en batch puedan realizar envíos

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4696,7 +4696,6 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         if (
             is_null($r->identity)
-            || is_null($r->identity->user_id)
             || is_null($problem->problem_id)
         ) {
             return $response;

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -22,7 +22,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
      */
     public static function getNominationStatusForProblem(
         int $problemId,
-        int $userId
+        ?int $userId
     ): array {
         $response = [
             'nominated' => false,
@@ -30,6 +30,10 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             'nominatedBeforeAc' => false,
             'dismissedBeforeAc' => false,
         ];
+
+        if (is_null($userId)) {
+            return $response;
+        }
 
         $sql = "SELECT
                     qnn.contents


### PR DESCRIPTION
# Description

Se arregla bug para que las identidades creadas en batch puedan realizar 
envíos de problemas.

Resulta que en la vista de detalles del problema existía una validación donde
las identidades que no contaban con un `user_id` mandaran el valor de `false`
a `isLoggedUser`, cosa que estaba mal.

![IdentitiesNewSubmission](https://github.com/omegaup/omegaup/assets/3230352/84758ed0-5b98-426b-96e5-012715a1ab16)


Fixes: #7454 


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
