### PR TITLE
Ai Editorial Generator - Controller

### DIFF
--- a/frontend/server/src/Controllers/AiEditorial.php
+++ b/frontend/server/src/Controllers/AiEditorial.php
@@ -142,7 +142,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
 
     /**
      * Review and approve/reject an AI editorial
-     * 
+     *
      * When approved, the editorial is published to gitserver
      *
      * @omegaup-request-param string $job_id

--- a/frontend/server/src/Controllers/AiEditorial.php
+++ b/frontend/server/src/Controllers/AiEditorial.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace OmegaUp\Controllers;
+
+/**
+ * AI Editorial Controller
+ *
+ * @psalm-type AiEditorialJobDetails=array{job_id: string, status: string, error_message: null|string, is_retriable: bool, created_at: \OmegaUp\Timestamp, problem_alias: string, md_en: null|string, md_es: null|string, md_pt: null|string}
+ */
+class AiEditorial extends \OmegaUp\Controllers\Controller {
+    const STATUS_QUEUED = 'queued';
+    const STATUS_PROCESSING = 'processing';
+    const STATUS_COMPLETED = 'completed';
+    const STATUS_FAILED = 'failed';
+
+    const REVIEW_STATUS_APPROVED = 'approved';
+    const REVIEW_STATUS_REJECTED = 'rejected';
+
+    // Rate limits
+    const MAX_JOBS_PER_HOUR = 5;
+    const COOLDOWN_MINUTES = 5;
+
+    /**
+     * Generate AI editorial for a problem
+     *
+     * @omegaup-request-param string $problem_alias
+     *
+     * @return array{status: string, job_id?: string}
+     */
+    public static function apiGenerate(\OmegaUp\Request $r): array {
+        $r->ensureIdentity();
+        $problemAlias = $r->ensureString(
+            'problem_alias',
+            fn (string $alias) => \OmegaUp\Validators::alias($alias)
+        );
+
+        $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
+        if (is_null($problem)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+
+        // Check if user has admin permissions for this problem
+        if (!\OmegaUp\Authorization::isProblemAdmin($r->identity, $problem)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException(
+                'userNotAllowed'
+            );
+        }
+
+        // Rate limiting: Check user's recent job count
+        if (is_null($r->identity->user_id)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException(
+                'userNotAllowed'
+            );
+        }
+        $recentJobs = \OmegaUp\DAO\AiEditorialJobs::countRecentJobsByUser(
+            $r->identity->user_id,
+            1 // 1 hour
+        );
+
+        if ($recentJobs >= self::MAX_JOBS_PER_HOUR) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid'
+            );
+        }
+
+        // Problem cooldown: Check if there's a recent job for this problem
+        if (is_null($problem->problem_id)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+        $lastJob = \OmegaUp\DAO\AiEditorialJobs::getLastJobForProblem(
+            $problem->problem_id
+        );
+
+        if (!is_null($lastJob)) {
+            $cooldownEnd = $lastJob->created_at->time + (self::COOLDOWN_MINUTES * 60);
+            if (time() < $cooldownEnd) {
+                throw new \OmegaUp\Exceptions\InvalidParameterException(
+                    'parameterInvalid'
+                );
+            }
+        }
+
+        // Create the job
+        $jobId = \OmegaUp\DAO\AiEditorialJobs::createJob(
+            $problem->problem_id,
+            $r->identity->user_id
+        );
+
+        return [
+            'status' => 'ok',
+            'job_id' => $jobId,
+        ];
+    }
+
+    /**
+     * Get status of an AI editorial job
+     *
+     * @omegaup-request-param string $job_id
+     *
+     * @return array{status: string, job?: AiEditorialJobDetails}
+     */
+    public static function apiStatus(\OmegaUp\Request $r): array {
+        $r->ensureIdentity();
+        $jobId = $r->ensureString('job_id');
+
+        $job = \OmegaUp\DAO\AiEditorialJobs::getByPK($jobId);
+        if (is_null($job)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
+        }
+
+        // Get problem to check permissions
+        if (is_null($job->problem_id)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+        $problem = \OmegaUp\DAO\Problems::getByPK($job->problem_id);
+        if (is_null($problem)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+
+        // Check if user has admin permissions for this problem
+        if (!\OmegaUp\Authorization::isProblemAdmin($r->identity, $problem)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException(
+                'userNotAllowed'
+            );
+        }
+
+        return [
+            'status' => 'ok',
+            'job' => [
+                'job_id' => strval($job->job_id),
+                'status' => strval($job->status),
+                'error_message' => $job->error_message,
+                'is_retriable' => boolval($job->is_retriable),
+                'created_at' => $job->created_at,
+                'problem_alias' => strval($problem->alias),
+                'md_en' => $job->md_en,
+                'md_es' => $job->md_es,
+                'md_pt' => $job->md_pt,
+            ],
+        ];
+    }
+
+    /**
+     * Review and approve/reject an AI editorial
+     *
+     * @omegaup-request-param string $job_id
+     * @omegaup-request-param string $action
+     * @omegaup-request-param null|string $language
+     *
+     * @return array{status: string}
+     */
+    public static function apiReview(\OmegaUp\Request $r): array {
+        $r->ensureIdentity();
+        $jobId = $r->ensureString('job_id');
+        $action = $r->ensureString('action');
+        $language = $r->ensureOptionalString('language');
+
+        if (!in_array($action, ['approve', 'reject'])) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid'
+            );
+        }
+
+        $job = \OmegaUp\DAO\AiEditorialJobs::getByPK($jobId);
+        if (is_null($job)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
+        }
+
+        // Get problem to check permissions
+        if (is_null($job->problem_id)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+        $problem = \OmegaUp\DAO\Problems::getByPK($job->problem_id);
+        if (is_null($problem)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
+        }
+
+        // Check if user has admin permissions for this problem
+        if (!\OmegaUp\Authorization::isProblemAdmin($r->identity, $problem)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException(
+                'userNotAllowed'
+            );
+        }
+
+        // Check if job is in completed status
+        if ($job->status !== self::STATUS_COMPLETED) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid'
+            );
+        }
+
+        if ($action === 'approve') {
+            // Update job status
+            \OmegaUp\DAO\AiEditorialJobs::updateJobStatus(
+                $jobId,
+                self::REVIEW_STATUS_APPROVED
+            );
+
+            // Publish the editorial using existing Problem API
+            $solutionMarkdown = null;
+            if ($language === 'en' && !is_null($job->md_en)) {
+                $solutionMarkdown = $job->md_en;
+            } elseif ($language === 'es' && !is_null($job->md_es)) {
+                $solutionMarkdown = $job->md_es;
+            } elseif ($language === 'pt' && !is_null($job->md_pt)) {
+                $solutionMarkdown = $job->md_pt;
+            } else {
+                // Default to English if no language specified or content not found
+                $solutionMarkdown = $job->md_en ?? $job->md_es ?? $job->md_pt;
+            }
+
+            if (!is_null($solutionMarkdown)) {
+                // Publish the editorial by calling a helper method
+                self::publishEditorial(
+                    $r->identity,
+                    $problem,
+                    $solutionMarkdown,
+                    $language
+                );
+            }
+        } else {
+            // Reject the job
+            \OmegaUp\DAO\AiEditorialJobs::updateJobStatus(
+                $jobId,
+                self::REVIEW_STATUS_REJECTED
+            );
+        }
+
+        return ['status' => 'ok'];
+    }
+
+    /**
+     * Helper method to publish AI editorial to problem solution
+     *
+     * @param \OmegaUp\DAO\VO\Identities $identity
+     * @param \OmegaUp\DAO\VO\Problems $problem
+     * @param string $solutionMarkdown
+     * @param null|string $language
+     */
+    private static function publishEditorial(
+        \OmegaUp\DAO\VO\Identities $identity,
+        \OmegaUp\DAO\VO\Problems $problem,
+        string $solutionMarkdown,
+        ?string $language
+    ): void {
+        // Create a new Request for the Problem::apiUpdateSolution call
+        $solutionRequest = new \OmegaUp\Request([
+            'problem_alias' => $problem->alias,
+            'solution' => $solutionMarkdown,
+            'message' => 'AI-generated editorial approved and published',
+            'lang' => $language ?? 'en',
+        ]);
+
+        // Set the identity for the request
+        $solutionRequest->identity = $identity;
+
+        // Call the existing Problem API to update the solution
+        \OmegaUp\Controllers\Problem::apiUpdateSolution($solutionRequest);
+    }
+}

