### PR TITLE
Fix/allow unauthenticated problem creator

### DIFF
--- a/frontend/www/js/omegaup/components/common/NavbarItems.vue
+++ b/frontend/www/js/omegaup/components/common/NavbarItems.vue
@@ -119,7 +119,6 @@
               T.navViewLatestSubmissions
             }}</a>
             <form
-              v-if="isLoggedIn && isMainUserIdentity && !isUnder13User"
               class="collapse-submenu"
             >
               <div class="btn-group d-flex">

--- a/frontend/www/js/omegaup/components/common/NavbarItems.vue
+++ b/frontend/www/js/omegaup/components/common/NavbarItems.vue
@@ -118,9 +118,7 @@
             <a class="dropdown-item" href="/submissions/">{{
               T.navViewLatestSubmissions
             }}</a>
-            <form
-              class="collapse-submenu"
-            >
+            <form class="collapse-submenu">
               <div class="btn-group d-flex">
                 <span class="dropdown-item">
                   {{ T.myproblemsListCreateProblem }}

--- a/frontend/www/problems/creator.php
+++ b/frontend/www/problems/creator.php
@@ -1,10 +1,10 @@
 <?php
 namespace OmegaUp;
 require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
-\OmegaUp\UITools::redirectToLoginIfNotLoggedIn();
 
 \OmegaUp\UITools::render(
     fn (\OmegaUp\Request $r) => \OmegaUp\Controllers\Problem::getCreatorForTypeScript(
         $r
     )
 );
+

--- a/frontend/www/problems/creator.php
+++ b/frontend/www/problems/creator.php
@@ -7,4 +7,3 @@ require_once(dirname(__DIR__, 2) . '/server/bootstrap.php');
         $r
     )
 );
-


### PR DESCRIPTION
## Description
This PR fixes issue #8228 by allowing unauthenticated users to access the problem creator page.

## Changes
- Removed authentication check from the problem creator dropdown menu in the navbar
- Removed authentication check from creator.php in  the problems

## Testing
- Verified that unauthenticated users can access the problem creator page
- Confirmed that the dropdown menu is visible without login
- Tested that the form submission works correctly

## Screenshots
![image](https://github.com/user-attachments/assets/bb7a05c8-4c04-4b5c-a91b-a825d01818bc)

## Checklist
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/) format
- [x] The PR description clearly describes the changes and their purpose
- [x] The PR is linked to the relevant issue (#8228)
- [x] The changes have been tested locally
- [x] The code follows the project's style guidelines