### PR TITLE
Ocultando temporalmente el EphemeralGrader en Cursos, Concursos y Pro…

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -180,7 +180,7 @@
         <template v-if="problem.accepts_submissions">
           <div class="d-none d-sm-block">
             <omegaup-arena-ephemeral-grader
-              v-if="!problem.karel_problem"
+              v-if="false"
               :problem="problem"
               :can-submit="user.loggedIn && !inContestOrCourse"
               :accepted-languages="filteredLanguages"


### PR DESCRIPTION
# Description

Se oculta temporalmente el Ephemeral grader para bajar un poco la concurrencia de envíos

![image](https://github.com/user-attachments/assets/eb26ccbc-bdec-4a4c-a67e-77ad576ed549)


# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
