### PR TITLE
Revirtiendo cambios en el script de agregar feedback como revisor

### DIFF
--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -401,25 +401,24 @@ def aggregate_reviewers_feedback_for_problem(
         cur.execute("""SELECT qn.`contents`
                        FROM `QualityNominations` as qn
                        WHERE qn.`nomination` = 'quality_tag'
-                       AND qn.`problem_id` = %s
-                       LIMIT 1;""",
+                       AND qn.`problem_id` = %s;""",
                     (problem_id,))
 
         total_votes = 0
         seal_positive_votes = 0
         level_tag_votes: DefaultDict[str, int] = collections.defaultdict(int)
         topic_tag_votes: Set[str] = set()
-        for row in cur.fetchone():
+        for row in cur.fetchall():
             try:
-                contents = json.loads(row)
+                contents = json.loads(row[0])
             except json.JSONDecodeError:  # pylint: disable=no-member
                 logging.exception('Failed to parse contents')
                 continue
             total_votes += 1
-            if contents['quality_seal'] is True:
+            if contents['quality_seal']:
                 seal_positive_votes += 1
-            if 'level' in contents and not contents['level'] is None:
-                level_tag_votes[contents['level']] += 1
+            if 'tag' in contents and not contents['tag'] is None:
+                level_tag_votes[contents['tag']] += 1
             if 'tags' in contents:
                 # Take the union of voted topic tags
                 topic_tag_votes.update(contents['tags'])
@@ -436,26 +435,10 @@ def aggregate_reviewers_feedback_for_problem(
             (seal_positive_votes > (total_votes / 2), problem_id))
 
         # Delete old level and topic tags for problem and add the new ones
-        if level_tag_votes:
-            most_voted_level = max(level_tag_votes,
-                                   key=lambda x: level_tag_votes.get(x, 0))
-            final_tags = list({(problem_id, tag) for tag in topic_tag_votes} |
-                              {(problem_id, most_voted_level)})
-            if most_voted_level is not None:
-                cur.execute("""DELETE FROM
-                                    `Problems_Tags`
-                                WHERE
-                                    `problem_id` = %s
-                                AND `tag_id` IN (
-                                    SELECT `tag_id`
-                                    FROM `Tags`
-                                    WHERE `name` LIKE CONCAT(
-                                        'problemLevel', '%')
-                                );""",
-                            (problem_id,))
-        else:
-            logging.warning('No level tags found for problem %d', problem_id)
-            final_tags = list({(problem_id, tag) for tag in topic_tag_votes})
+        most_voted_level = max(level_tag_votes,
+                               key=lambda x: level_tag_votes.get(x, 0))
+        final_tags = list({(problem_id, tag) for tag in topic_tag_votes} |
+                          {(problem_id, most_voted_level)})
 
         cur.execute("""DELETE FROM
                                `Problems_Tags`


### PR DESCRIPTION
# Description

Se regresa a su estado original la función `aggregate_reviewers_feedback_for_problem` que se encuentra en el script `aggregate_feedback`. 

Resulta que en el cambio del PR #8247 se solucionaron algunos errores en los controladores para que los revisores pudieran subir feedback de problemas. Para esto se aplicaron cambios en el script antes mencionado. Pero parece que en la forma que se aplicó la solución no es retroactivo a las nominaciones de calidad que ya existen. 

Como referencia, se obtuvo un snapshot de la vista de colecciones donde contenía los problemas:

![image](https://github.com/user-attachments/assets/0d500c43-3baa-440d-952e-0006b7b626f8)

Actualmente se muestra esto:

![image](https://github.com/user-attachments/assets/63cb57ed-d159-4e6f-8a2a-548f85a099a2)


Fixes: #8316 

# Comments

Por lo pronto, con revertir los cambios se deberían regresar los problemas a las colecciones correspondientes.

En un futuro se tendrá que arreglar este script para que funcione tanto para las nominaciones de calidad donde se requería el elemento `tag`, como para las nuevas nominaciones donde se propone que sea `level`.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
