### PR TITLE
docs: Translate setup documentation to English and Spanish

### DIFF
--- a/frontend/www/docs/Home.md
+++ b/frontend/www/docs/Home.md
@@ -1,32 +1,43 @@
 # omegaUp wiki
 ¡Te damos la bienvenida al repositorio de omegaUp!
 
-Aquí encontrarás información técnica de nuestro proyecto así como información de las funcionalidades de la plataforma
+Aquí encontrarás información técnica de nuestro proyecto así como información de las funcionalidades de la plataforma.
 
-# ¿Quieres ayudarnos a desarrollar?
+(Here you'll find technical information about our project, as well as documentation about the platform's features.)
+
+
+
+# ¿Quieres ayudarnos a desarrollar? (Want to help us develop?)
 
 En esta tabla encontraras los temas más importantes para comenzar a programar.
+(This table highlights the most important topics to help you get started with development:)
 
 | Topic                                                  | Description                                                  |
 | -----------------------------------------------------  | ------------------------------------------------------------ |
-| [Primeros pasos](https://github.com/omegaup/omegaup/wiki/Quiero-desarrollar-en-omegaUp) |[Instalación de máquina virtual](https://github.com/omegaup/omegaup/wiki/How-to-Set-Up-Your-Development-Environment-(English)), información técnica general  |
-| [Cómo empezar a desarrollar](https://github.com/omegaup/omegaup/wiki/C%C3%B3mo-Hacer-un-Pull-Request) | Configuraciones en git, cómo enviar un PR                    |
-| [Arquitectura](https://github.com/omegaup/omegaup/wiki/Arquitectura)  | Arquitectura de software de omegaUp.com                      |
-| [Release and Deployment](https://github.com/omegaup/omegaup/wiki/Release-&-deployment)  | Cómo y cuándo es el deployment                               |
+| [Primeros pasos ](https://github.com/omegaup/omegaup/wiki/Quiero-desarrollar-en-omegaUp)[ (Getting Started)](https://github.com/omegaup/omegaup/wiki/How-to-Set-Up-Your-Development-Environment-(English)) |Instalación de máquina virtual , información técnica(general  Virtual machine setup, general technical info )|
+| [Cómo empezar a desarrollar (How to Start Developing)](https://github.com/omegaup/omegaup/wiki/C%C3%B3mo-Hacer-un-Pull-Request) | Configuraciones en git, cómo enviar un PR    (Git setup, how to submit a PR           )      |
+| [Arquitectura (Architecture)](https://github.com/omegaup/omegaup/wiki/Arquitectura)  | Arquitectura de software de omegaUp.com     Arquitectura de software de omegaUp.com                 |
+| [Release and Deployment (Release and Deployment)](https://github.com/omegaup/omegaup/wiki/Release-&-deployment)  | Cómo y cuándo es el deployment     (When and how deployment happens   )                       |
 
-### :arrow_forward: :arrow_forward: :computer:  [Índice para desarrolladoras](https://github.com/omegaup/omegaup/wiki/Ligas-%C3%BAtiles)
+### :arrow_forward: :arrow_forward: :computer:  [Índice para desarrolladoras/ Developer Index](https://github.com/omegaup/omegaup/wiki/Ligas-%C3%BAtiles)
 
-# ¿Cómo usar las funcionalidades de omegaUp?
-omegaUp es una plataforma educativa donde puedes crear problemas, concursos y cursos. También te invitamos a visitar nuestro [blog](https://blog.omegaup.com/) para las actualizaciones más recientes.
+# ¿Cómo usar las funcionalidades de omegaUp? (How to use omegaUp features?)
 
- - [Cómo escribir problemas para omegaUp](https://github.com/omegaup/omegaup/wiki/C%C3%B3mo-escribir-problemas-para-omegaUp) 
- - [Corre un concurso en tu escuela](https://github.com/omegaup/omegaup/wiki/Corre-un-concurso-en-tu-escuela)
- - [Ambiente de evaluación](https://github.com/omegaup/omegaup/wiki/Ambiente-de-evaluaci%C3%B3n)
 
-# Navegadores soportados
+omegaUp es una plataforma educativa donde puedes crear problemas, concursos y cursos.
+(omegaUp is an educational platform where you can create problems, contests, and courses.)
 
+También te invitamos a visitar nuestro [blog](https://blog.omegaup.com/) para las actualizaciones más recientes.
+(We also invite you to visit our blog for the latest updates.)
+
+ - [Cómo escribir problemas para omegaUp How to write problems for omegaUp](https://github.com/omegaup/omegaup/wiki/C%C3%B3mo-escribir-problemas-para-omegaUp) 
+ - [Corre un concurso en tu escuela Run a contest at your school](https://github.com/omegaup/omegaup/wiki/Corre-un-concurso-en-tu-escuela)
+ - [Ambiente de evaluación Evaluation environment](https://github.com/omegaup/omegaup/wiki/Ambiente-de-evaluaci%C3%B3n)
+
+# Navegadores soportados / Supported Browsers
 
 Los navegadores oficialmente soportados son los siguientes:
+(The officially supported browsers are:)
 
 * [Chrome](https://www.chromium.org/getting-involved/dev-channel): Stable Channel
 


### PR DESCRIPTION
# Description

This PR updates the omegaUp documentation by translating the setup instructions into both **English** and **Spanish**. The goal is to make the documentation more accessible to contributors who are comfortable with English. This will help contributors efficiently set up the project locally and contribute to the codebase. 

The changes include:
- Translated the **Virtual Machine setup** documentation.
- Updated the **general technical information** to be bilingual (English & Spanish).


Fixes: #7430

# Comments
No additional comments for the reviewers. The change mainly involves documentation translation.

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/wiki/Coding-guidelines) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ]  If you are creating a feature, the new tests were added.
