### PR TITLE
Arreglando algunos tipos en el controlador de Cursos

### DIFF
--- a/frontend/server/src/Controllers/Certificate.php
+++ b/frontend/server/src/Controllers/Certificate.php
@@ -380,7 +380,13 @@ class Certificate extends \OmegaUp\Controllers\Controller {
         self::printCertificateVerificationCode($pdf, $verificationCode);
         self::printCertificateVerificationLink($pdf, $verificationCode);
 
-        return base64_encode($pdf->Output('', 'S'));
+        $output = $pdf->Output('', 'S');
+        if (!is_string($output)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'contestCertificatesError'
+            );
+        }
+        return base64_encode($output);
     }
 
     public static function getPlaceSuffix(int $n): string {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1837,19 +1837,19 @@ API to Create an assignment
 
 ### Parameters
 
-| Name                 | Type           | Description |
-| -------------------- | -------------- | ----------- |
-| `course_alias`       | `string`       |             |
-| `alias`              | `mixed`        |             |
-| `assignment_type`    | `mixed`        |             |
-| `description`        | `mixed`        |             |
-| `finish_time`        | `mixed`        |             |
-| `name`               | `mixed`        |             |
-| `order`              | `int\|null`    |             |
-| `problems`           | `null\|string` |             |
-| `publish_time_delay` | `mixed`        |             |
-| `start_time`         | `mixed`        |             |
-| `unlimited_duration` | `bool\|null`   |             |
+| Name                 | Type                           | Description |
+| -------------------- | ------------------------------ | ----------- |
+| `alias`              | `string`                       |             |
+| `assignment_type`    | `'homework'\|'lesson'\|'test'` |             |
+| `course_alias`       | `string`                       |             |
+| `description`        | `string`                       |             |
+| `name`               | `string`                       |             |
+| `start_time`         | `\OmegaUp\Timestamp`           |             |
+| `finish_time`        | `\OmegaUp\Timestamp\|null`     |             |
+| `order`              | `int\|null`                    |             |
+| `problems`           | `null\|string`                 |             |
+| `publish_time_delay` | `int\|null`                    |             |
+| `unlimited_duration` | `bool\|null`                   |             |
 
 ### Returns
 


### PR DESCRIPTION
# Description

Se arreglan algunos tipos en el controlador de Cursos para dejar de usar `mixed`

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
