### PR TITLE
Adding update_courses.yml, scripts/fetch_courses.py & scripts/fetch_prs.py to fetch omegaup course details through updated github PRs & MRs

### DIFF
--- a/.github/workflows/update_courses.yml
+++ b/.github/workflows/update_courses.yml
@@ -1,0 +1,32 @@
+name: Update Courses from omegaUp
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs daily at midnight UTC
+  workflow_dispatch:  # Allows manual trigger
+
+jobs:
+  update-courses:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+
+      - name: Install Dependencies
+        run: pip install requests
+
+      - name: Fetch Courses from omegaUp
+        run: python scripts/fetch_courses.py
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+          git add courses/
+          git commit -m "Automated update: omegaUp course content" || exit 0
+          git push

--- a/Omegaup_github_courses_README.md
+++ b/Omegaup_github_courses_README.md
@@ -1,0 +1,20 @@
+# omegaUp GitHub Course Management
+
+## Overview
+This feature allows managing **public courses** on omegaUp through GitHub.
+
+## Features
+- Fetches course content from omegaUp API.
+- Allows users to submit course improvements via PRs.
+- Automatically updates courses using GitHub Actions.
+
+## How It Works
+1. The script `fetch_courses.py` pulls courses from the omegaUp API and saves them in Markdown format.
+2. Contributors can suggest improvements via **GitHub Pull Requests**.
+3. The **GitHub Actions workflow** runs daily to update course content.
+
+## Running Locally
+To test the scripts locally:
+```sh
+export OMEGAUP_TOKEN="your_api_key"
+python scripts/fetch_courses.py

--- a/scripts/fetch_courses.py
+++ b/scripts/fetch_courses.py
@@ -1,0 +1,37 @@
+import requests
+import os
+
+# omegaUp API details
+OMEGAUP_API_URL = "https://omegaup.com/api/course/details/"
+OMEGAUP_TOKEN = os.getenv("OMEGAUP_TOKEN")  # Use GitHub Secret
+
+headers = {"Authorization": f"Bearer {OMEGAUP_TOKEN}"}
+
+def fetch_courses():
+    response = requests.get(OMEGAUP_API_URL, headers=headers)
+
+    if response.status_code == 200:
+        return response.json().get("courses", [])
+    else:
+        print("Error fetching courses:", response.json())
+        return []
+
+def save_course_to_file(course):
+    filename = f"courses/{course['alias']}.md"
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f"# {course['name']}\n\n")
+        f.write(course.get("description", "No description available."))
+    print(f"✅ Saved: {filename}")
+
+def update_courses():
+    courses = fetch_courses()
+    if not courses:
+        print("No courses found.")
+        return
+
+    os.makedirs("courses", exist_ok=True)
+    for course in courses:
+        save_course_to_file(course)
+
+if __name__ == "__main__":
+    update_courses()

--- a/scripts/fetch_prs.py
+++ b/scripts/fetch_prs.py
@@ -1,0 +1,36 @@
+import requests
+import os
+
+# GitHub repository details
+GITHUB_REPO = "omegaup/omegaup"
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")  # Use GitHub Secret
+
+headers = {
+    "Authorization": f"token {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github.v3+json"
+}
+
+def get_pull_requests():
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/pulls"
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        prs = response.json()
+        for pr in prs:
+            print(f"PR #{pr['number']} - {pr['title']} by {pr['user']['login']}")
+    else:
+        print("Error fetching PRs:", response.json())
+
+def merge_pr(pr_number):
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/pulls/{pr_number}/merge"
+    data = {"commit_title": "Merging PR"}
+    response = requests.put(url, headers=headers, json=data)
+
+    if response.status_code == 200:
+        print(f"PR #{pr_number} merged successfully!")
+    else:
+        print("Merge failed:", response.json())
+
+if __name__ == "__main__":
+    get_pull_requests()
+    # merge_pr(1)  # Uncomment this to merge a specific PR


### PR DESCRIPTION
# GSOC 2025 [New Feature: Public Courses on github](https://github.com/omegaup/omegaup/wiki/Google-Summer-of-Code-2025#public-courses-on-github)

# Description
omegaUp offers many [public courses](https://omegaup.com/course/) in Spanish open to everyone. They have been solely managed by omegaUp staff but we want to be able to manage them through github so anyone can suggest improvements to the content (through pull requests). The Mexican Olympiad in Informatics already [does this](https://github.com/ComiteMexicanoDeInformatica/Curso-OMI/blob/main/.github/workflows/continuous-integration.yaml) on a public course that they offer through omegaUp. We need to replicate what they have on our courses.

Expected results:
The content of public courses offered by omegaUp is managed through github and anybody is able to propose improvements through pull requests.

# Changes:
- Added **.github/workflows/update_courses.yml** file
- Added **scripts/fetch_prs** & **scripts/fetch_courses.py** files

# Local Testing:
- 
![Capture](https://github.com/user-attachments/assets/5fcdc8d7-22a6-4dc2-ab61-6c869323f183)
- I was unable to test it fully because of below error on http://localhost:8001/ after running docker compose:
```
Warning: require_once(/opt/omegaup/frontend/server/../../vendor/autoload.php): Failed to open stream: No such file or directory in /opt/omegaup/frontend/server/bootstrap.php on line 9

Fatal error: Uncaught Error: Failed opening required '/opt/omegaup/frontend/server/../../vendor/autoload.php' (include_path='.:/usr/share/php') in /opt/omegaup/frontend/server/bootstrap.php:9 Stack trace: #0 /opt/omegaup/frontend/www/index.php(3): require_once() #1 {main} thrown in /opt/omegaup/frontend/server/bootstrap.php on line 9

```
Preferred skills:

- git/github
- Python
- Continuos Integration
- REST APIs

- Possible mentor:

[heduenas](https://github.com/heduenas), [tvanessa](https://github.com/tvanessa)

Fixes: #[New Feature: Public Courses on github](https://github.com/omegaup/omegaup/wiki/Google-Summer-of-Code-2025#public-courses-on-github)

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
