### PR TITLE
Evitando llamar dos veces la función de remoteTime en la arena de concursos

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -111,9 +111,7 @@ OmegaUp.on('ready', async () => {
 
   let nextSubmissionTimestamp: null | Date = null;
   if (problemDetails?.nextSubmissionTimestamp != null) {
-    nextSubmissionTimestamp = time.remoteTime(
-      problemDetails?.nextSubmissionTimestamp.getTime(),
-    );
+    nextSubmissionTimestamp = problemDetails?.nextSubmissionTimestamp;
   }
 
   const contestContestant = new Vue({


### PR DESCRIPTION
# Description

Se elimina un llamado a la función de `remoteTime` para evitar que mostrar datos erroneos al realizar un envío 

Part of: #6748

# Comments

Faltará un cambio extra con la sugerencia de @heduenas de hacer una clase `LocalizedTime`  para poder distinguir entre un timestamp que ya se le aplicó `remoteTime` y uno que no.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
