### PR TITLE
Fix error in pre-push hook when verifying docker compose

### DIFF
--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -58,7 +58,7 @@ if [ $GIT_PUSH -eq 1 ]; then
 	fi
 fi
 
-if ! which docker compose >/dev/null; then
+if ! command -v docker compose &> /dev/null; then
 	echo -e "\033[0;31mERROR\033[0m: \`docker compose\` not found. Please run \`git push\` outside the container."
 	exit 1
 fi


### PR DESCRIPTION
# Description

Previously, the script used `which docker compose` to check if the command was available. However, in some environments, this method failed, causing Git push to incorrectly detect that it was being executed inside a container.
The issue likely stemmed from one of the following factors:
- Differences in Docker installation: Some newer versions do not include a separate docker-compose binary, leading to inconsistencies in detection.
- Variations in PATH: The script may have been executed in a context where which docker compose did not find the expected binary.
- Differences between local environments: Other users reported the same issue, suggesting that the validation method was unreliable in certain setups.
To fix this, the validation was changed to use `command -v docker compose`, which provides a more robust and reliable check for the command’s presence across different configurations.
This update ensures that developers can push their commits without encountering false errors related to the execution environment.

