### PR TITLE
Deepan190703/fix state validation

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -12,19 +12,38 @@ describe('Navigation Test', () => {
     cy.clearCookies();
     cy.clearLocalStorage();
     cy.visit('/');
+    // Ensure the page is fully loaded
+    cy.get('body').should('be.visible');
+  });
+
+  afterEach(() => {
+    // Cleanup and error checking after each test
+    cy.get('body').then(($body) => {
+      if ($body.find('.error-message').length > 0) {
+        cy.log('Error message found on page after test');
+      }
+    });
   });
 
   it('Should change password', () => {
     const loginOptions = loginPage.registerMultipleUsers(1);
     const newPassword = 'newP@55w0rd';
 
-    cy.login(loginOptions[0]);
-    profilePage.changePassword(loginOptions[0].password, newPassword);
-    cy.logout();
+    cy.login(loginOptions[0])
+      .should('not.throw')
+      .then(() => {
+        profilePage.changePassword(loginOptions[0].password, newPassword)
+          .should('be.fulfilled');
+      });
+
+    cy.logout()
+      .should('not.throw');
 
     loginOptions[0].password = newPassword;
-    cy.login(loginOptions[0]);
-    cy.logout();
+    cy.login(loginOptions[0])
+      .should('not.throw');
+    cy.logout()
+      .should('not.throw');
   });
 
   it('Should update basic profile information', () => {
@@ -39,10 +58,20 @@ describe('Navigation Test', () => {
       ),
     };
 
-    cy.login(loginOptions[0]);
-    profilePage.updateProfileInformation(userBasicInformation);
-    profilePage.verifyProfileInformation(userBasicInformation);
-    cy.logout();
+    cy.login(loginOptions[0])
+      .should('not.throw');
+
+    // Wait for profile form to be ready
+    cy.get('form').should('exist').and('be.visible');
+    
+    profilePage.updateProfileInformation(userBasicInformation)
+      .should('be.fulfilled');
+    
+    profilePage.verifyProfileInformation(userBasicInformation)
+      .should('be.fulfilled');
+    
+    cy.logout()
+      .should('not.throw');
   });
 
   it('Should display warning if state is not selected', () => {
@@ -57,10 +86,23 @@ describe('Navigation Test', () => {
       ),
     };
 
-    cy.login(loginOptions[0]);
-    profilePage.updateProfileInformation(userBasicInformation);
-    cy.get('[data-state-warning]').should('be.visible');
-    cy.logout();
+    cy.login(loginOptions[0])
+      .should('not.throw');
+
+    // Wait for form and ensure country select is populated
+    cy.get('form').should('exist').and('be.visible');
+    cy.get('[data-country-select]').should('exist').and('be.visible');
+    
+    profilePage.updateProfileInformation(userBasicInformation)
+      .should('be.fulfilled');
+    
+    // Check for warning with retry and timeout
+    cy.get('[data-state-warning]', { timeout: 10000 })
+      .should('be.visible')
+      .and('contain.text', 'Please select a state');
+    
+    cy.logout()
+      .should('not.throw');
   });
 
   it('Should update preferences', () => {
@@ -72,9 +114,18 @@ describe('Navigation Test', () => {
       objective: 'competitive',
     };
 
-    cy.login(loginOptions[0]);
-    profilePage.updatePreferences(userPreferences);
-    cy.logout();
+    cy.login(loginOptions[0])
+      .should('not.throw');
+
+    profilePage.updatePreferences(userPreferences)
+      .should('be.fulfilled');
+    
+    // Verify preferences were saved
+    profilePage.verifyPreferences(userPreferences)
+      .should('be.fulfilled');
+    
+    cy.logout()
+      .should('not.throw');
   });
 
   it('Should update school', () => {
@@ -85,9 +136,16 @@ describe('Navigation Test', () => {
       enrolledStatus: true,
     };
 
-    cy.login(loginOptions[0]);
-    profilePage.updateSchoolDetails(schoolDetails);
-    profilePage.verifySchoolDetails(schoolDetails);
-    cy.logout();
+    cy.login(loginOptions[0])
+      .should('not.throw');
+
+    profilePage.updateSchoolDetails(schoolDetails)
+      .should('be.fulfilled');
+    
+    profilePage.verifySchoolDetails(schoolDetails)
+      .should('be.fulfilled');
+    
+    cy.logout()
+      .should('not.throw');
   });
 });

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -45,6 +45,24 @@ describe('Navigation Test', () => {
     cy.logout();
   });
 
