### PR TITLE
Mejorando el mensaje de error cuando se crea un concurso con fechas inválidas

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2592,29 +2592,29 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @return array{status: string}
      *
-     * @omegaup-request-param mixed $admission_mode
-     * @omegaup-request-param mixed $alias
-     * @omegaup-request-param mixed $description
-     * @omegaup-request-param mixed $feedback
-     * @omegaup-request-param mixed $finish_time
-     * @omegaup-request-param mixed $languages
-     * @omegaup-request-param bool|null $needs_basic_information
-     * @omegaup-request-param mixed $penalty
-     * @omegaup-request-param mixed $penalty_calc_policy
-     * @omegaup-request-param mixed $penalty_type
-     * @omegaup-request-param mixed $points_decay_factor
-     * @omegaup-request-param null|string $problems
-     * @omegaup-request-param mixed $requests_user_information
-     * @omegaup-request-param mixed $scoreboard
-     * @omegaup-request-param null|string $score_mode
-     * @omegaup-request-param mixed $show_scoreboard_after
-     * @omegaup-request-param mixed $start_time
-     * @omegaup-request-param mixed $submissions_gap
-     * @omegaup-request-param bool|null $contest_for_teams
-     * @omegaup-request-param null|string $teams_group_alias
-     * @omegaup-request-param mixed $title
-     * @omegaup-request-param int|null $window_length
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
+     * @omegaup-request-param null|string $alias
      * @omegaup-request-param bool|null $check_plagiarism
+     * @omegaup-request-param bool|null $contest_for_teams
+     * @omegaup-request-param null|string $description
+     * @omegaup-request-param 'detailed'|'none'|'summary'|null $feedback
+     * @omegaup-request-param int $finish_time
+     * @omegaup-request-param null|string $languages
+     * @omegaup-request-param bool|null $needs_basic_information
+     * @omegaup-request-param int|null $penalty
+     * @omegaup-request-param 'max'|'sum'|null $penalty_calc_policy
+     * @omegaup-request-param 'contest_start'|'none'|'problem_open'|'runtime'|null $penalty_type
+     * @omegaup-request-param float|null $points_decay_factor
+     * @omegaup-request-param null|string $problems
+     * @omegaup-request-param bool|null $requests_user_information
+     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
+     * @omegaup-request-param float|null $scoreboard
+     * @omegaup-request-param bool|null $show_scoreboard_after
+     * @omegaup-request-param int $start_time
+     * @omegaup-request-param int $submissions_gap
+     * @omegaup-request-param null|string $teams_group_alias
+     * @omegaup-request-param null|string $title
+     * @omegaup-request-param int $window_length
      */
     public static function apiCreate(\OmegaUp\Request $r) {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
@@ -2974,7 +2974,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
-     * @omegaup-request-param OmegaUp\Timestamp|null $start_time
+     * @omegaup-request-param int $start_time
      * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title
@@ -4784,7 +4784,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
-     * @omegaup-request-param OmegaUp\Timestamp|null $start_time
+     * @omegaup-request-param int $start_time
      * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2808,7 +2808,12 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'score_mode',
             ['partial','all_or_nothing','max_per_group'],
         );
-        $submissionsGap = $r->ensureOptionalInt('submissions_gap', 0, null, $isRequired);
+        $submissionsGap = $r->ensureOptionalInt(
+            'submissions_gap',
+            0,
+            null,
+            $isRequired
+        );
         $r->ensureOptionalInt('penalty', 0, 10000, $isRequired);
         // Validate the submission_gap in minutes so that the error message
         // matches what is displayed in the UI.

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2808,15 +2808,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'score_mode',
             ['partial','all_or_nothing','max_per_group'],
         );
-        $r->ensureOptionalInt('submissions_gap', 0, null, $isRequired);
+        $submissionsGap = $r->ensureOptionalInt('submissions_gap', 0, null, $isRequired);
         $r->ensureOptionalInt('penalty', 0, 10000, $isRequired);
         // Validate the submission_gap in minutes so that the error message
         // matches what is displayed in the UI.
-        $r->ensureoptionalInt(
+        \OmegaUp\Validators::validateNumberInRange(
+            (
+                is_null($submissionsGap) ?
+                null :
+                floor(intval($submissionsGap) / 60)
+            ),
             'submissions_gap',
-            lowerBound: 1,
-            upperBound: intval(floor($contestLength / 60)),
-            required: $isRequired
+            1,
+            is_null($contestLength) ? null : floor($contestLength / 60),
+            $isRequired
         );
 
         $r->ensureOptionalEnum(

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2825,7 +2825,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             ),
             'submissions_gap',
             1,
-            is_null($contestLength) ? null : floor($contestLength / 60),
+            $contestLength === 0 ? null : floor($contestLength / 60),
             $isRequired
         );
 

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2643,11 +2643,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         /** @var null|list<string>|scalar $languages */
         $languages = $r['languages'];
