### PR TITLE
Deshabilitando botón de Enviar en IDE efímero cuando se realiza un envío

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -3846,13 +3846,13 @@ Create a new run
 
 ### Parameters
 
-| Name            | Type     | Description |
-| --------------- | -------- | ----------- |
-| `contest_alias` | `string` |             |
-| `language`      | `string` |             |
-| `problem_alias` | `string` |             |
-| `source`        | `string` |             |
-| `problemset_id` | `mixed`  |             |
+| Name            | Type           | Description |
+| --------------- | -------------- | ----------- |
+| `language`      | `string`       |             |
+| `problem_alias` | `string`       |             |
+| `source`        | `string`       |             |
+| `contest_alias` | `null\|string` |             |
+| `problemset_id` | `int\|null`    |             |
 
 ### Returns
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -146,10 +146,10 @@ class Run extends \OmegaUp\Controllers\Controller {
      *
      * @return array{isPractice: bool, problem: \OmegaUp\DAO\VO\Problems, contest: null|\OmegaUp\DAO\VO\Contests, problemsetContainer: null|\OmegaUp\DAO\VO\Contests|\OmegaUp\DAO\VO\Assignments, problemset: null|\OmegaUp\DAO\VO\Problemsets}
      *
-     * @omegaup-request-param string $contest_alias
+     * @omegaup-request-param null|string $contest_alias
      * @omegaup-request-param string $language
      * @omegaup-request-param string $problem_alias
-     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param int|null $problemset_id
      */
     private static function validateCreateRequest(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
@@ -194,34 +194,32 @@ class Run extends \OmegaUp\Controllers\Controller {
             'language',
             $allowedLanguages
         );
+        $problemsetId = $r->ensureOptionalInt('problemset_id');
+        $contestAlias = $r->ensureOptionalString(
+            'contest_alias',
+            required: false,
+            validator: fn (string $alias) => \OmegaUp\Validators::alias($alias)
+        );
 
         // Can't set both problemset_id and contest_alias at the same time.
-        if (!empty($r['problemset_id']) && !empty($r['contest_alias'])) {
+        if (!is_null($problemsetId) && !is_null($contestAlias)) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'incompatibleArgs',
                 'problemset_id and contest_alias'
             );
         }
 
-        /** @var null|int */
-        $problemsetId = null;
         /** @var null|\OmegaUp\DAO\VO\Contests|\OmegaUp\DAO\VO\Assignments */
         $problemsetContainer = null;
         /** @var null|\OmegaUp\DAO\VO\Contests */
         $contest = null;
-        if (!empty($r['problemset_id'])) {
-            // Got a problemset id directly.
-            $problemsetId = intval($r['problemset_id']);
+        if (!is_null($problemsetId)) {
             $problemsetContainer = \OmegaUp\DAO\Problemsets::getProblemsetContainer(
                 $problemsetId
             );
-        } elseif (!empty($r['contest_alias'])) {
+        } elseif (!is_null($contestAlias)) {
             // Got a contest alias, need to fetch the problemset id.
             // Validate contest
-            $contestAlias = $r->ensureString(
-                'contest_alias',
-                fn (string $alias) => \OmegaUp\Validators::alias($alias)
-            );
             $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
             if (is_null($contest)) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -373,10 +371,10 @@ class Run extends \OmegaUp\Controllers\Controller {
      *
      * @return array{guid: string, submit_delay: int, submission_deadline: \OmegaUp\Timestamp, nextSubmissionTimestamp: \OmegaUp\Timestamp}
      *
-     * @omegaup-request-param string $contest_alias
+     * @omegaup-request-param null|string $contest_alias
      * @omegaup-request-param string $language
      * @omegaup-request-param string $problem_alias
-     * @omegaup-request-param mixed $problemset_id
+     * @omegaup-request-param int|null $problemset_id
      * @omegaup-request-param string $source
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
@@ -384,7 +382,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         $r->ensureIdentity();
 
         // Validate request
-        \OmegaUp\Validators::validateStringNonEmpty($r['source'], 'source');
+        $source = $r->ensureString('source');
         [
             'isPractice' => $isPractice,
             'problem' => $problem,
@@ -536,7 +534,7 @@ class Run extends \OmegaUp\Controllers\Controller {
 
         // Call Grader
         try {
-            \OmegaUp\Grader::getInstance()->grade($run, trim($r['source']));
+            \OmegaUp\Grader::getInstance()->grade($run, trim($source));
         } catch (\Exception $e) {
             // Welp, it failed. We cannot make this a real transaction
             // because the Run row would not be visible from the Grader
@@ -1746,12 +1744,12 @@ class Run extends \OmegaUp\Controllers\Controller {
         // Check filter by problem, is optional
         /** @var null|\OmegaUp\DAO\VO\Problems */
         $problem = null;
-        if (!is_null($r['problem_alias'])) {
-            $problemAlias = $r->ensureString(
-                'problem_alias',
-                fn (string $alias) => \OmegaUp\Validators::alias($alias)
-            );
-
+        $problemAlias = $r->ensureOptionalString(
+            'problem_alias',
+            required: false,
+            validator: fn (string $alias) => \OmegaUp\Validators::alias($alias)
+        );
+        if (!is_null($problemAlias)) {
             $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
             if (is_null($problem)) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
@@ -1761,16 +1759,19 @@ class Run extends \OmegaUp\Controllers\Controller {
         }
 
         // Get user if we have something in username
+        $username = $r->ensureOptionalString(
+            'username',
+            required: false,
+            validator: fn (string $username) => \OmegaUp\Validators::normalUsername(
+                $username
+            )
+        );
         /** @var null|\OmegaUp\DAO\VO\Identities */
         $identity = null;
-        if (!is_null($r['username'])) {
-            \OmegaUp\Validators::validateStringNonEmpty(
-                $r['username'],
-                'username'
-            );
+        if (!is_null($username)) {
             try {
                 $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
-                    $r['username']
+                    $username
                 );
             } catch (\OmegaUp\Exceptions\NotFoundException $e) {
                 // If not found, simply ignore it

--- a/frontend/tests/controllers/RunCreateTest.php
+++ b/frontend/tests/controllers/RunCreateTest.php
@@ -633,7 +633,7 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         $login = self::login($this->contestantIdentity);
         $r = new \OmegaUp\Request([
             'auth_token' => $login->auth_token,
-            'contest_alias' => '', // Not inside a contest
+            // Not inside a contest
             'problem_alias' => $problemData['request']['problem_alias'],
             'language' => 'c11-gcc',
             'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
@@ -756,7 +756,7 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
         try {
             \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
-                'contest_alias' => '', // Not inside a contest
+                // Not inside a contest
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'language' => 'c11-gcc',
                 'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
@@ -786,7 +786,7 @@ class RunCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $login = self::login($this->contestantIdentity);
             $r = new \OmegaUp\Request([
                 'auth_token' => $login->auth_token,
-                'contest_alias' => '', // Not inside a contest
+                // Not inside a contest
                 'problem_alias' => $problemData['request']['problem_alias'],
                 'language' => 'c11-gcc',
                 'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",

--- a/frontend/www/js/omegaup/arena/submissions.ts
+++ b/frontend/www/js/omegaup/arena/submissions.ts
@@ -38,7 +38,7 @@ export function submitRun({
 }: RunSubmit): void {
   ui.reportEvent('submission', 'submit');
   const run: types.Run = {
-    guid: guid,
+    guid,
     submit_delay: submitDelay,
     username,
     classname,

--- a/frontend/www/js/omegaup/components/arena/EphemeralGrader.vue
+++ b/frontend/www/js/omegaup/components/arena/EphemeralGrader.vue
@@ -3,10 +3,11 @@
     :accepted-languages="acceptedLanguages"
     :initial-language="initialLanguage"
     :problem="problem"
-    :can-submit="canSubmit"
+    :should-show-submit-button="canSubmit"
     :can-run="canRun"
     :is-embedded="isEmbedded"
     :initial-theme="initialTheme"
+    :next-submission-timestamp="nextSubmissionTimestamp"
   >
   </ephemeral-ide>
 </template>
@@ -38,6 +39,7 @@ export default class EphemeralGrader extends Vue {
   @Prop({ default: true }) isEmbedded!: boolean;
   @Prop({ default: Util.MonacoThemes.VSLight })
   initialTheme!: Util.MonacoThemes;
+  @Prop({ default: null }) nextSubmissionTimestamp!: null | Date;
 
   // note: initial source is for the IDE is also supported
   get initialLanguage() {

--- a/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
+++ b/frontend/www/js/omegaup/components/arena/RunSubmitPopup.vue
@@ -112,6 +112,7 @@ export default class ArenaRunSubmitPopup extends Vue {
   handleChangeLanguage(language: string): void {
     this.selectedLanguage = language;
   }
+
   get canSubmit(): boolean {
     return this.nextSubmissionTimestamp.getTime() <= this.now;
   }

--- a/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
+++ b/frontend/www/js/omegaup/components/arena/RunsForCourses.vue
@@ -228,21 +228,44 @@
                 <button
                   v-else-if="useNewSubmissionButton"
                   class="w-100"
-                  @click="$emit('new-submission')"
+                  :disabled="!canSubmit"
+                  :class="{ disabled: !canSubmit }"
+                  @click="onSubmit"
                 >
-                  {{ newSubmissionDescription }}
+                  <omegaup-countdown
+                    v-if="!canSubmit"
+                    :target-time="nextSubmissionTimestamp"
+                    :countdown-format="
+                      omegaup.CountdownFormat.WaitBetweenUploadsSeconds
+                    "
+                    @finish="now = Date.now()"
+                  ></omegaup-countdown>
+                  <span v-else>{{ newSubmissionDescription }}</span>
                 </button>
                 <a
-                  v-else
+                  v-else-if="canSubmit"
                   :href="newSubmissionUrl"
-                  @click="$emit('new-submission')"
+                  @click="onSubmit"
                   >{{ newSubmissionDescription }}</a
                 >
+                <div v-else>
+                  <omegaup-countdown
+                    :target-time="nextSubmissionTimestamp"
+                    :countdown-format="
+                      omegaup.CountdownFormat.WaitBetweenUploadsSeconds
+                    "
+                    @finish="now = Date.now()"
+                  ></omegaup-countdown>
+                </div>
               </td>
             </tr>
           </tfoot>
           <tbody>
-            <tr v-for="run in paginatedRuns" :key="run.guid">
+            <tr
+              v-for="run in paginatedRuns"
+              :key="run.guid"
+              :class="{ selected: createdGuid === run.guid }"
+            >
               <td>{{ time.formatDateLocalHHMM(run.time) }}</td>
               <td v-show="showGUID">
                 <acronym :title="run.guid" data-run-guid>
@@ -489,6 +512,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch, Emit } from 'vue-property-decorator';
+import { omegaup } from '../../omegaup';
+import * as ui from '../../ui';
 import T from '../../lang';
 import { types } from '../../api_types';
 import * as time from '../../time';
@@ -496,6 +521,7 @@ import user_Username from '../user/Username.vue';
 import common_Typeahead from '../common/Typeahead.vue';
 import arena_RunDetailsPopup from './RunDetailsPopup.vue';
 import { DisqualificationType } from './Runs.vue';
+import omegaup_Countdown from '../Countdown.vue';
 import omegaup_Overlay from '../Overlay.vue';
 
 import { PaginationPlugin } from 'bootstrap-vue';
@@ -582,6 +608,7 @@ export enum PopupDisplayed {
     FontAwesomeIcon,
     'omegaup-arena-rundetails-popup': arena_RunDetailsPopup,
     'omegaup-overlay': omegaup_Overlay,
+    'omegaup-countdown': omegaup_Countdown,
     'omegaup-common-typeahead': common_Typeahead,
     'omegaup-user-username': user_Username,
   },
@@ -614,12 +641,15 @@ export default class RunsForCourses extends Vue {
   @Prop() requestFeedback!: boolean;
   @Prop({ default: 10 }) itemsPerPage!: number;
   @Prop({ default: false }) showGUID!: boolean;
+  @Prop({ default: null }) createdGuid!: null | string;
+  @Prop({ default: null }) nextSubmissionTimestamp!: null | Date;
 
   NumericOutputStatus = NumericOutputStatus;
   PopupDisplayed = PopupDisplayed;
   T = T;
   time = time;
   DisqualificationType = DisqualificationType;
+  omegaup = omegaup;
 
   filterLanguage: string = '';
   filterOffset: number = 0;
@@ -634,6 +664,7 @@ export default class RunsForCourses extends Vue {
   currentPage: number = 1;
   currentDataPage: number = 1;
   newFieldsLaunchDate: Date = new Date('2023-10-22');
+  now: number = Date.now();
 
   get totalRows(): number {
     if (this.totalRuns === undefined) {
@@ -647,6 +678,13 @@ export default class RunsForCourses extends Vue {
       return Math.ceil(this.totalRows / this.itemsPerPage);
     }
     return 1;
+  }
+
+  get canSubmit(): boolean {
+    if (!this.nextSubmissionTimestamp) {
+      return true;
+    }
+    return this.nextSubmissionTimestamp.getTime() <= this.now;
   }
 
   onPageClick(bvEvent: any, page: number): void {
@@ -1045,6 +1083,41 @@ export default class RunsForCourses extends Vue {
     }
   }
 
+  @Watch('createdGuid')
+  onCreatedGuidChanged(newValue: null | string) {
+    if (!newValue) {
+      return;
+    }
+
+    const singleProblemRuns = document.getElementsByClassName(
+      'single-problem-runs',
+    );
+    if (singleProblemRuns.length === 0) {
+      return;
+    }
+    singleProblemRuns[0].scrollIntoView({ behavior: 'smooth' });
+    const selectedElements = document.getElementsByClassName('selected');
+    setTimeout(() => {
+      Array.from(selectedElements).forEach((element) => {
+        element.classList.remove('selected');
+      });
+    }, 10000);
+  }
+
+  onSubmit(): void {
+    if (!this.canSubmit && this.nextSubmissionTimestamp) {
+      alert(
+        ui.formatString(T.arenaRunSubmitWaitBetweenUploads, {
+          submissionGap: Math.ceil(
+            (this.nextSubmissionTimestamp.getTime() - Date.now()) / 1000,
+          ),
+        }),
+      );
+      return;
+    }
+    this.$emit('new-submission');
+  }
+
   onRemoveFilter(filter: string): void {
     this.currentPage = 1;
     this.currentDataPage = 1;
@@ -1097,6 +1170,13 @@ export default class RunsForCourses extends Vue {
 
 <style lang="scss" scoped>
 @import '../../../../sass/main.scss';
+
+.selected {
+  background-color: var(--arena-runs-table-row-selected-background-color);
+  border: 2px solid var(--arena-runs-table-row-selected-border-color);
+  border-radius: 8px;
+  transition: background-color 10s ease, border-color 10s ease;
+}
 
 .text-break-all {
   word-break: break-all;

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -186,6 +186,7 @@
               :accepted-languages="filteredLanguages"
               :preferred-language="preferredLanguage"
               :last-run="lastRun"
+              :next-submission-timestamp="nextSubmissionTimestamp || new Date()"
             ></omegaup-arena-ephemeral-grader>
           </div>
           <div class="bg-white text-center p-4 d-sm-none border">
@@ -220,6 +221,8 @@
             :runs="runsByProblem"
             :show-details="true"
             :problemset-problems="[]"
+            :created-guid="createdGuid"
+            :next-submission-timestamp="nextSubmissionTimestamp || new Date()"
             :request-feedback="requestFeedback"
             :is-contest-finished="isContestFinished"
             @request-feedback="(guid) => $emit('request-feedback', guid)"
@@ -467,6 +470,7 @@ export default class ProblemDetails extends Vue {
   @Prop({ default: false }) inContestOrCourse!: boolean;
   @Prop({ default: null }) runDetailsData!: types.RunDetails | null;
   @Prop({ default: null }) guid!: null | string;
+  @Prop({ default: null }) createdGuid!: null | string;
   @Prop({ default: null }) problemAlias!: null | string;
   @Prop({ default: false }) isAdmin!: boolean;
   @Prop({ default: false }) showVisibilityIndicators!: boolean;

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -79,6 +79,7 @@ OmegaUp.on('ready', async () => {
           !payload.nominationStatus?.solved),
       guid,
       nextSubmissionTimestamp,
+      createdGuid: '',
       searchResultUsers: searchResultEmpty,
       searchResultProblems: searchResultEmpty,
     }),
@@ -110,6 +111,7 @@ OmegaUp.on('ready', async () => {
           isAdmin: payload.user.admin,
           showVisibilityIndicators: true,
           nextSubmissionTimestamp: this.nextSubmissionTimestamp,
+          createdGuid: this.createdGuid,
           shouldShowTabs: true,
           searchResultUsers: this.searchResultUsers,
           searchResultProblems: this.searchResultProblems,
@@ -175,6 +177,7 @@ OmegaUp.on('ready', async () => {
               .then((response) => {
                 problemDetailsView.nextSubmissionTimestamp =
                   response.nextSubmissionTimestamp;
+                problemDetailsView.createdGuid = response.guid;
 
                 submitRun({
                   guid: response.guid,
@@ -440,6 +443,7 @@ OmegaUp.on('ready', async () => {
             .then((response) => {
               problemDetailsView.nextSubmissionTimestamp =
                 response.nextSubmissionTimestamp;
+              problemDetailsView.createdGuid = response.guid;
               submitRun({
                 guid: response.guid,
                 submitDelay: response.submit_delay,

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -102,6 +102,8 @@
   --arena-runs-table-status-ac-font-color: #333;
   --arena-runs-table-status-ce-background-color: #f90;
   --arena-runs-table-status-ce-font-color: #fff;
+  --arena-runs-table-row-selected-background-color: #e0ffe0;
+  --arena-runs-table-row-selected-border-color: #468847;
   --arena-solvers-table-border-color: #cccccc;
   --arena-solvers-td-border-color: #cccccc;
   --arena-contest-list-empty-category-font-color: #aaaaaa;


### PR DESCRIPTION
# Description

Se arregla el issue que permitía mostrar el botón "Enviar" del IDE efímero, aún cuando ya se había realizado un envío previo.

Ahora se respeta el tiempo entre envíos para poder habilitar el botón. 

En general se atendieron los siguientes temas:

- [x] Deshabilitar el botón de enviar en la sección del ephemeral.
- [x] Hacer scroll a la sección de "Envíos" remarcando la última solución enviada.
- [x]Deshabilitar el botón de "Nuevo envío" de la sección de "Envíos" pudiendo agregar la leyenda de "Debes esperar X segundos entre envíos consecutivos.".
- [x] Habilitar botones de "Enviar".
- [x] Dejando de usar el tipo `mixed` en controlador de `Run`
- [x] Dejando de acceder directamente a los parámetros de los requests en controlador `Run`


![DisableSubmitButtonEphemeral](https://github.com/user-attachments/assets/da72a8d5-f849-44b5-82ab-99dba530dac2)


Fixes: #7857 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
