### PR TITLE
Cambiando el campo orden como mandatorio.

### DIFF
--- a/frontend/server/src/DAO/Base/ACLs.php
+++ b/frontend/server/src/DAO/Base/ACLs.php
@@ -171,22 +171,29 @@ abstract class ACLs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`ACLs`.`acl_id`',
+        string $orden = 'acl_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `ACLs`.`acl_id`,
                 `ACLs`.`owner_id`
             FROM
                 `ACLs`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ACLs.php
+++ b/frontend/server/src/DAO/Base/ACLs.php
@@ -162,7 +162,7 @@ abstract class ACLs {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ACLs> Un arreglo que contiene objetos del tipo
@@ -171,7 +171,7 @@ abstract class ACLs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`ACLs`.`acl_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -181,14 +181,12 @@ abstract class ACLs {
             FROM
                 `ACLs`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/AIEditorialJobs.php
+++ b/frontend/server/src/DAO/Base/AIEditorialJobs.php
@@ -280,11 +280,7 @@ abstract class AIEditorialJobs {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-<<<<<<< HEAD
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
-=======
      * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
->>>>>>> 20706e109 (Cambiando el campo orden como mandatorio.)
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\AIEditorialJobs> Un arreglo que contiene objetos del tipo
@@ -293,14 +289,21 @@ abstract class AIEditorialJobs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-<<<<<<< HEAD
-        ?string $orden = null,
-=======
-        string $orden = '`AI_Editorial_Jobs`.`job_id`',
->>>>>>> 20706e109 (Cambiando el campo orden como mandatorio.)
+        string $orden = 'job_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `AI_Editorial_Jobs`.`job_id`,
                 `AI_Editorial_Jobs`.`problem_id`,
@@ -316,24 +319,9 @@ abstract class AIEditorialJobs {
                 `AI_Editorial_Jobs`.`validation_verdict`
             FROM
                 `AI_Editorial_Jobs`
-        ';
-<<<<<<< HEAD
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
-=======
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
->>>>>>> 20706e109 (Cambiando el campo orden como mandatorio.)
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/AIEditorialJobs.php
+++ b/frontend/server/src/DAO/Base/AIEditorialJobs.php
@@ -280,7 +280,11 @@ abstract class AIEditorialJobs {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
+<<<<<<< HEAD
      * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+=======
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+>>>>>>> 20706e109 (Cambiando el campo orden como mandatorio.)
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\AIEditorialJobs> Un arreglo que contiene objetos del tipo
@@ -289,7 +293,11 @@ abstract class AIEditorialJobs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
+<<<<<<< HEAD
         ?string $orden = null,
+=======
+        string $orden = '`AI_Editorial_Jobs`.`job_id`',
+>>>>>>> 20706e109 (Cambiando el campo orden como mandatorio.)
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -309,6 +317,7 @@ abstract class AIEditorialJobs {
             FROM
                 `AI_Editorial_Jobs`
         ';
+<<<<<<< HEAD
         if (!is_null($orden)) {
             $sql .= (
                 ' ORDER BY `' .
@@ -317,6 +326,14 @@ abstract class AIEditorialJobs {
                 ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
             );
         }
