### PR TITLE
Fix #7471, adding spacing between Icons

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestCard.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestCard.vue
@@ -16,9 +16,9 @@
           </b-card-text>
         </b-col>
         <b-col class="col-md-3 col-sm-12 p-1 text-center">
-          <b-card-text>
+          <b-card-text class="d-flex justify-content-center align-items-center">
             <font-awesome-icon class="mr-1" icon="clipboard-list" />
-            {{ contest.organizer }}
+            <p class="m-0">{{ contest.organizer }}</p>
           </b-card-text>
         </b-col>
 
@@ -28,9 +28,10 @@
               ref="contestButtonScoreboard"
               :href="getContestScoreboardURL(contest.alias)"
               variant="success"
+              class="d-flex justify-content-center align-items-center"
             >
               <font-awesome-icon class="mr-1" icon="table" />
-              {{ T.contestButtonScoreboard }}
+              <p class="m-0">{{ T.contestButtonScoreboard }}</p>
             </b-button>
           </slot>
 
@@ -39,10 +40,10 @@
               <b-card-text
                 v-if="contest.participating"
                 ref="contestEnrollStatus"
-                class="contest-enroll-status"
+                class="contest-enroll-status d-flex justify-content-center align-items-center"
               >
                 <font-awesome-icon class="mr-1" icon="clipboard-check" />
-                {{ T.contestEnrollStatus }}
+                <p class="m-0">{{ T.contestEnrollStatus }}</p>
               </b-card-text>
             </slot>
           </div>
@@ -53,13 +54,13 @@
           <slot name="text-contest-date"></slot>
         </b-col>
         <b-col class="col-md-3 col-sm-12 p-1 text-center">
-          <b-card-text>
+          <b-card-text class="d-flex justify-content-center align-items-center">
             <font-awesome-icon class="mr-1" icon="stopwatch" />
-            {{
+            <p class="m-0">{{
               ui.formatString(T.contestDuration, {
                 duration: contestDuration,
               })
-            }}
+            }}</p>
           </b-card-text>
         </b-col>
         <b-col
@@ -67,9 +68,9 @@
         >
           <div class="d-flex align-items-center justify-content-center">
             <slot>
-              <b-card-text class="mr-3 m-0">
-                <font-awesome-icon icon="users" />
-                {{ contest.contestants }}
+              <b-card-text class="mr-3 m-0 d-flex justify-content-center align-items-center">
+                <font-awesome-icon icon="users" class="m-1"/>
+                <p class="m-0">{{ contest.contestants }}</p>
               </b-card-text>
             </slot>
             <slot name="contest-button-enter">
@@ -78,10 +79,10 @@
                 ref="contestButtonEnter"
                 :href="getContestURL(contest.alias)"
                 variant="primary"
-                class="button-style"
+                class="button-style d-flex justify-content-center align-items-center"
               >
                 <font-awesome-icon class="mr-1" icon="sign-in-alt" />
-                {{ T.contestButtonEnter }}
+                <p class="m-0">{{ T.contestButtonEnter }}</p>
               </b-button>
             </slot>
             <slot name="contest-button-see-details">
@@ -92,16 +93,16 @@
                 variant="primary"
                 class="text-center"
               >
-                <font-awesome-icon class="mr-1" icon="sign-in-alt" />
-                {{ T.contestButtonSeeDetails }}
+                <font-awesome-icon class="mr-1 d-flex justify-content-center align-items-center" icon="sign-in-alt" />
+                <p class="m-0">{{ T.contestButtonSeeDetails }}</p>
               </b-button>
             </slot>
           </div>
           <slot name="contest-dropdown">
             <b-dropdown variant="primary">
               <template #button-content>
-                <font-awesome-icon class="mr-1" icon="sign-in-alt" />
-                {{ T.contestButtonEnter }}
+                <font-awesome-icon class="mr-1 d-flex justify-content-center align-items-center" icon="sign-in-alt" />
+                <p class="m-0">{{ T.contestButtonEnter }}</p>
               </template>
               <b-dropdown-item :href="getVirtualContestURL(contest.alias)">{{
                 T.contestVirtualMode


### PR DESCRIPTION
# Description #7471 

## The cause of this bug
Because the previous code is as follows:
```jsx
<b-col class="col-md-3 col-sm-12 p-1 text-center">
   <b-card-text>
       <font-awesome-icon class="mr-1" icon="clipboard-list" />
       {{ contest.organizer }}
       </b-card-text>
</b-col>
```
it will cause a space between icon and text like that:
<img width="1201" alt="image" src="https://github.com/omegaup/omegaup/assets/6525061/e6b6996b-8b8c-42d3-b1ad-fe2f96ee37f6">
which is not expected and may cause unpredictable problems.

A better way to handle this, is wrap text with p tag and using flex-box to style this component. Thus I change this codeblock as follows:
```jsx
<b-col class="col-md-3 col-sm-12 p-1 text-center">
  <b-card-text class="d-flex justify-content-center align-items-center">
    <font-awesome-icon class="mr-1" icon="clipboard-list" />
    <p class="m-0">{{ contest.organizer }}</p>
  </b-card-text>
</b-col>
```
And the final display as we want:
<img width="963" alt="image" src="https://github.com/omegaup/omegaup/assets/6525061/e7dbf2ae-635b-4f76-9d56-66ca6aef62e2">

# ref
[Paragraphs, Lines, and Phrases](https://www.w3.org/TR/REC-html40/struct/text.html#h-9.1)