### PR TITLE
Arreglando script de CoTM para que sólo se tomen en cuenta usuarios que resuelven por primera vez en el mes un problema

### DIFF
--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -150,7 +150,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
 
     /**
      * Get all coder of the months based on month
-     * @return list<array{classname: string, country_id: string, email: null|string, ranking: int, time: string, user_id: int, username: string}>
+     * @return list<array{classname: string, country_id: string, email: null|string, problems_solved: int, ranking: int, score: float, time: string, user_id: int, username: string}>
      */
     final public static function getMonthlyList(
         string $firstDay,
@@ -165,7 +165,9 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             IFNULL(i.country_id, 'xx') AS country_id,
             e.email,
             u.user_id,
-            IFNULL(ur.classname, 'user-rank-unranked') AS classname
+            IFNULL(ur.classname, 'user-rank-unranked') AS classname,
+            cm.score,
+            cm.problems_solved
           FROM
             Coder_Of_The_Month cm
           INNER JOIN
@@ -184,7 +186,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
             cm.`ranking` ASC
           LIMIT 100
         ";
-        /** @var list<array{classname: string, country_id: string, email: null|string, ranking: int, time: string, user_id: int, username: string}> */
+        /** @var list<array{classname: string, country_id: string, email: null|string, problems_solved: int, ranking: int, score: float, time: string, user_id: int, username: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->getAll(
             $sql,
             [$date, $category]

--- a/frontend/tests/Factories/Run.php
+++ b/frontend/tests/Factories/Run.php
@@ -278,6 +278,8 @@ class Run {
         \OmegaUp\DAO\VO\Identities $identity,
         array $problemData,
         string $runCreationDate,
+        float $points = 1,
+        string $verdict = 'AC'
     ): array {
         $r = self::createRequestCommon(
             $problemData,
@@ -294,7 +296,7 @@ class Run {
             'response' => $response,
         ];
 
-        \OmegaUp\Test\Factories\Run::gradeRun($runData);
+        \OmegaUp\Test\Factories\Run::gradeRun($runData, $points, $verdict);
 
         // Force the submission to be in any date
         $submission = \OmegaUp\DAO\Submissions::getByGuid(

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -405,7 +405,7 @@ class Utils {
              dirname(__DIR__, 2) . '/stuff/cron/update_ranks.py' .
              ' --verbose ' .
              ' --update-coder-of-the-month ' .
-             ' --coders-list-count ' . escapeshellarg($codersListCount) .
+             ' --coders-list-count ' . escapeshellarg(strval($codersListCount)) .
              ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
              $host_arg .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -405,7 +405,11 @@ class Utils {
              dirname(__DIR__, 2) . '/stuff/cron/update_ranks.py' .
              ' --verbose ' .
              ' --update-coder-of-the-month ' .
-             ' --coders-list-count ' . escapeshellarg(strval($codersListCount)) .
+            ' --coders-list-count ' . escapeshellarg(
+                strval(
+                    $codersListCount
+                )
+            ) .
              ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
              $host_arg .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .

--- a/frontend/tests/Utils.php
+++ b/frontend/tests/Utils.php
@@ -377,7 +377,8 @@ class Utils {
     }
 
     public static function runUpdateRanks(
-        string $runDate = null
+        string $runDate = null,
+        int $codersListCount = 100
     ): void {
         // Ensure all suggestions are written to the database before invoking
         // the external script.
@@ -404,6 +405,7 @@ class Utils {
              dirname(__DIR__, 2) . '/stuff/cron/update_ranks.py' .
              ' --verbose ' .
              ' --update-coder-of-the-month ' .
+             ' --coders-list-count ' . escapeshellarg($codersListCount) .
              ' --logfile ' . escapeshellarg(OMEGAUP_LOG_FILE) .
              $host_arg .
              ' --user ' . escapeshellarg(OMEGAUP_DB_USER) .

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -1828,105 +1828,223 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
     ) {
         $gender = $category == 'all' ? 'male' : 'female';
         // Create a submissions mapping for different users, months, verdicts
-        // and problems. The winner for the current month should be user_01
-        // because all their submissions are in the current month. Submissions
-        // with verdict AC from past months should not be considered for the
-        // current month.
+        // and problems.
+        $usernames = ['user_01', 'user_02', 'user_03'];
+        $problems = ['problem_0', 'problem_1', 'problem_2', 'problem_3', 'problem_4'];
         $submissionsMapping = [
             0 => [
-                ['username' => 'user_01', 'runs' => [['WA', 0.0], ['WA', 0.0], ['PA', 0.6]]], // 0
-                ['username' => 'user_02', 'runs' => [['AC', 1.0], ['AC', 1.0], ['AC', 1.0]]], // 0
-                ['username' => 'user_03', 'runs' => [['AC', 1.0], ['AC', 1.0], ['WA', 0.0]]], // 0
+                'problem_0' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_1' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_2' => [
+                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.6],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0],
+                ],
+                'problem_3' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_4' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0], // 0
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 5
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0], // 4
+                ],
+                // First month: user_2 solved 5 problems for the first time
             ],
             1 => [
-                ['username' => 'user_01', 'runs' => [['PA', 0.5], ['WA', 0.0], ['AC', 1.0]]], // 0
-                ['username' => 'user_02', 'runs' => [['PA', 0.3], ['AC', 1.0], ['AC', 1.0]]], // 1
-                ['username' => 'user_03', 'runs' => [['AC', 1.0], ['AC', 1.0], ['WA', 0.0]]], // 0
+                'problem_0' => [
+                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_02', 'verdict' => 'PA', 'points' => 0.3],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_1' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_2' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0],
+                ],
+                'problem_3' => [
+                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_02', 'verdict' => 'PA', 'points' => 0.3],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_4' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0], // 1
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 0
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0], // 0
+                ],
+                // Second month: user_1 solved 1 problem for the first time
             ],
             2 => [
-                ['username' => 'user_01', 'runs' => [['CE', 0.0], ['AC', 1.0], ['AC', 1.0]]], // 1
-                ['username' => 'user_02', 'runs' => [['AC', 1.0], ['AC', 1.0], ['AC', 1.0]]], // 1
-                ['username' => 'user_03', 'runs' => [['AC', 1.0], ['AC', 1.0], ['PA', 0.2]]], // 0
+                'problem_0' => [
+                    ['username' => 'user_01', 'verdict' => 'CE', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_1' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.2],
+                ],
+                'problem_2' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_3' => [
+                    ['username' => 'user_01', 'verdict' => 'CE', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                ],
+                'problem_4' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0], // 2
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 0
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.2], // 1
+                ],
+                // Third month: user_3 is the winner even though user_1 solved
+                // more problems, because user_1 has already won the CoTM prize
             ],
-            3 => [
-                ['username' => 'user_01', 'runs' => [['WA', 0.0], ['AC', 1.0], ['AC', 1.0]]], // 2
-                ['username' => 'user_02', 'runs' => [['AC', 1.0], ['AC', 1.0], ['AC', 1.0]]], // 1
-                ['username' => 'user_03', 'runs' => [['PA', 0.9], ['AC', 1.0], ['AC', 1.0]]], // 1
+        ];
+        $expectedWinners = [
+            0 => [
+                ['username' => 'user_02', 'problems_solved' => 5],
+                ['username' => 'user_03', 'problems_solved' => 4],
+                // user_01 is not considered because they don't have any AC
             ],
-            4 => [
-                ['username' => 'user_01', 'runs' => [['PA', 0.2], ['AC', 1.0], ['AC', 1.0]]], // 3
-                ['username' => 'user_02', 'runs' => [['WA', 0.0], ['AC', 1.0], ['AC', 1.0]]], // 2
-                ['username' => 'user_03', 'runs' => [['AC', 1.0], ['AC', 1.0], ['CE', 0.0]]], // 1
+            1 => [
+                ['username' => 'user_01', 'problems_solved' => 1],
+                ['username' => 'user_03', 'problems_solved' => 0],
+                // user_02 is not considered because they have already won the
+                // CoTM prize
+            ],
+            2 => [
+                ['username' => 'user_03', 'problems_solved' => 1],
+                // user_01 and user_02 are not considered because they have
+                // already won the CoTM prize
             ],
         ];
 
         // Create 3 users and their identities
         $identities = [];
-        foreach ($submissionsMapping[0] as $index => $user) {
+        foreach ($usernames as $username) {
             [
-                'identity' => $identities[$index],
+                'identity' => $identities[$username],
             ] = \OmegaUp\Test\Factories\User::createUser(
                 new \OmegaUp\Test\Factories\UserParams(
-                    ['username' => $user['username']]
+                    ['username' => $username]
                 )
             );
-            self::updateIdentity($identities[$index], $gender);
+            self::updateIdentity($identities[$username], $gender);
         }
 
-        $runCreationDate = self::setFirstDayOfTheCurrentMonth();
-
+        // Create the problems
         $problemData = [];
-        foreach ($submissionsMapping as $indexProblem => $problemSubmissions) {
-            $problemData[$indexProblem] = \OmegaUp\Test\Factories\Problem::createProblem(
+        foreach ($problems as $problemAlias) {
+            $problemData[
+                $problemAlias
+            ] = \OmegaUp\Test\Factories\Problem::createProblem(
                 new \OmegaUp\Test\Factories\ProblemParams([
                     'quality_seal' => true,
-                    'alias' => 'problem_' . $indexProblem,
+                    'alias' => $problemAlias,
                 ])
             );
-            foreach ($problemSubmissions as $indexUser => $submissionsUser) {
-                foreach ($submissionsUser['runs'] as $month => $runInfo) {
-                    [$verdict, $points] = $runInfo;
+        }
+
+        $originalTime = \OmegaUp\Time::get();
+        // Create the runs by month
+        foreach ($submissionsMapping as $month => $problemsRuns) {
+            switch ($month) {
+                case 0:
+                    $runCreationDate = self::setFirstDayOfCustomMonths(
+                        monthsLeft: 3
+                    );
+                    $dateToCalculate = self::setFirstDayOfCustomMonths(
+                        monthsLeft: 2
+                    );
+                    break;
+                case 1:
+                    $runCreationDate = self::setFirstDayOfCustomMonths(
+                        monthsLeft: 2
+                    );
+                    $dateToCalculate = self::setFirstDayOfTheLastMonth();
+                    break;
+                case 2:
+                    $runCreationDate = self::setFirstDayOfTheLastMonth();
+                    $dateToCalculate = self::setFirstDayOfTheCurrentMonth();
+                    break;
+            }
+            foreach ($problemsRuns as $problemAlias => $submissionsProblem) {
+                foreach ($submissionsProblem as $runInfo) {
+                    [
+                        'username' => $username,
+                        'verdict' => $verdict,
+                        'points' => $points,
+                    ] = $runInfo;
                     if (is_null($points)) {
                         continue;
                     }
-                    switch ($month) {
-                        case 0:
-                            $runCreationDate = self::setFirstDayOfCustomMonths(
-                                monthsLeft: 2
-                            );
-                            break;
-                        case 1:
-                            $runCreationDate = self::setFirstDayOfTheLastMonth();
-                            break;
-                        case 2:
-                            $runCreationDate = self::setFirstDayOfTheCurrentMonth();
-                            break;
-                    }
                     \OmegaUp\Test\Factories\Run::createRunForSpecificProblem(
-                        $identities[$indexUser],
-                        $problemData[$indexProblem],
+                        $identities[$username],
+                        $problemData[$problemAlias],
                         $runCreationDate,
                         $points,
                         $verdict
                     );
                 }
             }
+
+            // Update the rankings
+            \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
+
+            // Getting the coder of the month regarding the date
+            \OmegaUp\Time::setTimeForTesting(
+                strtotime($dateToCalculate) + (60 * 60 * 24)
+            );
+            $coder = \OmegaUp\Controllers\User::apiCoderOfTheMonth(
+                new \OmegaUp\Request([
+                    'category' => $category,
+                ])
+            )['coderinfo'];
+            $this->assertSame(
+                $coder['username'],
+                $expectedWinners[$month][0]['username']
+            );
+            $codersList = \OmegaUp\Controllers\User::apiCoderOfTheMonthList(
+                new \OmegaUp\Request([
+                    'date' => $dateToCalculate,
+                    'category' => $category,
+                ])
+            )['coders'];
+            $this->assertSameSize($expectedWinners[$month], $codersList);
+            foreach ($expectedWinners[$month] as $index => $expectedWinner) {
+                $this->assertSame(
+                    $expectedWinner['username'],
+                    $codersList[$index]['username']
+                );
+                $this->assertSame(
+                    $expectedWinner['problems_solved'],
+                    $codersList[$index]['problems_solved']
+                );
+            }
+            $this->assertSame(
+                $expectedWinners[$month][0]['problems_solved'],
+                $codersList[0]['problems_solved']
+            );
+            \OmegaUp\Time::setTimeForTesting($originalTime);
         }
-        $runCreationDate = self::setFirstDayOfTheLastMonth();
-        \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
-
-        $today = date('Y-m-01', \OmegaUp\Time::get());
-
-        $response = $this->getCoderOfTheMonth(
-            $today,
-            'this month',
-            $category
-        );
-
-        $this->assertSame(
-            $identities[0]->username,
-            $response['coderinfo']['username']
-        );
     }
 
     private static function setFirstDayOfTheLastMonth() {

--- a/frontend/tests/controllers/CoderOfTheMonthTest.php
+++ b/frontend/tests/controllers/CoderOfTheMonthTest.php
@@ -1829,110 +1829,170 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
         $gender = $category == 'all' ? 'male' : 'female';
         // Create a submissions mapping for different users, months, verdicts
         // and problems.
-        $usernames = ['user_01', 'user_02', 'user_03'];
+        $usernames = ['user_01', 'user_02', 'user_03', 'user_04', 'user_05', 'user_06'];
         $problems = ['problem_0', 'problem_1', 'problem_2', 'problem_3', 'problem_4'];
         $submissionsMapping = [
             0 => [
                 'problem_0' => [
-                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_02', 'verdict' => 'WA', 'points' => 0.0],
                     ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_04', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.5],
                 ],
                 'problem_1' => [
                     ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.5],
                 ],
                 'problem_2' => [
-                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.6],
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
-                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_02', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'WA', 'points' => 0.0],
                 ],
                 'problem_3' => [
-                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
                     ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_04', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.5],
                 ],
                 'problem_4' => [
-                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0], // 0
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 5
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0], // 4
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0], // 1 - 1
+                    ['username' => 'user_02', 'verdict' => 'PA', 'points' => 0.1], // 1 - 1
+                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0], // 1 - 1
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0], // 3 - 3
+                    ['username' => 'user_05', 'verdict' => 'PA', 'points' => 0.3], // 4 - 4
+                    ['username' => 'user_06', 'verdict' => 'AC', 'points' => 1.0], // 1 - 1
                 ],
-                // First month: user_2 solved 5 problems for the first time
+                // First month: user_5 solved 4 problems for the first time
             ],
             1 => [
                 'problem_0' => [
-                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
-                    ['username' => 'user_02', 'verdict' => 'PA', 'points' => 0.3],
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
-                ],
-                'problem_1' => [
-                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
-                ],
-                'problem_2' => [
                     ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
                     ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
-                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0],
-                ],
-                'problem_3' => [
-                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
-                    ['username' => 'user_02', 'verdict' => 'PA', 'points' => 0.3],
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
-                ],
-                'problem_4' => [
-                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0], // 1
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 0
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0], // 0
-                ],
-                // Second month: user_1 solved 1 problem for the first time
-            ],
-            2 => [
-                'problem_0' => [
-                    ['username' => 'user_01', 'verdict' => 'CE', 'points' => 0.0],
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
-                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_04', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.5],
                 ],
                 'problem_1' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.5],
+                ],
+                'problem_2' => [
+                    ['username' => 'user_01', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_04', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_05', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.2],
+                ],
+                'problem_3' => [
                     ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
                     ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
                     ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.2],
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_05', 'verdict' => 'PA', 'points' => 0.2],
+                    ['username' => 'user_06', 'verdict' => 'WA', 'points' => 0.0],
+                ],
+                'problem_4' => [
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0], // 3 - 3
+                    ['username' => 'user_02', 'verdict' => 'WA', 'points' => 0.0], // 3 - 2
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.2], // 0 - 0
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0], // 3 - 1
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0], // 3 - 1
+                    ['username' => 'user_06', 'verdict' => 'AC', 'points' => 0.0], // 1 - 0
+                ],
+                // Second month: user_1 solved 3 problems for the first time
+            ],
+            2 => [
+                'problem_0' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.3],
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_05', 'verdict' => 'PA', 'points' => 0.3],
+                    ['username' => 'user_06', 'verdict' => 'WA', 'points' => 0.0],
+                ],
+                'problem_1' => [
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_04', 'verdict' => 'PA', 'points' => 0.5],
+                    ['username' => 'user_05', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_06', 'verdict' => 'AC', 'points' => 1.0],
                 ],
                 'problem_2' => [
                     ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0],
                     ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
                     ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_04', 'verdict' => 'WA', 'points' => 0.0],
+                    ['username' => 'user_05', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_06', 'verdict' => 'PA', 'points' => 0.3],
                 ],
                 'problem_3' => [
-                    ['username' => 'user_01', 'verdict' => 'CE', 'points' => 0.0],
+                    ['username' => 'user_01', 'verdict' => 'WA', 'points' => 0.0],
                     ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0],
                     ['username' => 'user_03', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_04', 'verdict' => 'AC', 'points' => 1.0],
+                    ['username' => 'user_05', 'verdict' => 'PA', 'points' => 0.3],
+                    ['username' => 'user_06', 'verdict' => 'WA', 'points' => 0.0],
                 ],
                 'problem_4' => [
-                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0], // 2
-                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 0
-                    ['username' => 'user_03', 'verdict' => 'PA', 'points' => 0.2], // 1
+                    ['username' => 'user_01', 'verdict' => 'AC', 'points' => 1.0], // 4 - 1
+                    ['username' => 'user_02', 'verdict' => 'AC', 'points' => 1.0], // 5 - 2
+                    ['username' => 'user_03', 'verdict' => 'WA', 'points' => 0.0], // 3 - 3
+                    ['username' => 'user_04', 'verdict' => 'PA', 'points' => 0.5], // 2 - 1
+                    ['username' => 'user_05', 'verdict' => 'WA', 'points' => 0.0], // 1 - 0
+                    ['username' => 'user_06', 'verdict' => 'AC', 'points' => 1.0], // 2 - 1
                 ],
                 // Third month: user_3 is the winner even though user_1 solved
-                // more problems, because user_1 has already won the CoTM prize
+                // more problems, because user_1 has already won the CoTM prize,
+                // and user_02 has resolved more problems but not for the first time
             ],
         ];
         $expectedWinners = [
             0 => [
-                ['username' => 'user_02', 'problems_solved' => 5],
-                ['username' => 'user_03', 'problems_solved' => 4],
-                // user_01 is not considered because they don't have any AC
+                ['username' => 'user_05', 'problems_solved' => 4],
+                ['username' => 'user_04', 'problems_solved' => 3],
+                ['username' => 'user_01', 'problems_solved' => 1],
+                ['username' => 'user_06', 'problems_solved' => 1],
+                ['username' => 'user_03', 'problems_solved' => 1],
+                //['username' => 'user_02', 'problems_solved' => 1],
+                // user_2 shouldn't be considered because only 5 users are set
+                // to be displayed
             ],
             1 => [
-                ['username' => 'user_01', 'problems_solved' => 1],
-                ['username' => 'user_03', 'problems_solved' => 0],
-                // user_02 is not considered because they have already won the
+                ['username' => 'user_01', 'problems_solved' => 3],
+                ['username' => 'user_02', 'problems_solved' => 2],
+                ['username' => 'user_04', 'problems_solved' => 1],
+                ['username' => 'user_06', 'problems_solved' => 0],
+                // user_05 is not considered because they have already won the
                 // CoTM prize
+                // user_03 is not considered because they don't have any AC run
+                // in the current month
+                // user_06 appears on the coders list because they have solved 1
+                // problem, but it was solved in the previous month
             ],
             2 => [
-                ['username' => 'user_03', 'problems_solved' => 1],
-                // user_01 and user_02 are not considered because they have
+                ['username' => 'user_03', 'problems_solved' => 3],
+                ['username' => 'user_02', 'problems_solved' => 2],
+                ['username' => 'user_06', 'problems_solved' => 1],
+                ['username' => 'user_04', 'problems_solved' => 1],
+                // user_01 and user_05 are not considered because they have
                 // already won the CoTM prize
             ],
         ];
@@ -2007,7 +2067,10 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
             }
 
             // Update the rankings
-            \OmegaUp\Test\Utils::runUpdateRanks($runCreationDate);
+            \OmegaUp\Test\Utils::runUpdateRanks(
+                $runCreationDate,
+                codersListCount: 5
+            );
 
             // Getting the coder of the month regarding the date
             \OmegaUp\Time::setTimeForTesting(
@@ -2028,21 +2091,24 @@ class CoderOfTheMonthTest extends \OmegaUp\Test\ControllerTestCase {
                     'category' => $category,
                 ])
             )['coders'];
-            $this->assertSameSize($expectedWinners[$month], $codersList);
+
+            $this->assertSameSize(
+                $expectedWinners[$month],
+                $codersList,
+                "Failed on month {$month}"
+            );
             foreach ($expectedWinners[$month] as $index => $expectedWinner) {
                 $this->assertSame(
                     $expectedWinner['username'],
-                    $codersList[$index]['username']
+                    $codersList[$index]['username'],
+                    "Failed the order of codersList on month {$month}"
                 );
                 $this->assertSame(
                     $expectedWinner['problems_solved'],
-                    $codersList[$index]['problems_solved']
+                    $codersList[$index]['problems_solved'],
+                    "Failed the number of problems solved on month {$month}"
                 );
             }
-            $this->assertSame(
-                $expectedWinners[$month][0]['problems_solved'],
-                $codersList[0]['problems_solved']
-            );
             \OmegaUp\Time::setTimeForTesting($originalTime);
         }
     }

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -29,16 +29,10 @@ class UserRank(NamedTuple):
     classname: str
 
 
-class UserProblemsSolvedScore(TypedDict):
+class UserProblems(TypedDict):
     '''Problems solved by a user and their calculated score'''
     solved: List[int]
     score: float
-
-
-class UserProblemsSolved(TypedDict):
-    '''Problems solved by a user in the selected month'''
-    problem_id: int
-    identity_id: int
 
 
 def get_first_day_of_next_month(
@@ -223,23 +217,10 @@ def get_cotm_eligible_users(
         'Getting the list of eligible users in the category [%s] for coder of '
         'the month', category
     )
-
-    get_first_time_solved_problem_by_user = get_first_time_solved(
-        cur_readonly,
-        first_day_of_current_month,
-        first_day_of_next_month
-    )
-
-    solved_problems_set = {
-        (item['identity_id'], item['problem_id'])
-        for item in get_first_time_solved_problem_by_user
-    }
-
     sql = f'''
             SELECT DISTINCT
                 IFNULL(i.user_id, 0) AS user_id,
                 i.identity_id,
-                p.problem_id,
                 i.username,
                 IFNULL(i.country_id, 'xx') AS country_id,
                 isc.school_id,
@@ -284,7 +265,7 @@ def get_cotm_eligible_users(
                 {last_12_coders_clause}
                 {gender_clause}
             GROUP BY
-                i.identity_id, p.problem_id
+                i.identity_id
             LIMIT 100;
             '''
     cur_readonly.execute(sql, (
@@ -292,14 +273,9 @@ def get_cotm_eligible_users(
         first_day_of_next_month,
     ))
 
-    eligible_users: List[UserRank] = []
-    added_users = set()
+    usernames: List[UserRank] = []
     for row in cur_readonly.fetchall():
-        if (row['identity_id'], row['problem_id']) not in solved_problems_set:
-            continue
-        if row['identity_id'] in added_users:
-            continue
-        eligible_users.append(UserRank(
+        usernames.append(UserRank(
             user_id=row['user_id'],
             identity_id=row['identity_id'],
             username=row['username'],
@@ -309,46 +285,8 @@ def get_cotm_eligible_users(
             problems_solved=0,
             score=0.0,
         ))
-        added_users.add(row['identity_id'])
-    return eligible_users
 
-
-def get_first_time_solved(
-    cur_readonly: mysql.connector.cursor.MySQLCursorDict,
-    first_day_of_current_month: datetime.date,
-    first_day_of_next_month: datetime.date,
-) -> List[UserProblemsSolved]:
-    '''Get the first time a problem was solved by a user'''
-
-    sql = '''
-        SELECT
-            s.identity_id,
-            s.problem_id,
-            MIN(s.time) AS first_time_solved
-        FROM
-            Submissions s
-        WHERE
-            s.verdict = 'AC'
-            AND s.type = 'normal'
-        GROUP BY
-            s.identity_id, s.problem_id
-    '''
-
-    cur_readonly.execute(sql)
-    result = cur_readonly.fetchall()
-
-    filtered_result = [
-        row for row in result
-        if (first_day_of_current_month <= row['first_time_solved'].date() <
-            first_day_of_next_month)
-    ]
-
-    user_problems: List[UserProblemsSolved] = [
-        {'problem_id': row['problem_id'], 'identity_id': row['identity_id']}
-        for row in filtered_result
-    ]
-
-    return user_problems
+    return usernames
 
 
 def get_eligible_problems(
@@ -400,12 +338,12 @@ def get_user_problems(
     problem_ids_str: str,
     eligible_users: List[UserRank],
     first_day_of_current_month: datetime.date,
-) -> Dict[int, UserProblemsSolvedScore]:
+) -> Dict[int, UserProblems]:
     '''Returns the problems solved by a user'''
 
     # Initialize a dictionary to store the problems solved and the score for
     # each user
-    user_problems: Dict[int, UserProblemsSolvedScore] = {
+    user_problems: Dict[int, UserProblems] = {
         user.identity_id:
             {'solved': [], 'score': 0.0} for user in eligible_users}
 

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -265,8 +265,7 @@ def get_cotm_eligible_users(
                 {last_12_coders_clause}
                 {gender_clause}
             GROUP BY
-                i.identity_id
-            LIMIT 100;
+                i.identity_id;
             '''
     cur_readonly.execute(sql, (
         first_day_of_current_month,

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -551,6 +551,7 @@ def compute_points_for_user(
     first_day_of_current_month: datetime.date,
     first_day_of_next_month: datetime.date,
     category: str,
+    coder_list_count: int,
 ) -> List[UserRank]:
     '''Computes the points for each eligible user'''
 
@@ -620,21 +621,19 @@ def compute_points_for_user(
     # Sort the updated users by score in descending order
     updated_users_sorted = sorted(
         updated_users, key=lambda user: user.score, reverse=True)
-    return updated_users_sorted
+    return updated_users_sorted[:coder_list_count]
 
 
-def update_coder_of_the_month_candidates(
+def update_cotm_candidates(
     cur: mysql.connector.cursor.MySQLCursorDict,
     cur_readonly: mysql.connector.cursor.MySQLCursorDict,
-    first_day_of_current_month: datetime.date,
     category: str,
-    update_coder_of_the_month: bool,
+    args: argparse.Namespace,
 ) -> None:
     '''Updates the list of candidates to coder of the current month'''
 
     logging.info('Updating the candidates to coder of the month...')
-    first_day_of_next_month = get_first_day_of_next_month(
-        first_day_of_current_month)
+    first_day_of_next_month = get_first_day_of_next_month(args.date)
 
     # First make sure there are not already selected coder of the month
     if check_existing_coder_of_the_month(cur_readonly,
@@ -647,11 +646,12 @@ def update_coder_of_the_month_candidates(
                                          category)
 
     candidates = compute_points_for_user(cur_readonly,
-                                         first_day_of_current_month,
+                                         args.date,
                                          first_day_of_next_month,
-                                         category)
+                                         category,
+                                         args.coders_list_count)
 
-    if update_coder_of_the_month:
+    if args.update_coder_of_the_month:
         # TODO: We need to insert the candidates in the database for testing
         # purposes. This condition will be removed in the future.
         for ranking, candidate in enumerate(candidates, start=1):
@@ -691,8 +691,7 @@ def update_users_stats(
     cur: mysql.connector.cursor.MySQLCursorDict,
     cur_readonly: mysql.connector.cursor.MySQLCursorDict,
     dbconn: mysql.connector.MySQLConnection,
-    date: datetime.date,
-    update_coder_of_the_month: bool,
+    args: argparse.Namespace,
 ) -> None:
     '''Updates all the information and ranks related to users'''
     logging.info('Updating users stats...')
@@ -715,9 +714,7 @@ def update_users_stats(
         dbconn.commit()
 
         try:
-            update_coder_of_the_month_candidates(cur, cur_readonly, date,
-                                                 'all',
-                                                 update_coder_of_the_month)
+            update_cotm_candidates(cur, cur_readonly, 'all', args)
             dbconn.commit()
         except:  # noqa: bare-except
             logging.exception(
@@ -725,9 +722,7 @@ def update_users_stats(
             raise
 
         try:
-            update_coder_of_the_month_candidates(cur, cur_readonly, date,
-                                                 'female',
-                                                 update_coder_of_the_month)
+            update_cotm_candidates(cur, cur_readonly, 'female', args)
             dbconn.commit()
         except:  # noqa: bare-except
             logging.exception(
@@ -785,10 +780,14 @@ def main() -> None:
                         type=_parse_date,
                         default=_default_date(),
                         help='The date the command should take as today')
+    parser.add_argument('--coders-list-count',
+                        type=int,
+                        default=100,
+                        help='The number of candidates to save in the DB')
     parser.add_argument('--update-coder-of-the-month',
                         action='store_true',
                         help='Update the Coder of the Month')
-    args = parser.parse_args()
+    args: argparse.Namespace = parser.parse_args()
     lib.logs.init(parser.prog, args)
 
     logging.info('Started')
@@ -800,8 +799,7 @@ def main() -> None:
                            dictionary=True) as cur, dbconn_readonly.cursor(
                                buffered=True, dictionary=True) as cur_readonly:
             update_problem_accepted_stats(cur, cur_readonly, dbconn.conn)
-            update_users_stats(cur, cur_readonly, dbconn.conn, args.date,
-                               args.update_coder_of_the_month)
+            update_users_stats(cur, cur_readonly, dbconn.conn, args)
             update_schools_stats(cur, cur_readonly, dbconn.conn, args.date)
     finally:
         dbconn.conn.close()


### PR DESCRIPTION
# Description

Se agregan mas validaciones para que solo se tomen en cuenta usuarios que resolvieron problemas por primera vez en el mes actual.

Lo que estaba sucediendo anteriormente es que el primer filtro lo que hacía era tomar en cuenta los primeros 100 usuarios que habían resuelto problemas en el mes actual. Pero si ya los habían resuelto en meses anteriores en el segundo filtro ya no se tomaban en cuenta y esto ocasionaba que existieran registros con puntaje 0.

Ahora se toma en cuenta la condición desde el primer filtro, de esta forma ya no deben existir registros con puntaje 0

Fixes: #7948 

# Comments

En un cambio posterior habrá que quitar el limite de 100 registros para que se obtengan todos. Y sólo al final, agregar el límite desde python para gerantizar que si se muestre el top 100, que que por el momento puede haber ocasiones en las que alguno de los filtros elimine a unos cuantos y la plataforma no muestre los 100 esperados.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
