### PR TITLE
Updated DatePicker for Editing Birthday in User Profile

### DIFF
--- a/frontend/www/js/omegaup/components/UpdatedDatePicker.vue
+++ b/frontend/www/js/omegaup/components/UpdatedDatePicker.vue
@@ -1,0 +1,90 @@
+<template>
+  <b-input-group size="16">
+    <!-- Editable Text Input -->
+    <b-form-input
+      v-model="stringValue"
+      :name="name"
+      :disabled="!enabled"
+      placeholder="YYYY-MM-DD"
+      :class="{ 'is-invalid': isInvalid }"
+      required
+      @change="onInputChange"
+    />
+    
+    <!-- Calendar Input -->
+    <b-form-datepicker
+      v-model="stringValue"
+      :min="minDateStr"
+      :max="maxDateStr"
+      button-only
+      right
+      :disabled="!enabled"
+      @input="onDateSelected"
+    />
+  </b-input-group>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Watch, Prop } from 'vue-property-decorator';
+import T from '../lang';
+import * as time from '../time';
+import { BFormDatepicker, BFormInput, BInputGroup } from 'bootstrap-vue';
+
+@Component({
+  components: { BFormDatepicker, BFormInput, BInputGroup },
+})
+export default class UpdatedDatePicker extends Vue {
+  T = T;
+
+  @Prop({ default: '' }) name!: string;
+  @Prop() value!: Date;
+  @Prop({ default: true }) enabled!: boolean;
+  @Prop({ default: T.datePickerFormat }) format!: string;
+  @Prop({ default: false }) isInvalid!: boolean;
+  @Prop({ default: null }) min!: Date | null;
+  @Prop({ default: null }) max!: Date | null;
+
+  private stringValue: string = '';
+
+  get minDateStr() {
+    return this.min ? time.formatDateLocal(this.min) : '';
+  }
+
+  get maxDateStr() {
+    return this.max ? time.formatDateLocal(this.max) : '';
+  }
+
+  mounted() {
+    this.updateStringValue();
+  }
+
+  @Watch('value', { immediate: true })
+  onValueChanged(newValue: Date) {
+    if (newValue && time.formatDateLocal(newValue) !== this.stringValue) {
+      this.stringValue = time.formatDateLocal(newValue);
+    }
+  }
+
+  updateStringValue() {
+    if (this.value && this.value instanceof Date && !isNaN(this.value.getTime())) {
+      this.stringValue = time.formatDateLocal(this.value);
+    } else {
+      this.stringValue = '';
+    }
+  }
+
+  onInputChange() {
+    const parsedDate = time.parseDateLocal(this.stringValue);
+    if (parsedDate) {
+      this.$emit('input', parsedDate);
+    }
+  }
+
+  onDateSelected(newDate: Date) {
+    if (newDate) {
+      this.$emit('input', newDate);
+      this.stringValue = time.formatDateLocal(newDate);
+    }
+  }
+}
+</script>

--- a/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
+++ b/frontend/www/js/omegaup/components/user/BasicInformationEdit.vue
@@ -88,11 +88,11 @@ import { dao, types } from '../../api_types';
 import T from '../../lang';
 import * as time from '../../time';
 import * as iso3166 from '@/third_party/js/iso-3166-2.js/iso3166.min.js';
-import DatePicker from '../DatePicker.vue';
+import UpdatedDatePicker from '../UpdatedDatePicker.vue';
 
 @Component({
   components: {
-    'omegaup-datepicker': DatePicker,
+    'omegaup-datepicker': UpdatedDatePicker,
   },
 })
 export default class UserBasicInformationEdit extends Vue {


### PR DESCRIPTION
# Description

This PR updates the DatePicker used to edit the birthday information within the user profile section.

**Updated UI:** Shown within red box

<img width="800" alt="update_ui" src="https://github.com/user-attachments/assets/3449769b-dbd7-4307-95f0-98e76080dc64" />

**Demo Video** 

https://github.com/user-attachments/assets/5798ef0a-0924-4cb3-9eb2-30d3c20848bf

Fixes: #4017 

# Comments

1. To ensure that the birthday is easily formatted, I provided the user with the option to either edit it directly in the text box or select it using the calendar on the right.
2. The original implementation is buggy when the text is edited (the year defaults to 1902).
3. I ensured that the user cannot enter incorrectly formatted strings.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
