### PR TITLE
Agregando el índice al campo verification_id de la tabla Users

### DIFF
--- a/frontend/database/00226_add_verification_id_index.sql
+++ b/frontend/database/00226_add_verification_id_index.sql
@@ -1,0 +1,3 @@
+-- Add the verification_id index to the Users table
+ALTER TABLE `Users`
+  ADD KEY `verification_id` (`verification_id`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1229,6 +1229,7 @@ CREATE TABLE `Users` (
   KEY `fk_main_email_id` (`main_email_id`),
   KEY `fk_main_identity_id` (`main_identity_id`),
   KEY `fk_parent_email_id` (`parent_email_id`),
+  KEY `verification_id` (`verification_id`),
   CONSTRAINT `fk_main_email_id` FOREIGN KEY (`main_email_id`) REFERENCES `Emails` (`email_id`),
   CONSTRAINT `fk_main_identity_id` FOREIGN KEY (`main_identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_parent_email_id` FOREIGN KEY (`parent_email_id`) REFERENCES `Emails` (`email_id`)


### PR DESCRIPTION
# Description

Se agrega el índice de `verification_id` en la tabla de `Users` para evitar queries de `FULL TABLE SCAN`

Fixes: #7773 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.