### PR TITLE
Agregando un paso extra a la configuración de rekarel

### DIFF
--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -44,7 +44,7 @@ ARG BRANCH=release
 ENV BRANCH=$BRANCH
 RUN git clone --branch=${BRANCH} --depth=1 --recurse-submodules --shallow-submodules https://github.com/omegaup/omegaup .
 WORKDIR /opt/omegaup/frontend/www/rekarel
-RUN npm install && npx gulp
+RUN npm install && npx gulp && npm run build
 WORKDIR /opt/omegaup
 RUN yarn install && yarn build
 RUN composer install --no-dev --classmap-authoritative
@@ -57,6 +57,7 @@ FROM alpine:latest AS frontend
 RUN apk add rsync
 RUN mkdir -p /var/lib/omegaup /opt/omegaup
 COPY --from=build /opt/omegaup /opt/omegaup
+COPY --from=build /opt/omegaup/frontend/www/rekarel/. /opt/omegaup/frontend/www/rekarel/
 COPY --from=build /var/lib/omegaup /var/lib/omegaup
 
 FROM ubuntu:jammy AS nginx

--- a/stuff/docker/entrypoint.dev.sh
+++ b/stuff/docker/entrypoint.dev.sh
@@ -4,6 +4,7 @@ set -e
 cd /opt/omegaup/frontend/www/rekarel
 npm install
 npx gulp
+npm run build
 
 # Execute the original command
 exec "$@"


### PR DESCRIPTION
# Description

Resulta que en algunos ambientes no es suficiente con ejecutar `npx gulp`, y se requiere que se construya todo el proyecto. Así que se agrega `npm run build` en la configuración de ReKarel

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
