### PR TITLE
Fix flaky `verifyFeedback` test

### DIFF
--- a/cypress/support/pageObjects/coursePage.ts
+++ b/cypress/support/pageObjects/coursePage.ts
@@ -224,7 +224,7 @@ export class CoursePage {
     cy.get('[data-clarification-answer-text]').should('contain', answer);
   }
 
-  leaveFeedbackOnSolution(feedbacks: { line: number, text: string }[]): void {
+  leaveFeedbackOnSolution(feedbacks: { line: number; text: string }[]): void {
     cy.get('[data-course-submisson-button]').click();
     cy.get('[data-runs-actions-button]').click();
     cy.get('[data-runs-show-details-button]').click();
@@ -235,7 +235,9 @@ export class CoursePage {
         cy.wrap(editor).should('be.visible');
 
         feedbacks.forEach(({ line, text }) => {
-          const gutterLines = editor.find('.CodeMirror-gutter-wrapper .CodeMirror-linenumber');
+          const gutterLines = editor.find(
+            '.CodeMirror-gutter-wrapper .CodeMirror-linenumber',
+          );
 
           // Ensure we have enough gutters
           expect(gutterLines.length).to.be.greaterThan(line);
@@ -272,7 +274,7 @@ export class CoursePage {
           .should('be.visible')
           .first()
           .click({ force: true });
-    });
+      });
   }
 
   verifyFeedback({
@@ -291,7 +293,7 @@ export class CoursePage {
       'contain',
       feedback,
     );
-    cy.get('.CodeMirror-lines', { timeout: 20000 }).should('be.visible');
+    cy.get('.CodeMirror-line', { timeout: 20000 }).should('be.visible');
     cy.get('.CodeMirror-line').then((rawHTMLElements) => {
       const userCode: Array<string> = [];
       Cypress.$.makeArray(rawHTMLElements).forEach((element) => {


### PR DESCRIPTION
# Description
The problem is most of the `CodeMirror` prefixed classes (`CodeMirror-sizer`, `CodeMirror-scroll`, ...) have position styles that make them not visible. A quick fix is to use `CodeMirror-line` class instead.

![Screenshot from 2024-09-04 23-17-04](https://github.com/user-attachments/assets/8cf9f484-de64-473a-8456-3ac984d0a186)

# Comments

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.