### PR TITLE
Add index on start_time column in Courses table for improved query performance

### DIFF
--- a/frontend/database/00232_add_start_time_index_courses.sql
+++ b/frontend/database/00232_add_start_time_index_courses.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Courses` ADD KEY `idx_start_time` (`start_time`);

--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -313,6 +313,7 @@ CREATE TABLE `Courses` (
   KEY `fk_cg_student_group_id` (`group_id`),
   KEY `school_id` (`school_id`),
   CONSTRAINT `fk_ca_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`),
+  KEY `idx_start_time` (`start_time`),
   CONSTRAINT `fk_cg_student_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups_` (`group_id`),
   CONSTRAINT `fk_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Un curso/clase que un maestro da.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -313,6 +313,7 @@ CREATE TABLE `Courses` (
   KEY `fk_ca_acl_id` (`acl_id`),
   KEY `fk_cg_student_group_id` (`group_id`),
   KEY `school_id` (`school_id`),
+  KEY `idx_start_time` (`start_time`),
   CONSTRAINT `fk_ca_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`),
   CONSTRAINT `fk_cg_student_group_id` FOREIGN KEY (`group_id`) REFERENCES `Groups_` (`group_id`),
   CONSTRAINT `fk_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`)


### PR DESCRIPTION
# Description

Added an index on the `start_time` column in the `Courses` table to improve query performance. This index will speed up operations that filter or sort by the course start time.

The changes include:
1. A new migration file (`00232_add_start_time_index_courses.sql`) that adds the index to existing databases
2. Updated schema files to include the new index in future database setups

This change should help with performance issues related to course listing and filtering.

Fixes: #8017 

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
