### PR TITLE
Mostrando incondicionalmente todos las categorías de nivel de problemas

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1421,8 +1421,16 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 GROUP BY
                     t.name;";
 
-        /** @var list<array{name: string, problems_per_tag: int}> */
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql);
+        /** @var list<array{name: string, problems_per_tag: float}> */
+        $result = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql);
+        $problems = [];
+        foreach ($result as $problem) {
+            $problems[] = [
+                'name' => $problem['name'],
+                'problems_per_tag' => intval($problem['problems_per_tag']),
+            ];
+        }
+        return $problems;
     }
 
     final public static function getRandomLanguageProblemAlias(): string {

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1421,7 +1421,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 GROUP BY
                     t.name;";
 
-        /** @var list<array{name: string, problems_per_tag: float}> */
+        /** @var list<array{name: string, problems_per_tag: float|null}> */
         $result = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql);
         $problems = [];
         foreach ($result as $problem) {

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1405,9 +1405,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
     final public static function getQualityProblemsPerTagCount(): array {
         $sql = "SELECT
                     t.name,
-                    COUNT(
-                        CASE WHEN p.quality_seal = 1 THEN p.problem_id END
-                    ) AS problems_per_tag
+                    SUM(IF(p.quality_seal = 1, 1, 0)) AS problems_per_tag
                 FROM
                     Tags t
                 LEFT JOIN

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1404,20 +1404,22 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
      */
     final public static function getQualityProblemsPerTagCount(): array {
         $sql = "SELECT
-                    t.name, COUNT(p.problem_id) AS problems_per_tag
+                    t.name,
+                    COUNT(
+                        CASE WHEN p.quality_seal = 1 THEN p.problem_id END
+                    ) AS problems_per_tag
                 FROM
-                    Problems p
-                INNER JOIN
+                    Tags t
+                LEFT JOIN
                     Problems_Tags pt
                 ON
-                    p.problem_id = pt.problem_id
-                INNER JOIN
-                    Tags t
-                ON
                     t.tag_id = pt.tag_id
+                LEFT JOIN
+                    Problems p
+                ON
+                    p.problem_id = pt.problem_id
                 WHERE
                     t.name LIKE CONCAT('problemLevel','%')
-                    AND p.quality_seal = 1
                 GROUP BY
                     t.name;";
 

--- a/frontend/www/js/omegaup/components/problem/Collection.vue
+++ b/frontend/www/js/omegaup/components/problem/Collection.vue
@@ -39,6 +39,7 @@
               <template #button>
                 <a
                   class="btn btn-primary"
+                  :class="{ disabled: collection.problems_per_tag == 0 }"
                   :href="`/problem/collection/${encodeURIComponent(
                     collection.name,
                   )}/`"
@@ -183,7 +184,7 @@ const problemLevelIcons: { [key: string]: string } = {
 })
 export default class Collection extends Vue {
   @Prop() levelTags!: string[];
-  @Prop() problemCount!: string[];
+  @Prop() problemCount!: { name: string; problems_per_tag: number }[];
   @Prop() allTags!: types.Tag[];
   T = T;
   ui = ui;


### PR DESCRIPTION
# Description

In this change, all cards containing the tag categories related to problem levels are displayed.

This is necessary to make changes to the problem collections UI, as it will show all the elements that this view can contain.

Part of: #7911

# Comments

When a collection doesn't contain any problems, the "View problems" button will be disabled.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
