### PR TITLE
Fixed bug of contest enrolled sectoin

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -254,7 +254,7 @@
                     >
                     <a
                       class="dropdown-item"
-                      href="/arena/?filter=participating"
+                      href="/arena/?filter=signedup"
                       data-nav-user-contests
                       >{{ T.navContestsEnrolled }}</a
                     >


### PR DESCRIPTION
# Description

The issue was with the invalid filter of "participating" in the enrolled contests api. I changed it to the correct "signedup" filter. Now all the enrolled contests are shown.

I created this test contest and then enrolled in this. Now it is listed when i go to enrolled contest section.

![image](https://github.com/user-attachments/assets/c95303e1-17f3-491f-8351-552ca4da3f30)


Fixes: #8034 

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
