### PR TITLE
Fixed Ranking Blob Post Link

### DIFF
--- a/frontend/www/js/omegaup/components/problem/BaseList.vue
+++ b/frontend/www/js/omegaup/components/problem/BaseList.vue
@@ -101,7 +101,7 @@
               <span>
                 <a
                   data-toggle="tooltip"
-                  href="https://blog.omegaup.com/el-nuevo-ranking-de-omegaup/"
+                  href="https://blog.omegaup.com/posts/el-nuevo-ranking-de-omegaup/"
                   rel="tooltip"
                   :title="T.wordsPointsForRank"
                   :data-original-title="T.wordsPointsForRankTooltip"

--- a/frontend/www/js/omegaup/components/user/Rank.vue
+++ b/frontend/www/js/omegaup/components/user/Rank.vue
@@ -11,7 +11,7 @@
               highCount: page * length,
             })
       }}
-      <a href="https://blog.omegaup.com/el-nuevo-ranking-de-omegaup/"
+      <a href="https://blog.omegaup.com/posts/el-nuevo-ranking-de-omegaup/"
         ><font-awesome-icon :icon="['fas', 'question-circle']" />
         {{ T.wordsRankingMeasurement }}</a
       >


### PR DESCRIPTION
# Description

I have fixed the incorrect link in the ranking page. The link previously pointed to:

[Incorrect URL] (https://blog.omegaup.com/el-nuevo-ranking-de-omegaup/)

It now correctly points to:

[Correct URL] (https://blog.omegaup.com/posts/el-nuevo-ranking-de-omegaup/)

Fixes: # (issue number)

# Comments

This is a minor change that updates the hyperlink to the correct URL. No additional modifications were made.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress, or both.
