### PR TITLE
Add validation and warning for state selection in user profile.

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -45,6 +45,24 @@ describe('Navigation Test', () => {
     cy.logout();
   });
 
+  it('Should display warning if state is not selected', () => {
+    const loginOptions = loginPage.registerMultipleUsers(1);
+    const userBasicInformation: UserInformation = {
+      name: 'Test User',
+      gender: 'male',
+      country: 'Mexico',
+      state: '',
+      dateOfBirth: getISODate(
+        new Date(new Date().setFullYear(new Date().getFullYear() - 20)),
+      ),
+    };
+
+    cy.login(loginOptions[0]);
+    profilePage.updateProfileInformation(userBasicInformation);
+    profilePage.validateStateSelection();
+    cy.logout();
+  });
+
   it('Should update preferences', () => {
     const loginOptions = loginPage.registerMultipleUsers(1);
     const userPreferences: UserPreferences = {

--- a/cypress/support/pageObjects/profilePage.ts
+++ b/cypress/support/pageObjects/profilePage.ts
@@ -163,6 +163,16 @@ export class ProfilePage {
     cy.get('[data-nav-user]').click();
     cy.get('button').contains(username).click();
   }
+
+  validateStateSelection(): void {
+    cy.get('[data-save-profile-changes-button]').click();
+    cy.get('[data-states]').then(($stateSelect) => {
+      const selectedState = $stateSelect.val();
+      if (!selectedState) {
+        cy.get('[data-state-warning]').should('be.visible');
+      }
+    });
+  }
 }
 
 export const profilePage = new ProfilePage();


### PR DESCRIPTION
Fixes #7904

Add validation and warning for state selection in user profile.

* Add validation mechanism in `cypress/support/pageObjects/profilePage.ts` to check if the state is selected.
* Display a warning message if the state is not selected in `cypress/support/pageObjects/profilePage.ts`.
* Update test cases in `cypress/e2e/navigation.cy.ts` to check for the warning related to state selection.