### PR TITLE
Rename `isGroupTeachingAssistantMember` to `isMemberOfAnyGroup`

### DIFF
--- a/frontend/server/src/Authorization.php
+++ b/frontend/server/src/Authorization.php
@@ -489,7 +489,7 @@ class Authorization {
      * @param \OmegaUp\DAO\VO\Identities $identity
      * @param list<\OmegaUp\DAO\VO\Groups> $groups
      */
-    public static function isGroupTeachingAssistantMember(
+    public static function isMemberOfAnyGroup(
         $identity,
         $groups = []
     ): bool {

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -5369,7 +5369,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         return \OmegaUp\Authorization::isTeachingAssistant(
             $identity,
             $course
-        ) || \OmegaUp\Authorization::isGroupTeachingAssistantMember(
+        ) || \OmegaUp\Authorization::isMemberOfAnyGroup(
             $identity,
             $groupsTeachingAssistants
         );

--- a/frontend/tests/controllers/CourseGroupTeachingAssistantTest.php
+++ b/frontend/tests/controllers/CourseGroupTeachingAssistantTest.php
@@ -35,7 +35,7 @@ class CourseGroupTeachingAssistantTest extends \OmegaUp\Test\ControllerTestCase 
         $userLogin = self::login($identity);
 
         $this->assertTrue(
-            \OmegaUp\Authorization::isGroupTeachingAssistantMember(
+            \OmegaUp\Authorization::isMemberOfAnyGroup(
                 $identity,
                 [$groupData['group']]
             )


### PR DESCRIPTION
# Description

The logic on that function is not specific to teaching assistant groups. It should be renamed to isMemberOfAnyGroup or something like that.

Fixes: #7565 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
