### PR TITLE
Moviendo la posición de los casos en run details popup

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunDetailsPopup.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetailsPopup.vue
@@ -8,7 +8,27 @@
           :guid="data.guid"
           :is-admin="data.admin"
         ></slot>
-        <div v-if="data.groups">
+        <div class="source_code">
+          <h3>{{ T.wordsSource }}</h3>
+          <a v-if="data.source_link" download="data.zip" :href="data.source">{{
+            T.wordsDownload
+          }}</a>
+          <slot v-else name="code-view" :guid="data.guid">
+            <omegaup-arena-feedback-code-view
+              :language="language"
+              :value="source"
+              :feedback-map="feedbackMap"
+              :feedback-thread-map="feedbackThreadMap"
+              @save-feedback-list="
+                (feedbackList) => onSaveFeedbackList(feedbackList, data.guid)
+              "
+              @submit-feedback-thread="
+                (feedback) => onSubmitFeedbackThread(feedback, data.guid)
+              "
+            ></omegaup-arena-feedback-code-view>
+          </slot>
+        </div>
+        <div v-if="data.groups" class="cases">
           <h3>{{ T.wordsCases }}</h3>
           <div></div>
           <table class="w-100">
@@ -105,24 +125,6 @@
             </tbody>
           </table>
         </div>
-        <h3>{{ T.wordsSource }}</h3>
-        <a v-if="data.source_link" download="data.zip" :href="data.source">{{
-          T.wordsDownload
-        }}</a>
-        <slot v-else name="code-view" :guid="data.guid">
-          <omegaup-arena-feedback-code-view
-            :language="language"
-            :value="source"
-            :feedback-map="feedbackMap"
-            :feedback-thread-map="feedbackThreadMap"
-            @save-feedback-list="
-              (feedbackList) => onSaveFeedbackList(feedbackList, data.guid)
-            "
-            @submit-feedback-thread="
-              (feedback) => onSubmitFeedbackThread(feedback, data.guid)
-            "
-          ></omegaup-arena-feedback-code-view>
-        </slot>
         <div v-if="data.compile_error" class="compile_error">
           <h3>{{ T.wordsCompilerOutput }}</h3>
           <pre class="compile_error">
@@ -170,7 +172,7 @@
             <code v-text="data.judged_by"></code>
           </pre>
         </div>
-        <div>
+        <div class="guid">
           <h3>{{ T.runGUID }}</h3>
           <acronym :title="data.guid" data-run-guid>
             <tt>{{ shortGuid }}</tt>


### PR DESCRIPTION
# Description

Se mueve la posción de los casos en el popup de RunDetails para que aparezcan debajo del código fuente.

Antes:
![Screenshot from 2024-05-21 01-51-00](https://github.com/omegaup/omegaup/assets/3230352/30213ea6-ab59-4c06-bb66-6e55ed9e185e)

Después:
![Screenshot from 2024-05-21 01-51-31](https://github.com/omegaup/omegaup/assets/3230352/302df095-04c6-48f4-9e17-836d87411d9d)


Fixes: #7602 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.