### PR TITLE
Remplazando un left join por un inner join en query

### DIFF
--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -983,7 +983,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             (participating.identity_id IS NOT NULL) AS participating
         FROM
             Contests
-        LEFT JOIN
+        INNER JOIN
             Problemset_Identities participating
         ON
             participating.problemset_id = Contests.problemset_id AND


### PR DESCRIPTION
# Description

Se cambia un `LEFT JOIN` por un `INNER JOIN` en query para obtener el listado de concursos para una identidad y con esto evitaremos un full scan table.

Fixes: #7787 

# Comments

Faltará investigar cual es el propósito de ese `UNION` en el query, debido a que al parecer los concursos que se obtienen de ahí deben ser muy similares a los concursos que se obtienen en otro UNION en ese mismo `query`.

En caso de que se obtenga el mismo resultado, se podrá eliminar este

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.