### PR TITLE
Conservar página de origen tras iniciar sesión con Google

### DIFF
--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -527,7 +527,8 @@ class Session extends \OmegaUp\Controllers\Controller {
 
     public static function loginViaGoogle(
         string $idToken,
-        string $gCsrfToken
+        string $gCsrfToken,
+        string $redirect
     ): void {
         // Verify the Google ID token on the server side:
         // https://developers.google.com/identity/gsi/web/guides/verify-google-id-token?hl=en
@@ -573,17 +574,20 @@ class Session extends \OmegaUp\Controllers\Controller {
 
         self::loginViaGoogleEmail(
             $payload['email'],
-            (isset($payload['name']) ? $payload['name'] : null)
+            (isset($payload['name']) ? $payload['name'] : null),
+            $redirect
         );
     }
 
     public static function loginViaGoogleEmail(
         string $email,
-        ?string $name = null
+        ?string $name = null,
+        ?string $redirect = null
     ): void {
-        self::thirdPartyLogin('Google', $email, $name);
+        $result = self::thirdPartyLogin('Google', $email, $name);
+        $isAccountCreation = $result['isAccountCreation'];
 
-        self::redirect();
+        self::redirect($redirect, $isAccountCreation);
     }
 
     /**
@@ -634,7 +638,7 @@ class Session extends \OmegaUp\Controllers\Controller {
     }
 
     private static function getRedirectUrl(?string $url = null): string {
-        $defaultRedirectUrl = '/profile/';
+        $defaultRedirectUrl = '/?fromLogin';
         if (is_null($url)) {
             return $defaultRedirectUrl;
         }
@@ -649,7 +653,12 @@ class Session extends \OmegaUp\Controllers\Controller {
             empty($redirectParsedUrl['host'])
         ) {
             $path = $redirectParsedUrl['path'] ?? '';
-            return $path !== '/logout/' ? $url : $defaultRedirectUrl;
+            if ($path === '/logout/') {
+                return $defaultRedirectUrl;
+            }
+
+            $separator = str_contains($url, '?') ? '&' : '?';
+            return $url . $separator . 'fromLogin';
         }
         $redirectUrl = "{$redirectParsedUrl['scheme']}://{$redirectParsedUrl['host']}";
         if (isset($redirectParsedUrl['port'])) {
@@ -658,8 +667,11 @@ class Session extends \OmegaUp\Controllers\Controller {
         return $redirectUrl === OMEGAUP_URL ? $url : $defaultRedirectUrl;
     }
 
-    private static function redirect(?string $redirect = null): void {
-        $redirectUrl = self::getRedirectUrl($redirect);
+    private static function redirect(?string $redirect = null, ?bool $isAccountCreation = false): void {
+        $redirectUrl = $isAccountCreation
+        ? '/profile?fromLogin'
+        : self::getRedirectUrl($redirect);
+
         header("Location: {$redirectUrl}");
         throw new \OmegaUp\Exceptions\ExitException();
     }

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -4800,6 +4800,7 @@ class User extends \OmegaUp\Controllers\Controller {
         $thirdPartyLogin = $r->ensureOptionalString('third_party_login');
         $gCsrfToken = $r->ensureOptionalString('g_csrf_token');
         $idToken = $r->ensureOptionalString('credential');
+        $redirect = $r->ensureOptionalString('redirect');
         if ($r->offsetExists('fb')) {
             $thirdPartyLogin = 'facebook';
         }
@@ -4823,7 +4824,8 @@ class User extends \OmegaUp\Controllers\Controller {
             } elseif (!is_null($gCsrfToken) && !is_null($idToken)) {
                 \OmegaUp\Controllers\Session::loginViaGoogle(
                     $idToken,
-                    $gCsrfToken
+                    $gCsrfToken,
+                    $redirect
                 );
             }
         } catch (\OmegaUp\Exceptions\ExitException $e) {

--- a/frontend/www/js/omegaup/login/signin.ts
+++ b/frontend/www/js/omegaup/login/signin.ts
@@ -24,8 +24,16 @@ OmegaUp.on('ready', () => {
   }
 
   function redirect(isAccountCreation: boolean): void {
+
     const params = new URLSearchParams(window.location.search);
     const pathname = params.get('redirect');
+    const fromLoginParam = '?fromLogin';
+
+    if (isAccountCreation) {
+      window.location.href = `/profile/${fromLoginParam}`;
+      return;
+    }
+
     if (pathname && pathname.indexOf('/') === 0) {
       window.location.href = pathname + '?fromLogin';
       return;
@@ -35,11 +43,7 @@ OmegaUp.on('ready', () => {
       window.location.href = pathname;
       return;
     }
-    const fromLoginParam = '?fromLogin';
-    if (isAccountCreation) {
-      window.location.href = `/profile/${fromLoginParam}`;
-      return;
-    }
+    
     window.location.href = `/${fromLoginParam}`;
   }
 


### PR DESCRIPTION
# Description

Se corrige el flujo de redirección al iniciar sesión para que el usuario regrese a la página que estaba visitando (p. ej. arena de concursos), salvo cuando se trate de una cuenta nueva, en cuyo caso se envía al perfil para completar configuración.

Fixes: #8087

# Comments

Cambios principales

- Google Sign‑In: ahora respeta returnUrl/redirect cuando exista y sea válida; deja de forzar siempre el perfil por defecto.
- Login interno: se reordena la lógica para validar primero si la cuenta es nueva y, solo si no lo es, usar la returnUrl.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
