### PR TITLE
Improve error handling in `ProblemArtifacts` and `GitServerBrowser` for problem downloads

### DIFF
--- a/frontend/server/src/ProblemArtifacts.php
+++ b/frontend/server/src/ProblemArtifacts.php
@@ -265,7 +265,7 @@ class ProblemArtifacts {
             passthru: true
         );
         $browser->headers[] = 'Accept: application/zip';
-        $response = $browser->exec();
+        $browser->exec();
         /** @var int */
         $httpStatusCode = curl_getinfo($browser->curl, CURLINFO_HTTP_CODE);
         if (
@@ -275,7 +275,7 @@ class ProblemArtifacts {
         ) {
             $this->log->error(
                 "Failed to download {$this->alias}:{$this->revision}. " .
-                "HTTP {$httpStatusCode}: \"{$response}\""
+                "HTTP {$httpStatusCode}"
             );
             throw new \OmegaUp\Exceptions\ServiceUnavailableException();
         }
@@ -371,13 +371,17 @@ class GitServerBrowser {
         curl_close($this->curl);
     }
 
-    public function exec(): string {
+    public function exec(): string|bool {
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->headers);
         $response = curl_exec($this->curl);
+        if ($response === true) {
+            //Passthru already sent output to browser, just return true
+            return true; //or return empty string if we don't want to change
+                         //the function signature
+        }
         if (!is_string($response)) {
             $curlErrno = curl_errno($this->curl);
             $curlError = curl_error($this->curl);
-            // Only log error if we're not in passthru mode to avoid sending output before headers
             if (!$this->passthru) {
                 \Monolog\Registry::omegaup()->withName('GitBrowser')->error(
                     "Failed to get contents for {$this->url}. " .


### PR DESCRIPTION
# Description

- Updated `ProblemArtifacts::download()` to handle HTTP status codes and log errors more effectively.
- Enhanced `GitServerBrowser::exec()` to correctly handle passthru mode and avoid `ServiceUnavailableException` for successful responses.
- Improved logging to provide clearer information about failures during problem artifact retrieval and downloads.

Part of: #8339

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
