### PR TITLE
fix: add missing label for logout button

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -324,6 +324,7 @@
                     }}</a>
                   </template>
                   <div class="dropdown-divider"></div>
+                  <!-- Logout button for desktop - navbar menu -->
                   <a
                     class="dropdown-item"
                     href="#"
@@ -343,17 +344,22 @@
               </li>
             </ul>
 
+            <!-- Logout button for mobile -->
             <a
               v-if="isLoggedIn"
-              class="navbar justify-content-end d-lg-none align-items-start pt-4"
+              class="navbar justify-content-end d-lg-none align-items-start pt-4 d-flex align-items-center"
               href="#"
               @click.prevent="logoutModalVisible = true"
             >
               <font-awesome-icon :icon="['fas', 'power-off']" />
+              <span class="ml-2">
+                {{ T.omegaupTitleLogout }}
+              </span>
             </a>
           </div>
         </div>
 
+        <!-- Logout button for desktop - navbar -->
         <a
           v-if="isLoggedIn"
           class="navbar justify-content-end d-none d-lg-block order-1"
@@ -361,6 +367,7 @@
           @click.prevent="logoutModalVisible = true"
         >
           <font-awesome-icon :icon="['fas', 'power-off']" />
+          {{ T.omegaupTitleLogout }}
         </a>
       </div>
     </nav>

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -329,7 +329,10 @@
                     href="#"
                     data-logout-button
                     @click.prevent="logoutModalVisible = true"
-                  ></a>
+                  >
+                    <font-awesome-icon :icon="['fas', 'power-off']" />
+                    {{ T.omegaupTitleLogout }}
+                  </a>
                   <omegaup-common-grader-status
                     v-show="isAdmin"
                     :status="errorMessage !== null ? 'down' : 'ok'"


### PR DESCRIPTION
# Description

Adds label for logout button.

### Current PROD
![image](https://github.com/user-attachments/assets/30c44f7e-4593-4e71-91c5-b96b6133949f)

### Fix
- Desktop (dropdown menu)
![image](https://github.com/user-attachments/assets/4eae5bd0-c085-45e9-8f9b-9ba0c39942c0)

- Desktop (navbar)
![image](https://github.com/user-attachments/assets/6684407a-18dc-46c3-aa3b-69f8fa0a3c5d)


- Mobile
![image](https://github.com/user-attachments/assets/592a8ce3-1b32-41d6-b7f5-e8f5afd5248a)





Fixes: #(issue)


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
