### PR TITLE
Agregando consideración de omitir los problemas en los que el usuario ha visto la solución

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,7 @@ jobs:
             python3 -m venv /opt/omegaup/stuff/venv && \
             . /opt/omegaup/stuff/venv/bin/activate && \
             python3 -m pip install wheel && \
-            python3 -m pip install -r /opt/omegaup/stuff/requirements.txt && \
-            python3 -m pip install --upgrade python-json-logger==3.2.1"
+            python3 -m pip install -r /opt/omegaup/stuff/requirements.txt"
           ./stuff/lint.sh --diagnostics-output=github validate --all < /dev/null
 
       - name: Run Psalm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,8 @@ jobs:
             python3 -m venv /opt/omegaup/stuff/venv && \
             . /opt/omegaup/stuff/venv/bin/activate && \
             python3 -m pip install wheel && \
-            python3 -m pip install -r /opt/omegaup/stuff/requirements.txt"
+            python3 -m pip install -r /opt/omegaup/stuff/requirements.txt && \
+            python3 -m pip install --upgrade python-json-logger==3.2.1"
           ./stuff/lint.sh --diagnostics-output=github validate --all < /dev/null
 
       - name: Run Psalm

--- a/frontend/tests/controllers/ProblemsForfeitedTest.php
+++ b/frontend/tests/controllers/ProblemsForfeitedTest.php
@@ -1,6 +1,4 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 /**
  * Tests for ProblemForfeitedController
  */
@@ -25,9 +23,8 @@ class ProblemsForfeitedTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     public function testGetSolution() {
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
-        $problems = [];
 
         $extraProblem = \OmegaUp\Test\Factories\Problem::createProblem();
 
@@ -65,7 +62,7 @@ class ProblemsForfeitedTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     public function testGetSolutionForbiddenAccessException() {
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
         $problems = [];
 
@@ -103,9 +100,8 @@ class ProblemsForfeitedTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     public function testGetNonexistentSolution() {
-        ['user' => $user, 'identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = self::login($identity);
-        $problems = [];
 
         $extraProblem = \OmegaUp\Test\Factories\Problem::createProblem(
             new \OmegaUp\Test\Factories\ProblemParams([

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -344,18 +344,28 @@ def get_user_problems(
 
     cur_readonly.execute(f'''
             SELECT
-                identity_id,
-                problem_id,
+                s.identity_id,
+                s.problem_id,
                 MIN(time) AS first_time_solved
             FROM
-                Submissions
+                Submissions s
+            INNER JOIN
+                Identities i
+            ON
+                i.identity_id = s.identity_id
+            LEFT JOIN
+                Problems_Forfeited pf
+            ON
+                pf.user_id = i.user_id
+                AND pf.problem_id = s.problem_id
             WHERE
-                identity_id IN ({identity_ids_str})
-                AND problem_id IN ({problem_ids_str})
+                s.identity_id IN ({identity_ids_str})
+                AND s.problem_id IN ({problem_ids_str})
                 AND verdict = 'AC'
                 AND type = 'normal'
+                AND forfeited_date IS NULL
             GROUP BY
-                identity_id, problem_id;
+                s.identity_id, s.problem_id;
     ''')
 
     # Populate user_problems dictionary with the problems solved by each user

--- a/stuff/docker/requirements.txt
+++ b/stuff/docker/requirements.txt
@@ -1,4 +1,4 @@
-python-json-logger>=2.0.2
+python-json-logger>=3.2.1
 mysql-connector-python>=8.0.28
 boto3>=1.20.26
 pika>=1.2.0

--- a/stuff/lib/logs.py
+++ b/stuff/lib/logs.py
@@ -12,16 +12,11 @@ import logging
 
 from typing import Any, Dict
 
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import jsonlogger  # type: ignore
 
 
-class _CustomJsonFormatter(jsonlogger.JsonFormatter):
+class _CustomJsonFormatter(jsonlogger.JsonFormatter):  # type: ignore
     """A JSON formatter that adds the level."""
-
-    def __init__(self) -> None:
-        # TODO(https://github.com/madzak/python-json-logger/pull/170): Remove
-        # the type: ignore annotation when v2.0.8 is released.
-        super().__init__()  # type: ignore
 
     def add_fields(
             self,

--- a/stuff/requirements.txt
+++ b/stuff/requirements.txt
@@ -12,7 +12,7 @@ pyparsing==3.0.7
 pytest-mock>=3.7.0
 pytest-stub==1.1.0
 pytest==6.2.5
-python-json-logger>=2.0.7
+python-json-logger>=3.2.1
 pytest-shutil>=1.7.0
 pytest-timeout==2.1.0
 types-requests==2.27.8


### PR DESCRIPTION
# Description

Se agregan los cambios necesarios en la consulta que obtiene los problemas que el usuario ha resuelto por primera vez en el mes para que verifique si este ya vio la solución del mismo para omitirlos del puntaje que calcula al coder del mes.

Fixes: #7885 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
