### PR TITLE
Modernizando el código en PHP de los controladores para código que se deprecará pronto

### DIFF
--- a/frontend/server/src/Controllers/Badge.php
+++ b/frontend/server/src/Controllers/Badge.php
@@ -28,7 +28,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
         $results = [];
         foreach ($aliases as $alias) {
             /** @psalm-suppress MixedOperand OMEGAUP_BADGES_ROOT is really a string. */
-            if (!is_dir(static::OMEGAUP_BADGES_ROOT . "/${alias}")) {
+            if (!is_dir(static::OMEGAUP_BADGES_ROOT . "/{$alias}")) {
                 continue;
             }
             $results[] = $alias;
@@ -116,7 +116,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param null|string $badge_alias
      */
-    public static function apiBadgeDetails(\OmegaUp\Request $r): array {
+    public static function apiBadgeDetails(\OmegaUp\Request $r) {
         $badgeAlias = $r->ensureString(
             'badge_alias',
             fn (string $alias) => \OmegaUp\Validators::alias($alias)

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -17,14 +17,14 @@ namespace OmegaUp\Controllers;
  * @psalm-type ConsentStatement=array{contest_alias: string, privacy_git_object_id?: string, share_user_information: bool|null, statement_type?: string}
  * @psalm-type Clarification=array{answer: null|string, assignment_alias?: null|string, author: string, clarification_id: int, contest_alias?: null|string, message: string, problem_alias: string, public: bool, receiver: null|string, time: \OmegaUp\Timestamp}
  * @psalm-type ProblemQualityPayload=array{canNominateProblem: bool, dismissed: bool, dismissedBeforeAc: bool, language?: string, nominated: bool, nominatedBeforeAc: bool, problemAlias: string, solved: bool, tried: bool}
- * @psalm-type ProblemsetProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter?: string, order: int, points: float, problem_id?: int, quality_payload?: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
+ * @psalm-type ProblemsetContestProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter: null|string, order: int, points: float, problem_id: int, quality_payload: null| ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
  * @psalm-type Signature=array{email: string, name: string, time: \OmegaUp\Timestamp}
  * @psalm-type ProblemVersion=array{author: Signature, commit: string, committer: Signature, message: string, parents: list<string>, tree: array<string, string>, version: string}
- * @psalm-type ProblemsetProblemWithVersions=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, languages: string, letter?: string, order: int, points: float, quality_payload?: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, versions: array{log: list<ProblemVersion>, published: string}, visibility: int, visits: int}
+ * @psalm-type ProblemsetProblemWithVersions=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, languages: string, letter: null|string, order: int, points: float, quality_payload: ProblemQualityPayload|null, quality_seal: bool, submissions: int, title: string, version: string, versions: array{log: list<ProblemVersion>, published: string}, visibility: int, visits: int}
  * @psalm-type ContestListMinePayload=array{contests: list<Contest>, privateContestsAlert: bool}
- * @psalm-type ContestDetails=array{admin: bool, admission_mode: string, alias: string, archived: bool, contest_for_teams: bool, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, has_submissions: bool, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems: list<ProblemsetProblem>, problemset_id: int, recommended: bool, requests_user_information: string, rerun_id?: int, score_mode: string, scoreboard: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty: bool, default_show_all_contestants_in_scoreboard: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
+ * @psalm-type ContestDetails=array{admin: bool, admission_mode: string, alias: string, archived: bool, contest_for_teams: bool, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, has_submissions: bool, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems: list<ProblemsetContestProblem>, problemset_id: int, recommended: bool, requests_user_information: string, rerun_id?: int, score_mode: string, scoreboard: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty: bool, default_show_all_contestants_in_scoreboard: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
  * @psalm-type ArenaContest=array{alias: string, director: string, finish_time: \OmegaUp\Timestamp|null, start_time: \OmegaUp\Timestamp|null, rerun_id?: int, title: string, window_length?: int}
- * @psalm-type ContestAdminDetails=array{admin: bool, admission_mode: string, alias: string, archived: bool, available_languages: array<string, string>, canSetRecommended: bool, contest_for_teams: bool, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, has_submissions: bool, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems?: list<ProblemsetProblem>, problemset_id: int, recommended?: bool, requests_user_information: string, rerun_id?: int, score_mode: string, scoreboard: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_penalty: bool, default_show_all_contestants_in_scoreboard: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
+ * @psalm-type ContestAdminDetails=array{admin: bool, admission_mode: string, alias: string, archived: bool, available_languages: array<string, string>, canSetRecommended: bool, contest_for_teams: bool, description: string, director: string, feedback: string, finish_time: \OmegaUp\Timestamp, has_submissions: bool, languages: list<string>, needs_basic_information: bool, opened: bool, original_contest_alias: null|string, original_problemset_id: int|null, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problems?: list<ProblemsetContestProblem>, problemset_id: int, recommended?: bool, requests_user_information: string, rerun_id?: int, score_mode: string, scoreboard: int, scoreboard_url: null|string, scoreboard_url_admin: null|string, show_penalty: bool, default_show_all_contestants_in_scoreboard: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap: int, title: string, window_length: int|null}
  * @psalm-type StatsPayload=array{alias: string, entity_type: string, cases_stats?: array<string, int>, pending_runs: list<string>, total_runs: int, verdict_counts: array<string, int>, max_wait_time?: \OmegaUp\Timestamp|null, max_wait_time_guid?: null|string, distribution?: array<int, int>, size_of_bucket?: float, total_points?: float}
  * @psalm-type ContestPublicDetails=array{admission_mode: string, alias: string, description: string, director: string, extra_note?: string|null, feedback: string, finish_time: \OmegaUp\Timestamp, languages: string, penalty: int, penalty_calc_policy: string, penalty_type: string, points_decay_factor: float, problemset_id: int, rerun_id: int|null, score_mode: string, scoreboard: int, show_penalty: bool, default_show_all_contestants_in_scoreboard: bool, show_scoreboard_after: bool, start_time: \OmegaUp\Timestamp, submissions_gap: int, title: string, user_registration_requested?: bool, user_registration_answered?: bool, user_registration_accepted?: bool|null, window_length: int|null}
  * @psalm-type ContestVirtualDetailsPayload=array{contest: ContestPublicDetails}
@@ -1514,8 +1514,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
     /**
      * Adding the version log to every problem in a contest
-     * @param list<ProblemsetProblem> $problems
-     * @return list<ProblemsetProblemWithVersions> $problems
+     * @param list<array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter: null|string, order: int, points: float, problem_id: int, quality_payload: null| ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}> $problems
+     * @return list<ProblemsetProblemWithVersions>
      */
     private static function addVersionsToProblems(
         array $problems,
@@ -1665,7 +1665,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $contest_alias
      */
-    public static function apiPublicDetails(\OmegaUp\Request $r): array {
+    public static function apiPublicDetails(\OmegaUp\Request $r) {
         try {
             $r->ensureIdentity();
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
@@ -1692,7 +1692,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     private static function getPublicDetails(
         $contest,
         ?\OmegaUp\DAO\VO\Identities $identity
-    ): array {
+    ) {
         // Whether the contest is private, verify that our user is invited
         if (
             !is_null($identity) &&
@@ -2015,7 +2015,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $contest_alias
      * @omegaup-request-param null|string $token
      */
-    public static function apiDetails(\OmegaUp\Request $r): array {
+    public static function apiDetails(\OmegaUp\Request $r) {
         try {
             $r->ensureIdentity();
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
@@ -2121,7 +2121,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Contests $contest,
         \OmegaUp\DAO\VO\Identities $adminIdentity,
         \OmegaUp\DAO\VO\Problemsets $problemset
-    ): array {
+    ) {
         if (is_null($contest->alias) || is_null($contest->problemset_id)) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
@@ -2161,7 +2161,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $contest_alias
      * @omegaup-request-param null|string $token
      */
-    public static function apiAdminDetails(\OmegaUp\Request $r): array {
+    public static function apiAdminDetails(\OmegaUp\Request $r) {
         $r->ensureMainUserIdentity();
         $contestAlias = $r->ensureString(
             'contest_alias',
@@ -4152,7 +4152,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $contest_alias
      * @omegaup-request-param null|string $token
      */
-    public static function apiScoreboard(\OmegaUp\Request $r): array {
+    public static function apiScoreboard(\OmegaUp\Request $r) {
         $contestAlias = $r->ensureString(
             'contest_alias',
             fn (string $alias) => \OmegaUp\Validators::alias($alias)

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -9,7 +9,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type Progress=array{score: float, max_score: float}
  * @psalm-type AssignmentProgress=array<string, Progress>
  * @psalm-type ProblemQualityPayload=array{canNominateProblem: bool, dismissed: bool, dismissedBeforeAc: bool, language?: string, nominated: bool, nominatedBeforeAc: bool, problemAlias: string, solved: bool, tried: bool}
- * @psalm-type ProblemsetProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter?: string, order: int, points: float, problem_id?: int, quality_payload?: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
+ * @psalm-type ProblemsetCourseProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter: string, order: int, points: float, quality_payload: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
  * @psalm-type IdentityRequest=array{accepted: bool|null, admin?: array{name: null|string, username: string}, classname: string, country: null|string, country_id: null|string, last_update: \OmegaUp\Timestamp|null, name: null|string, request_time: \OmegaUp\Timestamp, username: string}
  * @psalm-type CourseAdmin=array{role: string, username: string}
  * @psalm-type Clarification=array{answer: null|string, assignment_alias?: null|string, author: string, clarification_id: int, contest_alias?: null|string, message: string, problem_alias: string, public: bool, receiver: null|string, time: \OmegaUp\Timestamp}
@@ -42,7 +42,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type StudentProgressInCourse=array{assignments: array<string, array{problems: array<string, array{progress: float, score: float}>, progress: float, score: float}>, classname: string, country_id: null|string, courseProgress: float, courseScore: float, name: null|string, username: string}
  * @psalm-type AssignmentsProblemsPoints=array{alias: string, extraPoints: float, name: string, points: float, problems: list<array{alias: string, title: string, isExtraProblem: bool, order: int, points: float}>, order: int}
  * @psalm-type CourseNewPayload=array{is_admin: bool, hasVisitedSection: bool, is_curator: bool, languages: array<string, string>}
- * @psalm-type CourseEditPayload=array{admins: list<CourseAdmin>, teachingAssistants: list<CourseAdmin>, allLanguages: array<string, string>, assignmentProblems: list<ProblemsetProblem>, course: CourseDetails, groupsAdmins: list<CourseGroupAdmin>, groupsTeachingAssistants: list<CourseGroupAdmin>, identityRequests: list<IdentityRequest>, selectedAssignment: CourseAssignment|null, students: list<CourseStudent>, tags: list<string>}
+ * @psalm-type CourseEditPayload=array{admins: list<CourseAdmin>, teachingAssistants: list<CourseAdmin>, allLanguages: array<string, string>, assignmentProblems: list<ProblemsetCourseProblem>, course: CourseDetails, groupsAdmins: list<CourseGroupAdmin>, groupsTeachingAssistants: list<CourseGroupAdmin>, identityRequests: list<IdentityRequest>, selectedAssignment: CourseAssignment|null, students: list<CourseStudent>, tags: list<string>}
  * @psalm-type StudentsProgressPayload=array{course: CourseDetails, assignmentsProblems: list<AssignmentsProblemsPoints>, students: list<StudentProgressInCourse>, totalRows: int, page: int, length: int, pagerItems: list<PageItem>}
  * @psalm-type SubmissionFeedbackThread=array{author: string, authorClassname: string, submission_feedback_thread_id: int, text: string, timestamp: \OmegaUp\Timestamp}
  * @psalm-type SubmissionFeedback=array{author: string, author_classname: string, feedback: string, date: \OmegaUp\Timestamp, range_bytes_end: int|null, range_bytes_start: int|null, submission_feedback_id: int, feedback_thread?: list<SubmissionFeedbackThread>}
@@ -57,7 +57,7 @@ namespace OmegaUp\Controllers;
  * @psalm-type NavbarProblemsetProblem=array{acceptsSubmissions: bool, alias: string, bestScore: int, hasRuns: bool, maxScore: float|int, text: string, myBestScore?: float|null, hasMyRuns?: bool|null}
  * @psalm-type ArenaAssignment=array{alias: string|null, assignment_type: string, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string|null, problems: list<NavbarProblemsetProblem>, problemset_id: int, runs: list<Run>, start_time: \OmegaUp\Timestamp, totalRuns: int|null}
  * @psalm-type AssignmentDetailsPayload=array{showRanking: bool, scoreboard?: Scoreboard, courseDetails: CourseDetails, currentAssignment: ArenaAssignment, shouldShowFirstAssociatedIdentityRunWarning: bool, isTeachingAssistant: bool}
- * @psalm-type AssignmentDetails=array{admin: bool, alias: string, assignmentType: string, courseAssignments: list<CourseAssignment>, description: string, director: string, finishTime: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetProblem>, problemsetId: int, startTime: \OmegaUp\Timestamp}
+ * @psalm-type AssignmentDetails=array{admin: bool, alias: string, assignmentType: string, courseAssignments: list<CourseAssignment>, description: string, director: string, finishTime: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetCourseProblem>, problemsetId: int, startTime: \OmegaUp\Timestamp}
  * @psalm-type CourseScoreboardPayload=array{assignment: AssignmentDetails, problems: list<NavbarProblemsetProblem>, scoreboard: Scoreboard, scoreboardToken:null|string}
  * @psalm-type AddedProblem=array{alias: string, commit?: string, points: float, is_extra_problem?: bool}
  * @psalm-type Event=array{courseAlias?: string, courseName?: string, name: string, problem?: string}
@@ -1971,7 +1971,8 @@ class Course extends \OmegaUp\Controllers\Controller {
 
     /**
      * @param list<string> $courseTypes
-     * @return CoursesList
+     * @return array{admin: list<FilteredCourse>, public: list<FilteredCourse>, student: list<FilteredCourse>, archived: list<FilteredCourse>, teachingAssistant: list<FilteredCourse>}
+ * @psalm-type CourseCloneDetailsPayload=array{creator: array{classname: string, username: string}, details: CourseDetails, token: null|string}
      */
     private static function getCoursesList(
         \OmegaUp\DAO\VO\Identities $identity,
@@ -5406,7 +5407,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $alias
      */
-    public static function apiAdminDetails(\OmegaUp\Request $r): array {
+    public static function apiAdminDetails(\OmegaUp\Request $r) {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $courseAlias = $r->ensureString(
@@ -5631,7 +5632,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns details of a given assignment
      *
-     * @return array{admin: bool, alias: string, assignment_type: null|string, courseAssignments: list<CourseAssignment>, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetProblem>, problemset_id: int, start_time: \OmegaUp\Timestamp}
+     * @return array{admin: bool, alias: string, assignment_type: null|string, courseAssignments: list<CourseAssignment>, description: null|string, director: string, finish_time: \OmegaUp\Timestamp|null, name: string, problems: list<ProblemsetCourseProblem>, problemset_id: int, start_time: \OmegaUp\Timestamp}
      *
      * @omegaup-request-param string $assignment
      * @omegaup-request-param string $course
@@ -5719,7 +5720,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return list<ProblemsetProblem>
+     * @return list<ProblemsetCourseProblem>
      */
     private static function getProblemsByAssignment(
         string $assignmentAlias,
@@ -5948,7 +5949,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      *
      * @omegaup-request-param string $alias
      */
-    public static function apiDetails(\OmegaUp\Request $r): array {
+    public static function apiDetails(\OmegaUp\Request $r) {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
 
         $r->ensureIdentity();
@@ -6321,7 +6322,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $course
      * @omegaup-request-param null|string $token
      */
-    public static function apiAssignmentScoreboard(\OmegaUp\Request $r): array {
+    public static function apiAssignmentScoreboard(\OmegaUp\Request $r) {
         $r->ensureIdentity();
         $courseAlias = $r->ensureString(
             'course',

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -189,7 +189,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $group_alias
      * @omegaup-request-param string $scoreboard_alias
      */
-    public static function apiDetails(\OmegaUp\Request $r): array {
+    public static function apiDetails(\OmegaUp\Request $r) {
         $r->ensureIdentity();
         $groupAlias = $r->ensureString(
             'group_alias',

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2279,7 +2279,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     private static function getProblemSettings(
         \OmegaUp\DAO\VO\Problems $problem,
         string $commit
-    ): array {
+    ) {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::PROBLEM_SETTINGS,
             "{$problem->alias}-{$problem->commit}",

--- a/frontend/server/src/Controllers/Problemset.php
+++ b/frontend/server/src/Controllers/Problemset.php
@@ -4,7 +4,7 @@ namespace OmegaUp\Controllers;
 
 /**
  * @psalm-type ProblemQualityPayload=array{canNominateProblem: bool, dismissed: bool, dismissedBeforeAc: bool, language?: string, nominated: bool, nominatedBeforeAc: bool, problemAlias: string, solved: bool, tried: bool}
- * @psalm-type ProblemsetProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter?: string, order: int, points: float, problem_id?: int, quality_payload?: ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
+ * @psalm-type ProblemsetProblem=array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter: null|string, order: int, points: float, problem_id?: int, quality_payload: null| ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}
  * @psalm-type CourseAssignment=array{alias: string, assignment_type: string, description: string, finish_time: \OmegaUp\Timestamp|null, has_runs: bool, max_points: float, name: string, opened: bool, order: int, problemCount: int, problemset_id: int, publish_time_delay: int|null, scoreboard_url: string, scoreboard_url_admin: string, start_time: \OmegaUp\Timestamp}
  * @psalm-type ArenaProblemset=array{admin?: bool, admission_mode?: string, alias?: string, courseAssignments?: list<CourseAssignment>, director?: string, feedback?: string, finish_time: \OmegaUp\Timestamp|null, name?: string, opened?: bool, original_contest_alias?: string, original_problemset_id?: int, problems?: list<ProblemsetProblem>, problemset_id?: int, requests_user_information?: string, show_penalty?: bool, start_time?: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp, submissions_gap?: int, title?: string}
  * @psalm-type Problemset=array{admin?: bool, admission_mode?: string, alias?: string, archived?: bool, assignment_type?: null|string, contest_alias?: null|string, courseAssignments?: list<CourseAssignment>, description: null|string, director?: string, feedback?: string, finish_time?: \OmegaUp\Timestamp|null, has_submissions?: bool, languages?: list<string>, name?: string, needs_basic_information?: bool, opened?: bool, original_contest_alias?: null|string, original_problemset_id?: int|null, score_mode?: string, penalty?: int, penalty_calc_policy?: string, penalty_type?: string, points_decay_factor?: float, problems?: list<ProblemsetProblem>, problemset_id: int|null, requests_user_information?: string, rerun_id?: int, scoreboard?: int, scoreboard_url?: string, scoreboard_url_admin?: string, show_penalty?: bool, show_scoreboard_after?: bool, start_time?: \OmegaUp\Timestamp, submission_deadline?: \OmegaUp\Timestamp|null, submissions_gap?: int, title?: string, users?: list<array{access_time: \OmegaUp\Timestamp|null, country: null|string, email: null|string, user_id: int|null, username: string}>, window_length?: int|null}
@@ -175,7 +175,7 @@ class Problemset extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $token
      * @omegaup-request-param mixed $tokens
      */
-    public static function apiScoreboard(\OmegaUp\Request $r): array {
+    public static function apiScoreboard(\OmegaUp\Request $r) {
         [
             'problemset' => $problemset,
             'request' => $r,

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1707,19 +1707,19 @@ Returns details of a given assignment
 
 ### Returns
 
-| Name                | Type                        |
-| ------------------- | --------------------------- |
-| `admin`             | `boolean`                   |
-| `alias`             | `string`                    |
-| `assignment_type`   | `string`                    |
-| `courseAssignments` | `types.CourseAssignment[]`  |
-| `description`       | `string`                    |
-| `director`          | `string`                    |
-| `finish_time`       | `Date`                      |
-| `name`              | `string`                    |
-| `problems`          | `types.ProblemsetProblem[]` |
-| `problemset_id`     | `number`                    |
-| `start_time`        | `Date`                      |
+| Name                | Type                              |
+| ------------------- | --------------------------------- |
+| `admin`             | `boolean`                         |
+| `alias`             | `string`                          |
+| `assignment_type`   | `string`                          |
+| `courseAssignments` | `types.CourseAssignment[]`        |
+| `description`       | `string`                          |
+| `director`          | `string`                          |
+| `finish_time`       | `Date`                            |
+| `name`              | `string`                          |
+| `problems`          | `types.ProblemsetCourseProblem[]` |
+| `problemset_id`     | `number`                          |
+| `start_time`        | `Date`                            |
 
 ## `/api/course/assignmentScoreboard/`
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1256,7 +1256,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         string $directory,
         string $problemAlias,
         string $revision
-    ): array {
+    ) {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::PROBLEM_CASES_CONTENTS,
             "{$problemAlias}-{$revision}-{$directory}",
@@ -1610,8 +1610,10 @@ class Run extends \OmegaUp\Controllers\Controller {
         $signingAlgorithm = 'AWS4-HMAC-SHA256';
 
         $now = \OmegaUp\Time::get();
-        $datestamp = gmstrftime('%Y%m%d', $now);
-        $timestamp = gmstrftime('%Y%m%dT%H%M%SZ', $now);
+        $date = new \DateTimeImmutable('@' . $now);
+        $date = $date->setTimezone(new \DateTimeZone('UTC'));
+        $datestamp = $date->format('Ymd');
+        $timestamp = $date->format('Ymd\THis\Z');
         $emptySHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
         $headers = [
             'Host' => "{$bucketName}.{$serviceName}.amazonaws.com",

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -376,7 +376,7 @@ class School extends \OmegaUp\Controllers\Controller {
      *
      * @return array{schoolinfo: null|array{school_id: int, name: string, country_id: string|null, country: string|null, state: string|null}}
      */
-    public static function getSchoolOfTheMonth(string $date = null): array {
+    public static function getSchoolOfTheMonth(?string $date = null): array {
         $firstDay = self::getCurrentMonthFirstDay($date);
         $schoolsOfTheMonth = \OmegaUp\DAO\SchoolOfTheMonth::getByTime(
             $firstDay

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -145,7 +145,7 @@ class Session extends \OmegaUp\Controllers\Controller {
      *
      * @return CurrentSession
      */
-    public static function getCurrentSession(?\OmegaUp\Request $r = null): array {
+    public static function getCurrentSession(?\OmegaUp\Request $r = null) {
         if (
             defined('OMEGAUP_SESSION_CACHE_ENABLED') &&
             OMEGAUP_SESSION_CACHE_ENABLED === true &&
@@ -223,7 +223,7 @@ class Session extends \OmegaUp\Controllers\Controller {
     /**
      * @return CurrentSession
      */
-    private static function getCurrentSessionImplForAuthToken(?string $authToken): array {
+    private static function getCurrentSessionImplForAuthToken(?string $authToken) {
         $identityExt = null;
         if (!empty($authToken)) {
             $identityExt = \OmegaUp\DAO\AuthTokens::getIdentityByToken(
@@ -265,7 +265,7 @@ class Session extends \OmegaUp\Controllers\Controller {
         string $apiToken,
         ?string $username,
         string $cacheKey
-    ): array {
+    ) {
         $identityExt = \OmegaUp\DAO\APITokens::getIdentityByToken(
             $apiToken,
             $username

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1550,7 +1550,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param bool|null $omit_rank
      * @omegaup-request-param null|string $username
      */
-    public static function apiProfile(\OmegaUp\Request $r): array {
+    public static function apiProfile(\OmegaUp\Request $r) {
         self::authenticateOrAllowUnauthenticatedRequest($r);
 
         \OmegaUp\Validators::validateOptionalInEnum(
@@ -2008,7 +2008,7 @@ class User extends \OmegaUp\Controllers\Controller {
      */
     private static function getContestStats(
         \OmegaUp\DAO\VO\Identities $identity
-    ): array {
+    ) {
         // Get contests where identity had at least 1 run
         $contestsParticipated = \OmegaUp\DAO\Contests::getContestsParticipated(
             intval($identity->identity_id)
@@ -2834,7 +2834,7 @@ class User extends \OmegaUp\Controllers\Controller {
     public static function getAuthorsRank(
         int $offset,
         int $rowCount
-    ): array {
+    ) {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::AUTHORS_RANK,
             "{$offset}-{$rowCount}",
@@ -2888,7 +2888,7 @@ class User extends \OmegaUp\Controllers\Controller {
     public static function getAuthorsRankWithQualityProblems(
         int $offset,
         int $rowCount
-    ): array {
+    ) {
         return \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::AUTHORS_RANK_WITH_QUALITY_PROBLEMS,
             "{$offset}-{$rowCount}",

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -10,6 +10,8 @@ namespace OmegaUp\DAO;
  * {@link \OmegaUp\DAO\VO\ProblemsetProblems}.
  *
  * @access public
+ *
+ * @psalm-type ProblemQualityPayload=array{canNominateProblem: bool, dismissed: bool, dismissedBeforeAc: bool, language?: string, nominated: bool, nominatedBeforeAc: bool, problemAlias: string, solved: bool, tried: bool}
  */
 class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
     /**
@@ -111,7 +113,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
     /**
      * Get problemset problems including problemset alias, points, and order
      *
-     * @return list<array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, order: int, points: float, problem_id: int, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}>
+     * @return list<array{accepted: int, accepts_submissions: bool, alias: string, commit: string, difficulty: float, has_submissions: bool, input_limit: int, is_extra_problem: bool, languages: string, letter: null|string, order: int, points: float, problem_id: int, quality_payload: null|ProblemQualityPayload, quality_seal: bool, submissions: int, title: string, version: string, visibility: int, visits: int}>
      */
     final public static function getProblemsByProblemset(
         int $problemsetId,
@@ -175,6 +177,8 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         foreach ($rs as $problem) {
             $problem['accepts_submissions'] = !empty($problem['languages']);
             $problem['has_submissions'] = boolval($problem['has_submissions']);
+            $problem['letter'] = null;
+            $problem['quality_payload'] = null;
             $problems[] = $problem;
         }
         return $problems;

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2719,7 +2719,7 @@ export namespace types {
     director: string;
     finishTime?: Date;
     name: string;
-    problems: types.ProblemsetProblem[];
+    problems: types.ProblemsetCourseProblem[];
     problemsetId: number;
     startTime: Date;
   }
@@ -3031,7 +3031,7 @@ export namespace types {
     penalty_calc_policy: string;
     penalty_type: string;
     points_decay_factor: number;
-    problems?: types.ProblemsetProblem[];
+    problems?: types.ProblemsetContestProblem[];
     problemset_id: number;
     recommended?: boolean;
     requests_user_information: string;
@@ -3076,7 +3076,7 @@ export namespace types {
     penalty_calc_policy: string;
     penalty_type: string;
     points_decay_factor: number;
-    problems: types.ProblemsetProblem[];
+    problems: types.ProblemsetContestProblem[];
     problemset_id: number;
     recommended: boolean;
     requests_user_information: string;
@@ -3427,7 +3427,7 @@ export namespace types {
   export interface CourseEditPayload {
     admins: types.CourseAdmin[];
     allLanguages: { [key: string]: string };
-    assignmentProblems: types.ProblemsetProblem[];
+    assignmentProblems: types.ProblemsetCourseProblem[];
     course: types.CourseDetails;
     groupsAdmins: types.CourseGroupAdmin[];
     groupsTeachingAssistants: types.CourseGroupAdmin[];
@@ -4307,6 +4307,51 @@ export namespace types {
       username: string;
     }[];
     window_length?: number;
+  }
+
+  export interface ProblemsetContestProblem {
+    accepted: number;
+    accepts_submissions: boolean;
+    alias: string;
+    commit: string;
+    difficulty: number;
+    has_submissions: boolean;
+    input_limit: number;
+    is_extra_problem: boolean;
+    languages: string;
+    letter?: string;
+    order: number;
+    points: number;
+    problem_id: number;
+    quality_payload?: types.ProblemQualityPayload;
+    quality_seal: boolean;
+    submissions: number;
+    title: string;
+    version: string;
+    visibility: number;
+    visits: number;
+  }
+
+  export interface ProblemsetCourseProblem {
+    accepted: number;
+    accepts_submissions: boolean;
+    alias: string;
+    commit: string;
+    difficulty: number;
+    has_submissions: boolean;
+    input_limit: number;
+    is_extra_problem: boolean;
+    languages: string;
+    letter: string;
+    order: number;
+    points: number;
+    quality_payload: types.ProblemQualityPayload;
+    quality_seal: boolean;
+    submissions: number;
+    title: string;
+    version: string;
+    visibility: number;
+    visits: number;
   }
 
   export interface ProblemsetProblem {
@@ -5344,7 +5389,7 @@ export namespace messages {
     director: string;
     finish_time?: Date;
     name: string;
-    problems: types.ProblemsetProblem[];
+    problems: types.ProblemsetCourseProblem[];
     problemset_id: number;
     start_time: Date;
   };

--- a/stuff/docker/usr/bin/developer-environment.sh
+++ b/stuff/docker/usr/bin/developer-environment.sh
@@ -45,6 +45,47 @@ define('OMEGAUP_GITSERVER_URL', 'http://gitserver:33861');
 define('OMEGAUP_GRADER_URL', 'https://grader:21680');
 define('OMEGAUP_GITSERVER_SECRET_TOKEN', 'secret');
 define('OMEGAUP_CSRF_HOSTS', ['frontend', '127.0.0.1']);
+define('APC_USER_CACHE_CONTEST_INFO_TIMEOUT', 10);
+define('MAX_PROBLEMS_IN_CONTEST', 30);
+define(
+    'IMAGES_PATH',
+    sprintf('%s/www/img/', strval(OMEGAUP_ROOT))
+);
+define('IMAGES_URL_PATH', '/img/');
+define('APC_USER_CACHE_PROBLEM_STATEMENT_TIMEOUT', 60);
+define('APC_USER_CACHE_PROBLEM_STATS_TIMEOUT', 0);
+define('APC_USER_CACHE_PROBLEM_LIST_TIMEOUT', 60 * 30);
+define('IDENTITY_ANONYMOUS', 'identity_anonymous');
+define('IDENTITY_ADMIN', 'identity_admin');
+define('IDENTITY_NORMAL', 'identity_normal');
+define('APC_USER_CACHE_SESSION_TIMEOUT', 8 * 3600);
+define(
+    'TEMPLATES_PATH',
+    sprintf('%s/www/templates/', strval(OMEGAUP_ROOT))
+);
+define(
+    'INPUTS_PATH',
+    sprintf('%s/www/probleminput/', strval(OMEGAUP_ROOT))
+);
+define('OMEGAUP_URL', 'http://localhost');
+define('PASSWORD_RESET_TIMEOUT', 2 * 3600);
+define('PASSWORD_RESET_MIN_WAIT', 5 * 60);
+define('AWS_CLI_SECRET_ACCESS_KEY', null);
+define('AWS_CLI_ACCESS_KEY_ID', null);
+define('OMEGAUP_GRADER_SECRET', 'secret');
+define('OMEGAUP_FB_APPID', 'xxxxx');
+define('OMEGAUP_AUTH_TOKEN_COOKIE_NAME', 'ouat');
+define('OMEGAUP_FB_SECRET', 'xxxxx');
+define('OMEGAUP_MD5_SALT', 'omegaup');
+define(
+    'OMEGAUP_GOOGLE_CLIENTID',
+    '982542692060-lf9htvij4ba13fiufpqeldic0qqqvird.apps.googleusercontent.com'
+);
+define('OMEGAUP_RECAPTCHA_SECRET', 'xxxx');
+
+define('OMEGAUP_EMAIL_SENDY_SUBSCRIBE_URL', 'xxx');
+define('OMEGAUP_EMAIL_SENDY_LIST', 'xxx');
+define('APC_USER_CACHE_USER_RANK_TIMEOUT', 60 * 30);
 EOF
 ensure_contents "/opt/omegaup/frontend/server/config.php" "${config_contents}"
 


### PR DESCRIPTION
# Description

Actualmente usamos la versión de PHP  8.1.2, pero en la version 8.2 algunas cosas se deprecarán.

Intelliphense ya nos está enviando los warnings, así que en este cambio nos anticipamos para que la migración (cuando esta se de) sea más sencilla.

# Comments

Este cambio sólo se enfoca en cambios relacionados a controladores. Hay que abrir otros PRs para actualizar el resto de archivos.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
