### PR TITLE
Change initial language of `interactiveIdlSettings`

### DIFF
--- a/frontend/www/js/omegaup/grader/ephemeral.js
+++ b/frontend/www/js/omegaup/grader/ephemeral.js
@@ -254,7 +254,7 @@ const interactiveIdlSettings = {
       contents: 'request.input.interactive.idl',
       module: 'request.input.interactive.module_name',
     },
-    initialLanguage: 'idl',
+    initialLanguage: 'c',
     readOnly: isEmbedded,
     theme,
   },


### PR DESCRIPTION
# Description

The problem was that  the initial language was being set to `idl`, but that language is not present in `supportedLanguages` **(should it be?)**.
![Screenshot from 2024-06-03 18-00-49](https://github.com/omegaup/omegaup/assets/59091536/c8b2a60c-5124-48af-a51c-61015f88c417)
I changed initial language to `c`, which fixed the problem.

Fixes: #7629

# Comments

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
