### PR TITLE
changed http urls to https for spinner svg

### DIFF
--- a/frontend/www/grader/ephemeral/index-light.html
+++ b/frontend/www/grader/ephemeral/index-light.html
@@ -59,11 +59,11 @@
 				</select>
 				<button class="btn btn-sm btn-secondary mr-2 my-sm-0 ephemeral-button" data-run-button type="button">
 					<span>Run</span>
-					<img src="http://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
+					<img src="https://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
 				</button>
 				<button class="btn btn-sm btn-primary my-2 my-sm-0 ephemeral-button d-none" data-submit-button type="submit">
 					<span>Submit</span>
-					<img src="http://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
+					<img src="https://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
 				</button>
 			</form>
 		</nav>

--- a/frontend/www/grader/ephemeral/index.html
+++ b/frontend/www/grader/ephemeral/index.html
@@ -59,11 +59,11 @@
 				</select>
 				<button class="btn btn-sm btn-secondary mr-2 my-sm-0 ephemeral-button" data-run-button type="button">
 					<span>Run</span>
-					<img src="http://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
+					<img src="https://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
 				</button>
 				<button class="btn btn-sm btn-dark my-2 my-sm-0 ephemeral-button d-none" data-submit-button type="submit">
 					<span>Submit</span>
-					<img src="http://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
+					<img src="https://samherbert.net/svg-loaders/svg-loaders/tail-spin.svg" height="16" />
 				</button>
 			</form>
 		</nav>


### PR DESCRIPTION
# Problem

When loading the ephemeral grader, the run button and submit button would load in spinner SVGs which would cause mixed content warnings issues with chrome. 

# Solution

Change the svg url to be https vs http to remove the mixed content warning. 
 
Part of: #7542

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
