### PR TITLE
Fixed inconsistencies in the Dark theme of ephemeral grader

### DIFF
--- a/frontend/www/js/omegaup/grader/CaseSelector.vue
+++ b/frontend/www/js/omegaup/grader/CaseSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="root d-flex flex-column h-100">
+  <div class="root d-flex flex-column h-100" :class="theme">
     <div class="summary">
       {{ summary }}
     </div>
@@ -38,9 +38,8 @@
             type="button"
             :class="{
               'in-group': group.explicit,
-              active: currentCase == item.name && theme == 'vs',
-              'vs-dark': currentCase == item.name && theme == 'vs-dark',
-            }"
+              active: currentCase == item.name
+              }"
             @click="selectCase(item.name)"
           >
             <div class="text-truncate">
@@ -271,8 +270,20 @@ input[type='number'].case-weight {
   padding-left: 15px;
 }
 
-.vs-dark {
-  background: var(--vs-dark-background-color);
+/* Dark theme styles */
+.vs-dark .summary {
+  color: var(--vs-dark-font-color);
+  background-color: var(--vs-dark-background-color);
+}
+
+.vs-dark .list-group-item-action:not(.active) {
+  background-color: var(--vs-dark-background-color);
+  color: var(--vs-dark-font-color);
+  opacity: 0.6;
+}
+
+.vs-dark .list-group-item-action.active {
+  background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
 }
 </style>

--- a/frontend/www/js/omegaup/grader/CaseSelector.vue
+++ b/frontend/www/js/omegaup/grader/CaseSelector.vue
@@ -286,4 +286,8 @@ input[type='number'].case-weight {
   background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
 }
+.vs-dark .input-group input.form-control {
+  background-color: var(--vs-dark-background-color);
+  color: var(--vs-dark-font-color);
+}
 </style>

--- a/frontend/www/js/omegaup/grader/CaseSelector.vue
+++ b/frontend/www/js/omegaup/grader/CaseSelector.vue
@@ -38,8 +38,8 @@
             type="button"
             :class="{
               'in-group': group.explicit,
-              active: currentCase == item.name
-              }"
+              active: currentCase == item.name,
+            }"
             @click="selectCase(item.name)"
           >
             <div class="text-truncate">

--- a/frontend/www/js/omegaup/grader/CaseSelector.vue
+++ b/frontend/www/js/omegaup/grader/CaseSelector.vue
@@ -276,18 +276,57 @@ input[type='number'].case-weight {
   background-color: var(--vs-dark-background-color);
 }
 
