### PR TITLE
Arreglando la forma en la que se calcula el envio mas reciente.

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2842,8 +2842,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $lastRunTime = null;
 
                 if (($n = count($runsArray)) > 0) {
-                    $lastRun = $runsArray[$n - 1];
-                    $lastRunTime = $lastRun['time'];
+                    $lastRunTime = max(array_map(fn($run) => $run['time'], $runsArray));
                 }
                 $response['nextSubmissionTimestamp'] = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(
                     $container,
@@ -4803,8 +4802,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $lastRunTime = null;
 
         if (($n = count($runsPayload)) > 0) {
-            $lastRun = $runsPayload[$n - 1];
-            $lastRunTime = $lastRun['time'];
+            $lastRunTime = max(array_map(fn($run) => $run['time'], $runsPayload));
         }
 
         $nextSubmissionTimestamp = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2841,7 +2841,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             if ($container instanceof \OmegaUp\DAO\VO\Contests) {
                 $lastRunTime = null;
 
-                if (($n = count($runsArray)) > 0) {
+                if (count($runsArray) > 0) {
                     $lastRunTime = max(
                         array_map(
                             fn($run) => $run['time'],
@@ -4806,7 +4806,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $lastRunTime = null;
 
-        if (($n = count($runsPayload)) > 0) {
+        if (count($runsPayload) > 0) {
             $lastRunTime = max(
                 array_map(
                     fn($run) => $run['time'],

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2842,7 +2842,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $lastRunTime = null;
 
                 if (($n = count($runsArray)) > 0) {
-                    $lastRunTime = max(array_map(fn($run) => $run['time'], $runsArray));
+                    $lastRunTime = max(
+                        array_map(
+                            fn($run) => $run['time'],
+                            $runsArray
+                        )
+                    );
                 }
                 $response['nextSubmissionTimestamp'] = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(
                     $container,
@@ -4802,7 +4807,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $lastRunTime = null;
 
         if (($n = count($runsPayload)) > 0) {
-            $lastRunTime = max(array_map(fn($run) => $run['time'], $runsPayload));
+            $lastRunTime = max(
+                array_map(
+                    fn($run) => $run['time'],
+                    $runsPayload
+                )
+            );
         }
 
         $nextSubmissionTimestamp = \OmegaUp\DAO\Runs::nextSubmissionTimestamp(


### PR DESCRIPTION
# Description

La logica del contorller estaba suponiendo que el DAO regresa los envios en orden cronologico pero eso no parece ser el caso siempre.


Part of: https://github.com/omegaup/omegaup/issues/6748

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
