### PR TITLE
Evitando reevaluar envíos cuando no se modifican campos importantes

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -1361,7 +1361,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @param LimitsSettings $a
      * @param LimitsSettings $b
      */
-    private static function diffLimitsSettings(array $a, array $b): bool {
+    private static function diffLimitsSettings($a, $b): bool {
         if (
             self::parseDuration($a['TimeLimit']) !==
             self::parseDuration($b['TimeLimit'])
@@ -1401,7 +1401,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @param array{Limits: LimitsSettings, Slow: bool, Validator: array{GroupScorePolicy?: string, Lang?: string, Limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, Name: string, Tolerance: float}} $a
      * @param array{Limits: LimitsSettings, Slow: bool, Validator: array{GroupScorePolicy?: string, Lang?: string, Limits?: array{ExtraWallTime: string, MemoryLimit: int|string, OutputLimit: int|string, OverallWallTimeLimit: string, TimeLimit: string}, Name: string, Tolerance: float}} $b
      */
-    private static function diffProblemSettings(array $a, array $b): bool {
+    private static function diffProblemSettings($a, $b): bool {
         if (self::diffLimitsSettings($a['Limits'], $b['Limits'])) {
             return true;
         }
@@ -2320,7 +2320,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     private static function getProblemSettingsDistrib(
         \OmegaUp\DAO\VO\Problems $problem,
         string $commit
-    ): array {
+    ) {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::PROBLEM_SETTINGS_DISTRIB,
             "{$problem->alias}-{$problem->commit}",
@@ -4463,7 +4463,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @psalm-suppress ReferenceConstraintViolation for some reason, psalm cannot correctly infer the type for $problemSettings['Validator']['Limit']
      */
     private static function updateProblemSettings(
-        array &$problemSettings,
+        &$problemSettings,
         \OmegaUp\ProblemParams $params
     ): void {
         if (!is_null($params->extraWallTime)) {

--- a/frontend/server/src/ProblemParams.php
+++ b/frontend/server/src/ProblemParams.php
@@ -44,6 +44,15 @@ class ProblemParams extends BaseParams {
     const SHOW_DIFFS_EXAMPLES = 'examples';
     const SHOW_DIFFS_ALL = 'all';
 
+    // Group score policy
+    const GROUP_SCORE_POLICY_SUM_IF_NOT_ZERO = 'sum-if-not-zero';
+    const GROUP_SCORE_POLICY_MIN = 'min';
+
+    const VALID_GROUP_SCORE_POLICY_VALUES = [
+        self::GROUP_SCORE_POLICY_SUM_IF_NOT_ZERO,
+        self::GROUP_SCORE_POLICY_MIN,
+    ];
+
     /**
      * @readonly
      * @var string
@@ -205,7 +214,7 @@ class ProblemParams extends BaseParams {
             \OmegaUp\Validators::validateInEnum(
                 $params['group_score_policy'],
                 'group_score_policy',
-                ['sum-if-not-zero', 'min']
+                self::VALID_GROUP_SCORE_POLICY_VALUES
             );
         }
         if (isset($params['validator'])) {
@@ -295,7 +304,7 @@ class ProblemParams extends BaseParams {
         $this->allowUserAddTags = $params['allow_user_add_tags'] ?? false;
         $this->order = $params['order'] ?? 'normal';
         $this->showDiff = $params['show_diff'] ?? 'none';
-        $this->groupScorePolicy = $params['group_score_policy'] ?? null;
+        $this->groupScorePolicy = $params['group_score_policy'] ?? self::GROUP_SCORE_POLICY_SUM_IF_NOT_ZERO;
     }
 
     /**


### PR DESCRIPTION
# Description

Se arregla un bug que estaba ocasionando que se reevaluaran los envíos de un problema cuando se editaban campos que no ameritaban la reevaluación.

Resulta que cuando se creaba el problema no se estaba almacenando en gitserver el valor del campo `group_score_policy`. Entonces, al editar por primera vez el problema, ahora si se almacenaba el campo y esto ocasionaba que se generara una nueva versión del problema y por ende, se reevaluaban todos los envíos del problema.

Antes:
![RejudgedRunsOnEditProblemTitle](https://github.com/user-attachments/assets/34e769a3-37bb-4067-85a1-799a68667fd6)

Después:
![EditProblemTitleWithNoRejudge](https://github.com/user-attachments/assets/8acbe13f-9e0a-4326-a779-044d42a349a1)

Fixes: #7576 

# Comments

Falta agregar una prueba para evitar regresiones.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
