### PR TITLE
Actualizando los comandos de docker compose para la version 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
 
   frontend:

--- a/stuff/database_utils.py
+++ b/stuff/database_utils.py
@@ -41,10 +41,10 @@ def check_inside_container() -> None:
         sys.stderr.write('\nYou can use the following command to run '
                          'it inside the container:\n\n')
         sys.stderr.write(
-            f'    docker-compose exec -T frontend {shlex.join(sys.argv)}\n')
+            f'    docker compose exec -T frontend {shlex.join(sys.argv)}\n')
         sys.stderr.write('\n')
         sys.exit(1)
-    result = subprocess.run(['docker-compose', 'exec', '-T', 'frontend'] +
+    result = subprocess.run(['docker compose', 'exec', '-T', 'frontend'] +
                             sys.argv,
                             check=False)
     sys.exit(result.returncode)
@@ -102,7 +102,7 @@ def mysql(query: str,
     '''Runs the MySQL commandline client with |query| as query.'''
     args = []
     if container_check and not inside_container():
-        args.extend(['docker-compose', 'exec', '-T', 'frontend'])
+        args.extend(['docker compose', 'exec', '-T', 'frontend'])
     args += [_MYSQL_BINARY] + list(auth)
     if dbname:
         args.append(dbname)
@@ -124,7 +124,7 @@ def mysqldump(*,
     '''Runs the mysqldump commandline tool.'''
     args = []
     if container_check and not inside_container():
-        args.extend(['docker-compose', 'exec', '-T', 'frontend'])
+        args.extend(['docker compose', 'exec', '-T', 'frontend'])
     args += [_MYSQLDUMP_BINARY] + list(auth)
     if dbname:
         args.append(dbname)

--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -58,16 +58,16 @@ if [ $GIT_PUSH -eq 1 ]; then
 	fi
 fi
 
-if ! which docker-compose >/dev/null; then
-	echo -e "\033[0;31mERROR\033[0m: \`docker-compose\` not found. Please run \`git push\` outside the container."
+if ! which docker compose >/dev/null; then
+	echo -e "\033[0;31mERROR\033[0m: \`docker compose\` not found. Please run \`git push\` outside the container."
 	exit 1
 fi
 
-if ! docker-compose exec -T frontend true 2>/dev/null ; then
-	echo -e "\033[0;31mERROR\033[0m: The container is not running. Please run \`docker-compose up\` and try again."
+if ! docker compose exec -T frontend true 2>/dev/null ; then
+	echo -e "\033[0;31mERROR\033[0m: The container is not running. Please run \`docker compose up\` and try again."
 	exit 1
 fi
 
-docker-compose exec -T frontend python3 /opt/omegaup/stuff/database_schema.py validate $ARGS
-docker-compose exec -T frontend python3 /opt/omegaup/stuff/policy-tool.py validate
+docker compose exec -T frontend python3 /opt/omegaup/stuff/database_schema.py validate $ARGS
+docker compose exec -T frontend python3 /opt/omegaup/stuff/policy-tool.py validate
 exec "${OMEGAUP_ROOT}/stuff/lint.sh" $PRE_UPLOAD_ARGS validate $ARGS

--- a/stuff/runtests.sh
+++ b/stuff/runtests.sh
@@ -26,11 +26,11 @@ if [[ "${IN_DOCKER}" == 1 ]]; then
 	# type check.
 	"${OMEGAUP_ROOT}/stuff/mysql_types.sh"
 else
-	docker-compose exec -T frontend python3 "./stuff/db-migrate.py" validate
-	docker-compose exec -T frontend python3 "./stuff/policy-tool.py" validate
+	docker compose exec -T frontend python3 "./stuff/db-migrate.py" validate
+	docker compose exec -T frontend python3 "./stuff/policy-tool.py" validate
 	# This runs the controllers + badges PHPUnit tests, as well as the MySQL return
 	# type check.
-	docker-compose exec -T frontend "./stuff/mysql_types.sh"
+	docker compose exec -T frontend "./stuff/mysql_types.sh"
 fi
 
 "${OMEGAUP_ROOT}/vendor/bin/psalm" --show-info=false


### PR DESCRIPTION
# Description

Se actualizan los últimos comandos a la versión 2 de `dcoker-compose` para mantener integridad entre el ambiente local y los github actions donde se actualizaron recientemente estos mismos comandos.

Fixes: #7742 


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.