### PR TITLE
Agregando la función para actualizar el número de participantes para un concurso

### DIFF
--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -1548,6 +1548,102 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         ];
     }
 
+    public static function updateContestantsCount(
+        \OmegaUp\DAO\VO\Contests $contest
+    ): int {
+        $sql = 'UPDATE Contests c
+                SET contestants = (
+                    SELECT COUNT(*) FROM (
+                        SELECT
+                        i.identity_id
+                        FROM
+                        (
+                            SELECT
+                                raw_identities.identity_id
+                            FROM
+                            (
+                                SELECT
+                                    pi.identity_id
+                                FROM
+                                    Problemset_Identities pi
+                                WHERE
+                                    pi.problemset_id = ?
+
+                                UNION
+
+                                SELECT
+                                    gi.identity_id
+                                FROM
+                                    Group_Roles gr
+                                INNER JOIN
+                                    Groups_Identities gi
+                                ON
+                                    gi.group_id = gr.group_id
+                                WHERE
+                                    gr.acl_id = ?
+                                    AND gr.role_id = ? -- contestant role
+                            ) AS raw_identities
+                            GROUP BY
+                            raw_identities.identity_id
+                        ) AS ri
+                        INNER JOIN
+                            Identities i
+                        ON
+                            i.identity_id = ri.identity_id
+                        WHERE
+                        (
+                            i.user_id NOT IN (
+                                SELECT
+                                    ur.user_id
+                                FROM
+                                    User_Roles ur
+                                WHERE
+                                    ur.acl_id IN (?, ?)
+                                    AND ur.role_id = ? -- administrator role
+                            )
+                            AND i.identity_id NOT IN (
+                            SELECT
+                                gi.identity_id
+                            FROM
+                                Group_Roles gr
+                            INNER JOIN
+                                Groups_Identities gi ON gi.group_id = gr.group_id
+                            WHERE
+                                gr.acl_id IN (?, ?)
+                                AND gr.role_id = ?  -- administrator role
+                            )
+                            AND i.user_id != (
+                                SELECT
+                                    a.owner_id
+                                FROM
+                                    ACLs a
+                                WHERE
+                                    a.acl_id = ?
+                            )
+                            OR i.user_id IS NULL
+                        )
+                    ) AS participants
+                )
+                WHERE
+                    c.contest_id = ?;';
+        $params = [
+            $contest->problemset_id,
+            $contest->acl_id,
+            \OmegaUp\Authorization::CONTESTANT_ROLE,
+            $contest->acl_id,
+            \OmegaUp\Authorization::ADMIN_ROLE,
+            \OmegaUp\Authorization::ADMIN_ROLE,
+            $contest->acl_id,
+            \OmegaUp\Authorization::ADMIN_ROLE,
+            \OmegaUp\Authorization::ADMIN_ROLE,
+            $contest->acl_id,
+            $contest->contest_id,
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
     private static function getOrder(
         int $orderBy,
         string $defaultOrder = '`original_finish_time`',


### PR DESCRIPTION
# Description

Se argega la función encargada de actualizar el número de participantes en un concurso. En un PR previo ya se obtiene este datos desde la tabla de `Contests`. 

Así que este depende de que se aprueben los cambios de:

- #8323 
- #8324

para poder agregar pruebas correspondientes.

La función será llamada desde las siguientes APIs:

- `Contest::apiOpen`
- `Contest::apiAddUser`
- `Contest::apiRemoveUser`
- `Contest::apiAddGroup`
- `Contest::apiRemoveGroup`

que cubren por completo los puntos en los cuales puede actualizarse ese dato.

Fixes: #8321 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
