### PR TITLE
Agregando indices para optimizar query de submissions feed

### DIFF
--- a/frontend/database/00235_add_key_for_submissions_feed_feature.sql
+++ b/frontend/database/00235_add_key_for_submissions_feed_feature.sql
@@ -1,0 +1,7 @@
+-- Add index to the Users table
+ALTER TABLE `Users`
+  ADD KEY `idx_is_private` (`is_private`);
+
+-- Add index to the Submissions table
+ALTER TABLE `Submissions`
+  ADD KEY `idx_time_status` (`time`, `status`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1096,6 +1096,7 @@ CREATE TABLE `Submissions` (
   KEY `school_id` (`school_id`),
   KEY `school_id_problem_id` (`school_id`,`problem_id`),
   KEY `verdict_type_time` (`verdict`,`type`,`time`),
+  KEY `idx_time_status` (`time`,`status`),
   CONSTRAINT `fk_s_current_run_id` FOREIGN KEY (`current_run_id`) REFERENCES `Runs` (`run_id`),
   CONSTRAINT `fk_s_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_s_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`),
@@ -1253,6 +1254,7 @@ CREATE TABLE `Users` (
   KEY `fk_main_identity_id` (`main_identity_id`),
   KEY `fk_parent_email_id` (`parent_email_id`),
   KEY `verification_id` (`verification_id`),
+  KEY `idx_is_private` (`is_private`),
   CONSTRAINT `fk_main_email_id` FOREIGN KEY (`main_email_id`) REFERENCES `Emails` (`email_id`),
   CONSTRAINT `fk_main_identity_id` FOREIGN KEY (`main_identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_parent_email_id` FOREIGN KEY (`parent_email_id`) REFERENCES `Emails` (`email_id`)

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -233,10 +233,11 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
      * @return list<array{alias: string, classname: string, guid: string, language: string, memory: int, runtime: int, school_id: int|null, school_name: null|string, time: \OmegaUp\Timestamp, title: string, username: string, verdict: string}>
      */
     public static function getLatestSubmissions(
-        int $identityId = null,
+        ?int $identityId = null,
         ?int $page = 1,
-        int $rowsPerPage = 100,
+        ?int $rowsPerPage = 100,
     ): array {
+        $limitDate = gmdate('Y-m-d H:i:s', time() - 24 * 3600);
         if (is_null($identityId)) {
             $indexHint = 'USE INDEX(PRIMARY)';
         } else {
@@ -275,7 +276,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
             LEFT JOIN
                 Contests c ON c.contest_id = ps.contest_id
             WHERE
-                TIMESTAMPDIFF(SECOND, s.time, NOW()) <= 24 * 3600
+                s.`time` >= ?
                 AND s.status = 'ready'
                 AND u.is_private = 0
                 AND p.visibility >= ?
@@ -288,9 +289,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                     OR c.finish_time < s.time
                 )
         ";
-        $params = [
-            \OmegaUp\ProblemParams::VISIBILITY_PUBLIC,
-        ];
+        $params = [$limitDate, \OmegaUp\ProblemParams::VISIBILITY_PUBLIC];
 
         if (!is_null($identityId)) {
             $sql .= '

--- a/frontend/tests/controllers/SubmissionsFeedTest.php
+++ b/frontend/tests/controllers/SubmissionsFeedTest.php
@@ -139,7 +139,7 @@ class SubmissionsFeedTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\Test\Factories\Run::gradeRun($runData);
 
         $submissions = \OmegaUp\DAO\Submissions::getLatestSubmissions(
-            $identity->identity_id,
+            identityId: $identity->identity_id,
         );
         $this->assertCount(2, $submissions);
         $this->assertSame(
@@ -173,7 +173,7 @@ class SubmissionsFeedTest extends \OmegaUp\Test\ControllerTestCase {
         \OmegaUp\Test\Factories\Run::gradeRun($runData);
 
         $submissions = \OmegaUp\DAO\Submissions::getLatestSubmissions(
-            $identity->identity_id,
+            identityId: $identity->identity_id,
         );
         $this->assertEmpty($submissions);
     }


### PR DESCRIPTION
# Description

Se agregan los siguientes índices para la optimización de la consulta que obtiene los envíos de las últimas 24 horas:

- `idx_is_private` en la tabla de `Users`
- `idx_time_status` en la tabla de `Submissions`

También se deja de usar `TIMESTAMPDIFF` en favor de aprovechar de mejor forma los índices.

### EXPLAIN antes de agregar índices

| Tabla | Tipo   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| i | const | PRIMARY | Using temporary; Using filesort |
| ur | const | PRIMARY | unique row not found |
| u | ALL | fk_main_identity_id | Using where |
| s | ALL | problem_id,problemset_id,identity_id,fk_s_current_run_id | Using where; Using join buffer (hash join) |
| p | eq_ref | PRIMARY,idx_problems_visibility | Using where |
| sc | eq_ref | PRIMARY |  |
| ps | eq_ref | PRIMARY,problemset_id | Using where |
| c | eq_ref | PRIMARY,rerun_id | Using where |
| r | eq_ref | PRIMARY |  |


### EXPLAIN después de agregar índices

| Tabla | Tipo   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| i | const | PRIMARY | Using temporary; Using filesort |
| ur | const | PRIMARY | unique row not found |
| u | ref | fk_main_identity_id,idx_is_private | Using where |
| s | ref | problem_id,problemset_id,identity_id,fk_s_current_run_id,idx_time_status | Using where |
| p | eq_ref | PRIMARY,idx_problems_visibility | Using where |
| sc | eq_ref | PRIMARY |  |
| ps | eq_ref | PRIMARY,problemset_id | Using where |
| c | eq_ref | PRIMARY,rerun_id | Using where |
| r | eq_ref | PRIMARY |  |

Part of: #8265 
Part of: #8266 

# Comments

Cuando se libere el script con la creación de datos en masa, habrá que volver a revisar si ya se arregló esta posible ineficiencia

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
