### PR TITLE
Changed id of messages

### DIFF
--- a/frontend/www/js/omegaup/components/qualitynomination/PromotionPopup.vue
+++ b/frontend/www/js/omegaup/components/qualitynomination/PromotionPopup.vue
@@ -104,21 +104,21 @@ export default class QualityPromotionPopup extends Vue {
   @Prop({ default: false }) tried!: boolean;
   @Prop({
     default: () => [
-      { id: 0, description: T.qualityFormDifficultyVeryEasy },
-      { id: 1, description: T.qualityFormDifficultyEasy },
-      { id: 2, description: T.qualityFormDifficultyMedium },
-      { id: 3, description: T.qualityFormDifficultyHard },
-      { id: 4, description: T.qualityFormDifficultyVeryHard },
+      { id: 1, description: T.qualityFormDifficultyVeryEasy },
+      { id: 2, description: T.qualityFormDifficultyEasy },
+      { id: 3, description: T.qualityFormDifficultyMedium },
+      { id: 4, description: T.qualityFormDifficultyHard },
+      { id: 5, description: T.qualityFormDifficultyVeryHard },
     ],
   })
   difficultyLevels!: DifficultyLevel[];
   @Prop({
     default: () => [
-      { id: 0, description: T.qualityFormQualityVeryBad },
-      { id: 1, description: T.qualityFormQualityBad },
-      { id: 2, description: T.qualityFormQualityFair },
-      { id: 3, description: T.qualityFormQualityGood },
-      { id: 4, description: T.qualityFormQualityVeryGood },
+      { id: 1, description: T.qualityFormQualityVeryBad },
+      { id: 2, description: T.qualityFormQualityBad },
+      { id: 3, description: T.qualityFormQualityFair },
+      { id: 4, description: T.qualityFormQualityGood },
+      { id: 5, description: T.qualityFormQualityVeryGood },
     ],
   })
   qualityLevels!: QualityLevel[];


### PR DESCRIPTION
# Description

Changed the id of review messages to start from 1 instead of 0. This gives the correct boolean value which is used for disabling the submit review button.

![Screenshot 2024-03-24 180411](https://github.com/omegaup/omegaup/assets/67920373/e53f213a-1aac-4fe2-afc2-a8299135f271)


Fixes: #7515 

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
