### PR TITLE
Agregando índice en tabla de Schools para optimización de queries

### DIFF
--- a/frontend/database/00234_add_key_in_schools_table.sql
+++ b/frontend/database/00234_add_key_in_schools_table.sql
@@ -1,0 +1,3 @@
+-- Add index to the Schools table
+ALTER TABLE `Schools`
+  ADD KEY `idx_schools_score` (`score`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -993,6 +993,7 @@ CREATE TABLE `Schools` (
   KEY `country_id` (`country_id`),
   KEY `state_id` (`country_id`,`state_id`),
   KEY `idx_schools_name` (`name`),
+  KEY `idx_schools_score` (`score`),
   CONSTRAINT `fk_scc_country_id` FOREIGN KEY (`country_id`) REFERENCES `Countries` (`country_id`),
   CONSTRAINT `fk_ss_state_id` FOREIGN KEY (`country_id`, `state_id`) REFERENCES `States` (`country_id`, `state_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Catálogos para la normalización';

--- a/frontend/server/src/DAO/Schools.php
+++ b/frontend/server/src/DAO/Schools.php
@@ -90,6 +90,9 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
                 Schools s
             WHERE
                 s.score != 0
+        ';
+
+        $sqlOrder = '
             ORDER BY
                 s.`ranking` IS NULL, s.`ranking` ASC
         ';
@@ -116,7 +119,7 @@ class Schools extends \OmegaUp\DAO\Base\Schools {
 
         /** @var list<array{country_id: null|string, name: string, ranking: int|null, school_id: int, score: float}> */
         $rank = \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            $sql . $sqlFrom . $sqlLimit,
+            $sql . $sqlFrom . $sqlOrder . $sqlLimit,
             [
                 max(0, $page - 1) * $rowsPerPage,
                 $rowsPerPage,

--- a/stuff/git-hooks/pre-push
+++ b/stuff/git-hooks/pre-push
@@ -58,7 +58,7 @@ if [ $GIT_PUSH -eq 1 ]; then
 	fi
 fi
 
-if ! which docker compose >/dev/null; then
+if ! command -v docker compose &> /dev/null; then
 	echo -e "\033[0;31mERROR\033[0m: \`docker compose\` not found. Please run \`git push\` outside the container."
 	exit 1
 fi


### PR DESCRIPTION
# Description

Se agregan el siguiente índice útil para optimizar una consulta marcada como ineficiente:

- `idx_schools_score`

También se hace un pequeño ajuste a la consulta para no agregar el `ORDER BY` en la consulta que cuenta los elementos solamente.

Part of: #8259 
Part of: #8260 

# Comments

Falta ejecutar la segunda parte que es aplicar los cambios de `dao_schema.py` para poder cerrar los issues

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