--- a/frontend/server/src/Controllers/AiEditorial.php
+++ b/frontend/server/src/Controllers/AiEditorial.php
@@ -142,6 +142,8 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
 
     /**
      * Review and approve/reject an AI editorial
+     * 
+     * When approved, the editorial is published to gitserver
      *
      * @omegaup-request-param string $job_id
      * @omegaup-request-param string $action

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -320,6 +320,8 @@ Generate AI editorial for a problem
 
 Review and approve/reject an AI editorial
 
+When approved, the editorial is published to gitserver
+
 ### Parameters
 
 | Name       | Type           | Description |

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1,5 +1,9 @@
 - [Admin](#admin)
   - [`/api/admin/platformReportStats/`](#apiadminplatformreportstats)
+- [AiEditorial](#aieditorial)
+  - [`/api/aiEditorial/generate/`](#apiaieditorialgenerate)
+  - [`/api/aiEditorial/review/`](#apiaieditorialreview)
+  - [`/api/aiEditorial/status/`](#apiaieditorialstatus)
 - [Authorization](#authorization)
   - [`/api/authorization/problem/`](#apiauthorizationproblem)
 - [Badge](#badge)
@@ -287,6 +291,64 @@ Get stats for an overall platform report.
 | Name     | Type                                                                                                                                                                                                     |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `report` | `{ acceptedSubmissions: number; activeSchools: number; activeUsers: { [key: string]: number; }; courses: number; omiCourse: { attemptedUsers: number; completedUsers: number; passedUsers: number; }; }` |
+
+# AiEditorial
+
+AI Editorial Controller
+
+## `/api/aiEditorial/generate/`
+
+### Description
+
+Generate AI editorial for a problem
+
+### Parameters
+
+| Name            | Type     | Description |
+| --------------- | -------- | ----------- |
+| `problem_alias` | `string` |             |
+
+### Returns
+
+| Name     | Type     |
+| -------- | -------- |
+| `job_id` | `string` |
+
+## `/api/aiEditorial/review/`
+
+### Description
+
+Review and approve/reject an AI editorial
+
+### Parameters
+
+| Name       | Type           | Description |
+| ---------- | -------------- | ----------- |
+| `action`   | `string`       |             |
+| `job_id`   | `string`       |             |
+| `language` | `null\|string` |             |
+
+### Returns
+
+_Nothing_
+
+## `/api/aiEditorial/status/`
+
+### Description
+
+Get status of an AI editorial job
+
+### Parameters
+
+| Name     | Type     | Description |
+| -------- | -------- | ----------- |
+| `job_id` | `string` |             |
+
+### Returns
+
+| Name  | Type                          |
+| ----- | ----------------------------- |
+| `job` | `types.AiEditorialJobDetails` |
 
 # Authorization
 

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -97,6 +97,29 @@ export const Admin = {
   >('/api/admin/platformReportStats/'),
 };
 
+export const AiEditorial = {
+  generate: apiCall<
+    messages.AiEditorialGenerateRequest,
+    messages.AiEditorialGenerateResponse
+  >('/api/aiEditorial/generate/'),
+  review: apiCall<
+    messages.AiEditorialReviewRequest,
+    messages.AiEditorialReviewResponse
+  >('/api/aiEditorial/review/'),
+  status: apiCall<
+    messages.AiEditorialStatusRequest,
+    messages._AiEditorialStatusServerResponse,
+    messages.AiEditorialStatusResponse
+  >('/api/aiEditorial/status/', (x) => {
+    if (typeof x.job !== 'undefined' && x.job !== null)
+      x.job = ((x) => {
+        x.created_at = ((x: number) => new Date(x * 1000))(x.created_at);
+        return x;
+      })(x.job);
+    return x;
+  }),
+};
+
 export const Authorization = {
   problem: apiCall<
     messages.AuthorizationProblemRequest,

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -2608,6 +2608,18 @@ export namespace types {
     };
   }
 
+  export interface AiEditorialJobDetails {
+    created_at: Date;
+    error_message?: string;
+    is_retriable: boolean;
+    job_id: string;
+    md_en?: string;
+    md_es?: string;
+    md_pt?: string;
+    problem_alias: string;
+    status: string;
+  }
+
   export interface ApiToken {
     last_used: Date;
     name: string;
@@ -5062,6 +5074,15 @@ export namespace messages {
     };
   };
 
+  // AiEditorial
+  export type AiEditorialGenerateRequest = { [key: string]: any };
+  export type AiEditorialGenerateResponse = { job_id?: string };
+  export type AiEditorialReviewRequest = { [key: string]: any };
+  export type AiEditorialReviewResponse = {};
+  export type AiEditorialStatusRequest = { [key: string]: any };
+  export type _AiEditorialStatusServerResponse = any;
+  export type AiEditorialStatusResponse = { job?: types.AiEditorialJobDetails };
+
   // Authorization
   export type AuthorizationProblemRequest = { [key: string]: any };
   export type AuthorizationProblemResponse = {
@@ -5988,6 +6009,18 @@ export namespace controllers {
     platformReportStats: (
       params?: messages.AdminPlatformReportStatsRequest,
     ) => Promise<messages.AdminPlatformReportStatsResponse>;
+  }
+
+  export interface AiEditorial {
+    generate: (
+      params?: messages.AiEditorialGenerateRequest,
+    ) => Promise<messages.AiEditorialGenerateResponse>;
+    review: (
+      params?: messages.AiEditorialReviewRequest,
+    ) => Promise<messages.AiEditorialReviewResponse>;
+    status: (
+      params?: messages.AiEditorialStatusRequest,
+    ) => Promise<messages.AiEditorialStatusResponse>;
   }
 
   export interface Authorization {


### PR DESCRIPTION
# Description

Three APIs for AI editorial management:
- apiGenerate - Creates AI editorial generation jobs with rate limiting and permissions
- apiStatus - Retrieves job status, progress, and generated editorial content
- apiReview - Approves/rejects completed editorials for publication