### PR TITLE
Render initial tab based on anchor - Contest Edit Page

### DIFF
--- a/cypress/support/pageObjects/contestPage.ts
+++ b/cypress/support/pageObjects/contestPage.ts
@@ -134,8 +134,8 @@ export class ContestPage {
 
   createContest(contestOptions: ContestOptions, users: Array<string>, shouldShowIntro: boolean = true): void {
     cy.createContest(contestOptions, shouldShowIntro);
-
     cy.location('href').should('include', contestOptions.contestAlias);
+    cy.find('a[data-contest-new_form]').trigger('click');
     cy.get('[name="title"]').should('have.value', contestOptions.contestAlias);
     cy.get('[name="alias"]').should('have.value', contestOptions.contestAlias);
     cy.get('[name="description"]').should(

--- a/cypress/support/pageObjects/contestPage.ts
+++ b/cypress/support/pageObjects/contestPage.ts
@@ -135,7 +135,7 @@ export class ContestPage {
   createContest(contestOptions: ContestOptions, users: Array<string>, shouldShowIntro: boolean = true): void {
     cy.createContest(contestOptions, shouldShowIntro);
     cy.location('href').should('include', contestOptions.contestAlias);
-    cy.find('a[data-contest-new_form]').trigger('click');
+    cy.get('a[data-contest-new-form]').trigger('click');
     cy.get('[name="title"]').should('have.value', contestOptions.contestAlias);
     cy.get('[name="alias"]').should('have.value', contestOptions.contestAlias);
     cy.get('[name="description"]').should(

--- a/frontend/www/js/omegaup/components/contest/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/contest/Edit.test.ts
@@ -46,6 +46,7 @@ describe('Edit.vue', () => {
   const propsData: {
     admins: types.ContestAdmin[];
     details: types.ContestAdminDetails;
+    initialTab: string;
     groups: types.ContestGroup[];
     groupAdmins: types.ContestGroupAdmin[];
     problems: types.ProblemsetProblemWithVersions[];
@@ -56,6 +57,7 @@ describe('Edit.vue', () => {
   } = {
     admins: [],
     details,
+    initialTab: 'clone',
     groupAdmins: [],
     groups: [],
     problems: [],
@@ -71,11 +73,12 @@ describe('Edit.vue', () => {
 
     expect(wrapper.text()).toContain(T.contestDetailsGoToContest);
 
-    expect(wrapper.vm.showTab).toBe('new_form');
+    expect(wrapper.vm.showTab).toBe('clone');
   });
 
   it('Should handle a virtual contest', () => {
     propsData.details.rerun_id = 2;
+    propsData.initialTab = '';
     const wrapper = shallowMount(contest_Edit, {
       propsData,
     });
@@ -85,6 +88,7 @@ describe('Edit.vue', () => {
 
   it('Should handle a virtual contest from an original private contest', () => {
     propsData.details.rerun_id = 2;
+    propsData.initialTab = '';
     propsData.originalContestAdmissionMode = 'private';
     const wrapper = shallowMount(contest_Edit, {
       propsData,

--- a/frontend/www/js/omegaup/components/contest/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/contest/Edit.test.ts
@@ -94,6 +94,6 @@ describe('Edit.vue', () => {
       propsData,
     });
 
-    expect(wrapper.vm.showTab).toBe('links');
+    expect(wrapper.vm.showTab).toBe('problems');
   });
 });

--- a/frontend/www/js/omegaup/components/contest/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/contest/Edit.test.ts
@@ -94,6 +94,6 @@ describe('Edit.vue', () => {
       propsData,
     });
 
-    expect(wrapper.vm.showTab).toBe('problems');
+    expect(wrapper.vm.showTab).toBe('links');
   });
 });

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -21,7 +21,7 @@
         <a
           v-if="!virtual"
           href="#new_form"
-          data-contest-new_form
+          data-contest-new-form
           class="nav-link"
           :class="{ active: showTab === 'new_form' }"
           @click="showTab = 'new_form'"

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -365,16 +365,16 @@ export default class Edit extends Vue {
   alreadyArchived = this.details.archived;
 
   selectedTab(): string {
-    if (this.initialTab != null && this.initialTab != '') {
+    if (this.initialTab != '') {
       return this.initialTab;
     }
     if (!ui.isVirtual(this.details)) {
-      return 'new_form';
+      return 'problems';
     }
     if (this.originalContestAdmissionMode != 'private') {
       return 'contestants';
     }
-    return 'links';
+    return 'problems';
   }
 
   get activeTab(): string {

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -369,7 +369,7 @@ export default class Edit extends Vue {
       return this.initialTab;
     }
     if (!ui.isVirtual(this.details)) {
-      return 'problems';
+      return 'new_form';
     }
     if (this.originalContestAdmissionMode != 'private') {
       return 'contestants';

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -374,7 +374,7 @@ export default class Edit extends Vue {
     if (this.originalContestAdmissionMode != 'private') {
       return 'contestants';
     }
-    return 'problems';
+    return 'links';
   }
 
   get activeTab(): string {

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -343,6 +343,7 @@ import contest_Certificates from './Certificates.vue';
 export default class Edit extends Vue {
   @Prop() admins!: types.ContestAdmin[];
   @Prop() details!: types.ContestAdminDetails;
+  @Prop() initialTab!: string;
   @Prop() groups!: types.ContestGroup[];
   @Prop() groupAdmins!: types.ContestGroupAdmin[];
   @Prop() problems!: types.ProblemsetProblemWithVersions[];
@@ -363,6 +364,9 @@ export default class Edit extends Vue {
   alreadyArchived = this.details.archived;
 
   selectedTab(): string {
+    if (this.initialTab != '') {
+      return this.initialTab;
+    }
     if (!ui.isVirtual(this.details)) {
       return 'new_form';
     }

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -364,7 +364,7 @@ export default class Edit extends Vue {
   alreadyArchived = this.details.archived;
 
   selectedTab(): string {
-    if (this.initialTab != '') {
+    if (this.initialTab != null && this.initialTab != '') {
       return this.initialTab;
     }
     if (!ui.isVirtual(this.details)) {

--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -21,6 +21,7 @@
         <a
           v-if="!virtual"
           href="#new_form"
+          data-contest-new_form
           class="nav-link"
           :class="{ active: showTab === 'new_form' }"
           @click="showTab = 'new_form'"

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -25,6 +25,9 @@ OmegaUp.on('ready', () => {
     data: () => ({
       admins: payload.admins,
       details: payload.details,
+      initialTab: window.location.hash
+        ? window.location.hash.substring(1)
+        : '',
       groupAdmins: payload.group_admins,
       groups: payload.groups,
       problems: payload.problems,
@@ -152,6 +155,7 @@ OmegaUp.on('ready', () => {
         props: {
           admins: this.admins,
           details: this.details,
+          initialTab: this.initialTab,
           groupAdmins: this.groupAdmins,
           groups: this.groups,
           problems: this.problems,

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -25,9 +25,7 @@ OmegaUp.on('ready', () => {
     data: () => ({
       admins: payload.admins,
       details: payload.details,
-      initialTab: window.location.hash
-        ? window.location.hash.substring(1)
-        : '',
+      initialTab: window.location.hash ? window.location.hash.substring(1) : '',
       groupAdmins: payload.group_admins,
       groups: payload.groups,
       problems: payload.problems,

--- a/frontend/www/js/omegaup/contest/edit.ts
+++ b/frontend/www/js/omegaup/contest/edit.ts
@@ -25,7 +25,7 @@ OmegaUp.on('ready', () => {
     data: () => ({
       admins: payload.admins,
       details: payload.details,
-      initialTab: window.location.hash ? window.location.hash.substring(1) : '',
+      initialTab: window.location.hash?.substring(1) || '',
       groupAdmins: payload.group_admins,
       groups: payload.groups,
       problems: payload.problems,


### PR DESCRIPTION
# Description

This PR fixes the bug where the active tab gets changed when refreshed on the contest edit page.

Fixes: #7530 

https://github.com/omegaup/omegaup/assets/64671908/dc9f02b3-be6a-484f-81c0-d724d7795fbd


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
