### PR TITLE
Arreglando algunos errores en el archivo CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,23 @@
-# PHP, Python, and SQL files
-* .php @heduenas @pabo99
-* .py @heduenas @pabo99
-* .sql @heduenas @pabo99
+# CODEOWNERS for the used languages
 
-# Vue, TypeScript, JavaScript, HTML, and CSS files
-* .vue @carlosabcs @tvanessa
-* .ts @carlosabcs
-* .js @carlosabcs
-* .html @carlosabcs @tvanessa
-* .css @carlosabcs
+## PHP, Python, and SQL files
 
-# Lang files
-* .lang @tvanessa
+*.php @heduenas @pabo99
+*.py @heduenas @pabo99
+*.sql @heduenas @pabo99
 
-# Default owner for everything else
+## Vue, TypeScript, JavaScript, HTML, and CSS files
+
+*.vue @carlosabcs @tvanessa
+*.ts @carlosabcs
+*.js @carlosabcs
+*.html @carlosabcs @tvanessa
+*.css @carlosabcs
+
+## Lang files
+
+*.lang @tvanessa
+
+## Default owner for everything else
+
 * @heduenas


### PR DESCRIPTION
# Description

Al parecer, el archivo que se subió de `CODEOWNERS` para asignar la propiedad a cada tipo de archivos por revisar no tenía la sintaxis correcta, lo cual estaba ocasionando que todas los cambios requerían la revisión de @heduenas, ya que este es el propietario por defecto


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.