### PR TITLE
AI Editorial Generator - DAO files

### DIFF
--- a/frontend/server/src/DAO/AiEditorialJobs.php
+++ b/frontend/server/src/DAO/AiEditorialJobs.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * AiEditorialJobs Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\AiEditorialJobs}.
+ *
+ * @access public
+ */
+class AiEditorialJobs extends \OmegaUp\DAO\Base\AiEditorialJobs {
+    /**
+     * Creates a new AI editorial job
+     *
+     * @return string The generated job ID (UUID)
+     */
+    public static function createJob(
+        int $problemId,
+        int $userId
+    ): string {
+        $jobId = self::generateUuid();
+
+        $job = new \OmegaUp\DAO\VO\AiEditorialJobs([
+            'job_id' => $jobId,
+            'problem_id' => $problemId,
+            'user_id' => $userId,
+            'status' => 'queued',
+            'attempts' => 0,
+        ]);
+
+        self::save($job);
+        return $jobId;
+    }
+
+    /**
+     * Gets a job by its UUID
+     *
+     * @return \OmegaUp\DAO\VO\AiEditorialJobs|null
+     */
+    public static function getJobByUuid(string $jobId): ?\OmegaUp\DAO\VO\AiEditorialJobs {
+        return self::getByPK($jobId);
+    }
+
+    /**
+     * Updates job status and optional error message
+     */
+    public static function updateJobStatus(
+        string $jobId,
+        string $status,
+        ?string $errorMessage = null,
+        ?bool $isRetriable = null
+    ): void {
+        $job = self::getByPK($jobId);
+        if (is_null($job)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
+        }
+
+        $job->status = $status;
+        if (!is_null($errorMessage)) {
+            $job->error_message = $errorMessage;
+        }
+        if (!is_null($isRetriable)) {
+            $job->is_retriable = $isRetriable;
+        }
+
+        self::save($job);
+    }
+
+    /**
+     * Updates job content (editorials in multiple languages)
+     */
+    public static function updateJobContent(
+        string $jobId,
+        ?string $mdEn = null,
+        ?string $mdEs = null,
+        ?string $mdPt = null,
+        ?string $validationVerdict = null
+    ): void {
+        $job = self::getByPK($jobId);
+        if (is_null($job)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
+        }
+
+        if (!is_null($mdEn)) {
+            $job->md_en = $mdEn;
+        }
+        if (!is_null($mdEs)) {
+            $job->md_es = $mdEs;
+        }
+        if (!is_null($mdPt)) {
+            $job->md_pt = $mdPt;
+        }
+        if (!is_null($validationVerdict)) {
+            $job->validation_verdict = $validationVerdict;
+        }
+
+        self::save($job);
+    }
+
+    /**
+     * Counts recent jobs by user for rate limiting
+     */
+    public static function countRecentJobsByUser(
+        int $userId,
+        int $hours = 1
+    ): int {
+        $sql = '
+            SELECT COUNT(*)
+            FROM AI_Editorial_Jobs
+            WHERE user_id = ?
+              AND created_at > DATE_SUB(NOW(), INTERVAL ? HOUR)
+        ';
+
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            $sql,
+            [$userId, $hours]
+        );
+
+        return $count;
+    }
+
+    /**
+     * Gets the last job for a problem (for cooldown check)
+     *
+     * @return \OmegaUp\DAO\VO\AiEditorialJobs|null
+     */
+    public static function getLastJobForProblem(int $problemId): ?\OmegaUp\DAO\VO\AiEditorialJobs {
+        $sql = '
+            SELECT ' . \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\AiEditorialJobs::FIELD_NAMES,
+            'AI_Editorial_Jobs'
+        ) . '
+            FROM AI_Editorial_Jobs
+            WHERE problem_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+        ';
+
+        /** @var array{attempts: int, created_at: \OmegaUp\Timestamp, error_message: null|string, is_retriable: int, job_id: string, md_en: null|string, md_es: null|string, md_pt: null|string, problem_id: int, status: string, user_id: int, validation_verdict: null|string}|null */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow(
+            $sql,
+            [$problemId]
+        );
+        if (is_null($rs)) {
+            return null;
+        }
+
+        return new \OmegaUp\DAO\VO\AiEditorialJobs($rs);
+    }
+
+    /**
+     * Gets jobs by user with optional limit
+     *
+     * @return list<\OmegaUp\DAO\VO\AiEditorialJobs>
+     */
+    public static function getJobsByUser(
+        int $userId,
+        int $limit = 10
+    ): array {
+        $sql = '
+            SELECT ' . \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\AiEditorialJobs::FIELD_NAMES,
+            'AI_Editorial_Jobs'
+        ) . '
+            FROM AI_Editorial_Jobs
+            WHERE user_id = ?
+            ORDER BY created_at DESC
+            LIMIT ?
+        ';
+
+        /** @var list<array{attempts: int, created_at: \OmegaUp\Timestamp, error_message: null|string, is_retriable: int, job_id: string, md_en: null|string, md_es: null|string, md_pt: null|string, problem_id: int, status: string, user_id: int, validation_verdict: null|string}> */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$userId, $limit]
+        );
+
+        $jobs = [];
+        foreach ($rs as $row) {
+            $jobs[] = new \OmegaUp\DAO\VO\AiEditorialJobs($row);
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Gets jobs by problem
+     *
+     * @return list<\OmegaUp\DAO\VO\AiEditorialJobs>
+     */
+    public static function getJobsByProblem(int $problemId): array {
+        $sql = '
+            SELECT ' . \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\AiEditorialJobs::FIELD_NAMES,
+            'AI_Editorial_Jobs'
+        ) . '
+            FROM AI_Editorial_Jobs
+            WHERE problem_id = ?
+            ORDER BY created_at DESC
+        ';
+
+        /** @var list<array{attempts: int, created_at: \OmegaUp\Timestamp, error_message: null|string, is_retriable: int, job_id: string, md_en: null|string, md_es: null|string, md_pt: null|string, problem_id: int, status: string, user_id: int, validation_verdict: null|string}> */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$problemId]
+        );
+
+        $jobs = [];
+        foreach ($rs as $row) {
+            $jobs[] = new \OmegaUp\DAO\VO\AiEditorialJobs($row);
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Generates a UUID v4
+     *
+     * @return string
+     */
+    private static function generateUuid(): string {
+        $data = random_bytes(16);
+
+        // Set version to 0100
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+        // Set bits 6-7 to 10
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+}

--- a/frontend/server/src/DAO/AiEditorialJobs.php
+++ b/frontend/server/src/DAO/AiEditorialJobs.php
@@ -12,6 +12,9 @@ namespace OmegaUp\DAO;
  * @access public
  */
 class AiEditorialJobs extends \OmegaUp\DAO\Base\AiEditorialJobs {
+    /** @var int Hours that define whether a job is considered recent */
+    const RECENT_JOB_HOURS = 1;
+
     /**
      * Creates a new AI editorial job
      *
@@ -29,19 +32,11 @@ class AiEditorialJobs extends \OmegaUp\DAO\Base\AiEditorialJobs {
             'user_id' => $userId,
             'status' => 'queued',
             'attempts' => 0,
+            'is_retriable' => true,
         ]);
 
         self::save($job);
         return $jobId;
-    }
-
-    /**
-     * Gets a job by its UUID
-     *
-     * @return \OmegaUp\DAO\VO\AiEditorialJobs|null
-     */
-    public static function getJobByUuid(string $jobId): ?\OmegaUp\DAO\VO\AiEditorialJobs {
-        return self::getByPK($jobId);
     }
 
     /**
@@ -105,7 +100,7 @@ class AiEditorialJobs extends \OmegaUp\DAO\Base\AiEditorialJobs {
      */
     public static function countRecentJobsByUser(
         int $userId,
-        int $hours = 1
+        int $hours = self::RECENT_JOB_HOURS
     ): int {
         $sql = '
             SELECT COUNT(*)

--- a/frontend/server/src/DAO/Base/AiEditorialJobs.php
+++ b/frontend/server/src/DAO/Base/AiEditorialJobs.php
@@ -1,0 +1,364 @@
+<?php
+// WARNING: This file is auto-generated. Do not modify it directly.
+
+namespace OmegaUp\DAO\Base;
+
+/** AiEditorialJobs Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\AiEditorialJobs}.
+ * @access public
+ * @abstract
+ */
+abstract class AiEditorialJobs {
+    /**
+     * Guardar registros.
+     *
+     * Este metodo guarda el estado actual del objeto {@link \OmegaUp\DAO\VO\AiEditorialJobs}
+     * pasado en la base de datos. La llave primaria indicará qué instancia va
+     * a ser actualizada en base de datos. Si la llave primara o combinación de
+     * llaves primarias que describen una fila que no se encuentra en la base de
+     * datos, entonces save() creará una nueva fila, insertando en ese objeto
+     * el ID recién creado.
+     *
+     * @param \OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\AiEditorialJobs}.
+     * @return int Un entero mayor o igual a cero identificando el número de filas afectadas.
+     */
+    final public static function save(\OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs): int {
+        if (
+            is_null(
+                $AI_Editorial_Jobs->job_id
+            ) || is_null(
+                self::getByPK(
+                    $AI_Editorial_Jobs->job_id
+                )
+            )
+        ) {
+            return AiEditorialJobs::create($AI_Editorial_Jobs);
+        }
+        return AiEditorialJobs::update($AI_Editorial_Jobs);
+    }
+
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs El objeto de tipo AiEditorialJobs a actualizar.
+     * @return int Número de filas afectadas
+     */
+    final public static function update(\OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs): int {
+        $sql = '
+            UPDATE
+                `AI_Editorial_Jobs`
+            SET
+                `problem_id` = ?,
+                `user_id` = ?,
+                `status` = ?,
+                `error_message` = ?,
+                `is_retriable` = ?,
+                `attempts` = ?,
+                `md_en` = ?,
+                `md_es` = ?,
+                `md_pt` = ?,
+                `validation_verdict` = ?
+            WHERE
+                `job_id` = ?;';
+        $params = [
+            $AI_Editorial_Jobs->problem_id,
+            $AI_Editorial_Jobs->user_id,
+            $AI_Editorial_Jobs->status,
+            $AI_Editorial_Jobs->error_message,
+            $AI_Editorial_Jobs->is_retriable ? 1 : 0,
+            $AI_Editorial_Jobs->attempts,
+            $AI_Editorial_Jobs->md_en,
+            $AI_Editorial_Jobs->md_es,
+            $AI_Editorial_Jobs->md_pt,
+            $AI_Editorial_Jobs->validation_verdict,
+            $AI_Editorial_Jobs->job_id,
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\AiEditorialJobs} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\AiEditorialJobs}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return \OmegaUp\DAO\VO\AiEditorialJobs|null Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\AiEditorialJobs} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(string $job_id): ?\OmegaUp\DAO\VO\AiEditorialJobs {
+        $sql = '
+            SELECT
+                `AI_Editorial_Jobs`.`job_id`,
+                `AI_Editorial_Jobs`.`problem_id`,
+                `AI_Editorial_Jobs`.`user_id`,
+                `AI_Editorial_Jobs`.`status`,
+                `AI_Editorial_Jobs`.`error_message`,
+                `AI_Editorial_Jobs`.`is_retriable`,
+                `AI_Editorial_Jobs`.`attempts`,
+                `AI_Editorial_Jobs`.`created_at`,
+                `AI_Editorial_Jobs`.`md_en`,
+                `AI_Editorial_Jobs`.`md_es`,
+                `AI_Editorial_Jobs`.`md_pt`,
+                `AI_Editorial_Jobs`.`validation_verdict`
+            FROM
+                `AI_Editorial_Jobs`
+            WHERE
+                `AI_Editorial_Jobs`.`job_id` = ?
+            LIMIT 1;';
+        $params = [$job_id];
+        /** @var array{attempts: int, created_at: \OmegaUp\Timestamp, error_message: null|string, is_retriable: int, job_id: string, md_en: null|string, md_es: null|string, md_pt: null|string, problem_id: int, status: string, user_id: int, validation_verdict: null|string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\AiEditorialJobs($row);
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\AiEditorialJobs} suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\AiEditorialJobs}
+     * a crear.
+     * @return int Un entero mayor o igual a cero identificando el número de
+     * filas afectadas.
+     */
+    final public static function create(\OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs): int {
+        $sql = '
+            INSERT INTO `AI_Editorial_Jobs` (
+                `job_id`,
+                `problem_id`,
+                `user_id`,
+                `status`,
+                `error_message`,
+                `is_retriable`,
+                `attempts`,
+                `created_at`,
+                `md_en`,
+                `md_es`,
+                `md_pt`,
+                `validation_verdict`
+            ) VALUES (
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?,
+                ?
+            );';
+        $params = [
+            $AI_Editorial_Jobs->job_id,
+            $AI_Editorial_Jobs->problem_id,
+            $AI_Editorial_Jobs->user_id,
+            $AI_Editorial_Jobs->status,
+            $AI_Editorial_Jobs->error_message,
+            $AI_Editorial_Jobs->is_retriable ? 1 : 0,
+            $AI_Editorial_Jobs->attempts,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp($AI_Editorial_Jobs->created_at),
+            $AI_Editorial_Jobs->md_en,
+            $AI_Editorial_Jobs->md_es,
+            $AI_Editorial_Jobs->md_pt,
+            $AI_Editorial_Jobs->validation_verdict,
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Buscar registros.
+     *
+     * Este metodo proporciona capacidad de busqueda para conseguir un juego de
+     * objetos {@link \OmegaUp\DAO\VO\AiEditorialJobs} de la base de datos.
+     * Consiste en buscar todos los registros que coinciden con las variables
+     * del objeto {@link \OmegaUp\DAO\VO\AiEditorialJobs} pasado como argumento.
+     * Aquellas variables que tienen valores NULL seran excluidos en busqueda.
+     *
+     * <code>
+     *   // Example usage - get a set of all objects where column A = 1
+     *   $jobVO = new \OmegaUp\DAO\VO\AiEditorialJobs();
+     *   $jobVO->job_id = 1;
+     *   $resultObjects = \OmegaUp\DAO\AiEditorialJobs::search($jobVO);
+     *
+     *   foreach($resultObjects as $job){
+     *        echo $job->user_id . " ";
+     *   }
+     * </code>
+     *
+     * @param \OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs
+     * @return list<\OmegaUp\DAO\VO\AiEditorialJobs> Un arreglo de objetos de tipo {@link \OmegaUp\DAO\VO\AiEditorialJobs}
+     */
+    final public static function search(\OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs): array {
+        $clauses = [];
+        $params = [];
+        if (!is_null($AI_Editorial_Jobs->job_id)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`job_id` = ?';
+            $params[] = $AI_Editorial_Jobs->job_id;
+        }
+        if (!is_null($AI_Editorial_Jobs->problem_id)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`problem_id` = ?';
+            $params[] = $AI_Editorial_Jobs->problem_id;
+        }
+        if (!is_null($AI_Editorial_Jobs->user_id)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`user_id` = ?';
+            $params[] = $AI_Editorial_Jobs->user_id;
+        }
+        if (!is_null($AI_Editorial_Jobs->status)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`status` = ?';
+            $params[] = $AI_Editorial_Jobs->status;
+        }
+        if (!is_null($AI_Editorial_Jobs->error_message)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`error_message` = ?';
+            $params[] = $AI_Editorial_Jobs->error_message;
+        }
+        if (!is_null($AI_Editorial_Jobs->is_retriable)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`is_retriable` = ?';
+            $params[] = $AI_Editorial_Jobs->is_retriable ? 1 : 0;
+        }
+        if (!is_null($AI_Editorial_Jobs->attempts)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`attempts` = ?';
+            $params[] = $AI_Editorial_Jobs->attempts;
+        }
+        $clauses[] = '`AI_Editorial_Jobs`.`created_at` = ?';
+        $params[] = \OmegaUp\DAO\DAO::toMySQLTimestamp(
+            $AI_Editorial_Jobs->created_at
+        );
+        if (!is_null($AI_Editorial_Jobs->md_en)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`md_en` = ?';
+            $params[] = $AI_Editorial_Jobs->md_en;
+        }
+        if (!is_null($AI_Editorial_Jobs->md_es)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`md_es` = ?';
+            $params[] = $AI_Editorial_Jobs->md_es;
+        }
+        if (!is_null($AI_Editorial_Jobs->md_pt)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`md_pt` = ?';
+            $params[] = $AI_Editorial_Jobs->md_pt;
+        }
+        if (!is_null($AI_Editorial_Jobs->validation_verdict)) {
+            $clauses[] = '`AI_Editorial_Jobs`.`validation_verdict` = ?';
+            $params[] = $AI_Editorial_Jobs->validation_verdict;
+        }
+        $whereClause = 'WHERE ' . implode(' AND ', $clauses);
+        $sql = "
+            SELECT
+                `AI_Editorial_Jobs`.`job_id`,
+                `AI_Editorial_Jobs`.`problem_id`,
+                `AI_Editorial_Jobs`.`user_id`,
+                `AI_Editorial_Jobs`.`status`,
+                `AI_Editorial_Jobs`.`error_message`,
+                `AI_Editorial_Jobs`.`is_retriable`,
+                `AI_Editorial_Jobs`.`attempts`,
+                `AI_Editorial_Jobs`.`created_at`,
+                `AI_Editorial_Jobs`.`md_en`,
+                `AI_Editorial_Jobs`.`md_es`,
+                `AI_Editorial_Jobs`.`md_pt`,
+                `AI_Editorial_Jobs`.`validation_verdict`
+            FROM
+                `AI_Editorial_Jobs`
+            {$whereClause};";
+        /** @var list<array{attempts: int, created_at: \OmegaUp\Timestamp, error_message: null|string, is_retriable: int, job_id: string, md_en: null|string, md_es: null|string, md_pt: null|string, problem_id: int, status: string, user_id: int, validation_verdict: null|string}> */
+        $allData = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            $params
+        );
+        $allObjects = [];
+        foreach ($allData as $row) {
+            $allObjects[] = new \OmegaUp\DAO\VO\AiEditorialJobs($row);
+        }
+        return $allObjects;
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará la información de base de datos identificados por
+     * la clave primaria en el objeto {@link \OmegaUp\DAO\VO\AiEditorialJobs} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que no hay llaves primarias.
+     *
+     * @param \OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs El
+     * objeto de tipo \OmegaUp\DAO\VO\AiEditorialJobs a eliminar
+     * @return int El número de filas afectadas.
+     */
+    final public static function delete(\OmegaUp\DAO\VO\AiEditorialJobs $AI_Editorial_Jobs): int {
+        $sql = '
+            DELETE FROM
+                `AI_Editorial_Jobs`
+            WHERE
+                `job_id` = ?;';
+        $params = [$AI_Editorial_Jobs->job_id];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leera todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\AiEditorialJobs}.
+     * Este método consume una cantidad considerable de memoria porque
+     * almacenará en memoria todos los objetos de la tabla.
+     *
+     * @return list<\OmegaUp\DAO\VO\AiEditorialJobs> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\AiEditorialJobs}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        ?int $filasPorPagina = null,
+        ?string $orden = null,
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sql = '
+            SELECT
+                `AI_Editorial_Jobs`.`job_id`,
+                `AI_Editorial_Jobs`.`problem_id`,
+                `AI_Editorial_Jobs`.`user_id`,
+                `AI_Editorial_Jobs`.`status`,
+                `AI_Editorial_Jobs`.`error_message`,
+                `AI_Editorial_Jobs`.`is_retriable`,
+                `AI_Editorial_Jobs`.`attempts`,
+                `AI_Editorial_Jobs`.`created_at`,
+                `AI_Editorial_Jobs`.`md_en`,
+                `AI_Editorial_Jobs`.`md_es`,
+                `AI_Editorial_Jobs`.`md_pt`,
+                `AI_Editorial_Jobs`.`validation_verdict`
+            FROM
+                `AI_Editorial_Jobs`
+        ';
+        if (!is_null($orden)) {
+            $sql .= ' ORDER BY `' . \OmegaUp\MySQLConnection::getInstance()->escape(
+                $orden
+            ) . '` ' . ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC');
+        }
+        if (!is_null($pagina)) {
+            $sql .= ' LIMIT ' . (($pagina - 1) * intval(
+                $filasPorPagina
+            )) . ', ' . intval(
+                $filasPorPagina
+            );
+        }
+        /** @var list<array{attempts: int, created_at: \OmegaUp\Timestamp, error_message: null|string, is_retriable: int, job_id: string, md_en: null|string, md_es: null|string, md_pt: null|string, problem_id: int, status: string, user_id: int, validation_verdict: null|string}> */
+        $allData = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql);
+        $allObjects = [];
+        foreach ($allData as $row) {
+            $allObjects[] = new \OmegaUp\DAO\VO\AiEditorialJobs($row);
+        }
+        return $allObjects;
+    }
+}

--- a/frontend/server/src/DAO/VO/AiEditorialJobs.php
+++ b/frontend/server/src/DAO/VO/AiEditorialJobs.php
@@ -1,0 +1,178 @@
+<?php
+// WARNING: This file is auto-generated. Do not modify it directly.
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object file for table AI_Editorial_Jobs.
+ *
+ * VO does not have any behaviour except for storage.
+ * @access public
+ */
+class AiEditorialJobs extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'job_id' => true,
+        'problem_id' => true,
+        'user_id' => true,
+        'status' => true,
+        'error_message' => true,
+        'is_retriable' => true,
+        'attempts' => true,
+        'created_at' => true,
+        'md_en' => true,
+        'md_es' => true,
+        'md_pt' => true,
+        'validation_verdict' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['job_id'])) {
+            $this->job_id = strval($data['job_id']);
+        }
+        if (isset($data['problem_id'])) {
+            $this->problem_id = intval($data['problem_id']);
+        }
+        if (isset($data['user_id'])) {
+            $this->user_id = intval($data['user_id']);
+        }
+        if (isset($data['status'])) {
+            $this->status = strval($data['status']);
+        }
+        if (isset($data['error_message'])) {
+            $this->error_message = is_null(
+                $data['error_message']
+            ) ? null : strval(
+                $data['error_message']
+            );
+        }
+        if (isset($data['is_retriable'])) {
+            $this->is_retriable = boolval($data['is_retriable']);
+        }
+        if (isset($data['attempts'])) {
+            $this->attempts = intval($data['attempts']);
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(\OmegaUp\Time::get());
+        }
+        if (isset($data['md_en'])) {
+            $this->md_en = is_null(
+                $data['md_en']
+            ) ? null : strval(
+                $data['md_en']
+            );
+        }
+        if (isset($data['md_es'])) {
+            $this->md_es = is_null(
+                $data['md_es']
+            ) ? null : strval(
+                $data['md_es']
+            );
+        }
+        if (isset($data['md_pt'])) {
+            $this->md_pt = is_null(
+                $data['md_pt']
+            ) ? null : strval(
+                $data['md_pt']
+            );
+        }
+        if (isset($data['validation_verdict'])) {
+            $this->validation_verdict = is_null(
+                $data['validation_verdict']
+            ) ? null : strval(
+                $data['validation_verdict']
+            );
+        }
+    }
+
+    /**
+     * Identificador único del trabajo de editorial IA
+     * Llave Primaria
+     * @var string|null
+     */
+    public $job_id = null;
+
+    /**
+     * ID del problema para el cual se genera la editorial
+     * @var int|null
+     */
+    public $problem_id = null;
+
+    /**
+     * ID del usuario que solicitó la generación
+     * @var int|null
+     */
+    public $user_id = null;
+
+    /**
+     * Estado del trabajo (queued, processing, completed, failed, approved, rejected)
+     * @var string|null
+     */
+    public $status = 'queued';
+
+    /**
+     * Mensaje de error si el trabajo falló
+     * @var string|null
+     */
+    public $error_message = null;
+
+    /**
+     * Indica si el error permite reintentos
+     * @var bool|null
+     */
+    public $is_retriable = true;
+
+    /**
+     * Número de intentos de procesamiento
+     * @var int|null
+     */
+    public $attempts = 0;
+
+    /**
+     * Timestamp de creación del trabajo
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * Editorial generada en inglés (formato Markdown)
+     * @var string|null
+     */
+    public $md_en = null;
+
+    /**
+     * Editorial generada en español (formato Markdown)
+     * @var string|null
+     */
+    public $md_es = null;
+
+    /**
+     * Editorial generada en portugués (formato Markdown)
+     * @var string|null
+     */
+    public $md_pt = null;
+
+    /**
+     * Veredicto de validación del contenido generado
+     * @var string|null
+     */
+    public $validation_verdict = null;
+}


### PR DESCRIPTION
# Description
Data access layer for AI editorial jobs: value object, base CRUD operations, and business logic methods.
# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
