### PR TITLE
Bug fix where all the cases that used a layout were connected

### DIFF
--- a/frontend/www/js/omegaup/problem/creator/modules/cases.ts
+++ b/frontend/www/js/omegaup/problem/creator/modules/cases.ts
@@ -453,7 +453,9 @@ export const casesStore: Module<CasesState, RootState> = {
               lineID: uuid(),
               caseID: _case.caseID,
               label: lineInfo.label,
-              data: lineInfo.data,
+              data: {
+                ...lineInfo.data,
+              },
             }),
           );
           _case.lines = linesFromLayout;


### PR DESCRIPTION
# Description
This PR fixes a bug where all the cases enforced from same layout were connected.


**Before**:


https://github.com/user-attachments/assets/92656676-a68f-4ed7-810b-44cdcc07f4df


**After**:


https://github.com/user-attachments/assets/d2e22471-44d7-4993-82e4-f38d47934fba


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
