### PR TITLE
Arreglando el contador de la notificación por envío para la solicitud de feedback

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -23,8 +23,6 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             Submissions ss
         ON
             ss.submission_id = sf.submission_id
-        WHERE
-            sf.range_bytes_start IS NOT NULL
         GROUP BY
             ss.submission_id
     )';

--- a/frontend/tests/controllers/SubmissionFeedbackTest.php
+++ b/frontend/tests/controllers/SubmissionFeedbackTest.php
@@ -627,6 +627,16 @@ class SubmissionFeedbackTest extends \OmegaUp\Test\ControllerTestCase {
 
         $login = self::login($admin);
 
+        $runs = \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'assignment_alias' => $courseData['assignment_alias'],
+                'course_alias' => $courseData['course_alias'],
+            ])
+        )['templateProperties']['payload']['currentAssignment']['runs'];
+
+        $this->assertSame(1, $runs[0]['suggestions']);
+
         $feedbackList = \OmegaUp\Controllers\Run::apiGetSubmissionFeedback(
             new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
@@ -662,6 +672,17 @@ class SubmissionFeedbackTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertNull($feedbackList[0]['range_bytes_start']);
         $this->assertSame(1, $feedbackList[1]['range_bytes_start']);
         $this->assertSame($feedback, $feedbackList[1]['feedback']);
+
+        // This should be reflected in the course details for the admin
+        $runs = \OmegaUp\Controllers\Course::getCourseDetailsForTypeScript(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'assignment_alias' => $courseData['assignment_alias'],
+                'course_alias' => $courseData['course_alias'],
+            ])
+        )['templateProperties']['payload']['currentAssignment']['runs'];
+
+        $this->assertSame(2, $runs[0]['suggestions']);
 
         // Even when the feedback is updated, the feedback in the line 1 should
         // remain the same as originally set because updating the feedback in


### PR DESCRIPTION
# Description

Se arregla el número en el globo de notificación cuando el estudiante solicita retroalimentación en un envío.

Anteriormente esta solicitud se estaba ignorando en el conteo de las notificaciones, pero es importante que aparezca para que el organizador del curso identifique en cuáles envíos ya existe interacción, ya sea de él mismo o del estudiante:

![NotificationsForFeedbackRequest](https://github.com/user-attachments/assets/c254578a-1425-45b1-af70-24ba60e90384)


Fixes: #7744 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
