### PR TITLE
Agregando la función que obtendrá el listado de los últimos 12 coders del mes

### DIFF
--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -63,6 +63,9 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
      */
     final public static function getCodersOfTheMonth(string $category = 'all'): array {
         $date = date('Y-m-01', \OmegaUp\Time::get());
+
+        // This query should be always synchronized with the one in the cron
+        // update_ranks.py, specifically in the function get_last_12_coders_of_the_month.
         $sql = "
           SELECT
               cm.time,

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -572,15 +572,20 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
      * @dataProvider coderOfTheMonthCategoryProvider
      */
     public function testCoderOfTheMonthAfterYear(string $category) {
-        $this->markTestSkipped(
-            'This test is skipped until all the rules are applied.'
-        );
         $gender = $category == 'all' ? 'male' : 'female';
-        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser(
+            new \OmegaUp\Test\Factories\UserParams(
+                ['username' => 'identityA']
+            )
+        );
         self::updateIdentity($identity, $gender);
 
         // User "B" is always the second one in the ranking based on score
-        ['identity' => $identityB] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identityB] = \OmegaUp\Test\Factories\User::createUser(
+            new \OmegaUp\Test\Factories\UserParams(
+                ['username' => 'identityB']
+            )
+        );
         self::updateIdentity($identityB, $gender);
 
         // Using the first day of the month as "today" to avoid failures near

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -974,6 +974,285 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         );
     }
 
