### PR TITLE
Add state selection warning in profile page

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -45,6 +45,24 @@ describe('Navigation Test', () => {
     cy.logout();
   });
 
+  it('Should display warning if state is not selected', () => {
+    const loginOptions = loginPage.registerMultipleUsers(1);
+    const userBasicInformation: UserInformation = {
+      name: 'Test User',
+      gender: 'male',
+      country: 'Mexico',
+      state: '',
+      dateOfBirth: getISODate(
+        new Date(new Date().setFullYear(new Date().getFullYear() - 20)),
+      ),
+    };
+
+    cy.login(loginOptions[0]);
+    profilePage.updateProfileInformation(userBasicInformation);
+    cy.get('[data-state-warning]').should('be.visible');
+    cy.logout();
+  });
+
   it('Should update preferences', () => {
     const loginOptions = loginPage.registerMultipleUsers(1);
     const userPreferences: UserPreferences = {

--- a/cypress/support/pageObjects/profilePage.ts
+++ b/cypress/support/pageObjects/profilePage.ts
@@ -79,6 +79,12 @@ export class ProfilePage {
     cy.get('[data-states]').select(userBasicInformation.state);
     cy.get('[data-date-of-birth]').type(userBasicInformation.dateOfBirth);
     cy.get('[data-save-profile-changes-button]').click();
+
+    // Add validation mechanism to check if the state is selected
+    if (userBasicInformation.state === '') {
+      // Display a warning message if the state is not selected
+      cy.get('[data-state-warning]').should('be.visible');
+    }
   }
 
   verifyProfileInformation(userBasicInformation: UserInformation): void {


### PR DESCRIPTION
Fixes #7904

Add validation and warning for state selection in user profile.

* Add validation mechanism in `cypress/support/pageObjects/profilePage.ts` to check if the state is selected.
* Display a warning message if the state is not selected in `cypress/support/pageObjects/profilePage.ts`.
* Update test cases in `cypress/e2e/navigation.cy.ts` to check for the warning related to state selection.

# Checklist:
- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
