### PR TITLE
Regresando el anuncio de Discord al carrusel del home page

### DIFF
--- a/frontend/www/js/omegaup/carousel.config.ts
+++ b/frontend/www/js/omegaup/carousel.config.ts
@@ -104,7 +104,7 @@ const carouselConfig: {
     },
     description: {
       en:
-        'Join omegaUp\'s Discord server and hang out with your community, get help and learn about new projects.',
+        "Join omegaUp's Discord server and hang out with your community, get help and learn about new projects.",
       es:
         'Únete al servidor de Discord de omegaUp y convive con la comunidad, obtén ayuda y entérate de los nuevos proyectos.',
       pt:

--- a/frontend/www/js/omegaup/carousel.config.ts
+++ b/frontend/www/js/omegaup/carousel.config.ts
@@ -95,6 +95,31 @@ const carouselConfig: {
       target: '_blank',
     },
   },
+  {
+    image: '/media/homepage/discord_logo.svg',
+    title: {
+      en: 'Join our coders community',
+      es: 'Únete a nuestra comunidad de coders',
+      pt: 'Junte-se à nossa comunidade de coders',
+    },
+    description: {
+      en:
+        'Join omegaUp´s Discord server and hang out with your community, get help and learn about new projects.',
+      es:
+        'Únete al servidor de Discord de omegaUp y convive con la comunidad, obtén ayuda y entérate de los nuevos proyectos.',
+      pt:
+        'Junte-se ao servidor do Discord do omegaUp e convive com a comunidade, obtenha ajuda e aprenda sobre novos projetos.',
+    },
+    button: {
+      text: {
+        en: 'Join here',
+        es: 'Únete aquí',
+        pt: 'Junte-se aqui',
+      },
+      href: 'https://discord.com/invite/K3JFd9d3wk',
+      target: '_blank',
+    },
+  },
 ];
 
 export default carouselConfig;

--- a/frontend/www/js/omegaup/carousel.config.ts
+++ b/frontend/www/js/omegaup/carousel.config.ts
@@ -104,7 +104,7 @@ const carouselConfig: {
     },
     description: {
       en:
-        'Join omegaUp´s Discord server and hang out with your community, get help and learn about new projects.',
+        'Join omegaUp\'s Discord server and hang out with your community, get help and learn about new projects.',
       es:
         'Únete al servidor de Discord de omegaUp y convive con la comunidad, obtén ayuda y entérate de los nuevos proyectos.',
       pt:


### PR DESCRIPTION
# Description

Se agrega nuevamente el anuncio de Discord al Hompage de omegaUp

![image](https://github.com/user-attachments/assets/f92b8e47-d314-4858-b817-2bb701cf7997)


Fixes: #8338 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.