### PR TITLE
Modify problem edit page.

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Edit.test.ts
@@ -11,6 +11,7 @@ describe('Edit.vue', () => {
         data: {
           title: 'problem',
           alias: 'problem-alias',
+          initialTab: 'edit',
           timeLimit: 1000,
           extraWallTime: 0,
           memoryLimit: 32768,

--- a/frontend/www/js/omegaup/components/problem/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Edit.test.ts
@@ -11,7 +11,6 @@ describe('Edit.vue', () => {
         data: {
           title: 'problem',
           alias: 'problem-alias',
-          initialTab: 'edit',
           timeLimit: 1000,
           extraWallTime: 0,
           memoryLimit: 32768,
@@ -38,6 +37,7 @@ describe('Edit.vue', () => {
           },
         },
         initialLanguage: 'es',
+        initialTab: 'edit',
       },
     });
 

--- a/frontend/www/js/omegaup/components/problem/Edit.vue
+++ b/frontend/www/js/omegaup/components/problem/Edit.vue
@@ -17,95 +17,90 @@
         >
       </p>
     </div>
-    <ul class="nav nav-pills edit-problem-tabs mb-3">
-      <li class="nav-item dropdown">
+    <ul class="nav nav-pills edit-problem-tabs my-3">
+      <li class="nav-item" role="presentation">
         <a
-          href="#"
-          data-toggle="dropdown"
-          role="button"
-          class="nav-link active dropdown-toggle"
-          aria-haspopup="true"
-          aria-expanded="false"
-          >{{ activeTab }}</a
+          href="#edit"
+          data-tab-edit
+          class="nav-link"
+          :class="{ active: showTab === 'edit' }"
+          @click="showTab = 'edit'"
+          >{{ T.problemEditEditProblem }}</a
         >
-        <div class="dropdown-menu">
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-edit
-            class="dropdown-item"
-            :class="{ active: showTab === 'edit' }"
-            @click="showTab = 'edit'"
-            >{{ T.problemEditEditProblem }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-markdown
-            class="dropdown-item"
-            :class="{ active: showTab === 'markdown' }"
-            @click="showTab = 'markdown'"
-            >{{ T.problemEditEditMarkdown }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-version
-            class="dropdown-item"
-            :class="{ active: showTab === 'version' }"
-            @click="showTab = 'version'"
-            >{{ T.problemEditChooseVersion }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-solution
-            class="dropdown-item"
-            :class="{ active: showTab === 'solution' }"
-            @click="showTab = 'solution'"
-            >{{ T.problemEditSolution }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-admins
-            class="dropdown-item"
-            :class="{ active: showTab === 'admins' }"
-            @click="showTab = 'admins'"
-            >{{ T.problemEditAddAdmin }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-tags
-            class="dropdown-item"
-            :class="{ active: showTab === 'tags' }"
-            @click="showTab = 'tags'"
-            >{{ T.problemEditAddTags }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-download
-            class="dropdown-item"
-            :class="{ active: showTab === 'download' }"
-            @click="showTab = 'download'"
-            >{{ T.wordsDownload }}</a
-          >
-          <a
-            href="#"
-            data-toggle="tab"
-            data-tab-delete
-            class="dropdown-item"
-            :class="{ active: showTab === 'delete' }"
-            @click="showTab = 'delete'"
-            >{{ T.wordsDelete }}</a
-          >
-        </div>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#markdown"
+          data-tab-markdown
+          class="nav-link"
+          :class="{ active: showTab === 'markdown' }"
+          @click="showTab = 'markdown'"
+          >{{ T.problemEditEditMarkdown }}</a
+        >
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#version"
+          data-tab-version
+          class="nav-link"
+          :class="{ active: showTab === 'version' }"
+          @click="showTab = 'version'"
+          >{{ T.problemEditChooseVersion }}</a
+        >
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#solution"
+          data-tab-solution
+          class="nav-link"
+          :class="{ active: showTab === 'solution' }"
+          @click="showTab = 'solution'"
+          >{{ T.problemEditSolution }}</a
+        >
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#admins"
+          data-tab-admins
+          class="nav-link"
+          :class="{ active: showTab === 'admins' }"
+          @click="showTab = 'admins'"
+          >{{ T.problemEditAddAdmin }}</a
+        >
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#tags"
+          data-tab-tags
+          class="nav-link"
+          :class="{ active: showTab === 'tags' }"
+          @click="showTab = 'tags'"
+          >{{ T.problemEditAddTags }}</a
+        >
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#download"
+          data-tab-download
+          class="nav-link"
+          :class="{ active: showTab === 'download' }"
+          @click="showTab = 'download'"
+          >{{ T.wordsDownload }}</a
+        >
+      </li>
+      <li class="nav-item" role="presentation">
+        <a
+          href="#delete"
+          data-tab-delete
+          class="nav-link"
+          :class="{ active: showTab === 'delete' }"
+          @click="showTab = 'delete'"
+          >{{ T.wordsDelete }}</a
+        >
       </li>
     </ul>
 
-    <div class="tab-content">
+    <div class="tab-content mt-2">
       <div v-if="showTab === 'edit'" class="tab-pane active">
         <omegaup-problem-form
           :data="data"

--- a/frontend/www/js/omegaup/components/problem/Edit.vue
+++ b/frontend/www/js/omegaup/components/problem/Edit.vue
@@ -301,6 +301,7 @@ Vue.use(ModalPlugin);
 export default class ProblemEdit extends Vue {
   @Prop() data!: types.ProblemEditPayload;
   @Prop() admins!: types.ProblemAdmin[];
+  @Prop() initialTab!: string;
   @Prop() groups!: types.ProblemGroupAdmin[];
   @Prop({ default: null }) solution!: types.ProblemStatement | null;
   @Prop() statement!: types.ProblemStatement;
@@ -309,7 +310,7 @@ export default class ProblemEdit extends Vue {
 
   T = T;
   alias = this.data.alias;
-  showTab = 'edit';
+  showTab = this.initialTab;
   currentStatement: types.ProblemStatement = this.statement;
   showConfirmationModal = false;
 

--- a/frontend/www/js/omegaup/problem/edit.ts
+++ b/frontend/www/js/omegaup/problem/edit.ts
@@ -25,6 +25,9 @@ OmegaUp.on('ready', () => {
     data: () => ({
       admins: payload.admins,
       groups: payload.groupAdmins,
+      initialTab: window.location.hash
+        ? window.location.hash.substring(1)
+        : 'edit',
       publishedRevision: payload.publishedRevision,
       statement: payload.statement,
       solution: payload.solution || {
@@ -52,6 +55,7 @@ OmegaUp.on('ready', () => {
       return createElement('omegaup-problem-edit', {
         props: {
           data: payload,
+          initialTab: this.initialTab,
           originalVisibility: payload.visibility,
           admins: this.admins,
           groups: this.groups,


### PR DESCRIPTION
# Description

This pr modifies the contest edit page to imitate the course edit page.

Fixes: #5176


https://github.com/omegaup/omegaup/assets/64671908/062f7125-5e6c-48a9-bd74-d2a74d991364

# Comments

- I followed all the design aspects of the course page.
- Added href attribute for tabs.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