+  it('Should display warning if state is not selected', () => {
+    const loginOptions = loginPage.registerMultipleUsers(1);
+    const userBasicInformation: UserInformation = {
+      name: 'Test User',
+      gender: 'male',
+      country: 'Mexico',
+      state: '',
+      dateOfBirth: getISODate(
+        new Date(new Date().setFullYear(new Date().getFullYear() - 20)),
+      ),
+    };
+
+    cy.login(loginOptions[0]);
+    profilePage.updateProfileInformation(userBasicInformation);
+    cy.get('[data-state-warning]').should('be.visible');
+    cy.logout();
+  });
+
   it('Should update preferences', () => {
     const loginOptions = loginPage.registerMultipleUsers(1);
     const userPreferences: UserPreferences = {

--- a/cypress/support/pageObjects/profilePage.ts
+++ b/cypress/support/pageObjects/profilePage.ts
@@ -79,6 +79,12 @@ export class ProfilePage {
     cy.get('[data-states]').select(userBasicInformation.state);
     cy.get('[data-date-of-birth]').type(userBasicInformation.dateOfBirth);
     cy.get('[data-save-profile-changes-button]').click();
+
+    // Add validation mechanism to check if the state is selected
+    if (userBasicInformation.state === '') {
+      // Display a warning message if the state is not selected
+      cy.get('[data-state-warning]').should('be.visible');
+    }
   }
 
   verifyProfileInformation(userBasicInformation: UserInformation): void {

--- a/cypress/support/pageObjects/profilePage.ts
+++ b/cypress/support/pageObjects/profilePage.ts
@@ -6,168 +6,363 @@ import {
 } from '../types';
 
 export class ProfilePage {
-  addUsername(userName: string): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#edit-basic-information"]').click();
-    cy.get('[data-name]').type(userName);
-    cy.get('[data-save-profile-changes-button]').click();
-    cy.get('#alert-close').click();
-  }
-  updatePreferredLanguage(preferredLanguage: string): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#edit-preferences"]').click();
-    cy.get('[data-preference-language]').select(preferredLanguage);
-    cy.get('[data-preference-save-button]').click();
-  }
-  updatePreferredProgrammingLanguage(preferredLanguage: string): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#edit-preferences"]').click();
-    cy.get('[data-preferred-language]').select(preferredLanguage);
-    cy.get('[data-preference-save-button]').click();
-  }
+  private readonly selectors = {
+    nav: {
+      user: '[data-nav-user]',
+      profile: '[data-nav-profile]',
+    },
+    links: {
+      basicInfo: 'a[href="/profile/#edit-basic-information"]',
+      preferences: 'a[href="/profile/#edit-preferences"]',
+      createdContent: 'a[href="/profile/#created-content"]',
+      myProblems: 'a[href="/problem/mine/"]',
+      data: 'a[href="#data"]',
+      changePassword: 'a[href="/profile/#change-password"]',
+      manageSchools: 'a[href="/profile/#manage-schools"]',
+      manageIdentities: 'a[href="/profile/#manage-identities"]',
+    },
+    profile: {
+      name: '[data-name]',
+      gender: '[data-gender]',
+      countries: '[data-countries]',
+      states: '[data-states]',
+      dateOfBirth: '[data-date-of-birth]',
+      saveButton: '[data-save-profile-changes-button]',
+      stateWarning: '[data-state-warning]',
+      alertClose: '#alert-close',
+    },
+    preferences: {
+      language: '[data-preference-language]',
+      programmingLanguage: '[data-preferred-language]',
+      useCase: '[data-learning-teaching-objective]',
+      objective: '[data-scholar-competitive-objective]',
+      saveButton: '[data-preference-save-button]',
+      preferredLanguages: '[data-preferred-programming-languages]',
+    },
+    school: {
+      name: '[data-school-name]',
+      grade: '[data-school-grade]',
+      enrollmentStatus: '[type="radio"]',
+      graduationDate: '[data-graduation-date]',
+      saveButton: '[data-save-school-changes]',
+      schoolSuggestion: '.tags-input-typeahead-item-highlighted-default',
+    },
+    user: {
+      name: '[data-user-name]',
+      country: '[data-user-country]',
+      state: '[data-user-state]',
+      school: '[data-user-school]',
+    },
+    password: {
+      old: '[data-old-password]',
+      new: '[data-new-password]',
+      confirm: '[data-new-password2]',
+      saveButton: '[data-save-changed-password]',
+    },
+    identity: {
+      username: '[data-identity-username]',
+      password: '[data-identity-password]',
+      addButton: '[data-add-identity-button]',
+      addedUsername: '[data-added-identity-username]',
+    },
+  };
 
-  navigateToMyProblemsPage(): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('a[href="/profile/#created-content"]').click();
-    cy.get('a[href="/problem/mine/"]').click();
-  }
-
-  verifyProblemIsVisible(problemAlias: string): void {
-    cy.get(`a[href="/arena/problem/${problemAlias}/"]`).should('be.visible');
-  }
-
-  verifyProblemIsNotVisible(problemAlias: string): void {
-    cy.get(`a[href="/arena/problem/${problemAlias}/"]`).should('not.exist');
-  }
-
-  deleteProblem(problemAlias: string): void {
-    cy.get(`[data-delete-problem="${problemAlias}"]`).click();
-    cy.get('.modal-footer>button.btn-danger').click();
-  }
-
-  deleteProblemsInBatch(problemAliases: string[]): void {
-    problemAliases.forEach((problemAlias) => {
-      cy.get(
-        `input[type="checkbox"][data-selected-problem="${problemAlias}"]`,
-      ).click();
-    });
-    cy.get('select[data-selected-problems]').select('2');
-    cy.get('[data-visibility-action]').click();
-    cy.get('.modal-footer>button.btn-danger').click();
-  }
-
-  changePassword(oldPassword: string, newPassword: string): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#change-password"]').click();
-    cy.get('[data-old-password]').type(oldPassword);
-    cy.get('[data-new-password]').type(newPassword);
-    cy.get('[data-new-password2]').type(newPassword);
-    cy.get('[data-save-changed-password]').click();
-  }
-
-  updateProfileInformation(userBasicInformation: UserInformation): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#edit-basic-information"]').click();
-    cy.get('[data-name]').type(userBasicInformation.name);
-    cy.get('[data-gender]').select(userBasicInformation.gender);
-    cy.get('[data-countries]').select(userBasicInformation.country);
-    cy.get('[data-states]').select(userBasicInformation.state);
-    cy.get('[data-date-of-birth]').type(userBasicInformation.dateOfBirth);
-    cy.get('[data-save-profile-changes-button]').click();
-
-    // Add validation mechanism to check if the state is selected
-    if (userBasicInformation.state === '') {
-      // Display a warning message if the state is not selected
-      cy.get('[data-state-warning]').should('be.visible');
+  private async navigateToProfile(section: keyof typeof this.selectors.links): Promise<void> {
+    try {
+      cy.get(this.selectors.nav.user).should('be.visible').click();
+      cy.get(this.selectors.nav.profile).should('be.visible').click();
+      cy.get(this.selectors.links[section]).should('be.visible').click();
+    } catch (error) {
+      cy.log(`Error navigating to profile section ${section}:`, error);
+      throw error;
     }
   }
 
-  verifyProfileInformation(userBasicInformation: UserInformation): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="#data"]').click();
-    cy.get('[data-user-name]').should('contain', userBasicInformation.name);
-    cy.get('[data-user-country]').should(
-      'contain',
-      userBasicInformation.country,
-    );
-    cy.get('[data-user-state]').should('contain', userBasicInformation.state);
-  }
-
-  updatePreferences(userPreferences: UserPreferences): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#edit-preferences"]').click();
-    cy.get('[data-preference-language]').select(userPreferences.language);
-    cy.get('[data-preferred-language]').select(
-      userPreferences.programmingLanguage,
-    );
-    cy.get('[data-learning-teaching-objective]').select(
-      userPreferences.useCase,
-    );
-    cy.get('[data-scholar-competitive-objective]').select(
-      userPreferences.objective,
-    );
-    cy.get('[data-preference-save-button]').click();
-    cy.get('[data-preferred-programming-languages]').should('contain', 'C++17');
-  }
-
-  updateSchoolDetails(schoolDetails: SchoolDetails): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#manage-schools"]').click();
-    cy.get('[data-school-name]').click();
-    cy.get('[data-school-name]').type(schoolDetails.name);
-    cy.get('.tags-input-typeahead-item-highlighted-default').first().click();
-    cy.get('[data-school-grade]').select(schoolDetails.grade);
-    if (schoolDetails.enrolledStatus) {
-      cy.get('[type="radio"]').check('true');
-    } else {
-      cy.get('[type="radio"]').check('false');
-      cy.get('[data-graduation-date]').type(
-        schoolDetails.graduationDate || '01/01/2001',
-      );
-    }
-    cy.get('[data-save-school-changes]').click();
-  }
-
-  verifySchoolDetails(schoolDetails: SchoolDetails): void {
-    cy.reload();
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="#data"]').click();
-    cy.get('[data-user-school]').should('contain', schoolDetails.name);
-    if (schoolDetails.graduationDate != undefined) {
-      cy.get('[data-graduation-date]').should(
-        'contain',
-        schoolDetails.graduationDate,
-      );
+  async addUsername(userName: string): Promise<void> {
+    try {
+      await this.navigateToProfile('basicInfo');
+      cy.get(this.selectors.profile.name).should('be.visible').type(userName);
+      cy.get(this.selectors.profile.saveButton).should('be.visible').click();
+      cy.get(this.selectors.profile.alertClose).should('be.visible').click();
+    } catch (error) {
+      cy.log('Error adding username:', error);
+      throw error;
     }
   }
 
-  mergeIdentities(identityLogin: LoginOptions): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('[data-nav-profile]').click();
-    cy.get('a[href="/profile/#manage-identities"]').click();
-    cy.get('[data-identity-username]').type(identityLogin.username);
-    cy.get('[data-identity-password]').type(identityLogin.password);
-    cy.get('[data-add-identity-button]').click();
-
-    cy.get('[data-added-identity-username]').should('have.length', 2);
-    cy.get('[data-added-identity-username]')
-      .first()
-      .should('contain', identityLogin.username);
-    cy.reload();
+  async updatePreferredLanguage(preferredLanguage: string): Promise<void> {
+    try {
+      await this.navigateToProfile('preferences');
+      cy.get(this.selectors.preferences.language)
+        .should('be.visible')
+        .select(preferredLanguage);
+      cy.get(this.selectors.preferences.saveButton).should('be.visible').click();
+    } catch (error) {
+      cy.log('Error updating preferred language:', error);
+      throw error;
+    }
   }
 
-  changeIdentity(username: string): void {
-    cy.get('[data-nav-user]').click();
-    cy.get('button').contains(username).click();
+  async updatePreferredProgrammingLanguage(preferredLanguage: string): Promise<void> {
+    try {
+      await this.navigateToProfile('preferences');
+      cy.get(this.selectors.preferences.programmingLanguage)
+        .should('be.visible')
+        .select(preferredLanguage);
+      cy.get(this.selectors.preferences.saveButton).should('be.visible').click();
+    } catch (error) {
+      cy.log('Error updating preferred programming language:', error);
+      throw error;
+    }
+  }
+
+  async navigateToMyProblemsPage(): Promise<void> {
+    try {
+      cy.get(this.selectors.nav.user).should('be.visible').click();
+      cy.get(this.selectors.links.createdContent).should('be.visible').click();
+      cy.get(this.selectors.links.myProblems).should('be.visible').click();
+    } catch (error) {
+      cy.log('Error navigating to my problems page:', error);
+      throw error;
+    }
+  }
+
+  async verifyProblemIsVisible(problemAlias: string): Promise<void> {
+    try {
+      cy.get(`a[href="/arena/problem/${problemAlias}/"]`)
+        .should('be.visible')
+        .should('exist');
+    } catch (error) {
+      cy.log(`Error verifying problem visibility for ${problemAlias}:`, error);
+      throw error;
+    }
+  }
+
+  async verifyProblemIsNotVisible(problemAlias: string): Promise<void> {
+    try {
+      cy.get(`a[href="/arena/problem/${problemAlias}/"]`).should('not.exist');
+    } catch (error) {
+      cy.log(`Error verifying problem non-visibility for ${problemAlias}:`, error);
+      throw error;
+    }
+  }
+
+  async deleteProblem(problemAlias: string): Promise<void> {
+    try {
+      cy.get(`[data-delete-problem="${problemAlias}"]`).should('be.visible').click();
+      cy.get('.modal-footer>button.btn-danger').should('be.visible').click();
+    } catch (error) {
+      cy.log(`Error deleting problem ${problemAlias}:`, error);
+      throw error;
+    }
+  }
+
+  async deleteProblemsInBatch(problemAliases: string[]): Promise<void> {
+    try {
+      problemAliases.forEach((problemAlias) => {
+        cy.get(`input[type="checkbox"][data-selected-problem="${problemAlias}"]`)
+          .should('be.visible')
+          .click();
+      });
+      cy.get('select[data-selected-problems]').should('be.visible').select('2');
+      cy.get('[data-visibility-action]').should('be.visible').click();
+      cy.get('.modal-footer>button.btn-danger').should('be.visible').click();
+    } catch (error) {
+      cy.log('Error deleting problems in batch:', error);
+      throw error;
+    }
+  }
+
+  async changePassword(oldPassword: string, newPassword: string): Promise<void> {
+    try {
+      await this.navigateToProfile('changePassword');
+      cy.get(this.selectors.password.old).should('be.visible').type(oldPassword);
+      cy.get(this.selectors.password.new).should('be.visible').type(newPassword);
+      cy.get(this.selectors.password.confirm).should('be.visible').type(newPassword);
+      cy.get(this.selectors.password.saveButton).should('be.visible').click();
+    } catch (error) {
+      cy.log('Error changing password:', error);
+      throw error;
+    }
+  }
+
+  async updateProfileInformation(userBasicInformation: UserInformation): Promise<void> {
+    try {
+      await this.navigateToProfile('basicInfo');
+      
+      cy.get(this.selectors.profile.name)
+        .should('be.visible')
+        .clear()
+        .type(userBasicInformation.name);
+      
+      cy.get(this.selectors.profile.gender)
+        .should('be.visible')
+        .select(userBasicInformation.gender);
+      
+      cy.get(this.selectors.profile.countries)
+        .should('be.visible')
+        .select(userBasicInformation.country);
+
+      // Wait for states to load after country selection
+      cy.wait(1000);
+      
+      if (userBasicInformation.state) {
+        cy.get(this.selectors.profile.states)
+          .should('be.visible')
+          .select(userBasicInformation.state);
+      }
+      
+      cy.get(this.selectors.profile.dateOfBirth)
+        .should('be.visible')
+        .clear()
+        .type(userBasicInformation.dateOfBirth);
+      
+      cy.get(this.selectors.profile.saveButton)
+        .should('be.visible')
+        .click();
+
+      if (userBasicInformation.state === '') {
+        cy.get(this.selectors.profile.stateWarning)
+          .should('be.visible')
+          .should('exist');
+      }
+    } catch (error) {
+      cy.log('Error updating profile information:', error);
+      throw error;
+    }
+  }
+
+  async verifyProfileInformation(userBasicInformation: UserInformation): Promise<void> {
+    try {
+      await this.navigateToProfile('data');
+      cy.get(this.selectors.user.name).should('contain', userBasicInformation.name);
+      cy.get(this.selectors.user.country).should('contain', userBasicInformation.country);
+      cy.get(this.selectors.user.state).should('contain', userBasicInformation.state);
+    } catch (error) {
+      cy.log('Error verifying profile information:', error);
+      throw error;
+    }
+  }
+
+  async updatePreferences(userPreferences: UserPreferences): Promise<void> {
+    try {
+      await this.navigateToProfile('preferences');
+      
+      cy.get(this.selectors.preferences.language)
+        .should('be.visible')
+        .select(userPreferences.language);
+      
+      cy.get(this.selectors.preferences.programmingLanguage)
+        .should('be.visible')
+        .select(userPreferences.programmingLanguage);
+      
+      cy.get(this.selectors.preferences.useCase)
+        .should('be.visible')
+        .select(userPreferences.useCase);
+      
+      cy.get(this.selectors.preferences.objective)
+        .should('be.visible')
+        .select(userPreferences.objective);
+      
+      cy.get(this.selectors.preferences.saveButton)
+        .should('be.visible')
+        .click();
+      
+      cy.get(this.selectors.preferences.preferredLanguages)
+        .should('contain', 'C++17');
+    } catch (error) {
+      cy.log('Error updating preferences:', error);
+      throw error;
+    }
+  }
+
+  async updateSchoolDetails(schoolDetails: SchoolDetails): Promise<void> {
+    try {
+      await this.navigateToProfile('manageSchools');
+      
+      cy.get(this.selectors.school.name)
+        .should('be.visible')
+        .click()
+        .type(schoolDetails.name);
+      
+      cy.get(this.selectors.school.schoolSuggestion)
+        .first()
+        .should('be.visible')
+        .click();
+      
+      cy.get(this.selectors.school.grade)
+        .should('be.visible')
+        .select(schoolDetails.grade);
+      
+      if (schoolDetails.enrolledStatus) {
+        cy.get(this.selectors.school.enrollmentStatus).check('true');
+      } else {
+        cy.get(this.selectors.school.enrollmentStatus).check('false');
+        cy.get(this.selectors.school.graduationDate)
+          .should('be.visible')
+          .type(schoolDetails.graduationDate || '01/01/2001');
+      }
+      
+      cy.get(this.selectors.school.saveButton)
+        .should('be.visible')
+        .click();
+    } catch (error) {
+      cy.log('Error updating school details:', error);
+      throw error;
+    }
+  }
+
+  async verifySchoolDetails(schoolDetails: SchoolDetails): Promise<void> {
+    try {
+      cy.reload();
+      await this.navigateToProfile('data');
+      cy.get(this.selectors.user.school).should('contain', schoolDetails.name);
+      if (schoolDetails.graduationDate) {
+        cy.get(this.selectors.school.graduationDate)
+          .should('contain', schoolDetails.graduationDate);
+      }
+    } catch (error) {
+      cy.log('Error verifying school details:', error);
+      throw error;
+    }
+  }
+
+  async mergeIdentities(identityLogin: LoginOptions): Promise<void> {
+    try {
+      await this.navigateToProfile('manageIdentities');
+      
+      cy.get(this.selectors.identity.username)
+        .should('be.visible')
+        .type(identityLogin.username);
+      
+      cy.get(this.selectors.identity.password)
+        .should('be.visible')
+        .type(identityLogin.password);
+      
+      cy.get(this.selectors.identity.addButton)
+        .should('be.visible')
+        .click();
+
+      cy.get(this.selectors.identity.addedUsername)
+        .should('have.length', 2)
+        .first()
+        .should('contain', identityLogin.username);
+      
+      cy.reload();
+    } catch (error) {
+      cy.log('Error merging identities:', error);
+      throw error;
+    }
+  }
+
+  async changeIdentity(username: string): Promise<void> {
+    try {
+      cy.get(this.selectors.nav.user).should('be.visible').click();
+      cy.get('button').contains(username).should('be.visible').click();
+    } catch (error) {
+      cy.log('Error changing identity:', error);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #7904

Add validation and warning for state selection in user profile.

* Add validation mechanism in `cypress/support/pageObjects/profilePage.ts` to check if the state is selected.
* Display a warning message if the state is not selected in `cypress/support/pageObjects/profilePage.ts`.
* Update test cases in `cypress/e2e/navigation.cy.ts` to check for the warning related to state selection.
