### PR TITLE
Disable `OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE`

### DIFF
--- a/frontend/server/config.default.php
+++ b/frontend/server/config.default.php
@@ -92,7 +92,7 @@ try_define(
     sprintf('%s/www/templates/', strval(OMEGAUP_ROOT))
 );
 try_define('TEMPLATES_URL_PATH', '/templates/');
-try_define('OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE', true);
+try_define('OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE', false);
 try_define('OMEGAUP_GRADER_FAKE', false);
 
 # ####################################

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -63,6 +63,7 @@ try_define(
 );
 try_define('TEMPLATES_PATH', OMEGAUP_TEST_ROOT . '/templates/');
 try_define('INPUTS_PATH', OMEGAUP_TEST_ROOT . '/probleminput/');
+try_define('OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE', false);
 
 # #########################
 # CACHE CONFIG

--- a/frontend/tests/test_config.default.php
+++ b/frontend/tests/test_config.default.php
@@ -63,7 +63,7 @@ try_define(
 );
 try_define('TEMPLATES_PATH', OMEGAUP_TEST_ROOT . '/templates/');
 try_define('INPUTS_PATH', OMEGAUP_TEST_ROOT . '/probleminput/');
-try_define('OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE', false);
+try_define('OMEGAUP_ENABLE_REJUDGE_ON_PROBLEM_UPDATE', true);
 
 # #########################
 # CACHE CONFIG


### PR DESCRIPTION
Admins of old problems are (most likely not intendedly) triggering the rejudge of thousands of submissions.

Course/contest admins will still be able to rejudge entire problems when they update the problem version in their course/contest.

Fixes: #8313 