### PR TITLE
AI Editorial Generator - SQL script and the schema.sql file

### DIFF
--- a/frontend/database/00238_create_ai_editorial_jobs_table.sql
+++ b/frontend/database/00238_create_ai_editorial_jobs_table.sql
@@ -1,0 +1,22 @@
+-- AI Editorial Jobs table
+CREATE TABLE `AI_Editorial_Jobs` (
+    `job_id` varchar(36) NOT NULL COMMENT 'UUID identificador único del trabajo',
+    `problem_id` int NOT NULL COMMENT 'Identificador del problema',
+    `user_id` int NOT NULL COMMENT 'Usuario que solicitó la generación',
+    `status` enum('queued','processing','completed','failed','approved','rejected') NOT NULL DEFAULT 'queued' COMMENT 'Estado actual del trabajo',
+    `error_message` text COMMENT 'Mensaje de error en caso de fallo',
+    `is_retriable` tinyint(1) NOT NULL DEFAULT 1 COMMENT 'Indica si el error permite reintentos (1 = sí, 0 = no)',
+    `attempts` int NOT NULL DEFAULT 0 COMMENT 'Número de intentos realizados',
+    `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Hora de creación del trabajo',
+    `md_en` mediumtext NULL COMMENT 'Editorial generado en inglés',
+    `md_es` mediumtext NULL COMMENT 'Editorial generado en español',
+    `md_pt` mediumtext NULL COMMENT 'Editorial generado en portugués',
+    `validation_verdict` varchar(10) NULL COMMENT 'Veredicto de validación del código generado',
+    PRIMARY KEY (`job_id`),
+    KEY `idx_problem_id` (`problem_id`),
+    KEY `idx_user_id` (`user_id`),
+    KEY `idx_status` (`status`),
+    KEY `idx_created_at` (`created_at`),
+    CONSTRAINT `fk_aej_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT `fk_aej_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Trabajos de generación de editoriales con IA'; 

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -16,6 +16,30 @@ CREATE TABLE `ACLs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `AI_Editorial_Jobs` (
+  `job_id` varchar(36) NOT NULL COMMENT 'UUID identificador único del trabajo',
+  `problem_id` int NOT NULL COMMENT 'Identificador del problema',
+  `user_id` int NOT NULL COMMENT 'Usuario que solicitó la generación',
+  `status` enum('queued','processing','completed','failed','approved','rejected') NOT NULL DEFAULT 'queued' COMMENT 'Estado actual del trabajo',
+  `error_message` text COMMENT 'Mensaje de error en caso de fallo',
+  `is_retriable` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'Indica si el error permite reintentos (1 = sí, 0 = no)',
+  `attempts` int NOT NULL DEFAULT '0' COMMENT 'Número de intentos realizados',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Hora de creación del trabajo',
+  `md_en` mediumtext COMMENT 'Editorial generado en inglés',
+  `md_es` mediumtext COMMENT 'Editorial generado en español',
+  `md_pt` mediumtext COMMENT 'Editorial generado en portugués',
+  `validation_verdict` varchar(10) DEFAULT NULL COMMENT 'Veredicto de validación del código generado',
+  PRIMARY KEY (`job_id`),
+  KEY `idx_problem_id` (`problem_id`),
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_created_at` (`created_at`),
+  CONSTRAINT `fk_aej_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`),
+  CONSTRAINT `fk_aej_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Trabajos de generación de editoriales con IA';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `API_Tokens` (
   `apitoken_id` int NOT NULL AUTO_INCREMENT,
   `user_id` int NOT NULL,


### PR DESCRIPTION
# Description

AI Editorial Jobs table stores automated editorial generation requests for programming problems, tracking job status, user permissions, retriablity, generated multilingual content, and validation results.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
