### PR TITLE
Add DAO and VO files for managing carousel items

### DIFF
--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -86,6 +86,25 @@ CREATE TABLE `Auth_Tokens` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Carousel_Items` (
+  `corousel_item_id` int NOT NULL AUTO_INCREMENT,
+  `title` json NOT NULL,
+  `excerpt` json NOT NULL,
+  `image_url` varchar(255) DEFAULT NULL,
+  `link` varchar(255) DEFAULT NULL,
+  `button_title` json DEFAULT NULL,
+  `expiration_date` datetime DEFAULT NULL,
+  `status` enum('active','inactive') NOT NULL DEFAULT 'active',
+  `user_id` int NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`corousel_item_id`),
+  KEY `user_id` (`user_id`),
+  CONSTRAINT `Carousel_Items_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Tabla para almacenar noticias en la plataforma';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Certificates` (
   `certificate_id` int NOT NULL AUTO_INCREMENT,
   `identity_id` int NOT NULL,

--- a/frontend/server/src/DAO/Base/CarouselItems.php
+++ b/frontend/server/src/DAO/Base/CarouselItems.php
@@ -1,0 +1,328 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** CarouselItems Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\CarouselItems}.
+ * @access public
+ * @abstract
+ */
+abstract class CarouselItems {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\CarouselItems $Carousel_Items El objeto de tipo CarouselItems a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\CarouselItems $Carousel_Items
+    ): int {
+        $sql = '
+            UPDATE
+                `Carousel_Items`
+            SET
+                `title` = ?,
+                `excerpt` = ?,
+                `image_url` = ?,
+                `link` = ?,
+                `button_title` = ?,
+                `expiration_date` = ?,
+                `status` = ?,
+                `user_id` = ?,
+                `created_at` = ?,
+                `updated_at` = ?
+            WHERE
+                (
+                    `corousel_item_id` = ?
+                );';
+        $params = [
+            $Carousel_Items->title,
+            $Carousel_Items->excerpt,
+            $Carousel_Items->image_url,
+            $Carousel_Items->link,
+            $Carousel_Items->button_title,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Carousel_Items->expiration_date
+            ),
+            $Carousel_Items->status,
+            (
+                is_null($Carousel_Items->user_id) ?
+                null :
+                intval($Carousel_Items->user_id)
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Carousel_Items->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Carousel_Items->updated_at
+            ),
+            intval($Carousel_Items->corousel_item_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\CarouselItems} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\CarouselItems}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\CarouselItems Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\CarouselItems} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $corousel_item_id
+    ): ?\OmegaUp\DAO\VO\CarouselItems {
+        $sql = '
+            SELECT
+                `Carousel_Items`.`corousel_item_id`,
+                `Carousel_Items`.`title`,
+                `Carousel_Items`.`excerpt`,
+                `Carousel_Items`.`image_url`,
+                `Carousel_Items`.`link`,
+                `Carousel_Items`.`button_title`,
+                `Carousel_Items`.`expiration_date`,
+                `Carousel_Items`.`status`,
+                `Carousel_Items`.`user_id`,
+                `Carousel_Items`.`created_at`,
+                `Carousel_Items`.`updated_at`
+            FROM
+                `Carousel_Items`
+            WHERE
+                (
+                    `corousel_item_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$corousel_item_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\CarouselItems($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\CarouselItems} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\CarouselItems}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $corousel_item_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Carousel_Items`
+            WHERE
+                (
+                    `corousel_item_id` = ?
+                );';
+        $params = [$corousel_item_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\CarouselItems} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\CarouselItems $Carousel_Items El
+     * objeto de tipo \OmegaUp\DAO\VO\CarouselItems a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\CarouselItems $Carousel_Items
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Carousel_Items`
+            WHERE
+                (
+                    `corousel_item_id` = ?
+                );';
+        $params = [
+            $Carousel_Items->corousel_item_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\CarouselItems}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\CarouselItems> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\CarouselItems}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        ?string $orden = null,
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sql = '
+            SELECT
+                `Carousel_Items`.`corousel_item_id`,
+                `Carousel_Items`.`title`,
+                `Carousel_Items`.`excerpt`,
+                `Carousel_Items`.`image_url`,
+                `Carousel_Items`.`link`,
+                `Carousel_Items`.`button_title`,
+                `Carousel_Items`.`expiration_date`,
+                `Carousel_Items`.`status`,
+                `Carousel_Items`.`user_id`,
+                `Carousel_Items`.`created_at`,
+                `Carousel_Items`.`updated_at`
+            FROM
+                `Carousel_Items`
+        ';
+        if (!is_null($orden)) {
+            $sql .= (
+                ' ORDER BY `' .
+                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+                '` ' .
+                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+            );
+        }
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\CarouselItems(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\CarouselItems}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\CarouselItems $Carousel_Items El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\CarouselItems}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\CarouselItems $Carousel_Items
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Carousel_Items` (
+                    `title`,
+                    `excerpt`,
+                    `image_url`,
+                    `link`,
+                    `button_title`,
+                    `expiration_date`,
+                    `status`,
+                    `user_id`,
+                    `created_at`,
+                    `updated_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            $Carousel_Items->title,
+            $Carousel_Items->excerpt,
+            $Carousel_Items->image_url,
+            $Carousel_Items->link,
+            $Carousel_Items->button_title,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Carousel_Items->expiration_date
+            ),
+            $Carousel_Items->status,
+            (
+                is_null($Carousel_Items->user_id) ?
+                null :
+                intval($Carousel_Items->user_id)
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Carousel_Items->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Carousel_Items->updated_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Carousel_Items->corousel_item_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/VO/CarouselItems.php
+++ b/frontend/server/src/DAO/VO/CarouselItems.php
@@ -1,0 +1,203 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Carousel_Items`.
+ *
+ * @access public
+ */
+class CarouselItems extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'corousel_item_id' => true,
+        'title' => true,
+        'excerpt' => true,
+        'image_url' => true,
+        'link' => true,
+        'button_title' => true,
+        'expiration_date' => true,
+        'status' => true,
+        'user_id' => true,
+        'created_at' => true,
+        'updated_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['corousel_item_id'])) {
+            $this->corousel_item_id = intval(
+                $data['corousel_item_id']
+            );
+        }
+        if (isset($data['title'])) {
+            $this->title = is_scalar(
+                $data['title']
+            ) ? strval($data['title']) : '';
+        }
+        if (isset($data['excerpt'])) {
+            $this->excerpt = is_scalar(
+                $data['excerpt']
+            ) ? strval($data['excerpt']) : '';
+        }
+        if (isset($data['image_url'])) {
+            $this->image_url = is_scalar(
+                $data['image_url']
+            ) ? strval($data['image_url']) : '';
+        }
+        if (isset($data['link'])) {
+            $this->link = is_scalar(
+                $data['link']
+            ) ? strval($data['link']) : '';
+        }
+        if (isset($data['button_title'])) {
+            $this->button_title = is_scalar(
+                $data['button_title']
+            ) ? strval($data['button_title']) : '';
+        }
+        if (isset($data['expiration_date'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['expiration_date']
+             * @var \OmegaUp\Timestamp $this->expiration_date
+             */
+            $this->expiration_date = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['expiration_date']
+                )
+            );
+        }
+        if (isset($data['status'])) {
+            $this->status = is_scalar(
+                $data['status']
+            ) ? strval($data['status']) : '';
+        }
+        if (isset($data['user_id'])) {
+            $this->user_id = intval(
+                $data['user_id']
+            );
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['updated_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['updated_at']
+             * @var \OmegaUp\Timestamp $this->updated_at
+             */
+            $this->updated_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['updated_at']
+                )
+            );
+        } else {
+            $this->updated_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $corousel_item_id = 0;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $title = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $excerpt = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $image_url = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $link = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $button_title = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $expiration_date = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string
+     */
+    public $status = 'active';
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var int|null
+     */
+    public $user_id = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $updated_at;  // CURRENT_TIMESTAMP
+}


### PR DESCRIPTION
# Description

The DAO and VO files are required to interact with the table in mysql
We have added the table in a PR which have already been merged - #8047
In this PR we are adding the DAO and VO files for the table

 - Updated the dao_schema.sql file to include the `Carousel_Items` table.
 - Ran the script `./stuff/update-dao.sh` 
 - Updated the DAO and VO files for the new table `Carousel_Items`


Part of: #6916 

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
