### PR TITLE
Refactor get rank for type script

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -3979,7 +3979,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getRankToLoggedOutUserForTypeScript(\OmegaUp\Request $r){
+    public static function getRankToLoggedOutUserForTypeScript(\OmegaUp\Request $r) {
         $page = $r->ensureOptionalInt('page') ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $filter = $r->ensureOptionalEnum(
@@ -4040,7 +4040,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getRankToLoggedInUserForTypeScript(\OmegaUp\Request $r){
+    public static function getRankToLoggedInUserForTypeScript(\OmegaUp\Request $r) {
         $page = $r->ensureOptionalInt('page') ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $filter = $r->ensureOptionalEnum(

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -3965,9 +3965,9 @@ class User extends \OmegaUp\Controllers\Controller {
             $r->identity = null;
         }
         if (is_null($r->identity)) {
-            return getRankToLoggedOutUserForTypeScript($r);
+            return self::getRankToLoggedOutUserForTypeScript($r);
         }
-        return getRankToLoggedInUserForTypeScript($r);
+        return self::getRankToLoggedInUserForTypeScript($r);
     }
 
     /**
@@ -3979,7 +3979,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getRankToLoggedOutUserForTypeScript(\OmegaUp\Request $r) {
+    public static function getRankToLoggedOutUserForTypeScript(\OmegaUp\Request $r){
         $page = $r->ensureOptionalInt('page') ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $filter = $r->ensureOptionalEnum(
@@ -4040,7 +4040,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $length
      * @omegaup-request-param int|null $page
      */
-    public static function getRankToLoggedInUserForTypeScript(\OmegaUp\Request $r) {
+    public static function getRankToLoggedInUserForTypeScript(\OmegaUp\Request $r){
         $page = $r->ensureOptionalInt('page') ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $filter = $r->ensureOptionalEnum(


### PR DESCRIPTION
# Description

La funcion getRankForTypeScript fue separada en 2 funciones para los casos de un usuario loggeado (getRankToLoggedInUserForTypeScript) y uno no loggeado (getRankToLoggedOutUserForTypeScript), la funcion original se mantiene pero solo con el objeto de identificar el caso y redirigir a la funcion corresoindiente

Fixes: #(7401)

# Comments

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
