### PR TITLE
 Clear public tag input field after adding a tag to enhance user experience.

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -5,6 +5,7 @@
         <label class="font-weight-bold">{{ T.wordsPublicTags }}</label>
         <vue-typeahead-bootstrap
           v-if="canAddNewTags"
+          v-model="newPublicTag"
           data-tags-input
           :data="publicTags"
           :serializer="publicTagsSerializer"
@@ -200,11 +201,13 @@ export default class ProblemTags extends Vue {
   allowTags = this.initialAllowTags;
   problemLevelTag: string | null = this.problemLevel;
   newPrivateTag = '';
+  newPublicTag = '';
 
   addPublicTag(tag: string): void {
     if (this.canAddNewTags && !this.selectedPublicTags.includes(tag)) {
       this.$emit('emit-add-tag', this.alias, tag, true);
     }
+    this.newPublicTag = '';
   }
 
   addPrivateTag(): void {


### PR DESCRIPTION

# Description

Added functionality to clear the input field of public tags after a tag is successfully added, by preventing the previously entered tag from remaining in the input field.

( Resolved red border error on the public tag input field  )

Fixes: #7922

Video:

https://github.com/user-attachments/assets/9bb30c66-11d4-4d78-9b94-1da9b1b0997b













# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.

