### PR TITLE
Arreglando la propiedad de los problemas que se pueden borrar

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -4184,7 +4184,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 public: false,
                 showUserTags: $problem->allow_user_add_tags
             );
-            $problemArray['can_be_removed'] = \OmegaUp\DAO\Problems::hasSubmissionsOrHasBeenUsedInCoursesOrContests(
+            $problemArray['can_be_removed'] = !\OmegaUp\DAO\Problems::hasSubmissionsOrHasBeenUsedInCoursesOrContests(
                 $problem
             );
             $addedProblems[] = $problemArray;
@@ -4267,7 +4267,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 public: false,
                 showUserTags: $problem->allow_user_add_tags
             );
-            $problemArray['can_be_removed'] = \OmegaUp\DAO\Problems::hasSubmissionsOrHasBeenUsedInCoursesOrContests(
+            $problemArray['can_be_removed'] = !\OmegaUp\DAO\Problems::hasSubmissionsOrHasBeenUsedInCoursesOrContests(
                 $problem
             );
             $addedProblems[] = $problemArray;

--- a/frontend/tests/controllers/ProblemDeleteTest.php
+++ b/frontend/tests/controllers/ProblemDeleteTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * Testing delete problems feature
  */
@@ -12,7 +10,6 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
     public function testProblemCanNotBeDeletedAfterSubmissionsInACourseOrContest() {
         // Get a user
         [
-            'user' => $userLogin,
             'identity' => $identity,
         ] = \OmegaUp\Test\Factories\User::createUser();
 
@@ -35,7 +32,6 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Create our contestant
         [
-            'user' => $contestant,
             'identity' => $identity,
         ] = \OmegaUp\Test\Factories\User::createUser();
 
@@ -70,7 +66,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testAnonymousUserCannotSeeDeletedProblems() {
         // Get a user
-        ['user' => $userLogin, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         // Get problems
         $deletedProblemData = \OmegaUp\Test\Factories\Problem::createProblem(
@@ -103,7 +99,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Asserting deleted problem is not in the list
-        foreach ($response['results'] as $key => $problem) {
+        foreach ($response['results'] as $problem) {
             $this->assertNotEquals(
                 $deletedProblemData['request']['problem_alias'],
                 $problem['alias']
@@ -112,7 +108,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Asserting not deleted problem is in the list
         $problemIsInTheList = false;
-        foreach ($response['results'] as $key => $problem) {
+        foreach ($response['results'] as $problem) {
             if ($problemData['request']['problem_alias'] == $problem['alias']) {
                 $problemIsInTheList = true;
                 break;
@@ -126,7 +122,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testLoggedUserCannotSeeDeletedProblems() {
         // Get a user
-        ['user' => $userLogin, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         // Get problems
         $deletedProblemData = \OmegaUp\Test\Factories\Problem::createProblem(
@@ -156,7 +152,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
 
         // Asserting deleted problem is not in the list
-        foreach ($response['results'] as $key => $problem) {
+        foreach ($response['results'] as $problem) {
             $this->assertNotEquals(
                 $deletedProblemData['request']['problem_alias'],
                 $problem['alias']
@@ -165,7 +161,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Asserting not deleted problem is in the list
         $problemIsInTheList = false;
-        foreach ($response['results'] as $key => $problem) {
+        foreach ($response['results'] as $problem) {
             if ($problemData['request']['problem_alias'] == $problem['alias']) {
                 $problemIsInTheList = true;
                 break;
@@ -179,7 +175,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
 
         // Asserting deleted problem is not in the list
-        foreach ($response['problems'] as $key => $problem) {
+        foreach ($response['problems'] as $problem) {
             $this->assertNotEquals(
                 $deletedProblemData['request']['problem_alias'],
                 $problem['alias']
@@ -188,7 +184,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Asserting not deleted problem is in the list
         $problemIsInTheList = false;
-        foreach ($response['problems'] as $key => $problem) {
+        foreach ($response['problems'] as $problem) {
             if ($problemData['request']['problem_alias'] == $problem['alias']) {
                 $problemIsInTheList = true;
                 break;
@@ -202,7 +198,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
      */
     public function testSysadminCanSeeDeletedProblemsOnlyInAdminList() {
         // Get a user
-        ['user' => $userLogin, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['user' => $userLogin] = \OmegaUp\Test\Factories\User::createUser();
 
         // Get problems
         $deletedProblemData = \OmegaUp\Test\Factories\Problem::createProblem(
@@ -219,7 +215,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Get admin user
-        ['user' => $admin, 'identity' => $identityAdmin] = \OmegaUp\Test\Factories\User::createAdminUser();
+        ['identity' => $identityAdmin] = \OmegaUp\Test\Factories\User::createAdminUser();
 
         $login = self::login($identityAdmin);
 
@@ -235,7 +231,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
         ]));
 
         // Asserting deleted problem is not in the list
-        foreach ($response['results'] as $key => $problem) {
+        foreach ($response['results'] as $problem) {
             $this->assertNotEquals(
                 $deletedProblemData['request']['problem_alias'],
                 $problem['alias']
@@ -244,7 +240,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Asserting not deleted problem is in the list
         $problemIsInTheList = false;
-        foreach ($response['results'] as $key => $problem) {
+        foreach ($response['results'] as $problem) {
             if ($problemData['request']['problem_alias'] == $problem['alias']) {
                 $problemIsInTheList = true;
                 break;
@@ -259,7 +255,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Asserting deleted problem is in the list
         $deletedProblemIsInTheList = false;
-        foreach ($response['problems'] as $key => $problem) {
+        foreach ($response['problems'] as $problem) {
             if ($deletedProblemData['request']['problem_alias'] == $problem['alias']) {
                 $deletedProblemIsInTheList = true;
                 break;
@@ -269,7 +265,7 @@ class ProblemDeleteTest extends \OmegaUp\Test\ControllerTestCase {
 
         // Asserting not deleted problem is in the list
         $problemIsInTheList = false;
-        foreach ($response['problems'] as $key => $problem) {
+        foreach ($response['problems'] as $problem) {
             if ($problemData['request']['problem_alias'] == $problem['alias']) {
                 $problemIsInTheList = true;
                 break;

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -843,12 +843,12 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         // 5. Problem with runs and it belongs to a contest
         // 6. Problem with runs and it belongs to an assignment
         $problemsMapping = [
-            'noRunsNoContestNoAssignment' => false,
-            'noRunsContest' => true,
-            'noRunsAssignment' => true,
-            'runsNoContestNoAssignment' => true,
-            'runsContest' => true,
-            'runsAssignment' => true,
+            'noRunsNoContestNoAssignment' => true,
+            'noRunsContest' => false,
+            'noRunsAssignment' => false,
+            'runsNoContestNoAssignment' => false,
+            'runsContest' => false,
+            'runsAssignment' => false,
         ];
         $problemData = [];
         foreach ($problemsMapping as $problemAlias => $_) {
@@ -955,9 +955,32 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
 
         foreach ($problemsToRemove as $problem) {
             if ($problem['alias'] === 'noRunsNoContestNoAssignment') {
-                $this->assertFalse($problem['can_be_removed']);
-            } else {
                 $this->assertTrue($problem['can_be_removed']);
+            } else {
+                $this->assertFalse($problem['can_be_removed']);
+            }
+        }
+
+        $response = \OmegaUp\Controllers\Problem::apiAdminList(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ])
+        );
+
+        $problemsToRemove = array_map(
+            fn ($problem) => [
+                'problem_id' => $problem['problem_id'],
+                'alias' => $problem['alias'],
+                'can_be_removed' => $problem['can_be_removed'],
+            ],
+            $response['problems']
+        );
+
+        foreach ($problemsToRemove as $problem) {
+            if ($problem['alias'] === 'noRunsNoContestNoAssignment') {
+                $this->assertTrue($problem['can_be_removed']);
+            } else {
+                $this->assertFalse($problem['can_be_removed']);
             }
         }
     }

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -882,7 +882,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         if ($problemType === 'contest') {
             // Create a contest
             $contestData = \OmegaUp\Test\Factories\Contest::createContest();
-            // Add problem 2 and 5 to the contest
+            // Add problem to the contest
             \OmegaUp\Test\Factories\Contest::addProblemToContest(
                 $problemData,
                 $contestData
@@ -919,7 +919,7 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
                 $adminLogin
             );
 
-            // Add problem 3 and 6 to the assignment
+            // Add problem to the assignment
             \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
                 $adminLogin,
                 $courseData['course_alias'],

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -828,13 +828,11 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Test myList API
+     * A PHPUnit data provider for some problems used in different scenarios.
+     *
+     * @return list<array:{0: string, 1: bool, 2: bool, 3: string, 4: bool}>
      */
-    public function testPrepareProblemToRemoveMyList() {
-        // Create an admin and a student
-        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
-        ['identity' => $student] = \OmegaUp\Test\Factories\User::createUser();
-
+    public function problemProvider(): array {
         // Create 6 problems which each one is used in a different way:
         // 1. Problem with no runs and it doesn't belong to a contest nor an assignment
         // 2. Problem with no runs and it belongs to a contest
@@ -842,147 +840,144 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
         // 4. Problem with runs and it doesn't belong to a contest nor an assignment
         // 5. Problem with runs and it belongs to a contest
         // 6. Problem with runs and it belongs to an assignment
-        $problemsMapping = [
-            'noRunsNoContestNoAssignment' => true,
-            'noRunsContest' => false,
-            'noRunsAssignment' => false,
-            'runsNoContestNoAssignment' => false,
-            'runsContest' => false,
-            'runsAssignment' => false,
+        return [
+            ['noRunsNoContestNoAssignment', true,  false, 'none',    true],
+            ['noRunsContest',               true,  false, 'contest', false],
+            ['noRunsAssignment',            true,  false, 'course',  false],
+            ['runsNoContestNoAssignment',   true,  true,  'none',    false],
+            ['runsContest',                 true,  true,  'contest', false],
+            ['runsAssignment',              true,  true,  'course',  false],
+            ['noRunsNoContestNoAssignment', false, false, 'none',    true],
+            ['noRunsContest',               false, false, 'contest', false],
+            ['noRunsAssignment',            false, false, 'course',  false],
+            ['runsNoContestNoAssignment',   false, true,  'none',    false],
+            ['runsContest',                 false, true,  'contest', false],
+            ['runsAssignment',              false, true,  'course',  false],
         ];
-        $problemData = [];
-        foreach ($problemsMapping as $problemAlias => $_) {
-            $problemData[] = \OmegaUp\Test\Factories\Problem::createProblem(
-                new \OmegaUp\Test\Factories\ProblemParams([
-                    'author' => $identity,
-                    'alias' => $problemAlias,
-                ])
-            );
-        }
-        // Create a contest
-        $contestData = \OmegaUp\Test\Factories\Contest::createContest();
-        // Add problem 2 and 5 to the contest
-        \OmegaUp\Test\Factories\Contest::addProblemToContest(
-            $problemData[1],
-            $contestData
-        );
-        \OmegaUp\Test\Factories\Contest::addProblemToContest(
-            $problemData[4],
-            $contestData
-        );
+    }
 
-        // Add a student to the contest
-        \OmegaUp\Test\Factories\Contest::addUser($contestData, $student);
+    /**
+     * Test myList API
+     *
+     * @dataProvider problemProvider
+     */
+    public function testPrepareProblemToRemoveMyList(
+        string $problemAlias,
+        bool $adminedByMe,
+        bool $hasRuns,
+        string $problemType,
+        bool $expectedCanBeRemoved
+    ) {
+        // Create an admin and a student
+        ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $student] = \OmegaUp\Test\Factories\User::createUser();
 
-        // Student opens the contest
-        $login = self::login($student);
-        $response = \OmegaUp\Controllers\Contest::apiOpen(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'contest_alias' => $contestData['request']['alias']
-        ]));
-
-        // Student creates a run for problem 5
-        $runData = \OmegaUp\Test\Factories\Run::createRun(
-            $problemData[4],
-            $contestData,
-            $student
-        );
-
-        // The run is graded
-        \OmegaUp\Test\Factories\Run::gradeRun($runData);
-
-        $login = self::login($identity);
-        // Create a course with one assignment
-        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
-            $identity,
-            $login
-        );
-        // Add problem 3 and 6 to the assignment
-        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
-            $login,
-            $courseData['course_alias'],
-            $courseData['assignment_alias'],
-            [$problemData[2]]
-        );
-
-        \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
-            $login,
-            $courseData['course_alias'],
-            $courseData['assignment_alias'],
-            [$problemData[5]]
-        );
-
-        // Add a student to the course
-        \OmegaUp\Test\Factories\Course::addStudentToCourse(
-            $courseData,
-            $student
-        );
-
-        // Create a run for problem 6
-        \OmegaUp\Test\Factories\Run::createAssignmentRun(
-            $courseData['course_alias'],
-            $courseData['assignment_alias'],
-            $problemData[5],
-            $student
-        );
-
-        // The run is graded
-        \OmegaUp\Test\Factories\Run::gradeRun($runData);
-
-        // Create a run for problem 4, even if this problem is not in a contest
-        // or an assignment
-        $runData = \OmegaUp\Test\Factories\Run::createRunToProblem(
-            $problemData[3],
-            $student
-        );
-
-        // The run is graded
-        \OmegaUp\Test\Factories\Run::gradeRun($runData);
-
-        $login = self::login($identity);
-        $response = \OmegaUp\Controllers\Problem::apiMyList(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-        ]));
-
-        $problemsToRemove = array_map(
-            fn ($problem) => [
-                'problem_id' => $problem['problem_id'],
-                'alias' => $problem['alias'],
-                'can_be_removed' => $problem['can_be_removed'],
-            ],
-            $response['problems']
-        );
-
-        foreach ($problemsToRemove as $problem) {
-            if ($problem['alias'] === 'noRunsNoContestNoAssignment') {
-                $this->assertTrue($problem['can_be_removed']);
-            } else {
-                $this->assertFalse($problem['can_be_removed']);
-            }
-        }
-
-        $response = \OmegaUp\Controllers\Problem::apiAdminList(
-            new \OmegaUp\Request([
-                'auth_token' => $login->auth_token,
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'author' => $admin,
+                'alias' => $problemAlias,
             ])
         );
 
-        $problemsToRemove = array_map(
-            fn ($problem) => [
-                'problem_id' => $problem['problem_id'],
-                'alias' => $problem['alias'],
-                'can_be_removed' => $problem['can_be_removed'],
-            ],
-            $response['problems']
-        );
+        if ($problemType === 'contest') {
+            // Create a contest
+            $contestData = \OmegaUp\Test\Factories\Contest::createContest();
+            // Add problem 2 and 5 to the contest
+            \OmegaUp\Test\Factories\Contest::addProblemToContest(
+                $problemData,
+                $contestData
+            );
 
-        foreach ($problemsToRemove as $problem) {
-            if ($problem['alias'] === 'noRunsNoContestNoAssignment') {
-                $this->assertTrue($problem['can_be_removed']);
-            } else {
-                $this->assertFalse($problem['can_be_removed']);
+            // Add a student to the contest
+            \OmegaUp\Test\Factories\Contest::addUser($contestData, $student);
+
+            // Student opens the contest
+            $login = self::login($student);
+
+            $response = \OmegaUp\Controllers\Contest::apiOpen(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'contest_alias' => $contestData['request']['alias']
+                ])
+            );
+
+            if ($hasRuns) {
+                // Student creates a run for problem
+                $runData = \OmegaUp\Test\Factories\Run::createRun(
+                    $problemData,
+                    $contestData,
+                    $student
+                );
             }
+        } elseif ($problemType === 'course') {
+            // Login as admin
+            $adminLogin = self::login($admin);
+
+            // Create a course with one assignment
+            $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment(
+                $admin,
+                $adminLogin
+            );
+
+            // Add problem 3 and 6 to the assignment
+            \OmegaUp\Test\Factories\Course::addProblemsToAssignment(
+                $adminLogin,
+                $courseData['course_alias'],
+                $courseData['assignment_alias'],
+                [$problemData]
+            );
+
+            // Add a student to the course
+            \OmegaUp\Test\Factories\Course::addStudentToCourse(
+                $courseData,
+                $student
+            );
+
+            if ($hasRuns) {
+                // Student creates a run for problem
+                $runData = \OmegaUp\Test\Factories\Run::createAssignmentRun(
+                    $courseData['course_alias'],
+                    $courseData['assignment_alias'],
+                    $problemData,
+                    $student
+                );
+            }
+        } elseif ($hasRuns) {
+            // Student creates a run for problem
+            $runData = \OmegaUp\Test\Factories\Run::createRunToProblem(
+                $problemData,
+                $student
+            );
         }
+
+        if ($hasRuns) {
+            // The run is graded
+            \OmegaUp\Test\Factories\Run::gradeRun($runData);
+        }
+
+        // Login as admin
+        $adminLogin = self::login($admin);
+
+        if ($adminedByMe) {
+            $response = \OmegaUp\Controllers\Problem::apiAdminList(
+                new \OmegaUp\Request([
+                    'auth_token' => $adminLogin->auth_token,
+                ])
+            )['problems'];
+        } else {
+            $response = \OmegaUp\Controllers\Problem::apiMyList(
+                new \OmegaUp\Request([
+                    'auth_token' => $adminLogin->auth_token,
+                ])
+            )['problems'];
+        }
+
+        $canBeRemoved = array_filter(
+            $response,
+            fn($problem) => $problem['alias'] === $problemAlias
+        )[0]['can_be_removed'];
+
+        $this->assertSame($canBeRemoved, $expectedCanBeRemoved);
     }
 
     /**


### PR DESCRIPTION
# Description

In the PR #7476, the flag `can_be_removed` was added to the `List` and `AdminList` APIs.

However, it had a bug: the flag turned on when the problems actually couldn't be removed, and it turned off for problems that could be removed.

Part of: #7452 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
