### PR TITLE
Write cypress tests for `statement tab`

### DIFF
--- a/cypress/e2e/problem_creator.cy.ts
+++ b/cypress/e2e/problem_creator.cy.ts
@@ -1,4 +1,4 @@
-import { LoginOptions } from "../support/types";
+import { LoginOptions } from '../support/types';
 
 describe('Problem creator Test', () => {
   beforeEach(() => {
@@ -18,9 +18,12 @@ describe('Problem creator Test', () => {
 
     cy.get('[data-problem-creator-tab="statement"]').click();
 
-    cy.get('[data-problem-creator-editor-markdown]').type("Hello omegaUp!");
-    cy.get("[data-problem-creator-save-markdown]").click();
+    cy.get('[data-problem-creator-editor-markdown]').type('Hello omegaUp!');
+    cy.get('[data-problem-creator-save-markdown]').click();
 
-    cy.get("[data-problem-creator-previewer-markdown]").should("have.html", "<h1>Previsualización</h1>\n\n<p>Hello omegaUp!</p>")
+    cy.get('[data-problem-creator-previewer-markdown]').should(
+      'have.html',
+      '<h1>Previsualización</h1>\n\n<p>Hello omegaUp!</p>',
+    );
   });
-})
+});

--- a/cypress/e2e/problem_creator.cy.ts
+++ b/cypress/e2e/problem_creator.cy.ts
@@ -16,7 +16,7 @@ describe('Problem creator Test', () => {
 
     cy.visit('/problem/creator/');
     
-    cy.get('[data-problem-creator-statement-tab]').click();
+    cy.get('[data-problem-creator-tab="statement"]').click();
 
     cy.get('[data-problem-creator-editor-markdown]').type("Hello omegaUp!");
     cy.get("[data-problem-creator-save-markdown]").click();

--- a/cypress/e2e/problem_creator.cy.ts
+++ b/cypress/e2e/problem_creator.cy.ts
@@ -1,0 +1,26 @@
+import { LoginOptions } from "../support/types";
+
+describe('Problem creator Test', () => {
+  beforeEach(() => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+    cy.visit('/');
+  });
+
+  it('Should write and verify the problem statement statement', () => {
+    const loginOptions: LoginOptions = {
+      username: 'user',
+      password: 'user',
+    };
+    cy.login(loginOptions);
+
+    cy.visit('/problem/creator/');
+    
+    cy.get('[data-problem-creator-statement-tab]').click();
+
+    cy.get('[data-problem-creator-editor-markdown]').type("Hello omegaUp!");
+    cy.get("[data-problem-creator-save-markdown]").click();
+
+    cy.get("[data-problem-creator-previewer-markdown]").should("have.html", "<h1>Previsualización</h1>\n\n<p>Hello omegaUp!</p>")
+  });
+})

--- a/cypress/e2e/problem_creator.cy.ts
+++ b/cypress/e2e/problem_creator.cy.ts
@@ -15,7 +15,7 @@ describe('Problem creator Test', () => {
     cy.login(loginOptions);
 
     cy.visit('/problem/creator/');
-    
+
     cy.get('[data-problem-creator-tab="statement"]').click();
 
     cy.get('[data-problem-creator-editor-markdown]').type("Hello omegaUp!");

--- a/cypress/e2e/problem_creator.cy.ts
+++ b/cypress/e2e/problem_creator.cy.ts
@@ -7,7 +7,7 @@ describe('Problem creator Test', () => {
     cy.visit('/');
   });
 
-  it('Should write and verify the problem statement statement', () => {
+  it('Should write and verify the problem statement', () => {
     const loginOptions: LoginOptions = {
       username: 'user',
       password: 'user',

--- a/frontend/www/js/omegaup/components/problem/creator/Tabs.test.ts
+++ b/frontend/www/js/omegaup/components/problem/creator/Tabs.test.ts
@@ -25,7 +25,7 @@ describe('Tabs.vue', () => {
     // BootstrapVue takes a tick to render the content inside the tabs
     await Vue.nextTick();
 
-    const buttons = wrapper.findAll('[data-tab]');
+    const buttons = wrapper.findAll('[data-problem-creator-tab]');
     expect(expectedText.length).toEqual(buttons.length);
     for (let i = 0; i < buttons.length; i++) {
       expect(buttons.at(i).text()).toEqual(expectedText[i]);

--- a/frontend/www/js/omegaup/components/problem/creator/Tabs.vue
+++ b/frontend/www/js/omegaup/components/problem/creator/Tabs.vue
@@ -3,7 +3,7 @@
     <b-tab>
       <template #title>
         <BIconPencil class="mr-1" />
-        <span name="writing" data-problem-creator-statement-tab>
+        <span name="writing" data-problem-creator-tab="statement">
           {{ T.problemCreatorStatement }}</span
         >
       </template>
@@ -16,7 +16,7 @@
     <b-tab>
       <template #title>
         <BIconFileCode class="mr-1" />
-        <span name="code" data-problem-creator-code-tab>
+        <span name="code" data-problem-creator-tab="code">
           {{ T.problemCreatorCode }}</span
         >
       </template>
@@ -29,7 +29,7 @@
     <b-tab>
       <template #title>
         <BIconCheckCircle class="mr-1" />
-        <span name="testcases" data-problem-creator-cases-tab>
+        <span name="testcases" data-problem-creator-tab="cases">
           {{ T.problemCreatorTestCases }}</span
         >
       </template>
@@ -42,7 +42,7 @@
     <b-tab>
       <template #title>
         <BIconFileEarmarkCheck class="mr-1" />
-        <span name="solution" data-problem-creator-solution-tab>
+        <span name="solution" data-problem-creator-tab="solution">
           {{ T.problemCreatorSolution }}</span
         >
       </template>

--- a/frontend/www/js/omegaup/components/problem/creator/Tabs.vue
+++ b/frontend/www/js/omegaup/components/problem/creator/Tabs.vue
@@ -3,7 +3,9 @@
     <b-tab>
       <template #title>
         <BIconPencil class="mr-1" />
-        <span name="writing" data-tab> {{ T.problemCreatorStatement }}</span>
+        <span name="writing" data-problem-creator-statement-tab>
+          {{ T.problemCreatorStatement }}</span
+        >
       </template>
       <omegaup-problem-creator-statement-tab
         @show-update-success-message="
@@ -14,7 +16,9 @@
     <b-tab>
       <template #title>
         <BIconFileCode class="mr-1" />
-        <span name="code" data-tab> {{ T.problemCreatorCode }}</span>
+        <span name="code" data-problem-creator-code-tab>
+          {{ T.problemCreatorCode }}</span
+        >
       </template>
       <omegaup-problem-creator-code-tab
         @show-update-success-message="
@@ -25,7 +29,9 @@
     <b-tab>
       <template #title>
         <BIconCheckCircle class="mr-1" />
-        <span name="testcases" data-tab> {{ T.problemCreatorTestCases }}</span>
+        <span name="testcases" data-problem-creator-cases-tab>
+          {{ T.problemCreatorTestCases }}</span
+        >
       </template>
       <omegaup-problem-creator-cases-tab
         @download-input-file="
@@ -36,7 +42,9 @@
     <b-tab>
       <template #title>
         <BIconFileEarmarkCheck class="mr-1" />
-        <span name="solution" data-tab> {{ T.problemCreatorSolution }}</span>
+        <span name="solution" data-problem-creator-solution-tab>
+          {{ T.problemCreatorSolution }}</span
+        >
       </template>
       <omegaup-problem-creator-solution-tab
         @show-update-success-message="

--- a/frontend/www/js/omegaup/components/problem/creator/statement/StatementTab.vue
+++ b/frontend/www/js/omegaup/components/problem/creator/statement/StatementTab.vue
@@ -7,11 +7,13 @@
           <textarea
             ref="markdownInput"
             v-model="currentMarkdown"
+            data-problem-creator-editor-markdown
             class="wmd-input"
           ></textarea>
         </div>
         <div class="col-md-6">
           <omegaup-markdown
+            data-problem-creator-previewer-markdown
             :markdown="
               T.problemCreatorMarkdownPreviewInitialRender + currentMarkdown
             "
@@ -21,7 +23,12 @@
       </div>
       <div class="row">
         <div class="col-md-12">
-          <button class="btn btn-primary" type="submit" @click="updateMarkdown">
+          <button
+            data-problem-creator-save-markdown
+            class="btn btn-primary"
+            type="submit"
+            @click="updateMarkdown"
+          >
             {{ T.problemCreatorMarkdownSave }}
           </button>
         </div>


### PR DESCRIPTION
# Description

This PR adds `cypress` test for `statement tab`.

Fixes: #7592 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