+=======
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
+>>>>>>> 20706e109 (Cambiando el campo orden como mandatorio.)
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/APITokens.php
+++ b/frontend/server/src/DAO/Base/APITokens.php
@@ -190,10 +190,21 @@ abstract class APITokens {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`API_Tokens`.`apitoken_id`',
+        string $orden = 'apitoken_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `API_Tokens`.`apitoken_id`,
                 `API_Tokens`.`user_id`,
@@ -204,13 +215,9 @@ abstract class APITokens {
                 `API_Tokens`.`use_count`
             FROM
                 `API_Tokens`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/APITokens.php
+++ b/frontend/server/src/DAO/Base/APITokens.php
@@ -181,7 +181,7 @@ abstract class APITokens {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\APITokens> Un arreglo que contiene objetos del tipo
@@ -190,7 +190,7 @@ abstract class APITokens {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`API_Tokens`.`apitoken_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -205,14 +205,12 @@ abstract class APITokens {
             FROM
                 `API_Tokens`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Announcement.php
+++ b/frontend/server/src/DAO/Base/Announcement.php
@@ -170,7 +170,7 @@ abstract class Announcement {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Announcement> Un arreglo que contiene objetos del tipo
@@ -179,7 +179,7 @@ abstract class Announcement {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Announcement`.`announcement_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -191,14 +191,12 @@ abstract class Announcement {
             FROM
                 `Announcement`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Announcement.php
+++ b/frontend/server/src/DAO/Base/Announcement.php
@@ -179,10 +179,21 @@ abstract class Announcement {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Announcement`.`announcement_id`',
+        string $orden = 'announcement_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Announcement`.`announcement_id`,
                 `Announcement`.`user_id`,
@@ -190,13 +201,9 @@ abstract class Announcement {
                 `Announcement`.`description`
             FROM
                 `Announcement`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Assignments.php
+++ b/frontend/server/src/DAO/Base/Assignments.php
@@ -220,10 +220,21 @@ abstract class Assignments {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Assignments`.`assignment_id`',
+        string $orden = 'assignment_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Assignments`.`assignment_id`,
                 `Assignments`.`course_id`,
@@ -240,13 +251,9 @@ abstract class Assignments {
                 `Assignments`.`order`
             FROM
                 `Assignments`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Assignments.php
+++ b/frontend/server/src/DAO/Base/Assignments.php
@@ -211,7 +211,7 @@ abstract class Assignments {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Assignments> Un arreglo que contiene objetos del tipo
@@ -220,7 +220,7 @@ abstract class Assignments {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Assignments`.`assignment_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -241,14 +241,12 @@ abstract class Assignments {
             FROM
                 `Assignments`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -255,10 +255,21 @@ abstract class AuthTokens {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Auth_Tokens`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Auth_Tokens`.`user_id`,
                 `Auth_Tokens`.`identity_id`,
@@ -267,13 +278,9 @@ abstract class AuthTokens {
                 `Auth_Tokens`.`create_time`
             FROM
                 `Auth_Tokens`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -246,7 +246,7 @@ abstract class AuthTokens {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\AuthTokens> Un arreglo que contiene objetos del tipo
@@ -255,7 +255,7 @@ abstract class AuthTokens {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Auth_Tokens`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -268,14 +268,12 @@ abstract class AuthTokens {
             FROM
                 `Auth_Tokens`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CarouselItems.php
+++ b/frontend/server/src/DAO/Base/CarouselItems.php
@@ -204,10 +204,21 @@ abstract class CarouselItems {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Carousel_Items`.`carousel_item_id`',
+        string $orden = 'carousel_item_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Carousel_Items`.`carousel_item_id`,
                 `Carousel_Items`.`title`,
@@ -222,13 +233,9 @@ abstract class CarouselItems {
                 `Carousel_Items`.`updated_at`
             FROM
                 `Carousel_Items`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CarouselItems.php
+++ b/frontend/server/src/DAO/Base/CarouselItems.php
@@ -195,7 +195,7 @@ abstract class CarouselItems {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\CarouselItems> Un arreglo que contiene objetos del tipo
@@ -204,7 +204,7 @@ abstract class CarouselItems {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Carousel_Items`.`carousel_item_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -223,14 +223,12 @@ abstract class CarouselItems {
             FROM
                 `Carousel_Items`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Certificates.php
+++ b/frontend/server/src/DAO/Base/Certificates.php
@@ -210,10 +210,21 @@ abstract class Certificates {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Certificates`.`certificate_id`',
+        string $orden = 'certificate_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Certificates`.`certificate_id`,
                 `Certificates`.`identity_id`,
@@ -226,13 +237,9 @@ abstract class Certificates {
                 `Certificates`.`contest_place`
             FROM
                 `Certificates`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Certificates.php
+++ b/frontend/server/src/DAO/Base/Certificates.php
@@ -201,7 +201,7 @@ abstract class Certificates {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Certificates> Un arreglo que contiene objetos del tipo
@@ -210,7 +210,7 @@ abstract class Certificates {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Certificates`.`certificate_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -227,14 +227,12 @@ abstract class Certificates {
             FROM
                 `Certificates`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Clarifications.php
+++ b/frontend/server/src/DAO/Base/Clarifications.php
@@ -206,10 +206,21 @@ abstract class Clarifications {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Clarifications`.`clarification_id`',
+        string $orden = 'clarification_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Clarifications`.`clarification_id`,
                 `Clarifications`.`author_id`,
@@ -222,13 +233,9 @@ abstract class Clarifications {
                 `Clarifications`.`public`
             FROM
                 `Clarifications`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Clarifications.php
+++ b/frontend/server/src/DAO/Base/Clarifications.php
@@ -197,7 +197,7 @@ abstract class Clarifications {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Clarifications> Un arreglo que contiene objetos del tipo
@@ -206,7 +206,7 @@ abstract class Clarifications {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Clarifications`.`clarification_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -223,14 +223,12 @@ abstract class Clarifications {
             FROM
                 `Clarifications`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/CoderOfTheMonth.php
@@ -213,10 +213,21 @@ abstract class CoderOfTheMonth {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Coder_Of_The_Month`.`coder_of_the_month_id`',
+        string $orden = 'coder_of_the_month_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Coder_Of_The_Month`.`coder_of_the_month_id`,
                 `Coder_Of_The_Month`.`user_id`,
@@ -232,13 +243,9 @@ abstract class CoderOfTheMonth {
                 `Coder_Of_The_Month`.`certificate_status`
             FROM
                 `Coder_Of_The_Month`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/CoderOfTheMonth.php
@@ -204,7 +204,7 @@ abstract class CoderOfTheMonth {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\CoderOfTheMonth> Un arreglo que contiene objetos del tipo
@@ -213,7 +213,7 @@ abstract class CoderOfTheMonth {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Coder_Of_The_Month`.`coder_of_the_month_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -233,14 +233,12 @@ abstract class CoderOfTheMonth {
             FROM
                 `Coder_Of_The_Month`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ContestLog.php
+++ b/frontend/server/src/DAO/Base/ContestLog.php
@@ -180,7 +180,7 @@ abstract class ContestLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ContestLog> Un arreglo que contiene objetos del tipo
@@ -189,7 +189,7 @@ abstract class ContestLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Contest_Log`.`public_contest_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -203,14 +203,12 @@ abstract class ContestLog {
             FROM
                 `Contest_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ContestLog.php
+++ b/frontend/server/src/DAO/Base/ContestLog.php
@@ -189,10 +189,21 @@ abstract class ContestLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Contest_Log`.`public_contest_id`',
+        string $orden = 'public_contest_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Contest_Log`.`public_contest_id`,
                 `Contest_Log`.`contest_id`,
@@ -202,13 +213,9 @@ abstract class ContestLog {
                 `Contest_Log`.`time`
             FROM
                 `Contest_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Contests.php
+++ b/frontend/server/src/DAO/Base/Contests.php
@@ -283,10 +283,21 @@ abstract class Contests {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Contests`.`contest_id`',
+        string $orden = 'contest_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Contests`.`contest_id`,
                 `Contests`.`problemset_id`,
@@ -322,13 +333,9 @@ abstract class Contests {
                 `Contests`.`check_plagiarism`
             FROM
                 `Contests`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Contests.php
+++ b/frontend/server/src/DAO/Base/Contests.php
@@ -274,7 +274,7 @@ abstract class Contests {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Contests> Un arreglo que contiene objetos del tipo
@@ -283,7 +283,7 @@ abstract class Contests {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Contests`.`contest_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -323,14 +323,12 @@ abstract class Contests {
             FROM
                 `Contests`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Countries.php
+++ b/frontend/server/src/DAO/Base/Countries.php
@@ -200,7 +200,7 @@ abstract class Countries {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Countries> Un arreglo que contiene objetos del tipo
@@ -209,7 +209,7 @@ abstract class Countries {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Countries`.`country_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -219,14 +219,12 @@ abstract class Countries {
             FROM
                 `Countries`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Countries.php
+++ b/frontend/server/src/DAO/Base/Countries.php
@@ -209,22 +209,29 @@ abstract class Countries {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Countries`.`country_id`',
+        string $orden = 'country_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Countries`.`country_id`,
                 `Countries`.`name`
             FROM
                 `Countries`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CourseCloneLog.php
+++ b/frontend/server/src/DAO/Base/CourseCloneLog.php
@@ -190,7 +190,7 @@ abstract class CourseCloneLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\CourseCloneLog> Un arreglo que contiene objetos del tipo
@@ -199,7 +199,7 @@ abstract class CourseCloneLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Course_Clone_Log`.`course_clone_log_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -215,14 +215,12 @@ abstract class CourseCloneLog {
             FROM
                 `Course_Clone_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CourseCloneLog.php
+++ b/frontend/server/src/DAO/Base/CourseCloneLog.php
@@ -199,10 +199,21 @@ abstract class CourseCloneLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Course_Clone_Log`.`course_clone_log_id`',
+        string $orden = 'course_clone_log_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Course_Clone_Log`.`course_clone_log_id`,
                 `Course_Clone_Log`.`ip`,
@@ -214,13 +225,9 @@ abstract class CourseCloneLog {
                 `Course_Clone_Log`.`result`
             FROM
                 `Course_Clone_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequest.php
@@ -283,7 +283,7 @@ abstract class CourseIdentityRequest {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\CourseIdentityRequest> Un arreglo que contiene objetos del tipo
@@ -292,7 +292,7 @@ abstract class CourseIdentityRequest {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Course_Identity_Request`.`identity_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -308,14 +308,12 @@ abstract class CourseIdentityRequest {
             FROM
                 `Course_Identity_Request`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequest.php
@@ -292,10 +292,21 @@ abstract class CourseIdentityRequest {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Course_Identity_Request`.`identity_id`',
+        string $orden = 'identity_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Course_Identity_Request`.`identity_id`,
                 `Course_Identity_Request`.`course_id`,
@@ -307,13 +318,9 @@ abstract class CourseIdentityRequest {
                 `Course_Identity_Request`.`share_user_information`
             FROM
                 `Course_Identity_Request`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
@@ -188,7 +188,7 @@ abstract class CourseIdentityRequestHistory {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\CourseIdentityRequestHistory> Un arreglo que contiene objetos del tipo
@@ -197,7 +197,7 @@ abstract class CourseIdentityRequestHistory {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Course_Identity_Request_History`.`history_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -211,14 +211,12 @@ abstract class CourseIdentityRequestHistory {
             FROM
                 `Course_Identity_Request_History`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
@@ -197,10 +197,21 @@ abstract class CourseIdentityRequestHistory {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Course_Identity_Request_History`.`history_id`',
+        string $orden = 'history_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Course_Identity_Request_History`.`history_id`,
                 `Course_Identity_Request_History`.`identity_id`,
@@ -210,13 +221,9 @@ abstract class CourseIdentityRequestHistory {
                 `Course_Identity_Request_History`.`admin_id`
             FROM
                 `Course_Identity_Request_History`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Courses.php
+++ b/frontend/server/src/DAO/Base/Courses.php
@@ -241,10 +241,21 @@ abstract class Courses {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Courses`.`course_id`',
+        string $orden = 'course_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Courses`.`course_id`,
                 `Courses`.`name`,
@@ -268,13 +279,9 @@ abstract class Courses {
                 `Courses`.`recommended`
             FROM
                 `Courses`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Courses.php
+++ b/frontend/server/src/DAO/Base/Courses.php
@@ -232,7 +232,7 @@ abstract class Courses {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Courses> Un arreglo que contiene objetos del tipo
@@ -241,7 +241,7 @@ abstract class Courses {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Courses`.`course_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -269,14 +269,12 @@ abstract class Courses {
             FROM
                 `Courses`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Emails.php
+++ b/frontend/server/src/DAO/Base/Emails.php
@@ -174,23 +174,30 @@ abstract class Emails {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Emails`.`email_id`',
+        string $orden = 'email_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Emails`.`email_id`,
                 `Emails`.`email`,
                 `Emails`.`user_id`
             FROM
                 `Emails`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Emails.php
+++ b/frontend/server/src/DAO/Base/Emails.php
@@ -165,7 +165,7 @@ abstract class Emails {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Emails> Un arreglo que contiene objetos del tipo
@@ -174,7 +174,7 @@ abstract class Emails {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Emails`.`email_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -185,14 +185,12 @@ abstract class Emails {
             FROM
                 `Emails`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Favorites.php
+++ b/frontend/server/src/DAO/Base/Favorites.php
@@ -146,22 +146,29 @@ abstract class Favorites {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Favorites`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Favorites`.`user_id`,
                 `Favorites`.`problem_id`
             FROM
                 `Favorites`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Favorites.php
+++ b/frontend/server/src/DAO/Base/Favorites.php
@@ -137,7 +137,7 @@ abstract class Favorites {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Favorites> Un arreglo que contiene objetos del tipo
@@ -146,7 +146,7 @@ abstract class Favorites {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Favorites`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -156,14 +156,12 @@ abstract class Favorites {
             FROM
                 `Favorites`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupRoles.php
+++ b/frontend/server/src/DAO/Base/GroupRoles.php
@@ -153,23 +153,30 @@ abstract class GroupRoles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Group_Roles`.`group_id`',
+        string $orden = 'group_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Group_Roles`.`group_id`,
                 `Group_Roles`.`role_id`,
                 `Group_Roles`.`acl_id`
             FROM
                 `Group_Roles`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupRoles.php
+++ b/frontend/server/src/DAO/Base/GroupRoles.php
@@ -144,7 +144,7 @@ abstract class GroupRoles {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\GroupRoles> Un arreglo que contiene objetos del tipo
@@ -153,7 +153,7 @@ abstract class GroupRoles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Group_Roles`.`group_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -164,14 +164,12 @@ abstract class GroupRoles {
             FROM
                 `Group_Roles`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -176,7 +176,7 @@ abstract class Groups {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Groups> Un arreglo que contiene objetos del tipo
@@ -185,7 +185,7 @@ abstract class Groups {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Groups_`.`group_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -199,14 +199,12 @@ abstract class Groups {
             FROM
                 `Groups_`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -185,10 +185,21 @@ abstract class Groups {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Groups_`.`group_id`',
+        string $orden = 'group_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Groups_`.`group_id`,
                 `Groups_`.`acl_id`,
@@ -198,13 +209,9 @@ abstract class Groups {
                 `Groups_`.`description`
             FROM
                 `Groups_`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupsIdentities.php
+++ b/frontend/server/src/DAO/Base/GroupsIdentities.php
@@ -272,10 +272,21 @@ abstract class GroupsIdentities {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Groups_Identities`.`group_id`',
+        string $orden = 'group_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Groups_Identities`.`group_id`,
                 `Groups_Identities`.`identity_id`,
@@ -285,13 +296,9 @@ abstract class GroupsIdentities {
                 `Groups_Identities`.`is_invited`
             FROM
                 `Groups_Identities`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupsIdentities.php
+++ b/frontend/server/src/DAO/Base/GroupsIdentities.php
@@ -263,7 +263,7 @@ abstract class GroupsIdentities {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\GroupsIdentities> Un arreglo que contiene objetos del tipo
@@ -272,7 +272,7 @@ abstract class GroupsIdentities {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Groups_Identities`.`group_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -286,14 +286,12 @@ abstract class GroupsIdentities {
             FROM
                 `Groups_Identities`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupsScoreboards.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboards.php
@@ -176,7 +176,7 @@ abstract class GroupsScoreboards {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\GroupsScoreboards> Un arreglo que contiene objetos del tipo
@@ -185,7 +185,7 @@ abstract class GroupsScoreboards {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Groups_Scoreboards`.`group_scoreboard_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -199,14 +199,12 @@ abstract class GroupsScoreboards {
             FROM
                 `Groups_Scoreboards`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupsScoreboards.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboards.php
@@ -185,10 +185,21 @@ abstract class GroupsScoreboards {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Groups_Scoreboards`.`group_scoreboard_id`',
+        string $orden = 'group_scoreboard_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Groups_Scoreboards`.`group_scoreboard_id`,
                 `Groups_Scoreboards`.`group_id`,
@@ -198,13 +209,9 @@ abstract class GroupsScoreboards {
                 `Groups_Scoreboards`.`description`
             FROM
                 `Groups_Scoreboards`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
@@ -236,10 +236,21 @@ abstract class GroupsScoreboardsProblemsets {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Groups_Scoreboards_Problemsets`.`group_scoreboard_id`',
+        string $orden = 'group_scoreboard_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Groups_Scoreboards_Problemsets`.`group_scoreboard_id`,
                 `Groups_Scoreboards_Problemsets`.`problemset_id`,
@@ -247,13 +258,9 @@ abstract class GroupsScoreboardsProblemsets {
                 `Groups_Scoreboards_Problemsets`.`weight`
             FROM
                 `Groups_Scoreboards_Problemsets`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
@@ -227,7 +227,7 @@ abstract class GroupsScoreboardsProblemsets {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\GroupsScoreboardsProblemsets> Un arreglo que contiene objetos del tipo
@@ -236,7 +236,7 @@ abstract class GroupsScoreboardsProblemsets {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Groups_Scoreboards_Problemsets`.`group_scoreboard_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -248,14 +248,12 @@ abstract class GroupsScoreboardsProblemsets {
             FROM
                 `Groups_Scoreboards_Problemsets`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Identities.php
+++ b/frontend/server/src/DAO/Base/Identities.php
@@ -203,10 +203,21 @@ abstract class Identities {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Identities`.`identity_id`',
+        string $orden = 'identity_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Identities`.`identity_id`,
                 `Identities`.`username`,
@@ -220,13 +231,9 @@ abstract class Identities {
                 `Identities`.`current_identity_school_id`
             FROM
                 `Identities`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Identities.php
+++ b/frontend/server/src/DAO/Base/Identities.php
@@ -194,7 +194,7 @@ abstract class Identities {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Identities> Un arreglo que contiene objetos del tipo
@@ -203,7 +203,7 @@ abstract class Identities {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Identities`.`identity_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -221,14 +221,12 @@ abstract class Identities {
             FROM
                 `Identities`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/Base/IdentitiesSchools.php
@@ -182,7 +182,7 @@ abstract class IdentitiesSchools {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\IdentitiesSchools> Un arreglo que contiene objetos del tipo
@@ -191,7 +191,7 @@ abstract class IdentitiesSchools {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Identities_Schools`.`identity_school_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -205,14 +205,12 @@ abstract class IdentitiesSchools {
             FROM
                 `Identities_Schools`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/Base/IdentitiesSchools.php
@@ -191,10 +191,21 @@ abstract class IdentitiesSchools {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Identities_Schools`.`identity_school_id`',
+        string $orden = 'identity_school_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Identities_Schools`.`identity_school_id`,
                 `Identities_Schools`.`identity_id`,
@@ -204,13 +215,9 @@ abstract class IdentitiesSchools {
                 `Identities_Schools`.`end_time`
             FROM
                 `Identities_Schools`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/IdentityLoginLog.php
+++ b/frontend/server/src/DAO/Base/IdentityLoginLog.php
@@ -40,23 +40,30 @@ abstract class IdentityLoginLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Identity_Login_Log`.`identity_id`',
+        string $orden = 'identity_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Identity_Login_Log`.`identity_id`,
                 `Identity_Login_Log`.`ip`,
                 `Identity_Login_Log`.`time`
             FROM
                 `Identity_Login_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/IdentityLoginLog.php
+++ b/frontend/server/src/DAO/Base/IdentityLoginLog.php
@@ -31,7 +31,7 @@ abstract class IdentityLoginLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\IdentityLoginLog> Un arreglo que contiene objetos del tipo
@@ -40,7 +40,7 @@ abstract class IdentityLoginLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Identity_Login_Log`.`identity_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -51,14 +51,12 @@ abstract class IdentityLoginLog {
             FROM
                 `Identity_Login_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Interviews.php
+++ b/frontend/server/src/DAO/Base/Interviews.php
@@ -185,7 +185,7 @@ abstract class Interviews {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Interviews> Un arreglo que contiene objetos del tipo
@@ -194,7 +194,7 @@ abstract class Interviews {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Interviews`.`interview_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -209,14 +209,12 @@ abstract class Interviews {
             FROM
                 `Interviews`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Interviews.php
+++ b/frontend/server/src/DAO/Base/Interviews.php
@@ -194,10 +194,21 @@ abstract class Interviews {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Interviews`.`interview_id`',
+        string $orden = 'interview_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Interviews`.`interview_id`,
                 `Interviews`.`problemset_id`,
@@ -208,13 +219,9 @@ abstract class Interviews {
                 `Interviews`.`window_length`
             FROM
                 `Interviews`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Languages.php
+++ b/frontend/server/src/DAO/Base/Languages.php
@@ -170,23 +170,30 @@ abstract class Languages {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Languages`.`language_id`',
+        string $orden = 'language_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Languages`.`language_id`,
                 `Languages`.`name`,
                 `Languages`.`country_id`
             FROM
                 `Languages`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Languages.php
+++ b/frontend/server/src/DAO/Base/Languages.php
@@ -161,7 +161,7 @@ abstract class Languages {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Languages> Un arreglo que contiene objetos del tipo
@@ -170,7 +170,7 @@ abstract class Languages {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Languages`.`language_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -181,14 +181,12 @@ abstract class Languages {
             FROM
                 `Languages`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Messages.php
+++ b/frontend/server/src/DAO/Base/Messages.php
@@ -180,7 +180,7 @@ abstract class Messages {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Messages> Un arreglo que contiene objetos del tipo
@@ -189,7 +189,7 @@ abstract class Messages {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Messages`.`message_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -203,14 +203,12 @@ abstract class Messages {
             FROM
                 `Messages`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Messages.php
+++ b/frontend/server/src/DAO/Base/Messages.php
@@ -189,10 +189,21 @@ abstract class Messages {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Messages`.`message_id`',
+        string $orden = 'message_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Messages`.`message_id`,
                 `Messages`.`read`,
@@ -202,13 +213,9 @@ abstract class Messages {
                 `Messages`.`date`
             FROM
                 `Messages`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Notifications.php
+++ b/frontend/server/src/DAO/Base/Notifications.php
@@ -182,10 +182,21 @@ abstract class Notifications {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Notifications`.`notification_id`',
+        string $orden = 'notification_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Notifications`.`notification_id`,
                 `Notifications`.`user_id`,
@@ -194,13 +205,9 @@ abstract class Notifications {
                 `Notifications`.`contents`
             FROM
                 `Notifications`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Notifications.php
+++ b/frontend/server/src/DAO/Base/Notifications.php
@@ -173,7 +173,7 @@ abstract class Notifications {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Notifications> Un arreglo que contiene objetos del tipo
@@ -182,7 +182,7 @@ abstract class Notifications {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Notifications`.`notification_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -195,14 +195,12 @@ abstract class Notifications {
             FROM
                 `Notifications`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Permissions.php
+++ b/frontend/server/src/DAO/Base/Permissions.php
@@ -161,7 +161,7 @@ abstract class Permissions {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Permissions> Un arreglo que contiene objetos del tipo
@@ -170,7 +170,7 @@ abstract class Permissions {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Permissions`.`permission_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -181,14 +181,12 @@ abstract class Permissions {
             FROM
                 `Permissions`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Permissions.php
+++ b/frontend/server/src/DAO/Base/Permissions.php
@@ -170,23 +170,30 @@ abstract class Permissions {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Permissions`.`permission_id`',
+        string $orden = 'permission_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Permissions`.`permission_id`,
                 `Permissions`.`name`,
                 `Permissions`.`description`
             FROM
                 `Permissions`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Plagiarisms.php
+++ b/frontend/server/src/DAO/Base/Plagiarisms.php
@@ -193,7 +193,7 @@ abstract class Plagiarisms {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Plagiarisms> Un arreglo que contiene objetos del tipo
@@ -202,7 +202,7 @@ abstract class Plagiarisms {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Plagiarisms`.`plagiarism_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -217,14 +217,12 @@ abstract class Plagiarisms {
             FROM
                 `Plagiarisms`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Plagiarisms.php
+++ b/frontend/server/src/DAO/Base/Plagiarisms.php
@@ -202,10 +202,21 @@ abstract class Plagiarisms {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Plagiarisms`.`plagiarism_id`',
+        string $orden = 'plagiarism_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Plagiarisms`.`plagiarism_id`,
                 `Plagiarisms`.`contest_id`,
@@ -216,13 +227,9 @@ abstract class Plagiarisms {
                 `Plagiarisms`.`contents`
             FROM
                 `Plagiarisms`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
@@ -183,10 +183,21 @@ abstract class PrivacyStatementConsentLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`PrivacyStatement_Consent_Log`.`privacystatement_consent_id`',
+        string $orden = 'privacystatement_consent_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `PrivacyStatement_Consent_Log`.`privacystatement_consent_id`,
                 `PrivacyStatement_Consent_Log`.`identity_id`,
@@ -194,13 +205,9 @@ abstract class PrivacyStatementConsentLog {
                 `PrivacyStatement_Consent_Log`.`timestamp`
             FROM
                 `PrivacyStatement_Consent_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
@@ -174,7 +174,7 @@ abstract class PrivacyStatementConsentLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\PrivacyStatementConsentLog> Un arreglo que contiene objetos del tipo
@@ -183,7 +183,7 @@ abstract class PrivacyStatementConsentLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`PrivacyStatement_Consent_Log`.`privacystatement_consent_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -195,14 +195,12 @@ abstract class PrivacyStatementConsentLog {
             FROM
                 `PrivacyStatement_Consent_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/PrivacyStatements.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatements.php
@@ -161,7 +161,7 @@ abstract class PrivacyStatements {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\PrivacyStatements> Un arreglo que contiene objetos del tipo
@@ -170,7 +170,7 @@ abstract class PrivacyStatements {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`PrivacyStatements`.`privacystatement_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -181,14 +181,12 @@ abstract class PrivacyStatements {
             FROM
                 `PrivacyStatements`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/PrivacyStatements.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatements.php
@@ -170,23 +170,30 @@ abstract class PrivacyStatements {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`PrivacyStatements`.`privacystatement_id`',
+        string $orden = 'privacystatement_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `PrivacyStatements`.`privacystatement_id`,
                 `PrivacyStatements`.`git_object_id`,
                 `PrivacyStatements`.`type`
             FROM
                 `PrivacyStatements`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
+++ b/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
@@ -177,10 +177,21 @@ abstract class ProblemOfTheWeek {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problem_Of_The_Week`.`problem_of_the_week_id`',
+        string $orden = 'problem_of_the_week_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problem_Of_The_Week`.`problem_of_the_week_id`,
                 `Problem_Of_The_Week`.`problem_id`,
@@ -188,13 +199,9 @@ abstract class ProblemOfTheWeek {
                 `Problem_Of_The_Week`.`difficulty`
             FROM
                 `Problem_Of_The_Week`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
+++ b/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
@@ -168,7 +168,7 @@ abstract class ProblemOfTheWeek {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemOfTheWeek> Un arreglo que contiene objetos del tipo
@@ -177,7 +177,7 @@ abstract class ProblemOfTheWeek {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problem_Of_The_Week`.`problem_of_the_week_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -189,14 +189,12 @@ abstract class ProblemOfTheWeek {
             FROM
                 `Problem_Of_The_Week`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemViewed.php
+++ b/frontend/server/src/DAO/Base/ProblemViewed.php
@@ -225,7 +225,7 @@ abstract class ProblemViewed {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemViewed> Un arreglo que contiene objetos del tipo
@@ -234,7 +234,7 @@ abstract class ProblemViewed {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problem_Viewed`.`problem_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -245,14 +245,12 @@ abstract class ProblemViewed {
             FROM
                 `Problem_Viewed`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemViewed.php
+++ b/frontend/server/src/DAO/Base/ProblemViewed.php
@@ -234,23 +234,30 @@ abstract class ProblemViewed {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problem_Viewed`.`problem_id`',
+        string $orden = 'problem_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problem_Viewed`.`problem_id`,
                 `Problem_Viewed`.`identity_id`,
                 `Problem_Viewed`.`view_time`
             FROM
                 `Problem_Viewed`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Problems.php
+++ b/frontend/server/src/DAO/Base/Problems.php
@@ -247,10 +247,21 @@ abstract class Problems {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problems`.`problem_id`',
+        string $orden = 'problem_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problems`.`problem_id`,
                 `Problems`.`acl_id`,
@@ -278,13 +289,9 @@ abstract class Problems {
                 `Problems`.`allow_user_add_tags`
             FROM
                 `Problems`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Problems.php
+++ b/frontend/server/src/DAO/Base/Problems.php
@@ -238,7 +238,7 @@ abstract class Problems {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Problems> Un arreglo que contiene objetos del tipo
@@ -247,7 +247,7 @@ abstract class Problems {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problems`.`problem_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -279,14 +279,12 @@ abstract class Problems {
             FROM
                 `Problems`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsForfeited.php
+++ b/frontend/server/src/DAO/Base/ProblemsForfeited.php
@@ -225,7 +225,7 @@ abstract class ProblemsForfeited {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsForfeited> Un arreglo que contiene objetos del tipo
@@ -234,7 +234,7 @@ abstract class ProblemsForfeited {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problems_Forfeited`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -245,14 +245,12 @@ abstract class ProblemsForfeited {
             FROM
                 `Problems_Forfeited`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsForfeited.php
+++ b/frontend/server/src/DAO/Base/ProblemsForfeited.php
@@ -234,23 +234,30 @@ abstract class ProblemsForfeited {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problems_Forfeited`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problems_Forfeited`.`user_id`,
                 `Problems_Forfeited`.`problem_id`,
                 `Problems_Forfeited`.`forfeited_date`
             FROM
                 `Problems_Forfeited`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsLanguages.php
+++ b/frontend/server/src/DAO/Base/ProblemsLanguages.php
@@ -146,22 +146,29 @@ abstract class ProblemsLanguages {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problems_Languages`.`problem_id`',
+        string $orden = 'problem_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problems_Languages`.`problem_id`,
                 `Problems_Languages`.`language_id`
             FROM
                 `Problems_Languages`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsLanguages.php
+++ b/frontend/server/src/DAO/Base/ProblemsLanguages.php
@@ -137,7 +137,7 @@ abstract class ProblemsLanguages {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsLanguages> Un arreglo que contiene objetos del tipo
@@ -146,7 +146,7 @@ abstract class ProblemsLanguages {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problems_Languages`.`problem_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -156,14 +156,12 @@ abstract class ProblemsLanguages {
             FROM
                 `Problems_Languages`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsTags.php
+++ b/frontend/server/src/DAO/Base/ProblemsTags.php
@@ -221,7 +221,7 @@ abstract class ProblemsTags {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsTags> Un arreglo que contiene objetos del tipo
@@ -230,7 +230,7 @@ abstract class ProblemsTags {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problems_Tags`.`problem_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -241,14 +241,12 @@ abstract class ProblemsTags {
             FROM
                 `Problems_Tags`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsTags.php
+++ b/frontend/server/src/DAO/Base/ProblemsTags.php
@@ -230,23 +230,30 @@ abstract class ProblemsTags {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problems_Tags`.`problem_id`',
+        string $orden = 'problem_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problems_Tags`.`problem_id`,
                 `Problems_Tags`.`tag_id`,
                 `Problems_Tags`.`source`
             FROM
                 `Problems_Tags`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
+++ b/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
@@ -31,7 +31,7 @@ abstract class ProblemsetAccessLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsetAccessLog> Un arreglo que contiene objetos del tipo
@@ -40,7 +40,7 @@ abstract class ProblemsetAccessLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemset_Access_Log`.`problemset_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -52,14 +52,12 @@ abstract class ProblemsetAccessLog {
             FROM
                 `Problemset_Access_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
+++ b/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
@@ -40,10 +40,21 @@ abstract class ProblemsetAccessLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemset_Access_Log`.`problemset_id`',
+        string $orden = 'problemset_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemset_Access_Log`.`problemset_id`,
                 `Problemset_Access_Log`.`identity_id`,
@@ -51,13 +62,9 @@ abstract class ProblemsetAccessLog {
                 `Problemset_Access_Log`.`time`
             FROM
                 `Problemset_Access_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentities.php
@@ -290,10 +290,21 @@ abstract class ProblemsetIdentities {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemset_Identities`.`identity_id`',
+        string $orden = 'identity_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemset_Identities`.`identity_id`,
                 `Problemset_Identities`.`problemset_id`,
@@ -306,13 +317,9 @@ abstract class ProblemsetIdentities {
                 `Problemset_Identities`.`is_invited`
             FROM
                 `Problemset_Identities`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentities.php
@@ -281,7 +281,7 @@ abstract class ProblemsetIdentities {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsetIdentities> Un arreglo que contiene objetos del tipo
@@ -290,7 +290,7 @@ abstract class ProblemsetIdentities {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemset_Identities`.`identity_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -307,14 +307,12 @@ abstract class ProblemsetIdentities {
             FROM
                 `Problemset_Identities`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
@@ -255,7 +255,7 @@ abstract class ProblemsetIdentityRequest {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsetIdentityRequest> Un arreglo que contiene objetos del tipo
@@ -264,7 +264,7 @@ abstract class ProblemsetIdentityRequest {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemset_Identity_Request`.`identity_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -278,14 +278,12 @@ abstract class ProblemsetIdentityRequest {
             FROM
                 `Problemset_Identity_Request`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
@@ -264,10 +264,21 @@ abstract class ProblemsetIdentityRequest {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemset_Identity_Request`.`identity_id`',
+        string $orden = 'identity_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemset_Identity_Request`.`identity_id`,
                 `Problemset_Identity_Request`.`problemset_id`,
@@ -277,13 +288,9 @@ abstract class ProblemsetIdentityRequest {
                 `Problemset_Identity_Request`.`extra_note`
             FROM
                 `Problemset_Identity_Request`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
@@ -197,10 +197,21 @@ abstract class ProblemsetIdentityRequestHistory {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemset_Identity_Request_History`.`history_id`',
+        string $orden = 'history_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemset_Identity_Request_History`.`history_id`,
                 `Problemset_Identity_Request_History`.`identity_id`,
@@ -210,13 +221,9 @@ abstract class ProblemsetIdentityRequestHistory {
                 `Problemset_Identity_Request_History`.`admin_id`
             FROM
                 `Problemset_Identity_Request_History`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
@@ -188,7 +188,7 @@ abstract class ProblemsetIdentityRequestHistory {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsetIdentityRequestHistory> Un arreglo que contiene objetos del tipo
@@ -197,7 +197,7 @@ abstract class ProblemsetIdentityRequestHistory {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemset_Identity_Request_History`.`history_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -211,14 +211,12 @@ abstract class ProblemsetIdentityRequestHistory {
             FROM
                 `Problemset_Identity_Request_History`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
@@ -251,10 +251,21 @@ abstract class ProblemsetProblemOpened {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemset_Problem_Opened`.`problemset_id`',
+        string $orden = 'problemset_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemset_Problem_Opened`.`problemset_id`,
                 `Problemset_Problem_Opened`.`problem_id`,
@@ -262,13 +273,9 @@ abstract class ProblemsetProblemOpened {
                 `Problemset_Problem_Opened`.`open_time`
             FROM
                 `Problemset_Problem_Opened`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
@@ -242,7 +242,7 @@ abstract class ProblemsetProblemOpened {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsetProblemOpened> Un arreglo que contiene objetos del tipo
@@ -251,7 +251,7 @@ abstract class ProblemsetProblemOpened {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemset_Problem_Opened`.`problemset_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -263,14 +263,12 @@ abstract class ProblemsetProblemOpened {
             FROM
                 `Problemset_Problem_Opened`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblems.php
@@ -254,10 +254,21 @@ abstract class ProblemsetProblems {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemset_Problems`.`problemset_id`',
+        string $orden = 'problemset_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemset_Problems`.`problemset_id`,
                 `Problemset_Problems`.`problem_id`,
@@ -268,13 +279,9 @@ abstract class ProblemsetProblems {
                 `Problemset_Problems`.`is_extra_problem`
             FROM
                 `Problemset_Problems`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblems.php
@@ -245,7 +245,7 @@ abstract class ProblemsetProblems {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\ProblemsetProblems> Un arreglo que contiene objetos del tipo
@@ -254,7 +254,7 @@ abstract class ProblemsetProblems {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemset_Problems`.`problemset_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -269,14 +269,12 @@ abstract class ProblemsetProblems {
             FROM
                 `Problemset_Problems`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -204,7 +204,7 @@ abstract class Problemsets {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Problemsets> Un arreglo que contiene objetos del tipo
@@ -213,7 +213,7 @@ abstract class Problemsets {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Problemsets`.`problemset_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -233,14 +233,12 @@ abstract class Problemsets {
             FROM
                 `Problemsets`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -213,10 +213,21 @@ abstract class Problemsets {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Problemsets`.`problemset_id`',
+        string $orden = 'problemset_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Problemsets`.`problemset_id`,
                 `Problemsets`.`acl_id`,
@@ -232,13 +243,9 @@ abstract class Problemsets {
                 `Problemsets`.`interview_id`
             FROM
                 `Problemsets`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominationComments.php
+++ b/frontend/server/src/DAO/Base/QualityNominationComments.php
@@ -184,7 +184,7 @@ abstract class QualityNominationComments {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\QualityNominationComments> Un arreglo que contiene objetos del tipo
@@ -193,7 +193,7 @@ abstract class QualityNominationComments {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`QualityNomination_Comments`.`qualitynomination_comment_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -207,14 +207,12 @@ abstract class QualityNominationComments {
             FROM
                 `QualityNomination_Comments`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominationComments.php
+++ b/frontend/server/src/DAO/Base/QualityNominationComments.php
@@ -193,10 +193,21 @@ abstract class QualityNominationComments {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`QualityNomination_Comments`.`qualitynomination_comment_id`',
+        string $orden = 'qualitynomination_comment_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `QualityNomination_Comments`.`qualitynomination_comment_id`,
                 `QualityNomination_Comments`.`qualitynomination_id`,
@@ -206,13 +217,9 @@ abstract class QualityNominationComments {
                 `QualityNomination_Comments`.`contents`
             FROM
                 `QualityNomination_Comments`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominationLog.php
+++ b/frontend/server/src/DAO/Base/QualityNominationLog.php
@@ -183,7 +183,7 @@ abstract class QualityNominationLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\QualityNominationLog> Un arreglo que contiene objetos del tipo
@@ -192,7 +192,7 @@ abstract class QualityNominationLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`QualityNomination_Log`.`qualitynomination_log_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -207,14 +207,12 @@ abstract class QualityNominationLog {
             FROM
                 `QualityNomination_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominationLog.php
+++ b/frontend/server/src/DAO/Base/QualityNominationLog.php
@@ -192,10 +192,21 @@ abstract class QualityNominationLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`QualityNomination_Log`.`qualitynomination_log_id`',
+        string $orden = 'qualitynomination_log_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `QualityNomination_Log`.`qualitynomination_log_id`,
                 `QualityNomination_Log`.`qualitynomination_id`,
@@ -206,13 +217,9 @@ abstract class QualityNominationLog {
                 `QualityNomination_Log`.`rationale`
             FROM
                 `QualityNomination_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominationReviewers.php
+++ b/frontend/server/src/DAO/Base/QualityNominationReviewers.php
@@ -146,22 +146,29 @@ abstract class QualityNominationReviewers {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`QualityNomination_Reviewers`.`qualitynomination_id`',
+        string $orden = 'qualitynomination_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `QualityNomination_Reviewers`.`qualitynomination_id`,
                 `QualityNomination_Reviewers`.`user_id`
             FROM
                 `QualityNomination_Reviewers`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominationReviewers.php
+++ b/frontend/server/src/DAO/Base/QualityNominationReviewers.php
@@ -137,7 +137,7 @@ abstract class QualityNominationReviewers {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\QualityNominationReviewers> Un arreglo que contiene objetos del tipo
@@ -146,7 +146,7 @@ abstract class QualityNominationReviewers {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`QualityNomination_Reviewers`.`qualitynomination_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -156,14 +156,12 @@ abstract class QualityNominationReviewers {
             FROM
                 `QualityNomination_Reviewers`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominations.php
+++ b/frontend/server/src/DAO/Base/QualityNominations.php
@@ -192,10 +192,21 @@ abstract class QualityNominations {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`QualityNominations`.`qualitynomination_id`',
+        string $orden = 'qualitynomination_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `QualityNominations`.`qualitynomination_id`,
                 `QualityNominations`.`user_id`,
@@ -206,13 +217,9 @@ abstract class QualityNominations {
                 `QualityNominations`.`status`
             FROM
                 `QualityNominations`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/QualityNominations.php
+++ b/frontend/server/src/DAO/Base/QualityNominations.php
@@ -183,7 +183,7 @@ abstract class QualityNominations {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\QualityNominations> Un arreglo que contiene objetos del tipo
@@ -192,7 +192,7 @@ abstract class QualityNominations {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`QualityNominations`.`qualitynomination_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -207,14 +207,12 @@ abstract class QualityNominations {
             FROM
                 `QualityNominations`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Roles.php
+++ b/frontend/server/src/DAO/Base/Roles.php
@@ -161,7 +161,7 @@ abstract class Roles {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Roles> Un arreglo que contiene objetos del tipo
@@ -170,7 +170,7 @@ abstract class Roles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Roles`.`role_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -181,14 +181,12 @@ abstract class Roles {
             FROM
                 `Roles`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Roles.php
+++ b/frontend/server/src/DAO/Base/Roles.php
@@ -170,23 +170,30 @@ abstract class Roles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Roles`.`role_id`',
+        string $orden = 'role_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Roles`.`role_id`,
                 `Roles`.`name`,
                 `Roles`.`description`
             FROM
                 `Roles`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/RolesPermissions.php
+++ b/frontend/server/src/DAO/Base/RolesPermissions.php
@@ -146,22 +146,29 @@ abstract class RolesPermissions {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Roles_Permissions`.`role_id`',
+        string $orden = 'role_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Roles_Permissions`.`role_id`,
                 `Roles_Permissions`.`permission_id`
             FROM
                 `Roles_Permissions`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/RolesPermissions.php
+++ b/frontend/server/src/DAO/Base/RolesPermissions.php
@@ -137,7 +137,7 @@ abstract class RolesPermissions {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\RolesPermissions> Un arreglo que contiene objetos del tipo
@@ -146,7 +146,7 @@ abstract class RolesPermissions {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Roles_Permissions`.`role_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -156,14 +156,12 @@ abstract class RolesPermissions {
             FROM
                 `Roles_Permissions`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/RunCounts.php
+++ b/frontend/server/src/DAO/Base/RunCounts.php
@@ -215,23 +215,30 @@ abstract class RunCounts {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Run_Counts`.`date`',
+        string $orden = 'date',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Run_Counts`.`date`,
                 `Run_Counts`.`total`,
                 `Run_Counts`.`ac_count`
             FROM
                 `Run_Counts`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/RunCounts.php
+++ b/frontend/server/src/DAO/Base/RunCounts.php
@@ -206,7 +206,7 @@ abstract class RunCounts {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\RunCounts> Un arreglo que contiene objetos del tipo
@@ -215,7 +215,7 @@ abstract class RunCounts {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Run_Counts`.`date`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -226,14 +226,12 @@ abstract class RunCounts {
             FROM
                 `Run_Counts`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -210,10 +210,21 @@ abstract class Runs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Runs`.`run_id`',
+        string $orden = 'run_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Runs`.`run_id`,
                 `Runs`.`submission_id`,
@@ -230,13 +241,9 @@ abstract class Runs {
                 `Runs`.`judged_by`
             FROM
                 `Runs`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -201,7 +201,7 @@ abstract class Runs {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Runs> Un arreglo que contiene objetos del tipo
@@ -210,7 +210,7 @@ abstract class Runs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Runs`.`run_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -231,14 +231,12 @@ abstract class Runs {
             FROM
                 `Runs`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/RunsGroups.php
+++ b/frontend/server/src/DAO/Base/RunsGroups.php
@@ -171,7 +171,7 @@ abstract class RunsGroups {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\RunsGroups> Un arreglo que contiene objetos del tipo
@@ -180,7 +180,7 @@ abstract class RunsGroups {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Runs_Groups`.`case_run_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -193,14 +193,12 @@ abstract class RunsGroups {
             FROM
                 `Runs_Groups`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/RunsGroups.php
+++ b/frontend/server/src/DAO/Base/RunsGroups.php
@@ -180,10 +180,21 @@ abstract class RunsGroups {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Runs_Groups`.`case_run_id`',
+        string $orden = 'case_run_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Runs_Groups`.`case_run_id`,
                 `Runs_Groups`.`run_id`,
@@ -192,13 +203,9 @@ abstract class RunsGroups {
                 `Runs_Groups`.`verdict`
             FROM
                 `Runs_Groups`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
@@ -191,10 +191,21 @@ abstract class SchoolOfTheMonth {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`School_Of_The_Month`.`school_of_the_month_id`',
+        string $orden = 'school_of_the_month_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `School_Of_The_Month`.`school_of_the_month_id`,
                 `School_Of_The_Month`.`school_id`,
@@ -204,13 +215,9 @@ abstract class SchoolOfTheMonth {
                 `School_Of_The_Month`.`score`
             FROM
                 `School_Of_The_Month`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
@@ -182,7 +182,7 @@ abstract class SchoolOfTheMonth {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\SchoolOfTheMonth> Un arreglo que contiene objetos del tipo
@@ -191,7 +191,7 @@ abstract class SchoolOfTheMonth {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`School_Of_The_Month`.`school_of_the_month_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -205,14 +205,12 @@ abstract class SchoolOfTheMonth {
             FROM
                 `School_Of_The_Month`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Schools.php
+++ b/frontend/server/src/DAO/Base/Schools.php
@@ -174,7 +174,7 @@ abstract class Schools {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Schools> Un arreglo que contiene objetos del tipo
@@ -183,7 +183,7 @@ abstract class Schools {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Schools`.`school_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -197,14 +197,12 @@ abstract class Schools {
             FROM
                 `Schools`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Schools.php
+++ b/frontend/server/src/DAO/Base/Schools.php
@@ -183,10 +183,21 @@ abstract class Schools {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Schools`.`school_id`',
+        string $orden = 'school_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Schools`.`school_id`,
                 `Schools`.`country_id`,
@@ -196,13 +207,9 @@ abstract class Schools {
                 `Schools`.`score`
             FROM
                 `Schools`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
@@ -181,10 +181,21 @@ abstract class SchoolsProblemsSolvedPerMonth {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Schools_Problems_Solved_Per_Month`.`school_pspm_id`',
+        string $orden = 'school_pspm_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Schools_Problems_Solved_Per_Month`.`school_pspm_id`,
                 `Schools_Problems_Solved_Per_Month`.`school_id`,
@@ -192,13 +203,9 @@ abstract class SchoolsProblemsSolvedPerMonth {
                 `Schools_Problems_Solved_Per_Month`.`problems_solved`
             FROM
                 `Schools_Problems_Solved_Per_Month`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
@@ -172,7 +172,7 @@ abstract class SchoolsProblemsSolvedPerMonth {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\SchoolsProblemsSolvedPerMonth> Un arreglo que contiene objetos del tipo
@@ -181,7 +181,7 @@ abstract class SchoolsProblemsSolvedPerMonth {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Schools_Problems_Solved_Per_Month`.`school_pspm_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -193,14 +193,12 @@ abstract class SchoolsProblemsSolvedPerMonth {
             FROM
                 `Schools_Problems_Solved_Per_Month`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/States.php
+++ b/frontend/server/src/DAO/Base/States.php
@@ -213,7 +213,7 @@ abstract class States {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\States> Un arreglo que contiene objetos del tipo
@@ -222,7 +222,7 @@ abstract class States {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`States`.`country_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -233,14 +233,12 @@ abstract class States {
             FROM
                 `States`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/States.php
+++ b/frontend/server/src/DAO/Base/States.php
@@ -222,23 +222,30 @@ abstract class States {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`States`.`country_id`',
+        string $orden = 'country_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `States`.`country_id`,
                 `States`.`state_id`,
                 `States`.`name`
             FROM
                 `States`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SubmissionFeedback.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedback.php
@@ -191,7 +191,7 @@ abstract class SubmissionFeedback {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\SubmissionFeedback> Un arreglo que contiene objetos del tipo
@@ -200,7 +200,7 @@ abstract class SubmissionFeedback {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Submission_Feedback`.`submission_feedback_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -215,14 +215,12 @@ abstract class SubmissionFeedback {
             FROM
                 `Submission_Feedback`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SubmissionFeedback.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedback.php
@@ -200,10 +200,21 @@ abstract class SubmissionFeedback {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Submission_Feedback`.`submission_feedback_id`',
+        string $orden = 'submission_feedback_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Submission_Feedback`.`submission_feedback_id`,
                 `Submission_Feedback`.`identity_id`,
@@ -214,13 +225,9 @@ abstract class SubmissionFeedback {
                 `Submission_Feedback`.`range_bytes_end`
             FROM
                 `Submission_Feedback`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
@@ -186,10 +186,21 @@ abstract class SubmissionFeedbackThread {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Submission_Feedback_Thread`.`submission_feedback_thread_id`',
+        string $orden = 'submission_feedback_thread_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Submission_Feedback_Thread`.`submission_feedback_thread_id`,
                 `Submission_Feedback_Thread`.`submission_feedback_id`,
@@ -198,13 +209,9 @@ abstract class SubmissionFeedbackThread {
                 `Submission_Feedback_Thread`.`contents`
             FROM
                 `Submission_Feedback_Thread`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
@@ -177,7 +177,7 @@ abstract class SubmissionFeedbackThread {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\SubmissionFeedbackThread> Un arreglo que contiene objetos del tipo
@@ -186,7 +186,7 @@ abstract class SubmissionFeedbackThread {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Submission_Feedback_Thread`.`submission_feedback_thread_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -199,14 +199,12 @@ abstract class SubmissionFeedbackThread {
             FROM
                 `Submission_Feedback_Thread`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SubmissionLog.php
+++ b/frontend/server/src/DAO/Base/SubmissionLog.php
@@ -273,10 +273,21 @@ abstract class SubmissionLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Submission_Log`.`problemset_id`',
+        string $orden = 'problemset_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Submission_Log`.`problemset_id`,
                 `Submission_Log`.`submission_id`,
@@ -286,13 +297,9 @@ abstract class SubmissionLog {
                 `Submission_Log`.`time`
             FROM
                 `Submission_Log`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/SubmissionLog.php
+++ b/frontend/server/src/DAO/Base/SubmissionLog.php
@@ -264,7 +264,7 @@ abstract class SubmissionLog {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\SubmissionLog> Un arreglo que contiene objetos del tipo
@@ -273,7 +273,7 @@ abstract class SubmissionLog {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Submission_Log`.`problemset_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -287,14 +287,12 @@ abstract class SubmissionLog {
             FROM
                 `Submission_Log`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -213,7 +213,7 @@ abstract class Submissions {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Submissions> Un arreglo que contiene objetos del tipo
@@ -222,7 +222,7 @@ abstract class Submissions {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Submissions`.`submission_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -243,14 +243,12 @@ abstract class Submissions {
             FROM
                 `Submissions`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -222,10 +222,21 @@ abstract class Submissions {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Submissions`.`submission_id`',
+        string $orden = 'submission_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Submissions`.`submission_id`,
                 `Submissions`.`current_run_id`,
@@ -242,13 +253,9 @@ abstract class Submissions {
                 `Submissions`.`school_id`
             FROM
                 `Submissions`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Tags.php
+++ b/frontend/server/src/DAO/Base/Tags.php
@@ -170,23 +170,30 @@ abstract class Tags {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Tags`.`tag_id`',
+        string $orden = 'tag_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Tags`.`tag_id`,
                 `Tags`.`name`,
                 `Tags`.`public`
             FROM
                 `Tags`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Tags.php
+++ b/frontend/server/src/DAO/Base/Tags.php
@@ -161,7 +161,7 @@ abstract class Tags {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Tags> Un arreglo que contiene objetos del tipo
@@ -170,7 +170,7 @@ abstract class Tags {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Tags`.`tag_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -181,14 +181,12 @@ abstract class Tags {
             FROM
                 `Tags`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/TeamGroups.php
+++ b/frontend/server/src/DAO/Base/TeamGroups.php
@@ -179,7 +179,7 @@ abstract class TeamGroups {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\TeamGroups> Un arreglo que contiene objetos del tipo
@@ -188,7 +188,7 @@ abstract class TeamGroups {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Team_Groups`.`team_group_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -203,14 +203,12 @@ abstract class TeamGroups {
             FROM
                 `Team_Groups`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/TeamGroups.php
+++ b/frontend/server/src/DAO/Base/TeamGroups.php
@@ -188,10 +188,21 @@ abstract class TeamGroups {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Team_Groups`.`team_group_id`',
+        string $orden = 'team_group_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Team_Groups`.`team_group_id`,
                 `Team_Groups`.`acl_id`,
@@ -202,13 +213,9 @@ abstract class TeamGroups {
                 `Team_Groups`.`number_of_contestants`
             FROM
                 `Team_Groups`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/TeamUsers.php
+++ b/frontend/server/src/DAO/Base/TeamUsers.php
@@ -146,22 +146,29 @@ abstract class TeamUsers {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Team_Users`.`team_id`',
+        string $orden = 'team_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Team_Users`.`team_id`,
                 `Team_Users`.`identity_id`
             FROM
                 `Team_Users`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/TeamUsers.php
+++ b/frontend/server/src/DAO/Base/TeamUsers.php
@@ -137,7 +137,7 @@ abstract class TeamUsers {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\TeamUsers> Un arreglo que contiene objetos del tipo
@@ -146,7 +146,7 @@ abstract class TeamUsers {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Team_Users`.`team_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -156,14 +156,12 @@ abstract class TeamUsers {
             FROM
                 `Team_Users`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Teams.php
+++ b/frontend/server/src/DAO/Base/Teams.php
@@ -178,23 +178,30 @@ abstract class Teams {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Teams`.`team_id`',
+        string $orden = 'team_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Teams`.`team_id`,
                 `Teams`.`team_group_id`,
                 `Teams`.`identity_id`
             FROM
                 `Teams`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Teams.php
+++ b/frontend/server/src/DAO/Base/Teams.php
@@ -169,7 +169,7 @@ abstract class Teams {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Teams> Un arreglo que contiene objetos del tipo
@@ -178,7 +178,7 @@ abstract class Teams {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Teams`.`team_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -189,14 +189,12 @@ abstract class Teams {
             FROM
                 `Teams`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/TeamsGroupRoles.php
+++ b/frontend/server/src/DAO/Base/TeamsGroupRoles.php
@@ -144,7 +144,7 @@ abstract class TeamsGroupRoles {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\TeamsGroupRoles> Un arreglo que contiene objetos del tipo
@@ -153,7 +153,7 @@ abstract class TeamsGroupRoles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Teams_Group_Roles`.`team_group_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -164,14 +164,12 @@ abstract class TeamsGroupRoles {
             FROM
                 `Teams_Group_Roles`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/TeamsGroupRoles.php
+++ b/frontend/server/src/DAO/Base/TeamsGroupRoles.php
@@ -153,23 +153,30 @@ abstract class TeamsGroupRoles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Teams_Group_Roles`.`team_group_id`',
+        string $orden = 'team_group_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Teams_Group_Roles`.`team_group_id`,
                 `Teams_Group_Roles`.`role_id`,
                 `Teams_Group_Roles`.`acl_id`
             FROM
                 `Teams_Group_Roles`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -307,10 +307,21 @@ abstract class UserRank {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`User_Rank`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `User_Rank`.`user_id`,
                 `User_Rank`.`ranking`,
@@ -327,13 +338,9 @@ abstract class UserRank {
                 `User_Rank`.`timestamp`
             FROM
                 `User_Rank`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -298,7 +298,7 @@ abstract class UserRank {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\UserRank> Un arreglo que contiene objetos del tipo
@@ -307,7 +307,7 @@ abstract class UserRank {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`User_Rank`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -328,14 +328,12 @@ abstract class UserRank {
             FROM
                 `User_Rank`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UserRankCutoffs.php
+++ b/frontend/server/src/DAO/Base/UserRankCutoffs.php
@@ -31,7 +31,7 @@ abstract class UserRankCutoffs {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\UserRankCutoffs> Un arreglo que contiene objetos del tipo
@@ -40,7 +40,7 @@ abstract class UserRankCutoffs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`User_Rank_Cutoffs`.`score`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -51,14 +51,12 @@ abstract class UserRankCutoffs {
             FROM
                 `User_Rank_Cutoffs`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UserRankCutoffs.php
+++ b/frontend/server/src/DAO/Base/UserRankCutoffs.php
@@ -40,23 +40,30 @@ abstract class UserRankCutoffs {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`User_Rank_Cutoffs`.`score`',
+        string $orden = 'score',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `User_Rank_Cutoffs`.`score`,
                 `User_Rank_Cutoffs`.`percentile`,
                 `User_Rank_Cutoffs`.`classname`
             FROM
                 `User_Rank_Cutoffs`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UserRoles.php
+++ b/frontend/server/src/DAO/Base/UserRoles.php
@@ -144,7 +144,7 @@ abstract class UserRoles {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\UserRoles> Un arreglo que contiene objetos del tipo
@@ -153,7 +153,7 @@ abstract class UserRoles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`User_Roles`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -164,14 +164,12 @@ abstract class UserRoles {
             FROM
                 `User_Roles`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UserRoles.php
+++ b/frontend/server/src/DAO/Base/UserRoles.php
@@ -153,23 +153,30 @@ abstract class UserRoles {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`User_Roles`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `User_Roles`.`user_id`,
                 `User_Roles`.`role_id`,
                 `User_Roles`.`acl_id`
             FROM
                 `User_Roles`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Users.php
+++ b/frontend/server/src/DAO/Base/Users.php
@@ -274,7 +274,7 @@ abstract class Users {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\Users> Un arreglo que contiene objetos del tipo
@@ -283,7 +283,7 @@ abstract class Users {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Users`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -317,14 +317,12 @@ abstract class Users {
             FROM
                 `Users`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/Users.php
+++ b/frontend/server/src/DAO/Base/Users.php
@@ -283,10 +283,21 @@ abstract class Users {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Users`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Users`.`user_id`,
                 `Users`.`facebook_user_id`,
@@ -316,13 +327,9 @@ abstract class Users {
                 `Users`.`parent_email_id`
             FROM
                 `Users`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UsersBadges.php
+++ b/frontend/server/src/DAO/Base/UsersBadges.php
@@ -170,7 +170,7 @@ abstract class UsersBadges {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\UsersBadges> Un arreglo que contiene objetos del tipo
@@ -179,7 +179,7 @@ abstract class UsersBadges {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Users_Badges`.`user_badge_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -191,14 +191,12 @@ abstract class UsersBadges {
             FROM
                 `Users_Badges`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UsersBadges.php
+++ b/frontend/server/src/DAO/Base/UsersBadges.php
@@ -179,10 +179,21 @@ abstract class UsersBadges {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Users_Badges`.`user_badge_id`',
+        string $orden = 'user_badge_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Users_Badges`.`user_badge_id`,
                 `Users_Badges`.`user_id`,
@@ -190,13 +201,9 @@ abstract class UsersBadges {
                 `Users_Badges`.`assignation_time`
             FROM
                 `Users_Badges`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UsersExperiments.php
+++ b/frontend/server/src/DAO/Base/UsersExperiments.php
@@ -31,7 +31,7 @@ abstract class UsersExperiments {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\UsersExperiments> Un arreglo que contiene objetos del tipo
@@ -40,7 +40,7 @@ abstract class UsersExperiments {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '`Users_Experiments`.`user_id`',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -50,14 +50,12 @@ abstract class UsersExperiments {
             FROM
                 `Users_Experiments`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/frontend/server/src/DAO/Base/UsersExperiments.php
+++ b/frontend/server/src/DAO/Base/UsersExperiments.php
@@ -40,22 +40,29 @@ abstract class UsersExperiments {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '`Users_Experiments`.`user_id`',
+        string $orden = 'user_id',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 `Users_Experiments`.`user_id`,
                 `Users_Experiments`.`experiment`
             FROM
                 `Users_Experiments`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -290,21 +290,28 @@ abstract class {{ table.class_name }} {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        string $orden = '{{ table.fieldnames[0] }}',
+        string $orden = '{{ table.fieldnames[0].split(".")[-1] | replace("`", "") }}',
         string $tipoDeOrden = 'ASC'
     ): array {
-        $sql = '
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
             SELECT
                 {{ table.fieldnames|join(',\n                ') }}
             FROM
                 `{{ table.name }}`
-        ';
-        $sql .= (
-            ' ORDER BY `' .
-            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-            '` ' .
-            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-        );
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -281,7 +281,7 @@ abstract class {{ table.class_name }} {
      *
      * @param ?int $pagina Página a ver.
      * @param int $filasPorPagina Filas por página.
-     * @param ?string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
      * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
      *
      * @return list<\OmegaUp\DAO\VO\{{ table.class_name }}> Un arreglo que contiene objetos del tipo
@@ -290,7 +290,7 @@ abstract class {{ table.class_name }} {
     final public static function getAll(
         ?int $pagina = null,
         int $filasPorPagina = 100,
-        ?string $orden = null,
+        string $orden = '{{ table.fieldnames[0] }}',
         string $tipoDeOrden = 'ASC'
     ): array {
         $sql = '
@@ -299,14 +299,12 @@ abstract class {{ table.class_name }} {
             FROM
                 `{{ table.name }}`
         ';
-        if (!is_null($orden)) {
-            $sql .= (
-                ' ORDER BY `' .
-                \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
-                '` ' .
-                ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
-            );
-        }
+        $sql .= (
+            ' ORDER BY `' .
+            \OmegaUp\MySQLConnection::getInstance()->escape($orden) .
+            '` ' .
+            ($tipoDeOrden == 'DESC' ? 'DESC' : 'ASC')
+        );
         if (!is_null($pagina)) {
             $sql .= (
                 ' LIMIT ' .


### PR DESCRIPTION
# Description

Cambiando el orden en el metodo getAll de los daos como mandatorio, generando nuevamente los daos para que se vea los cambios efectuados en el archivo raiz dao.php

Fixes: #8015

# Comments

Son demasiadas lineas de cambios, dado que se efectuo el comando `./stuff/update-dao.sh` y se actualizaron todos los daos con los nuevos valores.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
