### PR TITLE
Ajustando ancho de username en navbar para evitar desborde si es demasiado largo

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -576,6 +576,15 @@ nav.navbar {
   width: 100%;
 }
 
+.username {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 20vw;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 @media (min-width: 992px) {
   .fullwidth-mobile-fit-lg {
     width: fit-content;


### PR DESCRIPTION
# Description

Estan fallando una serie de pruebas en Cypress, y parece que se debe a que los nombres de usuarios son demasiado extensos. 

Después de que se aprobó un cambio comenzaron a fallar y todo parece indicar a que este es el motivo

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.