-.vs-dark .list-group-item-action:not(.active) {
+.vs-dark .list-group-item {
   background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
-  opacity: 0.6;
+  border-color: #555;
+}
+
+.vs-dark .list-group-item-action {
+  background-color: var(--vs-dark-background-color);
+  color: var(--vs-dark-font-color);
+}
+
+.vs-dark .list-group-item-action:hover,
+.vs-dark .list-group-item-action:focus {
+  background-color: #3a3a3a;
+  color: var(--vs-dark-font-color);
 }
 
 .vs-dark .list-group-item-action.active {
-  background-color: var(--vs-dark-background-color);
+  background-color: #484848;
+  border-color: #666;
+}
+
+.vs-dark .list-group-item-secondary {
+  background-color: #2d2d2d;
   color: var(--vs-dark-font-color);
 }
+
+.vs-dark .close {
+  color: #aaa;
+}
+
+.vs-dark .close:hover {
+  color: #fff;
+}
+
 .vs-dark .input-group input.form-control {
   background-color: var(--vs-dark-background-color);
+  color: var(--vs-dark-font-color);
+  border-color: #555;
+}
+
+.vs-dark .btn-secondary {
+  background-color: #444;
+  border-color: #666;
+}
+
+.vs-dark .btn-secondary:hover {
+  background-color: #555;
+}
+
+.vs-dark .verdict {
   color: var(--vs-dark-font-color);
 }
 </style>

--- a/frontend/www/js/omegaup/grader/CaseSelector.vue
+++ b/frontend/www/js/omegaup/grader/CaseSelector.vue
@@ -279,7 +279,7 @@ input[type='number'].case-weight {
 .vs-dark .list-group-item {
   background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
-  border-color: #555;
+  border-color: var(--vs-dark-border-color-medium);
 }
 
 .vs-dark .list-group-item-action {
@@ -289,41 +289,45 @@ input[type='number'].case-weight {
 
 .vs-dark .list-group-item-action:hover,
 .vs-dark .list-group-item-action:focus {
-  background-color: #3a3a3a;
+  background-color: var(
+    --vs-dark-list-group-item-action-background-color--hover
+  );
   color: var(--vs-dark-font-color);
 }
 
 .vs-dark .list-group-item-action.active {
-  background-color: #484848;
-  border-color: #666;
+  background-color: var(
+    --vs-dark-list-group-item-action-background-color--active
+  );
+  border-color: var(--vs-dark-border-color-strong);
 }
 
 .vs-dark .list-group-item-secondary {
-  background-color: #2d2d2d;
+  background-color: var(--vs-dark-list-group-item-secondary-background-color);
   color: var(--vs-dark-font-color);
 }
 
 .vs-dark .close {
-  color: #aaa;
+  color: var(--vs-dark-close-color);
 }
 
 .vs-dark .close:hover {
-  color: #fff;
+  color: var(--vs-dark-close-color--hover);
 }
 
 .vs-dark .input-group input.form-control {
   background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
-  border-color: #555;
+  border-color: var(--vs-dark-border-color-medium);
 }
 
 .vs-dark .btn-secondary {
-  background-color: #444;
-  border-color: #666;
+  background-color: var(--vs-dark-btn-secondary-background-color);
+  border-color: var(--vs-dark-border-color-strong);
 }
 
 .vs-dark .btn-secondary:hover {
-  background-color: #555;
+  background-color: var(--vs-dark-btn-secondary-background-color--hover);
 }
 
 .vs-dark .verdict {

--- a/frontend/www/js/omegaup/grader/Ephemeral.vue
+++ b/frontend/www/js/omegaup/grader/Ephemeral.vue
@@ -774,6 +774,12 @@ div {
     background: var(--vs-dark-background-color);
     color: var(--vs-dark-font-color);
     border-bottom: 1px solid var(--vs-dark-background-color);
+
+  /* Target the language selector */
+  .form-control.form-control-sm[data-language-select] {
+    background-color: var(--vs-dark-background-color); 
+    color: var(--vs-dark-font-color); 
+    }
   }
   &.vs {
     background: var(--vs-background-color);

--- a/frontend/www/js/omegaup/grader/Ephemeral.vue
+++ b/frontend/www/js/omegaup/grader/Ephemeral.vue
@@ -775,10 +775,10 @@ div {
     color: var(--vs-dark-font-color);
     border-bottom: 1px solid var(--vs-dark-background-color);
 
-  /* Target the language selector */
-  .form-control.form-control-sm[data-language-select] {
-    background-color: var(--vs-dark-background-color); 
-    color: var(--vs-dark-font-color); 
+    /* Target the language selector */
+    .form-control.form-control-sm[data-language-select] {
+      background-color: var(--vs-dark-background-color);
+      color: var(--vs-dark-font-color);
     }
   }
   &.vs {

--- a/frontend/www/js/omegaup/grader/IDESettings.vue
+++ b/frontend/www/js/omegaup/grader/IDESettings.vue
@@ -256,6 +256,18 @@ form {
   &.vs-dark {
     background: var(--vs-dark-background-color);
     color: var(--vs-dark-font-color);
+
+    .form-control {
+      background-color: var(--vs-dark-background-color);
+      color: var(--vs-dark-font-color);
+    }
+
+    .form-control:focus {
+      border-color: #007bff;
+      box-shadow: 0 0 0 3px rgba($omegaup-blue, 0.4);
+      background-color: var(--vs-dark-background-color);
+      color: var(--vs-dark-font-color);
+    }
   }
   &.vs {
     background: var(--vs-background-color);

--- a/frontend/www/js/omegaup/grader/IDESettings.vue
+++ b/frontend/www/js/omegaup/grader/IDESettings.vue
@@ -263,7 +263,7 @@ form {
     }
 
     .form-control:focus {
-      border-color: #007bff;
+      border-color: var(--vs-dark-selected-form-border-color);
       box-shadow: 0 0 0 3px rgba($omegaup-blue, 0.4);
       background-color: var(--vs-dark-background-color);
       color: var(--vs-dark-font-color);

--- a/frontend/www/js/omegaup/grader/MonacoEditor.vue
+++ b/frontend/www/js/omegaup/grader/MonacoEditor.vue
@@ -177,22 +177,19 @@ export default class MonacoEditor extends Vue {
 /* Dark theme styles */
 .vs-dark .editor-toolbar {
   background: var(--vs-dark-background-color);
-  border-bottom: 1px solid var(--vs-dark-border-color);
 }
 
 .vs-dark .editor-toolbar label {
-  background: var(--vs-dark-label-background-color);
+  background: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
-  border: 1px solid var(--vs-dark-font-color-light);
 }
 
 .vs-dark .editor-toolbar select {
-  background-color: var(--vs-dark-select-background-color);
+  background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
-  border: 1px solid var(--vs-dark-font-color-light);
 }
 
 .vs-dark .editor {
-  border: 1px solid var(--vs-dark-font-color-light);
+  border: 1px solid var(--vs-dark-font-color);
 }
 </style>

--- a/frontend/www/js/omegaup/grader/MonacoEditor.vue
+++ b/frontend/www/js/omegaup/grader/MonacoEditor.vue
@@ -155,15 +155,15 @@ export default class MonacoEditor extends Vue {
 @import '../../../sass/main.scss';
 
 .editor-toolbar {
-  background: var(--moncao-editor-toolbar-background-color);
-  border-bottom: 1px solid var(--moncao-editor-toolbar-border-bottom-color);
+  background: var(--monaco-editor-toolbar-background-color);
+  border-bottom: 1px solid var(--monaco-editor-toolbar-border-bottom-color);
 }
 
 .editor-toolbar label {
   font-size: 12px;
-  background: var(--moncao-editor-toolbar-label-background-color);
-  color: var(--moncao-editor-toolbar-label-color);
-  border: 1px solid var(--moncao-editor-toolbar-label-border-color);
+  background: var(--monaco-editor-toolbar-label-background-color);
+  color: var(--monaco-editor-toolbar-label-color);
+  border: 1px solid var(--monaco-editor-toolbar-label-border-color);
 }
 
 .editor-toolbar select {
@@ -171,7 +171,7 @@ export default class MonacoEditor extends Vue {
 }
 
 .editor {
-  border: 1px solid var(--moncao-editor-toolbar-label-border-color);
+  border: 1px solid var(--monaco-editor-toolbar-label-border-color);
 }
 
 /* Dark theme styles */

--- a/frontend/www/js/omegaup/grader/MonacoEditor.vue
+++ b/frontend/www/js/omegaup/grader/MonacoEditor.vue
@@ -1,5 +1,6 @@
 <template>
-  <div :class="['h-100', 'd-flex', 'flex-column', theme]"> <div class="editor-toolbar d-flex align-items-center p-1 form-inline">
+  <div :class="['h-100', 'd-flex', 'flex-column', theme]">
+    <div class="editor-toolbar d-flex align-items-center p-1 form-inline">
       <label class="mr-1 mb-0 p-1">{{ T.fontSize }}</label>
       <select
         v-model="selectedFontSize"
@@ -175,7 +176,7 @@ export default class MonacoEditor extends Vue {
 
 /* Dark theme styles */
 .vs-dark .editor-toolbar {
-  background: var(--vs-dark-background-color) ;
+  background: var(--vs-dark-background-color);
   border-bottom: 1px solid var(--vs-dark-border-color);
 }
 

--- a/frontend/www/js/omegaup/grader/MonacoEditor.vue
+++ b/frontend/www/js/omegaup/grader/MonacoEditor.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="h-100 d-flex flex-column">
-    <div class="editor-toolbar d-flex align-items-center p-1 form-inline">
+  <div :class="['h-100', 'd-flex', 'flex-column', theme]"> <div class="editor-toolbar d-flex align-items-center p-1 form-inline">
       <label class="mr-1 mb-0 p-1">{{ T.fontSize }}</label>
       <select
         v-model="selectedFontSize"
@@ -172,5 +171,27 @@ export default class MonacoEditor extends Vue {
 
 .editor {
   border: 1px solid var(--moncao-editor-toolbar-label-border-color);
+}
+
+/* Dark theme styles */
+.vs-dark .editor-toolbar {
+  background: var(--vs-dark-background-color) ;
+  border-bottom: 1px solid var(--vs-dark-border-color);
+}
+
+.vs-dark .editor-toolbar label {
+  background: var(--vs-dark-label-background-color);
+  color: var(--vs-dark-font-color);
+  border: 1px solid var(--vs-dark-font-color-light);
+}
+
+.vs-dark .editor-toolbar select {
+  background-color: var(--vs-dark-select-background-color);
+  color: var(--vs-dark-font-color);
+  border: 1px solid var(--vs-dark-font-color-light);
+}
+
+.vs-dark .editor {
+  border: 1px solid var(--vs-dark-font-color-light);
 }
 </style>

--- a/frontend/www/js/omegaup/grader/ZipViewer.vue
+++ b/frontend/www/js/omegaup/grader/ZipViewer.vue
@@ -99,7 +99,7 @@ textarea {
 .vs-dark .list-group-item {
   background-color: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
-  border-color: #555;
+  border-color: var(--vs-dark-border-color-medium);
 }
 
 .vs-dark .list-group-item-action {
@@ -108,18 +108,22 @@ textarea {
 
 .vs-dark .list-group-item-action:hover,
 .vs-dark .list-group-item-action:focus {
-  background-color: #3a3a3a;
+  background-color: var(
+    --vs-dark-list-group-item-action-background-color--hover
+  );
   color: var(--vs-dark-font-color);
 }
 
 .vs-dark .list-group-item-action.active {
-  background-color: #484848;
-  border-color: #666;
+  background-color: var(
+    --vs-dark-list-group-item-action-background-color--active
+  );
+  border-color: var(--vs-dark-border-color-strong);
   color: var(--vs-dark-font-color);
 }
 
 .vs-dark .list-group-item.disabled {
-  background-color: #333;
-  color: #888;
+  background-color: var(--vs-dark-list-group-item-disabled-background-color);
+  color: var(--vs-dark-list-group-item-disabled-color);
 }
 </style>

--- a/frontend/www/js/omegaup/grader/ZipViewer.vue
+++ b/frontend/www/js/omegaup/grader/ZipViewer.vue
@@ -1,11 +1,10 @@
 <template>
-  <div class="root d-flex flex-row h-100">
+  <div class="root d-flex flex-row h-100" :class="theme">
     <div class="filenames">
       <div class="list-group">
         <button
           v-if="!zip"
           class="text-truncate list-group-item list-group-item-action disabled"
-          :class="theme"
           type="button"
         >
           <em>{{ T.wordsEmpty }}</em>
@@ -17,8 +16,7 @@
           class="text-truncate list-group-item list-group-item-action"
           type="button"
           :class="{
-            active: active === name && theme === 'vs',
-            'vs-dark': active === name && theme === 'vs-dark',
+            active: active === name,
           }"
           :title="name"
           @click="select(item)"
@@ -93,5 +91,35 @@ textarea {
 .vs-dark {
   background: var(--vs-dark-background-color);
   color: var(--vs-dark-font-color);
+}
+.vs-dark .filenames {
+  background-color: var(--vs-dark-background-color);
+}
+
+.vs-dark .list-group-item {
+  background-color: var(--vs-dark-background-color);
+  color: var(--vs-dark-font-color);
+  border-color: #555;
+}
+
+.vs-dark .list-group-item-action {
+  color: var(--vs-dark-font-color);
+}
+
+.vs-dark .list-group-item-action:hover,
+.vs-dark .list-group-item-action:focus {
+  background-color: #3a3a3a;
+  color: var(--vs-dark-font-color);
+}
+
+.vs-dark .list-group-item-action.active {
+  background-color: #484848;
+  border-color: #666;
+  color: var(--vs-dark-font-color);
+}
+
+.vs-dark .list-group-item.disabled {
+  background-color: #333;
+  color: #888;
 }
 </style>

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -261,8 +261,8 @@
   --vs-font-color: #333;
   --vs-dark-background-color: #222;
   --vs-dark-font-color: #d4d4d4;
-  --vs-dark-border-color-medium: #555; /* Used for list items, inputs */
-  --vs-dark-border-color-strong: #666; /* Used for active list items, secondary buttons */
+  --vs-dark-border-color-medium: #555;
+  --vs-dark-border-color-strong: #666;
   --vs-dark-list-group-item-disabled-background-color: #333;
   --vs-dark-list-group-item-disabled-color: #888;
   --vs-dark-list-group-item-action-background-color--hover: #3a3a3a;
@@ -271,7 +271,7 @@
   --vs-dark-close-color: #aaa;
   --vs-dark-close-color--hover: #fff;
   --vs-dark-btn-secondary-background-color: #444;
-  --vs-dark-btn-secondary-background-color--hover: #555; /* Note: Same value as border-color-medium, but different semantic use */
+  --vs-dark-btn-secondary-background-color--hover: #555;
   --vs-dark-selected-form-border-color: #007bff;
   // GRADER ZIP BUTTONS
   --zip-button-color--hover: #fff;

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -295,10 +295,10 @@
   // GENERAL
   --general-in-maintainance-color: #4b4b4b;
 
-  //MONCAO EDITOR
-  --moncao-editor-toolbar-background-color: #f4f4f4;
-  --moncao-editor-toolbar-label-background-color: #e1e1e1;
-  --moncao-editor-toolbar-label-color: #777777;
-  --moncao-editor-toolbar-label-border-color: #cccccc;
-  --moncao-editor-toolbar-border-bottom-color: #ccc;
+  //MONACO EDITOR
+  --monaco-editor-toolbar-background-color: #f4f4f4;
+  --monaco-editor-toolbar-label-background-color: #e1e1e1;
+  --monaco-editor-toolbar-label-color: #777777;
+  --monaco-editor-toolbar-label-border-color: #cccccc;
+  --monaco-editor-toolbar-border-bottom-color: #ccc;
 }

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -261,7 +261,18 @@
   --vs-font-color: #333;
   --vs-dark-background-color: #222;
   --vs-dark-font-color: #d4d4d4;
-
+  --vs-dark-border-color-medium: #555; /* Used for list items, inputs */
+  --vs-dark-border-color-strong: #666; /* Used for active list items, secondary buttons */
+  --vs-dark-list-group-item-disabled-background-color: #333;
+  --vs-dark-list-group-item-disabled-color: #888;
+  --vs-dark-list-group-item-action-background-color--hover: #3a3a3a;
+  --vs-dark-list-group-item-action-background-color--active: #484848;
+  --vs-dark-list-group-item-secondary-background-color: #2d2d2d;
+  --vs-dark-close-color: #aaa;
+  --vs-dark-close-color--hover: #fff;
+  --vs-dark-btn-secondary-background-color: #444;
+  --vs-dark-btn-secondary-background-color--hover: #555; /* Note: Same value as border-color-medium, but different semantic use */
+  --vs-dark-selected-form-border-color: #007bff;
   // GRADER ZIP BUTTONS
   --zip-button-color--hover: #fff;
 


### PR DESCRIPTION
# Description

Applied the dark theme to the contrasting elements in the ephemeral grader.

Fixes: #8176 

# Demo
https://www.loom.com/share/9e7fb704f63e4cbe900b7cc5c7f709a7?sid=15b41de9-b9d4-4a59-b932-8da3b28201c7

# Comments
I think there is a type in the variable names. Shouldn't this be "monaco" instead of "moncao"?
![image](https://github.com/user-attachments/assets/b4e3c17f-30a4-488f-b6e7-bd21857d4b6c)
