### PR TITLE
Mejorando la forma de obtener el listado de concursos para una identidad

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -35,7 +35,6 @@
   - [`/api/contest/create/`](#apicontestcreate)
   - [`/api/contest/createVirtual/`](#apicontestcreatevirtual)
   - [`/api/contest/details/`](#apicontestdetails)
-  - [`/api/contest/getNumberOfContestants/`](#apicontestgetnumberofcontestants)
   - [`/api/contest/list/`](#apicontestlist)
   - [`/api/contest/listParticipating/`](#apicontestlistparticipating)
   - [`/api/contest/myList/`](#apicontestmylist)
@@ -892,22 +891,6 @@ in the contest, \OmegaUp\Controllers\Contest::apiOpen() must be used.
 ```typescript
 types.ContestDetails;
 ```
-
-## `/api/contest/getNumberOfContestants/`
-
-### Description
-
-### Parameters
-
-| Name          | Type     | Description |
-| ------------- | -------- | ----------- |
-| `contest_ids` | `string` |             |
-
-### Returns
-
-| Name       | Type                         |
-| ---------- | ---------------------------- |
-| `response` | `{ [key: number]: number; }` |
 
 ## `/api/contest/list/`
 

--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -866,13 +866,14 @@ class ContestListTest extends \OmegaUp\Test\ControllerTestCase {
             ['ends', [2, 3, 1, 4], false],
             ['duration', [3, 2, 4, 1], true],
             ['organizer', [4, 1, 2, 3], false],
-            ['signedup', [3, 1, 2, 4], true],
+            ['signedup', [1, 3, 4, 2], true],
         ];
     }
 
     /**
      * @param string $sortOrder
      * @param list<int> $expectedOrder
+     * @param bool $expectedParticipating
      *
      * @dataProvider sortOrderProvider
      */

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -394,10 +394,6 @@ export const Contest = {
       );
     return x;
   }),
-  getNumberOfContestants: apiCall<
-    messages.ContestGetNumberOfContestantsRequest,
-    messages.ContestGetNumberOfContestantsResponse
-  >('/api/contest/getNumberOfContestants/'),
   list: apiCall<
     messages.ContestListRequest,
     messages._ContestListServerResponse,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5166,10 +5166,6 @@ export namespace messages {
   export type ContestDetailsRequest = { [key: string]: any };
   export type _ContestDetailsServerResponse = any;
   export type ContestDetailsResponse = types.ContestDetails;
-  export type ContestGetNumberOfContestantsRequest = { [key: string]: any };
-  export type ContestGetNumberOfContestantsResponse = {
-    response: { [key: number]: number };
-  };
   export type ContestListRequest = { [key: string]: any };
   export type _ContestListServerResponse = any;
   export type ContestListResponse = {
@@ -6093,9 +6089,6 @@ export namespace controllers {
     details: (
       params?: messages.ContestDetailsRequest,
     ) => Promise<messages.ContestDetailsResponse>;
-    getNumberOfContestants: (
-      params?: messages.ContestGetNumberOfContestantsRequest,
-    ) => Promise<messages.ContestGetNumberOfContestantsResponse>;
     list: (
       params?: messages.ContestListRequest,
     ) => Promise<messages.ContestListResponse>;


### PR DESCRIPTION
# Description

Se optimiza la consulta para obtener el listado de concursos para una identidad. La consulta estaba saliendo demasiado cara, así que se realizaron las siguientes mejoras:

- Se obtiene el número de concursantes directamente de la tabla de Contests (pendiente que se apruebe el PR #8323 ) y se evita el uso de una CTE (Common Table Expression) mas costosa.
- Se utiliza `UNION ALL` en lugar de `UNION DISTINCT` para utilizar de una mejor forma los índices.
- Se agregan los filtros en cada `UNION` para evitar escaneos de tablas completas.
- Se elimina `apiGetNumberOfContestants` y todas las funciones que se requerían para obtener el número de participantes por concurso. Ahora esta información vendrá en la tabla de `Contests`

Con todos estos cambios, los resultados del `EXPLAIN` quedan de la siguiente forma:

| Tabla | Tipo   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| \<derived2\> | ALL |  | Using temporary |
| Contests | eq_ref | PRIMARY,rerun_id,acl_id |  |
| a | eq_ref | PRIMARY,fk_au_owner_id |  |
| organizer | ref | user_id | Using index |
| \<derived3\> | ALL |  | Using temporary |
| organizer | const | PRIMARY,user_id |  |
| a | ref | PRIMARY,fk_au_owner_id | Using index |
| c_org | ref | acl_id,idx_archived_recommended_endcheck | Using where |
| c_par | ref | fk_cop_problemset_id,idx_archived_recommended_endcheck | Using index condition |
| pi | eq_ref | PRIMARY,problemset_id,identity_id | Using index |
| gi | ref | PRIMARY,group_id,identity_id | Using index |
| gr | ref | PRIMARY,group_id,role_id,acl_id | Using index |
| c_grp | ref | PRIMARY,rerun_id,idx_archived_recommended_endcheck | Using where; Using index |
| p | ref | acl_id,contest_id | Using where |
| t | ref | team_group_identity,identity_id,team_group_id |  |
| tgr | ref | PRIMARY,team_group_id,role_id,acl_id | Using index |
| c_tms | ref | PRIMARY,rerun_id,idx_archived_recommended_endcheck | Using where; Using index |
| p | ref | acl_id,contest_id | Using where |
| i | const | PRIMARY,user_id |  |
| ur | ref | PRIMARY,user_id,role_id,acl_id | Using index |
| c_adm | ref | acl_id,idx_archived_recommended_endcheck | Using where |
| gi | ref | PRIMARY,group_id,identity_id | Using index |
| gr | ref | PRIMARY,group_id,role_id,acl_id | Using index |
| c_adg | ref | acl_id,idx_archived_recommended_endcheck | Using where |
| c_pub | ref | idx_archived_recommended_endcheck, idx_admission_archived_recommended_endcheck | Using index condition; Using where |
| participating | eq_ref | PRIMARY,problemset_id,identity_id | Using index |

Part of: #8321 

# Comments

Queda pendiente agregar la función para calcular el numero de participantes cada que se agreguen/eliminen desde la vista de Edición de concurso. También cuando se unen participantes sin invitación a los concursos públicos.

Esto se puede realizar en un cambio aparte porque los concursos exixtentes ya deberían tener actualizado este dato con el script del PR #8323 

También se podrán agregar pruebas para validar que el conteo está funcionando correctamente 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
