### PR TITLE
Arregando el número globo de notificaciones con las sugerencias de un envío para organizadores

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -24,7 +24,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         ON
             ss.submission_id = sf.submission_id
         WHERE
-            ss.problem_id = ?
+            sf.range_bytes_start IS NOT NULL
         GROUP BY
             ss.submission_id
     )';
@@ -239,7 +239,6 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
 
         if (!is_null($problemsetId)) {
             $cteSubmissionsFeedback = self::$ctesubmissionFeedbackForProblemset;
-            $val[] = $problemsetId;
 
             $suggestionsCountField = 'IFNULL(ssff.suggestions, 0) AS suggestions';
             $suggestionsJoin = 'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
@@ -1019,7 +1018,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             $suggestionsCountField = 'IFNULL(ssff.suggestions, 0) AS suggestions';
             $suggestionsJoin = 'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
             $whereClause = ' AND s.problemset_id = ?';
-            $params = [$problemId, $problemId, $identityId, $problemsetId];
+            $params = [$problemId, $identityId, $problemsetId];
         }
 
         $sql = "{$cteSubmissionsFeedback}

--- a/frontend/www/js/omegaup/components/arena/Runs.vue
+++ b/frontend/www/js/omegaup/components/arena/Runs.vue
@@ -297,11 +297,6 @@
                 >
                   <font-awesome-icon :icon="['fas', 'question-circle']" />
                 </button>
-                <span
-                  v-if="run.submission_feedback_id !== null && showDisqualify"
-                  class="position-absolute top-0 end-0 badge badge-pill badge-danger"
-                  >1
-                </span>
               </td>
               <td v-if="showPoints" class="numeric">{{ points(run) }}</td>
               <td v-if="showPoints" class="numeric">{{ penalty(run) }}</td>


### PR DESCRIPTION
# Description

En la sección de envíos de un curso se arregla el icono con la cantidad de sugerencias agregadas por un administrador en determinado envío.

El motivo por el cual no funcionaba correctamente es porque en un origen, la Common Table Expression que se agregó para contabilizar el número de sugerencias dejadas por un organizador en cierto envío estaba filtrando sólo los envíos que pertenecían a un problema en específico. 

![image](https://github.com/user-attachments/assets/9c7aa5ea-cd7c-43de-86a4-088ab05366ed)

El caso para los envíos de un organizador no funcionaba porque a este le aparecen concentrados los envíos de todos los problemas que pertenecen a un problemset (a un assignment en este caso).

Pro lo pronto se quitan todos los filtrosen la CTE. Habrá que monitorear si en un futuro se tiene que agregar el filtro correspondiente a cada una de las vistas.

Fixes: #7733

# Comments

También se aprovecha este PR para eliminar un icono que se había quedado en un lugar donde no corresponde, en el listado de envíos de un concurso. Ya no se muestra donde no debería estarse mostrando:

![image](https://github.com/user-attachments/assets/3b98d3c0-c95f-4964-90d5-65fed9806817)

Faltará agregar las pruebas

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
