### PR TITLE
Agregando el username en los logs de coder del mes

### DIFF
--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -673,6 +673,7 @@ def debug_coder_of_the_month_candidates(
     for ranking, candidate in enumerate(candidates, start=1):
         log_entry = {
             "user_id": candidate.user_id,
+            "username": candidate.username,
             "time": first_day_of_next_month.isoformat(),
             "ranking": ranking,
             "school_id": candidate.school_id,


### PR DESCRIPTION
# Description

Para poder realizar una depuración mas exhaustiva del script de candidatos a coder del mes será necesario obtener los usernames  de cada usuario.

Part of: #7874 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.