### PR TITLE
Habilitando la vista de coders del mes históricos

### DIFF
--- a/frontend/www/js/omegaup/components/coderofthemonth/CodersList.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/CodersList.vue
@@ -1,9 +1,5 @@
 <template>
-  <div v-if="isDisabled" class="system-in-maintainance m-5 text-center">
-    <omegaup-markdown :markdown="T.systemInMaintainance"></omegaup-markdown>
-    <font-awesome-icon :icon="['fas', 'cogs']" />
-  </div>
-  <table v-else class="table table-striped table-hover table-responsive-sm">
+  <table class="table table-striped table-hover table-responsive-sm">
     <thead>
       <tr>
         <th scope="col" class="text-center"></th>
@@ -50,31 +46,15 @@ import user_Username from '../user/Username.vue';
 import country_Flag from '../CountryFlag.vue';
 import { types } from '../../api_types';
 
-import omegaup_Markdown from '../Markdown.vue';
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faCogs } from '@fortawesome/free-solid-svg-icons';
-library.add(faCogs);
-
 @Component({
   components: {
     'omegaup-user-username': user_Username,
     'omegaup-countryflag': country_Flag,
-    'omegaup-markdown': omegaup_Markdown,
-    'font-awesome-icon': FontAwesomeIcon,
   },
 })
 export default class CoderOfTheMonthList extends Vue {
   @Prop() coders!: types.CoderOfTheMonthList[];
-  @Prop({ default: true }) isDisabled!: boolean;
 
   T = T;
 }
 </script>
-
-<style scoped lang="scss">
-.system-in-maintainance {
-  font-size: 180%;
-  color: var(--general-in-maintainance-color);
-}
-</style>


### PR DESCRIPTION
# Description

Se habilita la vista de Coder del mes para validar que el script donde se actualizó el coder del mes de Agosto 2024 funcionó correctamente.

![image](https://github.com/user-attachments/assets/6476f390-507e-4041-a263-f683b6db9906)


Fixes: #7797 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.