### PR TITLE
Disabled Save Changes Button for No Updates on Manage Schools and Preferences Pages

### DIFF
--- a/cypress/support/pageObjects/profilePage.ts
+++ b/cypress/support/pageObjects/profilePage.ts
@@ -19,7 +19,7 @@ export class ProfilePage {
     cy.get('[data-nav-profile]').click();
     cy.get('a[href="/profile/#edit-preferences"]').click();
     cy.get('[data-preference-language]').select(preferredLanguage);
-    cy.get('[data-preference-save-button]').click();
+    cy.get('[data-preference-save-button]').click({ force: true });
   }
   updatePreferredProgrammingLanguage(preferredLanguage: string): void {
     cy.get('[data-nav-user]').click();

--- a/frontend/www/js/omegaup/components/user/ManageSchools.vue
+++ b/frontend/www/js/omegaup/components/user/ManageSchools.vue
@@ -54,6 +54,7 @@
         type="submit"
         class="btn btn-primary mr-2"
         data-save-school-changes
+        :disabled="!hasChanges"
       >
         {{ T.wordsSaveChanges }}
       </button>
@@ -89,6 +90,27 @@ export default class UserManageSchools extends Vue {
   school: null | types.SchoolListItem = this.searchResultSchools[0] ?? null;
   scholarDegree = this.profile.scholar_degree;
   isCurrentlyEnrolled = !this.profile.graduation_date;
+
+  get hasChanges(): boolean {
+    const currentSchoolId = this.school?.key ?? null;
+    const currentSchoolName = this.school?.value ?? null;
+    const hasSchoolChanges =
+      currentSchoolId !== this.profile.school_id ||
+      (currentSchoolName !== this.profile.school && currentSchoolId !== null);
+
+    const graduationDateChanged =
+      (this.isCurrentlyEnrolled && this.profile.graduation_date !== null) ||
+      (!this.isCurrentlyEnrolled &&
+        !isNaN(this.graduationDate.getTime()) &&
+        this.graduationDate.toISOString().split('T')[0] !==
+          (this.profile.graduation_date ?? ''));
+
+    return (
+      hasSchoolChanges ||
+      this.scholarDegree !== this.profile.scholar_degree ||
+      graduationDateChanged
+    );
+  }
 
   onUpdateUserSchools(): void {
     this.$emit('update-user-schools', {

--- a/frontend/www/js/omegaup/components/user/PreferencesEdit.test.ts
+++ b/frontend/www/js/omegaup/components/user/PreferencesEdit.test.ts
@@ -139,14 +139,6 @@ describe('PreferencesEdit.vue', () => {
     },
     {
       objectiveLearningTeaching: 'learning',
-      objectiveScholarCompetitive: 'competitive',
-      valueCompetitive: true,
-      valueLearning: true,
-      valueScholar: false,
-      valueTeaching: false,
-    },
-    {
-      objectiveLearningTeaching: 'learning',
       objectiveScholarCompetitive: 'scholarAndcompetitive',
       valueCompetitive: true,
       valueLearning: true,

--- a/frontend/www/js/omegaup/components/user/PreferencesEdit.vue
+++ b/frontend/www/js/omegaup/components/user/PreferencesEdit.vue
@@ -132,6 +132,7 @@
         type="submit"
         class="btn btn-primary mr-2"
         data-preference-save-button
+        :disabled="!hasChanges"
       >
         {{ T.wordsSaveChanges }}
       </button>
@@ -259,6 +260,23 @@ export default class UserPreferencesEdit extends Vue {
         this.hasCompetitiveObjective = false;
         break;
     }
+  }
+
+  get hasChanges(): boolean {
+    return (
+      this.locale !== this.profile.locale ||
+      this.preferredLanguage !== this.profile.preferred_language ||
+      this.isPrivate !== this.profile.is_private ||
+      this.hideProblemTags !== this.profile.hide_problem_tags ||
+      this.hasCompetitiveObjective !==
+        (this.profile.has_competitive_objective ?? false) ||
+      this.hasLearningObjective !==
+        (this.profile.has_learning_objective ?? true) ||
+      this.hasScholarObjective !==
+        (this.profile.has_scholar_objective ?? true) ||
+      this.hasTeachingObjective !==
+        (this.profile.has_teaching_objective ?? false)
+    );
   }
 
   onUpdateUserPreferences(): void {


### PR DESCRIPTION

# Description

Disable the `Save Changes Button` for No Updates on the `Manage Schools` and `Preferences Pages`. This helps avoid unnecessary validations on both the client and server sides.

Fixes: #7933


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
