### PR TITLE
Make the URLs in markdown open in new tab based on the domain.

### DIFF
--- a/frontend/www/js/omegaup/markdown.test.ts
+++ b/frontend/www/js/omegaup/markdown.test.ts
@@ -30,8 +30,9 @@ describe('markdown', () => {
     });
 
     it('Should handle OmegaUp domain links', () => {
-      expect(converter.makeHtml('[OmegaUp](http://omegaup.com/)')).toEqual(
-        '<p><a href="http://omegaup.com/">OmegaUp</a></p>',
+      const url = window.location.origin;
+      expect(converter.makeHtml(`[OmegaUp](${url})`)).toEqual(
+        `<p><a href="${url}">OmegaUp</a></p>`,
       );
     });
 

--- a/frontend/www/js/omegaup/markdown.test.ts
+++ b/frontend/www/js/omegaup/markdown.test.ts
@@ -19,27 +19,35 @@ describe('markdown', () => {
 
     it('Should handle path-style links', () => {
       expect(converter.makeHtml('[foo](/foo)')).toEqual(
-        '<p><a href="/foo">foo</a></p>',
+        '<p><a href="/foo" target="_blank" rel="noopener noreferrer">foo</a></p>',
       );
     });
 
     it('Should handle path-style links with titles', () => {
       expect(converter.makeHtml('[foo](/foo "foo")')).toEqual(
-        '<p><a href="/foo" title="foo">foo</a></p>',
+        '<p><a href="/foo" target="_blank" rel="noopener noreferrer" title="foo">foo</a></p>',
+      );
+    });
+
+    it('Should handle OmegaUp domain links', () => {
+      expect(converter.makeHtml('[OmegaUp](http://omegaup.com/)')).toEqual(
+        '<p><a href="http://omegaup.com/">OmegaUp</a></p>',
       );
     });
 
     it('Should handle mailto links', () => {
       expect(
         converter.makeHtml('[foo](mailto:foo@foo.com?subject=foo)'),
-      ).toEqual('<p><a href="mailto:foo@foo.com?subject=foo">foo</a></p>');
+      ).toEqual(
+        '<p><a href="mailto:foo@foo.com?subject=foo" target="_blank" rel="noopener noreferrer">foo</a></p>',
+      );
     });
 
     it('Should handle mailto links with titles', () => {
       expect(
         converter.makeHtml('[foo](mailto:foo@foo.com?subject=foo "foo")'),
       ).toEqual(
-        '<p><a href="mailto:foo@foo.com?subject=foo" title="foo">foo</a></p>',
+        '<p><a href="mailto:foo@foo.com?subject=foo" target="_blank" rel="noopener noreferrer" title="foo">foo</a></p>',
       );
     });
 

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -539,6 +539,20 @@ export class Converter {
         );
       },
     );
+
+    this._converter.hooks.chain('postConversion', (text: string): string => {
+      return text.replace(/<a href="[^"]+?"/g, (match: string) => {
+        const url = match.slice(9, -1);
+        if (
+          !url.startsWith('https://omegaup') &&
+          !url.startsWith('http://omegaup')
+        ) {
+          return match + ' target="_blank" rel="noopener noreferrer"';
+        } else {
+          return match;
+        }
+      });
+    });
   }
 
   public get converter(): Markdown.Converter {

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -541,12 +541,15 @@ export class Converter {
     );
 
     this._converter.hooks.chain('postConversion', (text: string): string => {
-      return text.replace(/<a href="([^"]+?)"/g, (match: string, url: string) => {
-        if (url.startsWith(window.location.origin)) {
-          return match;
-        }
-        return `${match} target="_blank" rel="noopener noreferrer"`;
-      });
+      return text.replace(
+        /<a href="([^"]+?)"/g,
+        (match: string, url: string) => {
+          if (url.startsWith(window.location.origin)) {
+            return match;
+          }
+          return `${match} target="_blank" rel="noopener noreferrer"`;
+        },
+      );
     });
   }
 

--- a/frontend/www/js/omegaup/markdown.ts
+++ b/frontend/www/js/omegaup/markdown.ts
@@ -541,16 +541,11 @@ export class Converter {
     );
 
     this._converter.hooks.chain('postConversion', (text: string): string => {
-      return text.replace(/<a href="[^"]+?"/g, (match: string) => {
-        const url = match.slice(9, -1);
-        if (
-          !url.startsWith('https://omegaup') &&
-          !url.startsWith('http://omegaup')
-        ) {
-          return match + ' target="_blank" rel="noopener noreferrer"';
-        } else {
+      return text.replace(/<a href="([^"]+?)"/g, (match: string, url: string) => {
+        if (url.startsWith(window.location.origin)) {
           return match;
         }
+        return `${match} target="_blank" rel="noopener noreferrer"`;
       });
     });
   }


### PR DESCRIPTION
Modify the code to make the URLs in markdown open in new tab based on the domain of the linked site.

Refer to @pabo99's comment [here](https://github.com/omegaup/omegaup/issues/3078#issuecomment-1964811231).


https://github.com/omegaup/omegaup/assets/64671908/a5bd06a7-00b7-4abb-8261-80aec56d9401

Fixes: #3078 

# Comments

Modified the `postConversion` hook to modify the <a> tag to add `rel` and `target` attributes if the URL is of external site.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
