### PR TITLE
Ocultando temporalmente la información de Escuela del mes en Homepage

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -4252,7 +4252,7 @@ class User extends \OmegaUp\Controllers\Controller {
                             'female'
                         )['coderinfo']
                     ],
-                    'schoolOfTheMonthData' => \OmegaUp\Controllers\School::getSchoolOfTheMonth()['schoolinfo'],
+                    'schoolOfTheMonthData' => null,
                     'userRank' => self::getTopCodersOfTheMonth(
                         $rowCount
                     ),


### PR DESCRIPTION
# Description

Cuando se deshabilitó la funcionalidad de Escuela del mes, se había quedado visible el componente que está en la página de inicio.

En este cambio se deja de mandar información para que se oculte temporalmente.

Se tendrá que habilitar nuevamente cuando se vuelva a prender el cronjob de escuela del mes

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.