### PR TITLE
Temporarily remove Sponsor column from footer

### DIFF
--- a/frontend/www/js/omegaup/components/common/Footer.vue
+++ b/frontend/www/js/omegaup/components/common/Footer.vue
@@ -64,7 +64,7 @@
             </li>
           </ul>
         </div>
-        <div
+        <!-- <div
           class="footer-list-section footer-sponsors w-50 mb-4 mb-lg-0 mx-auto"
         >
           <h4 class="column-title">{{ T.frontPageFooterSponsors }}</h4>
@@ -79,7 +79,7 @@
               </a>
             </li>
           </ul>
-        </div>
+        </div> -->
         <div
           class="footer-list-section footer-organization d-inline-block w-50 mb-4"
         >


### PR DESCRIPTION
This removes the Sponsor column from the footer until new sponsors are secured, as discussed in issue #8094. The layout of remaining footer columns adjusts automatically to fill the space.

Fixes: #8094

# Description

This PR removes the Sponsor column from the footer until new sponsors are secured, as discussed in issue #8094. The layout of remaining footer columns has been adjusted to automatically fill the available space.


Changes implemented:
- Removed the Sponsor column HTML markup from the footer template
- Adjusted CSS styling to ensure remaining columns redistribute properly
- Maintained responsive behavior across all screen sizes


Fixes: #8094 


# Checklist:

- The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp
- All existing tests pass
- Verified layout on multiple screen sizes
- No console errors detected