### PR TITLE
Fix missing error highlighting in profile basic information fields

### DIFF
--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.test.ts
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.test.ts
@@ -140,4 +140,26 @@ describe('BasicInformationEdit.vue', () => {
       ],
     ]);
   });
+
+  it('Should show error when username contains spaces', async () => {
+    const wrapper = mount(user_Basic_Information_Edit, {
+      propsData: basicInformationEditProps,
+    });
+
+    await wrapper.find('input[data-username]').setValue('invalid username');
+    await wrapper.find('button[type="submit"]').trigger('submit');
+
+    expect(
+      wrapper.emitted('update-user-basic-information-error'),
+    ).toBeDefined();
+    expect(wrapper.emitted('update-user-basic-information-error')).toEqual([
+      [
+        {
+          description: T.userEditUsernameNoSpaces,
+        },
+      ],
+    ]);
+    
+    expect(wrapper.find('input[data-username]').classes()).toContain('is-invalid');
+  });
 });

--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.test.ts
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.test.ts
@@ -84,7 +84,7 @@ describe('BasicInformationEdit.vue', () => {
       propsData: basicInformationEditProps,
     });
 
-    await wrapper.find('input[data-username]').setValue('omegaup modified');
+    await wrapper.find('input[data-username]').setValue('omegaup_modified');
     await wrapper.find('input[data-name]').setValue('omegaUp admin modified');
     await wrapper.findComponent(date_Picker).setValue('2001-01-01');
     await wrapper
@@ -105,7 +105,7 @@ describe('BasicInformationEdit.vue', () => {
     expect(wrapper.emitted('update-user-basic-information')).toEqual([
       [
         {
-          username: 'omegaup modified',
+          username: 'omegaup_modified',
           name: 'omegaUp admin modified',
           gender: 'other',
           country_id: 'CA',

--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.test.ts
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.test.ts
@@ -141,25 +141,31 @@ describe('BasicInformationEdit.vue', () => {
     ]);
   });
 
-  it('Should show error when username contains spaces', async () => {
+  it('Should show error when username is invalid', async () => {
     const wrapper = mount(user_Basic_Information_Edit, {
       propsData: basicInformationEditProps,
     });
 
-    await wrapper.find('input[data-username]').setValue('invalid username');
+    // Test invalid characters
+    await wrapper.find('input[data-username]').setValue('invalid@username');
     await wrapper.find('button[type="submit"]').trigger('submit');
-
-    expect(
-      wrapper.emitted('update-user-basic-information-error'),
-    ).toBeDefined();
     expect(wrapper.emitted('update-user-basic-information-error')).toEqual([
-      [
-        {
-          description: T.userEditUsernameNoSpaces,
-        },
-      ],
+      [{ description: T.parameterInvalidAlias }],
     ]);
-    
-    expect(wrapper.find('input[data-username]').classes()).toContain('is-invalid');
+    expect(wrapper.find('input[data-username]').classes()).toContain(
+      'is-invalid',
+    );
+
+    // Test too short username
+    await wrapper.find('input[data-username]').setValue('a');
+    expect(wrapper.find('input[data-username]').classes()).toContain(
+      'is-invalid',
+    );
+
+    // Test empty username
+    await wrapper.find('input[data-username]').setValue('');
+    expect(wrapper.find('input[data-username]').classes()).toContain(
+      'is-invalid',
+    );
   });
 });

--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
@@ -6,7 +6,15 @@
   >
     <div class="form-group">
       <label>{{ T.username }}</label>
-      <input v-model="username" data-username class="form-control" />
+      <input
+        v-model="username"
+        data-username
+        class="form-control"
+        :class="{ 'is-invalid': !isValidUsername }"
+      />
+      <div v-if="!isValidUsername" class="invalid-feedback">
+        {{ T.userEditUsernameNoSpaces }}
+      </div>
     </div>
     <div class="form-group">
       <label>{{ T.wordsName }}</label>
@@ -118,7 +126,18 @@ export default class UserBasicInformationEdit extends Vue {
     return subdivisions;
   }
 
+  get isValidUsername(): boolean {
+    return !this.username.includes(' ');
+  }
+
   onUpdateUserBasicInformation(): void {
+    if (!this.isValidUsername) {
+      this.$emit('update-user-basic-information-error', {
+        description: T.userEditUsernameNoSpaces,
+      });
+      return;
+    }
+
     if (this.name && this.name.length > 50) {
       this.$emit('update-user-basic-information-error', {
         description: T.userEditNameTooLong,
@@ -146,3 +165,16 @@ export default class UserBasicInformationEdit extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.is-invalid {
+  border-color: var(--danger) !important;
+}
+
+.invalid-feedback {
+  display: block;
+  color: var(--danger);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+</style>

--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
@@ -13,7 +13,7 @@
         :class="{ 'is-invalid': !isValidUsername }"
       />
       <div v-if="!isValidUsername" class="invalid-feedback">
-        {{ T.userEditUsernameNoSpaces }}
+        {{ T.parameterInvalidAlias }}
       </div>
     </div>
     <div class="form-group">
@@ -127,13 +127,17 @@ export default class UserBasicInformationEdit extends Vue {
   }
 
   get isValidUsername(): boolean {
-    return !this.username.includes(' ');
+    if (!this.username || this.username.length < 2) {
+      return false;
+    }
+    // Using the same regex pattern as the server
+    return !/[^a-zA-Z0-9_.-]/.test(this.username);
   }
 
   onUpdateUserBasicInformation(): void {
     if (!this.isValidUsername) {
       this.$emit('update-user-basic-information-error', {
-        description: T.userEditUsernameNoSpaces,
+        description: T.parameterInvalidAlias,
       });
       return;
     }
@@ -165,16 +169,3 @@ export default class UserBasicInformationEdit extends Vue {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-.is-invalid {
-  border-color: var(--danger) !important;
-}
-
-.invalid-feedback {
-  display: block;
-  color: var(--danger);
-  font-size: 0.875rem;
-  margin-top: 0.25rem;
-}
-</style>


### PR DESCRIPTION
# Description

These changes will:
1. Add real-time validation of the username field
2. Show a red border when the username contains spaces
3. Prevent form submission when the username is invalid
4. Add a test case to verify this behavior
5. The input field will turn red as soon as a space is detected in the username, and return to normal when the username is valid.

<img width="1439" alt="Screenshot 2024-10-31 at 4 14 33 PM" src="https://github.com/user-attachments/assets/2bcef04b-b1cd-49d5-89b2-b9e31cb72bbc">

Fixes: #7781 
# Comments

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