-        $languages = (
-            empty($languages) || !is_array($languages) ?
-            null :
-            join(',', $languages)
-        );
+
         $forTeams = $r->ensureOptionalBool('contest_for_teams') ?? false;
         $teamsGroupsAlias = $forTeams ? $r->ensureString(
             'teams_group_alias',
@@ -2701,27 +2697,27 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param null|string $alias
+     * @omegaup-request-param bool|null $check_plagiarism
      * @omegaup-request-param bool|null $contest_for_teams
      * @omegaup-request-param null|string $description
-     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param 'detailed'|'none'|'summary'|null $feedback
      * @omegaup-request-param int $finish_time
-     * @omegaup-request-param mixed $languages
-     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
+     * @omegaup-request-param null|string $languages
      * @omegaup-request-param int|null $penalty
-     * @omegaup-request-param mixed $penalty_calc_policy
-     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param 'max'|'sum'|null $penalty_calc_policy
+     * @omegaup-request-param 'contest_start'|'none'|'problem_open'|'runtime'|null $penalty_type
      * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param null|string $problems
+     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
      * @omegaup-request-param int $start_time
-     * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param int $submissions_gap
+     * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title
      * @omegaup-request-param int $window_length
-     * @omegaup-request-param bool|null $check_plagiarism
      */
     private static function validateCommonCreateOrUpdate(
         \OmegaUp\Request $r,
@@ -2729,24 +2725,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Contests $contest = null,
         bool $isRequired = true
     ): void {
-        \OmegaUp\Validators::validateOptionalStringNonEmpty(
-            $r['title'],
-            'title',
-            $isRequired
-        );
-        \OmegaUp\Validators::validateOptionalStringNonEmpty(
-            $r['description'],
-            'description',
-            $isRequired
-        );
+        $r->ensureOptionalString('title', $isRequired);
+        $r->ensureOptionalString('description', $isRequired);
 
         // Get the actual start and finish time of the contest, considering that
         // in case of update, parameters can be optional
         $startTime = $r->ensureOptionalTimestamp(
             'start_time',
-            null,
-            null,
-            $isRequired
+            required: $isRequired
         ) ?? (
             is_null($contest)
                 ? null
@@ -2756,9 +2742,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         $finishTime = $r->ensureOptionalTimestamp(
             'finish_time',
-            null,
-            null,
-            $isRequired
+            required: $isRequired
         ) ?? (
             is_null($contest)
                 ? null
@@ -2768,10 +2752,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         // Calculate the actual contest length
-        $contestLength = null;
+        $contestLength = 0;
         if (!is_null($finishTime) && !is_null($startTime)) {
-            // Validate start & finish time
-            if ($startTime->time > $finishTime->time) {
+            // Validate start & finish time where finish_time must be strictly
+            // greater than start_time
+            if ($startTime->time >= $finishTime->time) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'contestNewInvalidStartTime',
                     'finish_time'
@@ -2792,19 +2777,15 @@ class Contest extends \OmegaUp\Controllers\Controller {
         if (!empty($r['window_length'])) {
             $r->ensureOptionalInt(
                 'window_length',
-                0,
-                is_null($contestLength) ? null : intval($contestLength / 60)
+                lowerBound: 0,
+                upperBound: intval(floor($contestLength / 60)),
+                required: false
             );
         }
 
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['admission_mode'],
+        $r->ensureOptionalEnum(
             'admission_mode',
-            [
-                'public',
-                'private',
-                'registration',
-            ]
+            ['public', 'private', 'registration']
         );
         $contestAlias = $r->ensureOptionalString(
             'alias',
@@ -2831,44 +2812,33 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $r->ensureOptionalInt('penalty', 0, 10000, $isRequired);
         // Validate the submission_gap in minutes so that the error message
         // matches what is displayed in the UI.
-        \OmegaUp\Validators::validateNumberInRange(
-            (
-                is_null($r['submissions_gap']) ?
-                null :
-                floor(intval($r['submissions_gap']) / 60)
-            ),
+        $r->ensureoptionalInt(
             'submissions_gap',
-            1,
-            is_null($contestLength) ? null : floor($contestLength / 60),
-            $isRequired
+            lowerBound: 1,
+            upperBound: intval(floor($contestLength / 60)),
+            required: $isRequired
         );
 
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['feedback'],
+        $r->ensureOptionalEnum(
             'feedback',
             ['none', 'summary', 'detailed'],
             $isRequired
         );
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['penalty_type'],
+        $r->ensureOptionalEnum(
             'penalty_type',
             ['contest_start', 'problem_open', 'runtime', 'none'],
             $isRequired
         );
-        \OmegaUp\Validators::validateOptionalInEnum(
-            $r['penalty_calc_policy'],
+        $r->ensureOptionalEnum(
             'penalty_calc_policy',
             ['sum', 'max']
         );
-        \OmegaUp\Validators::validateOptionalStringNonEmpty(
-            $r['problems'],
-            'problems'
-        );
+        $problems = $r->ensureOptionalString('problems');
 
         // Problems is optional
-        if (!is_null($r['problems'])) {
+        if (!is_null($problems)) {
             /** @var list<array{problem: string, points: int}>|null */
-            $requestProblems = json_decode($r['problems'], associative: true);
+            $requestProblems = json_decode($problems, associative: true);
             if (!is_array($requestProblems)) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'invalidParameters',
@@ -2905,37 +2875,33 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // Show scoreboard is always optional
         $r->ensureOptionalBool('show_scoreboard_after');
 
-        // languages is required only when a contest is created
-        if ($isRequired && empty($r['languages'])) {
-            throw new \OmegaUp\Exceptions\InvalidParameterException(
-                'parameterEmpty',
-                'languages'
-            );
-        }
-
-        if (is_string($r['languages'])) {
-            $r['languages'] = explode(',', $r['languages']);
-        }
-        if (is_array($r['languages'])) {
-            foreach ($r['languages'] as $language) {
-                \OmegaUp\Validators::validateOptionalInEnum(
-                    $language,
-                    'languages',
-                    array_keys(
-                        \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
-                    )
-                );
-            }
-        }
-
         $forTeams = $r->ensureOptionalBool('contest_for_teams') ?? false;
         if ($forTeams) {
-            \OmegaUp\Validators::validateAlias(
-                $r['teams_group_alias'],
-                'teams_group_alias'
+            $r->ensureString(
+                'teams_group_alias',
+                fn (string $alias) => \OmegaUp\Validators::alias($alias)
             );
         }
         $r->ensureOptionalBool('check_plagiarism') ?? false;
+
+        // languages is required only when a contest is created
+        $languagesAsString = $r->ensureOptionalString('languages', $isRequired);
+        if (is_null($languagesAsString)) {
+            return;
+        }
+        $languages = explode(',', $languagesAsString);
+        foreach ($languages as $language) {
+            if (empty($language)) {
+                continue;
+            }
+            \OmegaUp\Validators::validateInEnum(
+                $language,
+                'languages',
+                array_keys(
+                    \OmegaUp\Controllers\Run::SUPPORTED_LANGUAGES
+                )
+            );
+        }
     }
 
     /**
@@ -2944,19 +2910,20 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @throws \OmegaUp\Exceptions\InvalidParameterException
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param null|string $alias
+     * @omegaup-request-param bool|null $check_plagiarism
      * @omegaup-request-param bool|null $contest_for_teams
      * @omegaup-request-param null|string $description
-     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param 'detailed'|'none'|'summary'|null $feedback
      * @omegaup-request-param int $finish_time
-     * @omegaup-request-param mixed $languages
-     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
+     * @omegaup-request-param null|string $languages
      * @omegaup-request-param int|null $penalty
-     * @omegaup-request-param mixed $penalty_calc_policy
-     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param 'max'|'sum'|null $penalty_calc_policy
+     * @omegaup-request-param 'contest_start'|'none'|'problem_open'|'runtime'|null $penalty_type
      * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param null|string $problems
+     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
      * @omegaup-request-param int $start_time
@@ -2964,7 +2931,6 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title
      * @omegaup-request-param int $window_length
-     * @omegaup-request-param bool|null $check_plagiarism
      */
     private static function validateCreate(
         \OmegaUp\Request $r,
@@ -2982,27 +2948,27 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @return \OmegaUp\DAO\VO\Contests
      *
-     * @omegaup-request-param mixed $admission_mode
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
      * @omegaup-request-param null|string $alias
+     * @omegaup-request-param bool|null $check_plagiarism
      * @omegaup-request-param bool|null $contest_for_teams
      * @omegaup-request-param null|string $description
-     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param 'detailed'|'none'|'summary'|null $feedback
      * @omegaup-request-param int $finish_time
-     * @omegaup-request-param mixed $languages
-     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
+     * @omegaup-request-param null|string $languages
      * @omegaup-request-param int|null $penalty
-     * @omegaup-request-param mixed $penalty_calc_policy
-     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param 'max'|'sum'|null $penalty_calc_policy
+     * @omegaup-request-param 'contest_start'|'none'|'problem_open'|'runtime'|null $penalty_type
      * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param null|string $problems
+     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
      * @omegaup-request-param OmegaUp\Timestamp|null $start_time
-     * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param int $submissions_gap
+     * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title
      * @omegaup-request-param int $window_length
-     * @omegaup-request-param bool|null $check_plagiarism
      */
     private static function validateUpdate(
         \OmegaUp\Request $r,
@@ -4790,29 +4756,29 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param null|string $admission_mode
      * @omegaup-request-param null|string $alias
+     * @omegaup-request-param bool|null $check_plagiarism
      * @omegaup-request-param string $contest_alias
      * @omegaup-request-param bool|null $contest_for_teams
      * @omegaup-request-param bool|null $default_show_all_contestants_in_scoreboard
      * @omegaup-request-param null|string $description
-     * @omegaup-request-param mixed $feedback
+     * @omegaup-request-param 'detailed'|'none'|'summary'|null $feedback
      * @omegaup-request-param int $finish_time
-     * @omegaup-request-param mixed $languages
+     * @omegaup-request-param null|string $languages
      * @omegaup-request-param bool|null $needs_basic_information
-     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param int|null $penalty
-     * @omegaup-request-param mixed $penalty_calc_policy
-     * @omegaup-request-param mixed $penalty_type
+     * @omegaup-request-param 'max'|'sum'|null $penalty_calc_policy
+     * @omegaup-request-param 'contest_start'|'none'|'problem_open'|'runtime'|null $penalty_type
      * @omegaup-request-param float|null $points_decay_factor
      * @omegaup-request-param null|string $problems
      * @omegaup-request-param 'no'|'optional'|'required'|null $requests_user_information
+     * @omegaup-request-param 'all_or_nothing'|'max_per_group'|'partial'|null $score_mode
      * @omegaup-request-param float|null $scoreboard
      * @omegaup-request-param bool|null $show_scoreboard_after
-     * @omegaup-request-param \OmegaUp\Timestamp|null $start_time
+     * @omegaup-request-param OmegaUp\Timestamp|null $start_time
      * @omegaup-request-param int $submissions_gap
      * @omegaup-request-param null|string $teams_group_alias
      * @omegaup-request-param null|string $title
      * @omegaup-request-param int $window_length
-     * @omegaup-request-param bool|null $check_plagiarism
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1401,33 +1401,33 @@ Update a Contest
 
 ### Parameters
 
-| Name                                         | Type                                                 | Description |
-| -------------------------------------------- | ---------------------------------------------------- | ----------- |
-| `contest_alias`                              | `string`                                             |             |
-| `finish_time`                                | `int`                                                |             |
-| `submissions_gap`                            | `int`                                                |             |
-| `window_length`                              | `int`                                                |             |
-| `admission_mode`                             | `null\|string`                                       |             |
-| `alias`                                      | `null\|string`                                       |             |
-| `check_plagiarism`                           | `bool\|null`                                         |             |
-| `contest_for_teams`                          | `bool\|null`                                         |             |
-| `default_show_all_contestants_in_scoreboard` | `bool\|null`                                         |             |
-| `description`                                | `null\|string`                                       |             |
-| `feedback`                                   | `mixed`                                              |             |
-| `languages`                                  | `mixed`                                              |             |
-| `needs_basic_information`                    | `bool\|null`                                         |             |
-| `penalty`                                    | `int\|null`                                          |             |
-| `penalty_calc_policy`                        | `mixed`                                              |             |
-| `penalty_type`                               | `mixed`                                              |             |
-| `points_decay_factor`                        | `float\|null`                                        |             |
-| `problems`                                   | `null\|string`                                       |             |
-| `requests_user_information`                  | `'no'\|'optional'\|'required'\|null`                 |             |
-| `score_mode`                                 | `'all_or_nothing'\|'max_per_group'\|'partial'\|null` |             |
-| `scoreboard`                                 | `float\|null`                                        |             |
-| `show_scoreboard_after`                      | `bool\|null`                                         |             |
-| `start_time`                                 | `\OmegaUp\Timestamp\|null`                           |             |
-| `teams_group_alias`                          | `null\|string`                                       |             |
-| `title`                                      | `null\|string`                                       |             |
+| Name                                         | Type                                                       | Description |
+| -------------------------------------------- | ---------------------------------------------------------- | ----------- |
+| `contest_alias`                              | `string`                                                   |             |
+| `finish_time`                                | `int`                                                      |             |
+| `submissions_gap`                            | `int`                                                      |             |
+| `window_length`                              | `int`                                                      |             |
+| `admission_mode`                             | `null\|string`                                             |             |
+| `alias`                                      | `null\|string`                                             |             |
+| `check_plagiarism`                           | `bool\|null`                                               |             |
+| `contest_for_teams`                          | `bool\|null`                                               |             |
+| `default_show_all_contestants_in_scoreboard` | `bool\|null`                                               |             |
+| `description`                                | `null\|string`                                             |             |
+| `feedback`                                   | `'detailed'\|'none'\|'summary'\|null`                      |             |
+| `languages`                                  | `null\|string`                                             |             |
+| `needs_basic_information`                    | `bool\|null`                                               |             |
+| `penalty`                                    | `int\|null`                                                |             |
+| `penalty_calc_policy`                        | `'max'\|'sum'\|null`                                       |             |
+| `penalty_type`                               | `'contest_start'\|'none'\|'problem_open'\|'runtime'\|null` |             |
+| `points_decay_factor`                        | `float\|null`                                              |             |
+| `problems`                                   | `null\|string`                                             |             |
+| `requests_user_information`                  | `'no'\|'optional'\|'required'\|null`                       |             |
+| `score_mode`                                 | `'all_or_nothing'\|'max_per_group'\|'partial'\|null`       |             |
+| `scoreboard`                                 | `float\|null`                                              |             |
+| `show_scoreboard_after`                      | `bool\|null`                                               |             |
+| `start_time`                                 | `OmegaUp\Timestamp\|null`                                  |             |
+| `teams_group_alias`                          | `null\|string`                                             |             |
+| `title`                                      | `null\|string`                                             |             |
 
 ### Returns
 

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -822,31 +822,31 @@ Creates a new contest
 
 ### Parameters
 
-| Name                        | Type           | Description |
-| --------------------------- | -------------- | ----------- |
-| `admission_mode`            | `mixed`        |             |
-| `alias`                     | `mixed`        |             |
-| `check_plagiarism`          | `bool\|null`   |             |
-| `contest_for_teams`         | `bool\|null`   |             |
-| `description`               | `mixed`        |             |
-| `feedback`                  | `mixed`        |             |
-| `finish_time`               | `mixed`        |             |
-| `languages`                 | `mixed`        |             |
-| `needs_basic_information`   | `bool\|null`   |             |
-| `penalty`                   | `mixed`        |             |
-| `penalty_calc_policy`       | `mixed`        |             |
-| `penalty_type`              | `mixed`        |             |
-| `points_decay_factor`       | `mixed`        |             |
-| `problems`                  | `null\|string` |             |
-| `requests_user_information` | `mixed`        |             |
-| `score_mode`                | `null\|string` |             |
-| `scoreboard`                | `mixed`        |             |
-| `show_scoreboard_after`     | `mixed`        |             |
-| `start_time`                | `mixed`        |             |
-| `submissions_gap`           | `mixed`        |             |
-| `teams_group_alias`         | `null\|string` |             |
-| `title`                     | `mixed`        |             |
-| `window_length`             | `int\|null`    |             |
+| Name                        | Type                                                       | Description |
+| --------------------------- | ---------------------------------------------------------- | ----------- |
+| `finish_time`               | `int`                                                      |             |
+| `start_time`                | `int`                                                      |             |
+| `submissions_gap`           | `int`                                                      |             |
+| `window_length`             | `int`                                                      |             |
+| `admission_mode`            | `'private'\|'public'\|'registration'\|null`                |             |
+| `alias`                     | `null\|string`                                             |             |
+| `check_plagiarism`          | `bool\|null`                                               |             |
+| `contest_for_teams`         | `bool\|null`                                               |             |
+| `description`               | `null\|string`                                             |             |
+| `feedback`                  | `'detailed'\|'none'\|'summary'\|null`                      |             |
+| `languages`                 | `null\|string`                                             |             |
+| `needs_basic_information`   | `bool\|null`                                               |             |
+| `penalty`                   | `int\|null`                                                |             |
+| `penalty_calc_policy`       | `'max'\|'sum'\|null`                                       |             |
+| `penalty_type`              | `'contest_start'\|'none'\|'problem_open'\|'runtime'\|null` |             |
+| `points_decay_factor`       | `float\|null`                                              |             |
+| `problems`                  | `null\|string`                                             |             |
+| `requests_user_information` | `bool\|null`                                               |             |
+| `score_mode`                | `'all_or_nothing'\|'max_per_group'\|'partial'\|null`       |             |
+| `scoreboard`                | `float\|null`                                              |             |
+| `show_scoreboard_after`     | `bool\|null`                                               |             |
+| `teams_group_alias`         | `null\|string`                                             |             |
+| `title`                     | `null\|string`                                             |             |
 
 ### Returns
 
@@ -1405,6 +1405,7 @@ Update a Contest
 | -------------------------------------------- | ---------------------------------------------------------- | ----------- |
 | `contest_alias`                              | `string`                                                   |             |
 | `finish_time`                                | `int`                                                      |             |
+| `start_time`                                 | `int`                                                      |             |
 | `submissions_gap`                            | `int`                                                      |             |
 | `window_length`                              | `int`                                                      |             |
 | `admission_mode`                             | `null\|string`                                             |             |
@@ -1425,7 +1426,6 @@ Update a Contest
 | `score_mode`                                 | `'all_or_nothing'\|'max_per_group'\|'partial'\|null`       |             |
 | `scoreboard`                                 | `float\|null`                                              |             |
 | `show_scoreboard_after`                      | `bool\|null`                                               |             |
-| `start_time`                                 | `OmegaUp\Timestamp\|null`                                  |             |
 | `teams_group_alias`                          | `null\|string`                                             |             |
 | `title`                                      | `null\|string`                                             |             |
 

--- a/frontend/server/src/CourseParams.php
+++ b/frontend/server/src/CourseParams.php
@@ -18,6 +18,12 @@ class CourseParams {
     const COURSE_REQUEST_USER_INFORMATION_OPTIONAL = 'optional';
     const COURSE_REQUEST_USER_INFORMATION_REQUIRED = 'required';
 
+    const VALID_ADMISSION_MODES = [
+        self::COURSE_ADMISSION_MODE_PRIVATE,
+        self::COURSE_ADMISSION_MODE_REGISTRATION,
+        self::COURSE_ADMISSION_MODE_PUBLIC,
+    ];
+
     /**
      * @readonly
      * @var string
@@ -140,11 +146,7 @@ class CourseParams {
             \OmegaUp\Validators::validateInEnum(
                 $params['admission_mode'],
                 'admission_mode',
-                [
-                    \OmegaUp\CourseParams::COURSE_ADMISSION_MODE_PRIVATE,
-                    \OmegaUp\CourseParams::COURSE_ADMISSION_MODE_REGISTRATION,
-                    \OmegaUp\CourseParams::COURSE_ADMISSION_MODE_PUBLIC,
-                ]
+                \OmegaUp\CourseParams::VALID_ADMISSION_MODES
             );
         }
         if (!is_null($params['requests_user_information'])) {

--- a/frontend/tests/Factories/Contest.php
+++ b/frontend/tests/Factories/Contest.php
@@ -10,6 +10,12 @@ class ContestParams {
     public $title;
 
     /**
+     * @readonly
+     * @var string
+     */
+    public $description;
+
+    /**
      * @var string
      */
     public $admissionMode;
@@ -46,7 +52,7 @@ class ContestParams {
 
     /**
      * @readonly
-     * @var null|list<string>
+     * @var list<string>
      */
     public $languages;
 
@@ -129,10 +135,23 @@ class ContestParams {
     public $penaltyType;
 
     /**
-     * @param array{alias?: string, admissionMode?: string, basicInformation?: bool, checkPlagiarism?: bool, contestDirector?: \OmegaUp\DAO\VO\Identities, contestDirectorUser?: \OmegaUp\DAO\VO\Users, contestForTeams?: bool, feedback?: string, finishTime?: \OmegaUp\Timestamp, languages?: ?list<string>, lastUpdated?: \OmegaUp\Timestamp, penaltyCalcPolicy?: string, penaltyType?: string, requestsUserInformation?: string, scoreboardPct?: int, scoreMode?: string, showScoreboardAfter?: bool, startTime?: \OmegaUp\Timestamp, teamsGroupAlias?: string, title?: string, windowLength?: ?int} $params
+     * @readonly
+     * @var int
+     */
+    public $submissionsGap;
+
+    /**
+     * @readonly
+     * @var float
+     */
+    public $pointsDecayFactor;
+
+    /**
+     * @param array{alias?: string, admissionMode?: string, basicInformation?: bool, checkPlagiarism?: bool, contestDirector?: \OmegaUp\DAO\VO\Identities, contestDirectorUser?: \OmegaUp\DAO\VO\Users, contestForTeams?: bool, feedback?: string, finishTime?: \OmegaUp\Timestamp, languages?: list<string>, lastUpdated?: \OmegaUp\Timestamp, penaltyCalcPolicy?: string, penaltyType?: string, requestsUserInformation?: string, scoreboardPct?: int, scoreMode?: string, showScoreboardAfter?: bool, startTime?: \OmegaUp\Timestamp, teamsGroupAlias?: string, title?: string, windowLength?: ?int} $params
      */
     public function __construct($params = []) {
         $this->title = $params['title'] ?? \OmegaUp\Test\Utils::createRandomString();
+        $this->description = $params['description'] ?? 'description';
         $this->alias = $params['alias'] ?? substr($this->title, 0, 20);
         $this->admissionMode = $params['admissionMode'] ?? 'public';
         $this->basicInformation = $params['basicInformation'] ?? false;
@@ -174,6 +193,8 @@ class ContestParams {
         $this->checkPlagiarism = $params['checkPlagiarism'] ?? false;
         $this->showScoreboardAfter = $params['showScoreboardAfter'] ?? false;
         $this->scoreboardPct = $params['scoreboardPct'] ?? 100;
+        $this->submissionsGap = $params['submissionsGap'] ?? 60;
+        $this->pointsDecayFactor = $params['pointsDecayFactor'] ?? 0.02;
     }
 }
 
@@ -200,7 +221,7 @@ class Contest {
         // Set context
         $r = new \OmegaUp\Request([
             'title' => $params->title,
-            'description' => 'description',
+            'description' => $params->description,
             'start_time' => (new \OmegaUp\Timestamp($params->startTime))->time,
             'finish_time' => (new \OmegaUp\Timestamp(
                 $params->finishTime
@@ -211,14 +232,14 @@ class Contest {
             'window_length' => $params->windowLength,
             'admission_mode' => $params->admissionMode,
             'alias' => $params->alias,
-            'points_decay_factor' => '0.02',
+            'points_decay_factor' => $params->pointsDecayFactor,
             'score_mode' => $params->scoreMode,
-            'submissions_gap' => '60',
+            'submissions_gap' => $params->submissionsGap,
             'feedback' => $params->feedback,
             'penalty' => 100,
             'scoreboard' => $params->scoreboardPct,
             'penalty_type' => $params->penaltyType,
-            'languages' => $params->languages,
+            'languages' => join(',', $params->languages),
             'recommended' => 0, // This is just a default value, it is not honored by apiCreate.
             'needs_basic_information' => $params->basicInformation,
             'requests_user_information' => $params->requestsUserInformation,

--- a/frontend/tests/badges/BadgesTest.php
+++ b/frontend/tests/badges/BadgesTest.php
@@ -248,7 +248,7 @@ class BadgesTest extends \OmegaUp\Test\BadgesTestCase {
             new \OmegaUp\Test\Factories\ContestParams(
                 [
                     'contestDirector' => $identityTwo,
-                    'languages' => 'c11-gcc',
+                    'languages' => ['c11-gcc'],
                 ]
             )
         );

--- a/frontend/tests/controllers/ContestCreateTest.php
+++ b/frontend/tests/controllers/ContestCreateTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * ContestCreateTest
  */
@@ -72,7 +70,7 @@ class ContestCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $r['auth_token'] = $login->auth_token;
 
             try {
-                $response = \OmegaUp\Controllers\Contest::apiCreate($r);
+                \OmegaUp\Controllers\Contest::apiCreate($r);
                 $this->fail("Exception was expected. Parameter: {$key}");
             } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
                 $this->assertSame('parameterEmpty', $e->getMessage());
@@ -190,7 +188,7 @@ class ContestCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $r['auth_token'] = $login->auth_token;
 
         try {
-            $response = \OmegaUp\Controllers\Contest::apiCreate($r);
+            \OmegaUp\Controllers\Contest::apiCreate($r);
             $this->fail('Should have failed');
         } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
             $this->assertSame(
@@ -264,6 +262,34 @@ class ContestCreateTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
+     * Public contest with same start and finish time is not valid.
+     */
+    public function testCreateContestWithWrongDates() {
+        $currentTime = \OmegaUp\Time::get();
+
+        // Create a valid contest Request object
+        $contestData = \OmegaUp\Test\Factories\Contest::getRequest(
+            new \OmegaUp\Test\Factories\ContestParams([
+                'startTime' => $currentTime,
+                'finishTime' => $currentTime,
+            ])
+        );
+        $r = $contestData['request'];
+        $contestDirector = $contestData['director'];
+
+        // Log in the user and set the auth token in the new request
+        $login = self::login($contestDirector);
+        $r['auth_token'] = $login->auth_token;
+
+        try {
+            \OmegaUp\Controllers\Contest::apiCreate($r);
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('contestNewInvalidStartTime', $e->getMessage());
+        }
+    }
+
+    /**
      * Creates a contest with window length, and review contestant
      * only can create run inside sumbission window
      */
@@ -289,7 +315,7 @@ class ContestCreateTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Create a contestant
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         // Add contestant to contest
         \OmegaUp\Test\Factories\Contest::addUser($contest, $identity);
@@ -405,9 +431,6 @@ class ContestCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $problem,
             $contest
         );
-
-        // Create a contestant
-        $login = self::login($contest['director']);
 
         // Create a contest request
         $response = \OmegaUp\DAO\Contests::getByAlias(

--- a/frontend/tests/controllers/ContestRemoveProblemTest.php
+++ b/frontend/tests/controllers/ContestRemoveProblemTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * Tests of the \OmegaUp\Controllers\Contest::apiRemoveProblem
  */
@@ -170,7 +168,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);
 
@@ -204,7 +202,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         // Call API
-        $response = \OmegaUp\Controllers\Contest::apiUpdate($r);
+        \OmegaUp\Controllers\Contest::apiUpdate($r);
     }
 
     /**
@@ -216,7 +214,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             new \OmegaUp\Test\Factories\ContestParams(
                 [
                     'admissionMode' => 'private',
-                    'languages' => 'c11-gcc',
+                    'languages' => ['c11-gcc'],
                 ]
             )
         );
@@ -292,7 +290,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             new \OmegaUp\Test\Factories\ContestParams(
                 [
                     'admissionMode' => 'private',
-                    'languages' => 'c11-gcc',
+                    'languages' => ['c11-gcc'],
                 ]
             )
         );
@@ -377,7 +375,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -420,7 +418,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $contestData
         );
 
-        ['user' => $secondaryAdmin, 'identity' => $secondaryIdentityAdmin] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $secondaryIdentityAdmin] = \OmegaUp\Test\Factories\User::createUser();
 
         // Prepare request
         $login = \OmegaUp\Test\ControllerTestCase::login(
@@ -473,10 +471,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        [
-            'user' => $contestant,
-            'identity' => $identity,
-        ] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -526,7 +521,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -571,7 +566,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -605,7 +600,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -648,7 +643,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             $problemData,
             $contestData
         );
-        ['user' => $contestant, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
 
         \OmegaUp\Test\Factories\Contest::addUser($contestData, $identity);
 
@@ -669,7 +664,7 @@ class ContestRemoveProblemTest extends \OmegaUp\Test\ControllerTestCase {
             'acl_id' => \OmegaUp\Authorization::SYSTEM_ACL,
         ]));
 
-        $response = \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
+        \OmegaUp\Test\Factories\Contest::removeProblemFromContest(
             $problemData,
             $contestData
         );

--- a/frontend/tests/controllers/ProblemUpdateTest.php
+++ b/frontend/tests/controllers/ProblemUpdateTest.php
@@ -1679,7 +1679,7 @@ class ProblemUpdateTest extends \OmegaUp\Test\ControllerTestCase {
             // Create a contest in the past with one run.
             $pastContestData = \OmegaUp\Test\Factories\Contest::createContest(
                 new \OmegaUp\Test\Factories\ContestParams([
-                    'startTime' => $originalTime - 60 * 60,
+                    'startTime' => $originalTime - 120 * 60,
                     'finishTime' => $originalTime - 5 * 60,
                     'contestDirector' => $contestDirector,
                 ])

--- a/frontend/tests/controllers/SchoolRankTest.php
+++ b/frontend/tests/controllers/SchoolRankTest.php
@@ -222,7 +222,7 @@ class SchoolRankTest extends \OmegaUp\Test\ControllerTestCase {
         // User3 automatically organizes a contest
         $contestData = \OmegaUp\Test\Factories\Contest::createContest(
             new \OmegaUp\Test\Factories\ContestParams(
-                ['languages' => 'c11-gcc']
+                ['languages' => ['c11-gcc']]
             )
         );
         $identities[] = $contestData['director'];

--- a/stuff/bootstrap.json
+++ b/stuff/bootstrap.json
@@ -1716,7 +1716,7 @@
 				"api": "/contest/update/",
 				"params": {
 					"contest_alias": "pasado",
-					"finish_time": "$NOW$",
+					"finish_time": "$NOW$+1",
 					"languages": "c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,cpp20-gcc,cpp20-clang,java,kt,py2,py3,rb,cs,pas,hs,lua,go,rs,js"
 				}
 			}


### PR DESCRIPTION
# Description

Se mejora la descripción del error cuando se elige una misma fecha de inicio que de finalización.

También se aprovecha el PR para dejar de usar el request  en las validaciones de crear y/o actualizar un concurso.


Fixes: #7747 

# Comments

En un cambio separado será conveniente crear la clase `ContestParams`para que esta se encargue de armar el objeto cencurso tal como se hace en los cursos.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
