### PR TITLE
Arreglando error en el cronjob de aggregate_feedback

### DIFF
--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -436,9 +436,12 @@ def aggregate_reviewers_feedback_for_problem(
 
         # Delete old level and topic tags for problem and add the new ones
         most_voted_level = max(level_tag_votes,
-                               key=lambda x: level_tag_votes.get(x, 0))
-        final_tags = list({(problem_id, tag) for tag in topic_tag_votes} |
-                          {(problem_id, most_voted_level)})
+                               key=lambda x: level_tag_votes.get(x, 0),
+                               default=None)
+        final_tags = list({(problem_id, tag) for tag in topic_tag_votes})
+        # Avoid adding None as a tag
+        if most_voted_level is not None:
+            final_tags.append((problem_id, most_voted_level))
 
         cur.execute("""DELETE FROM
                                `Problems_Tags`


### PR DESCRIPTION
# Description

Se arregla un error que estaba ocurriendo en el cronjob de `aggregate_feedback.py`, en específico en la función `aggregate_reviewers_feedback_for_problem`.

En `most_voted_level` se debe almacenar el nivel mas votado,. Pero resulta que por algún error en la UI y en los controladores se subieron un par de sugerencias donde no se almacenó el `tag` de nivel. Esto ocasiona que la función `max` arroje un error.

En un futuro se deben realizar mas validaciones para que esto no ocurra.

Fixes: #8329 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
