### PR TITLE
Disable Run button for a certain period, similar to Submit button

### DIFF
--- a/frontend/www/js/omegaup/grader/Ephemeral.vue
+++ b/frontend/www/js/omegaup/grader/Ephemeral.vue
@@ -68,6 +68,8 @@
         <button
           v-if="isRunButton"
           class="btn btn-sm btn-secondary mr-2 my-sm-0 ephemeral-button"
+          :disabled="!canRun || !canSubmit"
+          :class="{ disabled: !canRun || !canSubmit }"
           data-run-button
           @click.prevent="handleRun"
         >


### PR DESCRIPTION
# Description

The feature ensures that both the "Submit" and "Run" buttons are disabled for a specific period after "Submit" being clicked. Previously, only the "Submit" button was blocked, but now the "Run" button also follows the same behavior

Fixes: #8105

Video:


https://github.com/user-attachments/assets/0aced0fc-e6b6-4c83-b98f-e813a8b8a9cf


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
