### PR TITLE
Instalando explícitamente docker-compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,14 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install -y wait-for-it
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
       - name: Download the Docker containers
         run: |
           docker-compose pull
@@ -452,6 +460,14 @@ jobs:
       - name: Install retry
         run: |
           sudo apt-get update -y && sudo apt-get install -y retry
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
 
       - name: Download the Docker containers
         run: |


### PR DESCRIPTION
# Description

For some reason, GitHub Actions is failing to download the Docker containers. It seems like Docker Compose is not installed.

Therefore, this PR intends to install it manually.