### PR TITLE
[FEATURE] Add checkbox to edit contest UI to mark them as recommended #7957

### DIFF
--- a/frontend/www/js/omegaup/components/contest/NewForm.vue
+++ b/frontend/www/js/omegaup/components/contest/NewForm.vue
@@ -27,7 +27,7 @@
         </button>
       </div>
       <form class="contest-form" @submit.prevent="onSubmit">
-        <div class="row">
+        <div class="row">oooo
           <div class="form-group col-md-6">
             <label>{{ T.wordsTitle }}</label>
             <input
@@ -212,6 +212,20 @@
               {{ T.contestNewFormImmediateFeedbackDesc }}
             </p>
           </div>
+          <div class="form-group col-md-6" v-if="isSiteAdminOrSupport">
+          <label>{{ T.contestNewFormRecommended }}</label>
+          <div class="checkbox">
+           <label>
+            <input
+             v-model="recommended"
+             type="checkbox"
+           />
+        {{ T.wordsEnable }}
+      </label>
+      </div>
+      <p class="help-block">{{ T.contestNewFormRecommendedDesc }}</p>
+      </div>
+      </div>
           <div class="form-group col-md-6">
             <label>{{ T.contestNewFormForTeams }}</label>
             <div class="checkbox">
@@ -425,6 +439,9 @@ export default class NewForm extends Vue {
   @Prop({ default: false }) contestForTeams!: boolean;
   @Prop({ default: null }) problems!: types.ProblemsetProblemWithVersions[];
   @Prop({ default: true }) hasVisitedSection!: boolean;
+  @Prop({ default: false }) initialRecommended!: boolean;
+  @Prop({ default: false }) isSiteAdminOrSupport!: boolean;
+
 
   T = T;
   ScoreMode = ScoreMode;
@@ -451,7 +468,7 @@ export default class NewForm extends Vue {
   currentContestForTeams = this.contestForTeams;
   currentTeamsGroupAlias = this.teamsGroupAlias;
   titlePlaceHolder = '';
-
+  recommended = this.initialRecommended;
   mounted() {
     const title = T.createContestInteractiveGuideTitle;
     if (!this.hasVisitedSection) {
@@ -608,6 +625,7 @@ export default class NewForm extends Vue {
       needs_basic_information: this.needsBasicInformation,
       requests_user_information: this.requestsUserInformation,
       contest_for_teams: this.currentContestForTeams,
+      recommended: this.recommended,
     };
     if (this.windowLengthEnabled && this.windowLength) {
       contest.window_length = this.windowLength;


### PR DESCRIPTION
Description:

This PR adds a checkbox to the contest creation/edit UI that allows site-admins and support ACL members to mark contests as recommended. The checkbox is conditionally rendered based on the user's role, ensuring only authorized users can access it.
Changes:

Added a Recommended Checkbox:

A new checkbox is added to the contest form, located in the same row as the Feedback dropdown.

The checkbox is only visible to users with the isSiteAdminOrSupport role.

Bound the Checkbox to recommended:

The checkbox is bound to the recommended property using v-model.

The recommended status is included in the form submission.

Props and Data Initialization:

Added initialRecommended and isSiteAdminOrSupport props to initialize the recommended property and control the visibility of the checkbox.

#For Site-Admins/Support Users
-------------------------------------------------------------
| Feedback:            [Dropdown Menu]                      |
| Recommended:         [☑ Enable]                           |
-------------------------------------------------------------
For Regular Users
-------------------------------------------------------------
| Feedback:            [Dropdown Menu]                      |
-------------------------------------------------------------

Notes:
This feature is part of issue #7957

The checkbox is styled to match the existing form design.

Backend integration for the recommended field is required.

 Checklist:

Verify that the checkbox only appears for site-admins and support ACL members.

Ensure the recommended status is correctly included in the form submission.

Confirm that the backend handles the recommended field appropriately.


