### PR TITLE
Fix double scrolbar

### DIFF
--- a/frontend/www/js/omegaup/components/course/ViewProgress.vue
+++ b/frontend/www/js/omegaup/components/course/ViewProgress.vue
@@ -406,7 +406,6 @@ export default class CourseViewProgress extends Vue {
 }
 
 .table-fixed {
-  max-height: 80vh;
   overflow: auto;
 
   thead {


### PR DESCRIPTION
# Description

Remove the max-height for the container, which was causing the double scrollbar. 

![image](https://github.com/user-attachments/assets/3815580b-c497-43e1-afe6-1d269fca2e52)

Fixes: #4684 

# Comments

An alternative way could have be to make `max-height:50vh` instead of removing it, this allows it to be always in view in the browser.  But the double scroll would be there, but its easier to use. 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