+    public function coderOfTheMonthDuringOneYear(string $category) {
+        $gender = $category == 'all' ? 'male' : 'female';
+
+        // Create a submissions mapping for different users solving problems
+        // in different months during a year
+        $submissionsMapping = [
+            0 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 2],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            1 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 2],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            2 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 2],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            3 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 2],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            4 => [
+                ['username' => 'user_01', 'numRuns' => 1],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            5 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 8],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            6 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 2],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            7 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 2],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            8 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 2],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            9 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 2],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            10 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 2],
+                ['username' => 'user_07', 'numRuns' => 0],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            11 => [
+                ['username' => 'user_01', 'numRuns' => 0],
+                ['username' => 'user_02', 'numRuns' => 0],
+                ['username' => 'user_03', 'numRuns' => 0],
+                ['username' => 'user_04', 'numRuns' => 0],
+                ['username' => 'user_05', 'numRuns' => 0],
+                ['username' => 'user_06', 'numRuns' => 0],
+                ['username' => 'user_07', 'numRuns' => 2],
+                ['username' => 'user_08', 'numRuns' => 0],
+                ['username' => 'user_09', 'numRuns' => 0],
+                ['username' => 'user_10', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_12', 'numRuns' => 0],
+                ['username' => 'user_13', 'numRuns' => 0],
+            ],
+            12 => [
+                ['username' => 'user_01', 'numRuns' => 5],
+                ['username' => 'user_02', 'numRuns' => 8],
+                ['username' => 'user_03', 'numRuns' => 3],
+                ['username' => 'user_04', 'numRuns' => 4],
+                ['username' => 'user_05', 'numRuns' => 9],
+                ['username' => 'user_06', 'numRuns' => 2],
+                ['username' => 'user_07', 'numRuns' => 6],
+                ['username' => 'user_08', 'numRuns' => 4],
+                ['username' => 'user_09', 'numRuns' => 2],
+                ['username' => 'user_10', 'numRuns' => 5],
+                ['username' => 'user_11', 'numRuns' => 6],
+                ['username' => 'user_12', 'numRuns' => 3],
+                ['username' => 'user_13', 'numRuns' => 1],
+            ],
+        ];
+
+        $expectedWinners = [
+            0 => 'user_09',
+            1 => 'user_03',
+            2 => 'user_10',
+            3 => 'user_02',
+            4 => 'user_01',
+            5 => 'user_08',
+            6 => 'user_06',
+            7 => 'user_04',
+            8 => 'user_05',
+            9 => 'user_12',
+            10 => 'user_06',
+            11 => 'user_07',
+            12 => 'user_13',
+        ];
+
+        // Create the identities
+        $identities = [];
+
+        foreach ($submissionsMapping[0] as $index => $user) {
+            [
+                'identity' => $identities[$index],
+            ] = \OmegaUp\Test\Factories\User::createUser(
+                new \OmegaUp\Test\Factories\UserParams(
+                    ['username' => $user['username']]
+                )
+            );
+            self::updateIdentity($identities[$index], $gender);
+        }
+        foreach ($submissionsMapping as $month => $submissions) {
+            /*foreach ($submissions as $submission) {
+                ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+                self::updateIdentity($identity, $gender);
+                $identities[$submission['username']] = $identity;
+            }*/
+        }
+
+        $runCreationDate = self::setFirstDayOfTheCurrentMonth();
+        foreach ($submissionsMapping as $months) {
+            foreach ($months as $index => $submissions) {
+                $this->createRuns(
+                    $identities[$index],
+                    $runCreationDate,
+                    $submissions['numRuns']
+                );
+            }
+            $runCreationDate = date(
+                'Y-m-d',
+                strtotime(
+                    $runCreationDate . ' +1 day'
+                )
+            );
+
+            \OmegaUp\Test\Utils::runUpdateRanks();
+            /*$response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForTypeScript(
+                new \OmegaUp\Request([
+                    'category' => $category,
+                ])
+            )['templateProperties']['payload'];
+
+            foreach ($response['candidatesToCoderOfTheMonth'] as $index => $candidate) {
+                $expectedCandidates = array_filter(
+                    $submissions,
+                    fn($element) => $element['expectedPosition'] === $index
+                );
+                $expectedCandidate = array_pop($expectedCandidates);
+                $this->assertSame(
+                    $expectedCandidate['username'],
+                    $candidate['username'],
+                    "Failed in the iteration for the day {$runCreationDate}, user {$candidate['username']}"
+                );
+            }*/
+        }
+        //['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+    }
+
     /**
      * Test the API behavior when there is more than one candidate for Coder of
      * the Month during the first days of the current month
@@ -1115,5 +1394,14 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         )->format(
             'Y-m-d'
         );
+    }
+
+    private static function setFirstDayOfCustomMonths(int $monthsLeft = 2) {
+        return (new DateTimeImmutable(
+            date(
+                'Y-m-d',
+                \OmegaUp\Time::get()
+            )
+        ))->modify("first day of -{$monthsLeft} months")->format('Y-m-d');
     }
 }

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -974,7 +974,10 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         );
     }
 
-    public function coderOfTheMonthDuringOneYear(string $category) {
+    /**
+     * @dataProvider coderOfTheMonthCategoryProvider
+     */
+    public function testCoderOfTheMonthDuringOneYear(string $category) {
         $gender = $category == 'all' ? 'male' : 'female';
 
         // Create a submissions mapping for different users solving problems
@@ -989,7 +992,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_06', 'numRuns' => 0],
                 ['username' => 'user_07', 'numRuns' => 0],
                 ['username' => 'user_08', 'numRuns' => 0],
-                ['username' => 'user_09', 'numRuns' => 2],
+                ['username' => 'user_09', 'numRuns' => 1],
                 ['username' => 'user_10', 'numRuns' => 0],
                 ['username' => 'user_11', 'numRuns' => 0],
                 ['username' => 'user_12', 'numRuns' => 0],
@@ -998,7 +1001,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             1 => [
                 ['username' => 'user_01', 'numRuns' => 0],
                 ['username' => 'user_02', 'numRuns' => 0],
-                ['username' => 'user_03', 'numRuns' => 2],
+                ['username' => 'user_03', 'numRuns' => 1],
                 ['username' => 'user_04', 'numRuns' => 0],
                 ['username' => 'user_05', 'numRuns' => 0],
                 ['username' => 'user_06', 'numRuns' => 0],
@@ -1020,14 +1023,14 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_07', 'numRuns' => 0],
                 ['username' => 'user_08', 'numRuns' => 0],
                 ['username' => 'user_09', 'numRuns' => 0],
-                ['username' => 'user_10', 'numRuns' => 2],
+                ['username' => 'user_10', 'numRuns' => 1],
                 ['username' => 'user_11', 'numRuns' => 0],
                 ['username' => 'user_12', 'numRuns' => 0],
                 ['username' => 'user_13', 'numRuns' => 0],
             ],
             3 => [
                 ['username' => 'user_01', 'numRuns' => 0],
-                ['username' => 'user_02', 'numRuns' => 2],
+                ['username' => 'user_02', 'numRuns' => 1],
                 ['username' => 'user_03', 'numRuns' => 0],
                 ['username' => 'user_04', 'numRuns' => 0],
                 ['username' => 'user_05', 'numRuns' => 0],
@@ -1063,7 +1066,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_05', 'numRuns' => 0],
                 ['username' => 'user_06', 'numRuns' => 0],
                 ['username' => 'user_07', 'numRuns' => 0],
-                ['username' => 'user_08', 'numRuns' => 8],
+                ['username' => 'user_08', 'numRuns' => 1],
                 ['username' => 'user_09', 'numRuns' => 0],
                 ['username' => 'user_10', 'numRuns' => 0],
                 ['username' => 'user_11', 'numRuns' => 0],
@@ -1076,12 +1079,12 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_03', 'numRuns' => 0],
                 ['username' => 'user_04', 'numRuns' => 0],
                 ['username' => 'user_05', 'numRuns' => 0],
-                ['username' => 'user_06', 'numRuns' => 2],
+                ['username' => 'user_06', 'numRuns' => 0],
                 ['username' => 'user_07', 'numRuns' => 0],
                 ['username' => 'user_08', 'numRuns' => 0],
                 ['username' => 'user_09', 'numRuns' => 0],
                 ['username' => 'user_10', 'numRuns' => 0],
-                ['username' => 'user_11', 'numRuns' => 0],
+                ['username' => 'user_11', 'numRuns' => 1],
                 ['username' => 'user_12', 'numRuns' => 0],
                 ['username' => 'user_13', 'numRuns' => 0],
             ],
@@ -1089,7 +1092,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_01', 'numRuns' => 0],
                 ['username' => 'user_02', 'numRuns' => 0],
                 ['username' => 'user_03', 'numRuns' => 0],
-                ['username' => 'user_04', 'numRuns' => 2],
+                ['username' => 'user_04', 'numRuns' => 1],
                 ['username' => 'user_05', 'numRuns' => 0],
                 ['username' => 'user_06', 'numRuns' => 0],
                 ['username' => 'user_07', 'numRuns' => 0],
@@ -1105,7 +1108,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_02', 'numRuns' => 0],
                 ['username' => 'user_03', 'numRuns' => 0],
                 ['username' => 'user_04', 'numRuns' => 0],
-                ['username' => 'user_05', 'numRuns' => 2],
+                ['username' => 'user_05', 'numRuns' => 1],
                 ['username' => 'user_06', 'numRuns' => 0],
                 ['username' => 'user_07', 'numRuns' => 0],
                 ['username' => 'user_08', 'numRuns' => 0],
@@ -1127,7 +1130,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_09', 'numRuns' => 0],
                 ['username' => 'user_10', 'numRuns' => 0],
                 ['username' => 'user_11', 'numRuns' => 0],
-                ['username' => 'user_12', 'numRuns' => 2],
+                ['username' => 'user_12', 'numRuns' => 1],
                 ['username' => 'user_13', 'numRuns' => 0],
             ],
             10 => [
@@ -1136,7 +1139,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_03', 'numRuns' => 0],
                 ['username' => 'user_04', 'numRuns' => 0],
                 ['username' => 'user_05', 'numRuns' => 0],
-                ['username' => 'user_06', 'numRuns' => 2],
+                ['username' => 'user_06', 'numRuns' => 1],
                 ['username' => 'user_07', 'numRuns' => 0],
                 ['username' => 'user_08', 'numRuns' => 0],
                 ['username' => 'user_09', 'numRuns' => 0],
@@ -1152,7 +1155,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_04', 'numRuns' => 0],
                 ['username' => 'user_05', 'numRuns' => 0],
                 ['username' => 'user_06', 'numRuns' => 0],
-                ['username' => 'user_07', 'numRuns' => 2],
+                ['username' => 'user_07', 'numRuns' => 1],
                 ['username' => 'user_08', 'numRuns' => 0],
                 ['username' => 'user_09', 'numRuns' => 0],
                 ['username' => 'user_10', 'numRuns' => 0],
@@ -1161,18 +1164,18 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'user_13', 'numRuns' => 0],
             ],
             12 => [
-                ['username' => 'user_01', 'numRuns' => 5],
-                ['username' => 'user_02', 'numRuns' => 8],
-                ['username' => 'user_03', 'numRuns' => 3],
-                ['username' => 'user_04', 'numRuns' => 4],
-                ['username' => 'user_05', 'numRuns' => 9],
+                ['username' => 'user_01', 'numRuns' => 2],
+                ['username' => 'user_02', 'numRuns' => 2],
+                ['username' => 'user_03', 'numRuns' => 2],
+                ['username' => 'user_04', 'numRuns' => 2],
+                ['username' => 'user_05', 'numRuns' => 2],
                 ['username' => 'user_06', 'numRuns' => 2],
-                ['username' => 'user_07', 'numRuns' => 6],
-                ['username' => 'user_08', 'numRuns' => 4],
+                ['username' => 'user_07', 'numRuns' => 2],
+                ['username' => 'user_08', 'numRuns' => 2],
                 ['username' => 'user_09', 'numRuns' => 2],
-                ['username' => 'user_10', 'numRuns' => 5],
-                ['username' => 'user_11', 'numRuns' => 6],
-                ['username' => 'user_12', 'numRuns' => 3],
+                ['username' => 'user_10', 'numRuns' => 2],
+                ['username' => 'user_11', 'numRuns' => 2],
+                ['username' => 'user_12', 'numRuns' => 2],
                 ['username' => 'user_13', 'numRuns' => 1],
             ],
         ];
