### PR TITLE
Fix scoreboard overflow UI issue

### DIFF
--- a/cypress/e2e/contest.cy.ts
+++ b/cypress/e2e/contest.cy.ts
@@ -119,7 +119,7 @@ describe('Contest Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 1);
-    cy.get(`.${userLoginOptions[0].username} > td:nth-child(4)`).should(
+    cy.get(`.${userLoginOptions[0].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -358,11 +358,11 @@ describe('Contest Test', () => {
       cy.get('a[href="#ranking"]').click();
       cy.get('[data-table-scoreboard]').should('be.visible');
       cy.get('[data-table-scoreboard-username]').should('have.length', 2);
-      cy.get(`.${userLoginOptions[0].username} > td:nth-child(4)`).should(
+      cy.get(`.${userLoginOptions[0].username} > td:nth-child(5)`).should(
         'contain',
         '+100.00',
       );
-      cy.get(`.${userLoginOptions[1].username} > td:nth-child(4)`).should(
+      cy.get(`.${userLoginOptions[1].username} > td:nth-child(5)`).should(
         'contain',
         '-',
       );
@@ -388,7 +388,7 @@ describe('Contest Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 1);
-    cy.get(`.${userLoginOptions[0].username} > td:nth-child(4)`).should(
+    cy.get(`.${userLoginOptions[0].username} > td:nth-child(5)`).should(
       'contain',
       '0.00',
     );
@@ -426,7 +426,7 @@ describe('Contest Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 2);
-    cy.get(`.${userLoginOptions[0].username} > td:nth-child(4)`).should(
+    cy.get(`.${userLoginOptions[0].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );

--- a/cypress/e2e/course.cy.ts
+++ b/cypress/e2e/course.cy.ts
@@ -86,7 +86,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 3);
-    cy.get(`.${loginOptions[0].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[0].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -99,7 +99,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 3);
-    cy.get(`.${loginOptions[2].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[2].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -112,7 +112,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 3);
-    cy.get(`.${loginOptions[3].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[3].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -121,15 +121,15 @@ describe('Course Test', () => {
     cy.login(loginOptions[1]);
     coursePage.enterCourseAssignmentPage(courseOptions.courseAlias);
     cy.get('[data-course-scoreboard-button]').click();
-    cy.get(`.${loginOptions[0].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[0].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
-    cy.get(`.${loginOptions[2].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[2].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
-    cy.get(`.${loginOptions[3].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[3].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -297,7 +297,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 2);
-    cy.get(`.${loginOptions[1].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[1].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -311,7 +311,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 2);
-    cy.get(`.${loginOptions[2].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[2].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -320,11 +320,11 @@ describe('Course Test', () => {
     cy.login(loginOptions[0]);
     coursePage.enterCourseAssignmentPage(courseOptions.courseAlias);
     cy.get('[data-course-scoreboard-button]').click();
-    cy.get(`.${loginOptions[1].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[1].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
-    cy.get(`.${loginOptions[2].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[2].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -369,7 +369,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 2);
-    cy.get(`.${loginOptions[1].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[1].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );
@@ -384,7 +384,7 @@ describe('Course Test', () => {
     cy.get('a[href="#ranking"]').click();
     cy.get('[data-table-scoreboard]').should('be.visible');
     cy.get('[data-table-scoreboard-username]').should('have.length', 2);
-    cy.get(`.${loginOptions[2].username} > td:nth-child(4)`).should(
+    cy.get(`.${loginOptions[2].username} > td:nth-child(5)`).should(
       'contain',
       '+100.00',
     );

--- a/frontend/www/js/omegaup/components/arena/Scoreboard.vue
+++ b/frontend/www/js/omegaup/components/arena/Scoreboard.vue
@@ -56,12 +56,12 @@
             <th><!-- legend --></th>
             <th><!-- position --></th>
             <th>{{ T.contestParticipant }}</th>
+            <th>{{ T.wordsTotal }}</th>
             <th v-for="(problem, index) in problems" :key="problem.alias">
               <a :href="'#problems/' + problem.alias" :title="problem.alias">{{
                 ui.columnName(index)
               }}</a>
             </th>
-            <th :colspan="2 + problems.length">{{ T.wordsTotal }}</th>
           </tr>
         </thead>
         <tbody>
@@ -86,6 +86,14 @@
                   width="16"
                 />
               </td>
+              <td>
+                <div class="points">
+                  {{ user.total.points.toFixed(digitsAfterDecimalPoint) }}
+                </div>
+                <div class="penalty">
+                  {{ user.total.penalty }} ({{ totalRuns(user) }})
+                </div>
+              </td>
 
               <td
                 v-for="(problem, problemIndex) in user.problems"
@@ -103,14 +111,6 @@
                   </div>
                 </template>
                 <template v-else> - </template>
-              </td>
-              <td>
-                <div class="points">
-                  {{ user.total.points.toFixed(digitsAfterDecimalPoint) }}
-                </div>
-                <div class="penalty">
-                  {{ user.total.penalty }} ({{ totalRuns(user) }})
-                </div>
               </td>
             </tr>
           </template>
@@ -232,7 +232,6 @@ export default class ArenaScoreboard extends Vue {
 <style lang="scss" scoped>
 @import '../../../../sass/main.scss';
 .omegaup-scoreboard {
-  max-width: 900px;
   margin: 0 auto;
 
   a {
@@ -270,6 +269,12 @@ export default class ArenaScoreboard extends Vue {
     .penalty {
       font-size: 70%;
     }
+  }
+
+  .user {
+    text-wrap: balance;
+    overflow-wrap: break-word;
+    max-width: 200px;
   }
 
   .accepted {


### PR DESCRIPTION
# Description

Modify the scoreboard: show total score first, and wrap user or team names

New layout:
<img width="1386" alt="image" src="https://github.com/omegaup/omegaup/assets/41598384/f08537b6-71b1-4e5d-901c-6405ca841701">


Previous UI:
<img width="1387" alt="image" src="https://github.com/omegaup/omegaup/assets/41598384/257add46-9538-49c5-b5ce-8e76158ced7b">


Fixes: #7180

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
