### PR TITLE
Cambiando el uso de LIKE CONCAT a WHERE MATCH AGAINST.

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -233,17 +233,16 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         if (!is_null($query)) {
             if (is_numeric($query)) {
                 $clauses[] = [
-                    "(
-                    p.title LIKE CONCAT('%', ?, '%') OR
-                    p.alias LIKE CONCAT('%', ?, '%') OR
+                    '(
+                    MATCH(p.alias, p.title) AGAINST (?) OR
                     p.problem_id = ?
-                    )",
-                    [$query, $query, intval($query)],
+                    )',
+                    [$query, intval($query)],
                 ];
             } else {
                 $clauses[] = [
-                    "(p.title LIKE CONCAT('%', ?, '%') OR p.alias LIKE CONCAT('%', ?, '%'))",
-                    [$query, $query],
+                    'MATCH(p.alias, p.title) AGAINST (?)',
+                    [$query],
                 ];
             }
         }
@@ -1013,8 +1012,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         if (!empty($query)) {
             $sql .= '
                 WHERE
-                    p.`title` LIKE CONCAT("%", ?, "%") OR
-                    p.`alias` LIKE CONCAT("%", ?, "%")
+                    MATCH(p.alias, p.title) AGAINST (?)
             ';
             $params[] = $query;
             $params[] = $query;
@@ -1111,10 +1109,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         $sqlQuery = '';
         if (!empty($query)) {
             $sqlQuery = ' AND (
-                p.title LIKE CONCAT("%", ?, "%") OR
-                p.alias LIKE CONCAT("%", ?, "%")
+                MATCH(p.alias, p.title) AGAINST (?)
             )';
-            $params[] = $query;
             $params[] = $query;
         }
 
@@ -1183,10 +1179,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         $sqlQuery = '';
         if (!empty($query)) {
             $sqlQuery = ' AND (
-                p.title LIKE CONCAT("%", ?, "%") OR
-                p.alias LIKE CONCAT("%", ?, "%")
+                MATCH(p.alias, p.title) AGAINST (?)
             )';
-            $params[] = $query;
             $params[] = $query;
         }
 
@@ -1567,8 +1561,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                             Problems p
                         WHERE
                             (
-                                title LIKE CONCAT('%', ?, '%') OR
-                                alias LIKE CONCAT('%', ?, '%') OR
+                                MATCH(p.alias, p.title) AGAINST (?)
                                 problem_id = ?
                             )
                         UNION ALL


### PR DESCRIPTION
# Description

Quitando el uso de LIKE CONCAT a WHERE MATCH AGAINST para las consultas dadas en el archivo `DAO/Problems.php`.

Fixes: #8273