@@ -1184,12 +1187,15 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             3 => 'user_02',
             4 => 'user_01',
             5 => 'user_08',
-            6 => 'user_06',
+            6 => 'user_11',
             7 => 'user_04',
             8 => 'user_05',
             9 => 'user_12',
             10 => 'user_06',
             11 => 'user_07',
+            // user_13 is the only one who has solved a problem in the last month
+            // and hasn't won in the last 12 months, even when they have solved
+            // less number of problems than the other users.
             12 => 'user_13',
         ];
 
@@ -1206,51 +1212,33 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             );
             self::updateIdentity($identities[$index], $gender);
         }
-        foreach ($submissionsMapping as $month => $submissions) {
-            /*foreach ($submissions as $submission) {
-                ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
-                self::updateIdentity($identity, $gender);
-                $identities[$submission['username']] = $identity;
-            }*/
-        }
 
-        $runCreationDate = self::setFirstDayOfTheCurrentMonth();
-        foreach ($submissionsMapping as $months) {
-            foreach ($months as $index => $submissions) {
+        $initialMonth = 14;
+        $runCreationDate = self::setFirstDayOfCustomMonths($initialMonth);
+        foreach ($submissionsMapping as $month => $months) {
+            foreach ($months as $submissionIndex => $submissions) {
                 $this->createRuns(
-                    $identities[$index],
+                    $identities[$submissionIndex],
                     $runCreationDate,
                     $submissions['numRuns']
                 );
             }
-            $runCreationDate = date(
-                'Y-m-d',
-                strtotime(
-                    $runCreationDate . ' +1 day'
-                )
+            $submissions = \OmegaUp\DAO\Submissions::getAll();
+
+            \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
+            $coderOfTheMonth = $this->getCoderOfTheMonth(
+                $runCreationDate,
+                '1 month',
+                $category
+            )['coderinfo'];
+
+            $this->assertSame(
+                $coderOfTheMonth['username'],
+                $expectedWinners[$month]
             );
 
-            \OmegaUp\Test\Utils::runUpdateRanks();
-            /*$response = \OmegaUp\Controllers\User::getCoderOfTheMonthDetailsForTypeScript(
-                new \OmegaUp\Request([
-                    'category' => $category,
-                ])
-            )['templateProperties']['payload'];
-
-            foreach ($response['candidatesToCoderOfTheMonth'] as $index => $candidate) {
-                $expectedCandidates = array_filter(
-                    $submissions,
-                    fn($element) => $element['expectedPosition'] === $index
-                );
-                $expectedCandidate = array_pop($expectedCandidates);
-                $this->assertSame(
-                    $expectedCandidate['username'],
-                    $candidate['username'],
-                    "Failed in the iteration for the day {$runCreationDate}, user {$candidate['username']}"
-                );
-            }*/
+            $runCreationDate = self::setFirstDayOfTheCurrentMonth();
         }
-        //['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
     }
 
     /**
@@ -1396,7 +1384,7 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         );
     }
 
-    private static function setFirstDayOfCustomMonths(int $monthsLeft = 2) {
+    private static function setFirstDayOfCustomMonths(int $monthsLeft) {
         return (new DateTimeImmutable(
             date(
                 'Y-m-d',

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -98,12 +98,10 @@ def remove_coder_of_the_month_candidates(
 
 def get_last_12_coders_of_the_month(
     cur_readonly: mysql.connector.cursor.MySQLCursorDict,
-    date: datetime.date,
+    first_day_of_current_month: datetime.date,
     category: str,
 ) -> List[str]:
     '''Returns the last 12 coders of the month, to avoid repeating users'''
-
-    first_day_of_current_month = date
 
     # Note: This query should be always syncronized with the one in the
     # function getCodersOfTheMonth located in the /DAO/CoderOfTheMonth.php file

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -189,6 +189,65 @@ def get_coder_of_the_month_candidates(
     return candidates
 
 
+def get_last_12_coders_of_the_month(
+    cur_readonly: mysql.connector.cursor.MySQLCursorDict,
+    date: datetime.date,
+    category: str,
+) -> List[str]:
+    '''Returns the last 12 coders of the month, to avoid repeating users'''
+
+    first_day_of_current_month = date
+
+    # Note: This query should be always syncronized with the one in the
+    # function getCodersOfTheMonth located in the /DAO/CoderOfTheMonth.php file
+    sql = '''
+          SELECT
+              cm.time,
+              i.username,
+              IFNULL(i.country_id, 'xx') AS country_id,
+              e.email,
+              IFNULL(ur.classname, 'user-rank-unranked') AS classname
+          FROM
+              Coder_Of_The_Month cm
+          INNER JOIN
+              Users u ON u.user_id = cm.user_id
+          INNER JOIN
+              Identities i ON i.identity_id = u.main_identity_id
+          LEFT JOIN
+              Emails e ON e.user_id = u.user_id
+          LEFT JOIN
+              User_Rank ur ON ur.user_id = cm.user_id
+          WHERE
+              (cm.selected_by IS NOT NULL
+              OR (
+                  cm.`ranking` = 1 AND
+                  NOT EXISTS (
+                      SELECT
+                          *
+                      FROM
+                          Coder_Of_The_Month
+                      WHERE
+                          time = cm.time AND
+                          selected_by IS NOT NULL AND
+                          category = %s
+                  )
+              ))
+              AND cm.category = %s
+              AND cm.time <= %s
+          ORDER BY
+              cm.time DESC
+          LIMIT
+              0, 12;
+    '''
+    cur_readonly.execute(sql, (category, category, first_day_of_current_month))
+
+    coders = []
+    for row in cur_readonly.fetchall():
+        coders.append(row['username'])
+
+    return coders
+
+
 def insert_coder_of_the_month_candidates(
     cur: mysql.connector.cursor.MySQLCursorDict,
     first_day_of_next_month: datetime.date,

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -15,6 +15,7 @@ from database.coder_of_the_month import check_existing_coder_of_the_month
 from database.coder_of_the_month import get_coder_of_the_month_candidates
 from database.coder_of_the_month import get_cotm_eligible_users
 from database.coder_of_the_month import get_eligible_problems
+from database.coder_of_the_month import get_last_12_coders_of_the_month
 from database.coder_of_the_month import remove_coder_of_the_month_candidates
 from database.coder_of_the_month import insert_coder_of_the_month_candidates
 
@@ -615,67 +616,13 @@ def update_coder_of_the_month_candidates(
 
     logging.info(problems)
 
-    coders = get_last_12_coders_of_the_month(cur_readonly, category)
+    coders = get_last_12_coders_of_the_month(
+        cur_readonly,
+        _default_date(),
+        category
+    )
 
     logging.info(coders)
-
-
-def get_last_12_coders_of_the_month(
-    cur_readonly: mysql.connector.cursor.MySQLCursorDict,
-    category: str,
-) -> List[str]:
-    '''Returns the last 12 coders of the month, to avoid repeating users'''
-
-    first_day_of_current_month = _default_date()
-
-    # Note: This query should be always syncronized with the one in the
-    # function getCodersOfTheMonth located in the /DAO/CoderOfTheMonth.php file
-    sql = '''
-          SELECT
-              cm.time,
-              i.username,
-              IFNULL(i.country_id, 'xx') AS country_id,
-              e.email,
-              IFNULL(ur.classname, 'user-rank-unranked') AS classname
-          FROM
-              Coder_Of_The_Month cm
-          INNER JOIN
-              Users u ON u.user_id = cm.user_id
-          INNER JOIN
-              Identities i ON i.identity_id = u.main_identity_id
-          LEFT JOIN
-              Emails e ON e.user_id = u.user_id
-          LEFT JOIN
-              User_Rank ur ON ur.user_id = cm.user_id
-          WHERE
-              (cm.selected_by IS NOT NULL
-              OR (
-                  cm.`ranking` = 1 AND
-                  NOT EXISTS (
-                      SELECT
-                          *
-                      FROM
-                          Coder_Of_The_Month
-                      WHERE
-                          time = cm.time AND
-                          selected_by IS NOT NULL AND
-                          category = %s
-                  )
-              ))
-              AND cm.category = %s
-              AND cm.time <= %s
-          ORDER BY
-              cm.time DESC
-          LIMIT
-              0, 12;
-    '''
-    cur_readonly.execute(sql, (category, category, first_day_of_current_month))
-
-    coders = []
-    for row in cur_readonly.fetchall():
-        coders.append(row['username'])
-
-    return coders
 
 
 def update_users_stats(

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -549,15 +549,27 @@ def compute_points_for_user(
     cur_readonly: mysql.connector.cursor.MySQLCursorDict,
     first_day_of_current_month: datetime.date,
     first_day_of_next_month: datetime.date,
-    gender_clause: str,
+    category: str,
 ) -> List[UserRank]:
     '''Computes the points for each eligible user'''
+
+    if category == 'female':
+        gender_clause = " AND i.gender = 'female'"
+    else:
+        gender_clause = ""
+
+    last_12_coders = get_last_12_coders_of_the_month(
+        cur_readonly,
+        _default_date(),
+        category
+    )
 
     eligible_users = get_cotm_eligible_users(
         cur_readonly,
         first_day_of_current_month,
         first_day_of_next_month,
-        gender_clause
+        gender_clause,
+        last_12_coders
     )
 
     eligible_problems = get_eligible_problems(
@@ -637,28 +649,15 @@ def update_coder_of_the_month_candidates(
     remove_coder_of_the_month_candidates(cur, first_day_of_next_month,
                                          category)
 
-    if category == 'female':
-        gender_clause = " AND i.gender = 'female'"
-    else:
-        gender_clause = ""
-
     candidates = compute_points_for_user(cur_readonly,
                                          first_day_of_current_month,
                                          first_day_of_next_month,
-                                         gender_clause)
+                                         category)
 
     for index, candidate in enumerate(candidates):
         ranking = index + 1
         insert_coder_of_the_month_candidates(cur, first_day_of_next_month,
                                              ranking, category, candidate)
-
-    coders = get_last_12_coders_of_the_month(
-        cur_readonly,
-        _default_date(),
-        category
-    )
-
-    logging.info(coders)
 
 
 def update_users_stats(

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -560,7 +560,7 @@ def compute_points_for_user(
 
     last_12_coders = get_last_12_coders_of_the_month(
         cur_readonly,
-        _default_date(),
+        first_day_of_current_month,
         category
     )
 


### PR DESCRIPTION
# Description

Se agrega la función que se encargará de obtener el listado de los ganadores a la insignia de coder del mes del último año.

Esto será útil para poder fitrarlos a estos de la lista de candidatos a ganar en el mes actual.

Part of: #7884 

# Comments

En el PR #7899  se decidió mover toda la lógica de la base dee datos a un archivo nuevo. En este momento ya es necesario que ese PR se apruebe para poder liberar espacio en el archivo `update_ranks.py` debido a que este ya está obteniendo un error de pylint por exceso de líneas en el script.

Se quedará como draft, además de que falta agregar una prueba
# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
