### PR TITLE
Fix: Cloning a contest leaves the list of languages empty for the clone

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2368,6 +2368,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'admission_mode' => 'private', // Cloned contests start in private
                                            // admission_mode
             'check_plagiarism' => $originalContest->check_plagiarism,
+            'languages' => $originalContest->languages,
         ]);
 
         \OmegaUp\DAO\DAO::transBegin();


### PR DESCRIPTION
# Description

This PR fixes a bug where cloning a contest did not copy the list of allowed languages from the original contest. The cloned contest now retains the same language settings as the original.

**Fixes:** [#8022](https://github.com/omegaup/omegaup/issues/8022)

# Comments

The issue was caused by the `languages` field not being included when creating the cloned contest.  
I have verified that the fix correctly copies the languages.

# Checklist

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If needed, new tests were added to validate the fix.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.

# Screenshot
![image](https://github.com/user-attachments/assets/a5783b80-5dc4-4d47-b15a-29d37739b429)


The languages appear when I made a new clone after changing the code.
