### PR TITLE
Agregando el metodo countAll() a todos los DAO

### DIFF
--- a/frontend/server/src/DAO/Base/ACLs.php
+++ b/frontend/server/src/DAO/Base/ACLs.php
@@ -111,6 +111,25 @@ abstract class ACLs {
     }
 
     /**
+     * Contar todos los registros en `ACLs`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `ACLs`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/AIEditorialJobs.php
+++ b/frontend/server/src/DAO/Base/AIEditorialJobs.php
@@ -229,6 +229,25 @@ abstract class AIEditorialJobs {
     }
 
     /**
+     * Contar todos los registros en `AI_Editorial_Jobs`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `AI_Editorial_Jobs`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/APITokens.php
+++ b/frontend/server/src/DAO/Base/APITokens.php
@@ -130,6 +130,25 @@ abstract class APITokens {
     }
 
     /**
+     * Contar todos los registros en `API_Tokens`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `API_Tokens`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Announcement.php
+++ b/frontend/server/src/DAO/Base/Announcement.php
@@ -119,6 +119,25 @@ abstract class Announcement {
     }
 
     /**
+     * Contar todos los registros en `Announcement`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Announcement`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Assignments.php
+++ b/frontend/server/src/DAO/Base/Assignments.php
@@ -160,6 +160,25 @@ abstract class Assignments {
     }
 
     /**
+     * Contar todos los registros en `Assignments`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Assignments`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -195,6 +195,25 @@ abstract class AuthTokens {
     }
 
     /**
+     * Contar todos los registros en `Auth_Tokens`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Auth_Tokens`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/CarouselItems.php
+++ b/frontend/server/src/DAO/Base/CarouselItems.php
@@ -144,6 +144,25 @@ abstract class CarouselItems {
     }
 
     /**
+     * Contar todos los registros en `Carousel_Items`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Carousel_Items`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Certificates.php
+++ b/frontend/server/src/DAO/Base/Certificates.php
@@ -150,6 +150,25 @@ abstract class Certificates {
     }
 
     /**
+     * Contar todos los registros en `Certificates`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Certificates`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Clarifications.php
+++ b/frontend/server/src/DAO/Base/Clarifications.php
@@ -146,6 +146,25 @@ abstract class Clarifications {
     }
 
     /**
+     * Contar todos los registros en `Clarifications`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Clarifications`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/CoderOfTheMonth.php
@@ -153,6 +153,25 @@ abstract class CoderOfTheMonth {
     }
 
     /**
+     * Contar todos los registros en `Coder_Of_The_Month`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Coder_Of_The_Month`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ContestLog.php
+++ b/frontend/server/src/DAO/Base/ContestLog.php
@@ -129,6 +129,25 @@ abstract class ContestLog {
     }
 
     /**
+     * Contar todos los registros en `Contest_Log`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Contest_Log`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Contests.php
+++ b/frontend/server/src/DAO/Base/Contests.php
@@ -223,6 +223,25 @@ abstract class Contests {
     }
 
     /**
+     * Contar todos los registros en `Contests`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Contests`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Countries.php
+++ b/frontend/server/src/DAO/Base/Countries.php
@@ -149,6 +149,25 @@ abstract class Countries {
     }
 
     /**
+     * Contar todos los registros en `Countries`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Countries`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/CourseCloneLog.php
+++ b/frontend/server/src/DAO/Base/CourseCloneLog.php
@@ -139,6 +139,25 @@ abstract class CourseCloneLog {
     }
 
     /**
+     * Contar todos los registros en `Course_Clone_Log`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Course_Clone_Log`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequest.php
@@ -230,6 +230,25 @@ abstract class CourseIdentityRequest {
     }
 
     /**
+     * Contar todos los registros en `Course_Identity_Request`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Course_Identity_Request`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
@@ -137,6 +137,25 @@ abstract class CourseIdentityRequestHistory {
     }
 
     /**
+     * Contar todos los registros en `Course_Identity_Request_History`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Course_Identity_Request_History`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Courses.php
+++ b/frontend/server/src/DAO/Base/Courses.php
@@ -181,6 +181,25 @@ abstract class Courses {
     }
 
     /**
+     * Contar todos los registros en `Courses`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Courses`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Emails.php
+++ b/frontend/server/src/DAO/Base/Emails.php
@@ -114,6 +114,25 @@ abstract class Emails {
     }
 
     /**
+     * Contar todos los registros en `Emails`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Emails`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Favorites.php
+++ b/frontend/server/src/DAO/Base/Favorites.php
@@ -84,6 +84,25 @@ abstract class Favorites {
     }
 
     /**
+     * Contar todos los registros en `Favorites`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Favorites`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/GroupRoles.php
+++ b/frontend/server/src/DAO/Base/GroupRoles.php
@@ -89,6 +89,25 @@ abstract class GroupRoles {
     }
 
     /**
+     * Contar todos los registros en `Group_Roles`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Group_Roles`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -125,6 +125,25 @@ abstract class Groups {
     }
 
     /**
+     * Contar todos los registros en `Groups_`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Groups_`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/GroupsIdentities.php
+++ b/frontend/server/src/DAO/Base/GroupsIdentities.php
@@ -210,6 +210,25 @@ abstract class GroupsIdentities {
     }
 
     /**
+     * Contar todos los registros en `Groups_Identities`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Groups_Identities`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/GroupsScoreboards.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboards.php
@@ -125,6 +125,25 @@ abstract class GroupsScoreboards {
     }
 
     /**
+     * Contar todos los registros en `Groups_Scoreboards`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Groups_Scoreboards`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
@@ -174,6 +174,25 @@ abstract class GroupsScoreboardsProblemsets {
     }
 
     /**
+     * Contar todos los registros en `Groups_Scoreboards_Problemsets`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Groups_Scoreboards_Problemsets`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Identities.php
+++ b/frontend/server/src/DAO/Base/Identities.php
@@ -143,6 +143,25 @@ abstract class Identities {
     }
 
     /**
+     * Contar todos los registros en `Identities`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Identities`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/Base/IdentitiesSchools.php
@@ -131,6 +131,25 @@ abstract class IdentitiesSchools {
     }
 
     /**
+     * Contar todos los registros en `Identities_Schools`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Identities_Schools`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Interviews.php
+++ b/frontend/server/src/DAO/Base/Interviews.php
@@ -134,6 +134,25 @@ abstract class Interviews {
     }
 
     /**
+     * Contar todos los registros en `Interviews`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Interviews`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Languages.php
+++ b/frontend/server/src/DAO/Base/Languages.php
@@ -110,6 +110,25 @@ abstract class Languages {
     }
 
     /**
+     * Contar todos los registros en `Languages`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Languages`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Messages.php
+++ b/frontend/server/src/DAO/Base/Messages.php
@@ -129,6 +129,25 @@ abstract class Messages {
     }
 
     /**
+     * Contar todos los registros en `Messages`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Messages`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Notifications.php
+++ b/frontend/server/src/DAO/Base/Notifications.php
@@ -122,6 +122,25 @@ abstract class Notifications {
     }
 
     /**
+     * Contar todos los registros en `Notifications`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Notifications`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Permissions.php
+++ b/frontend/server/src/DAO/Base/Permissions.php
@@ -110,6 +110,25 @@ abstract class Permissions {
     }
 
     /**
+     * Contar todos los registros en `Permissions`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Permissions`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Plagiarisms.php
+++ b/frontend/server/src/DAO/Base/Plagiarisms.php
@@ -142,6 +142,25 @@ abstract class Plagiarisms {
     }
 
     /**
+     * Contar todos los registros en `Plagiarisms`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Plagiarisms`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
@@ -123,6 +123,25 @@ abstract class PrivacyStatementConsentLog {
     }
 
     /**
+     * Contar todos los registros en `PrivacyStatement_Consent_Log`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `PrivacyStatement_Consent_Log`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/PrivacyStatements.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatements.php
@@ -110,6 +110,25 @@ abstract class PrivacyStatements {
     }
 
     /**
+     * Contar todos los registros en `PrivacyStatements`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `PrivacyStatements`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
+++ b/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
@@ -117,6 +117,25 @@ abstract class ProblemOfTheWeek {
     }
 
     /**
+     * Contar todos los registros en `Problem_Of_The_Week`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problem_Of_The_Week`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemViewed.php
+++ b/frontend/server/src/DAO/Base/ProblemViewed.php
@@ -172,6 +172,25 @@ abstract class ProblemViewed {
     }
 
     /**
+     * Contar todos los registros en `Problem_Viewed`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problem_Viewed`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Problems.php
+++ b/frontend/server/src/DAO/Base/Problems.php
@@ -187,6 +187,25 @@ abstract class Problems {
     }
 
     /**
+     * Contar todos los registros en `Problems`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problems`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsForfeited.php
+++ b/frontend/server/src/DAO/Base/ProblemsForfeited.php
@@ -172,6 +172,25 @@ abstract class ProblemsForfeited {
     }
 
     /**
+     * Contar todos los registros en `Problems_Forfeited`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problems_Forfeited`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsLanguages.php
+++ b/frontend/server/src/DAO/Base/ProblemsLanguages.php
@@ -84,6 +84,25 @@ abstract class ProblemsLanguages {
     }
 
     /**
+     * Contar todos los registros en `Problems_Languages`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problems_Languages`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsTags.php
+++ b/frontend/server/src/DAO/Base/ProblemsTags.php
@@ -168,6 +168,25 @@ abstract class ProblemsTags {
     }
 
     /**
+     * Contar todos los registros en `Problems_Tags`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problems_Tags`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentities.php
@@ -228,6 +228,25 @@ abstract class ProblemsetIdentities {
     }
 
     /**
+     * Contar todos los registros en `Problemset_Identities`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problemset_Identities`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
@@ -202,6 +202,25 @@ abstract class ProblemsetIdentityRequest {
     }
 
     /**
+     * Contar todos los registros en `Problemset_Identity_Request`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problemset_Identity_Request`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
@@ -137,6 +137,25 @@ abstract class ProblemsetIdentityRequestHistory {
     }
 
     /**
+     * Contar todos los registros en `Problemset_Identity_Request_History`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problemset_Identity_Request_History`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
@@ -187,6 +187,25 @@ abstract class ProblemsetProblemOpened {
     }
 
     /**
+     * Contar todos los registros en `Problemset_Problem_Opened`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problemset_Problem_Opened`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblems.php
@@ -192,6 +192,25 @@ abstract class ProblemsetProblems {
     }
 
     /**
+     * Contar todos los registros en `Problemset_Problems`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problemset_Problems`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -153,6 +153,25 @@ abstract class Problemsets {
     }
 
     /**
+     * Contar todos los registros en `Problemsets`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problemsets`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/QualityNominationComments.php
+++ b/frontend/server/src/DAO/Base/QualityNominationComments.php
@@ -133,6 +133,25 @@ abstract class QualityNominationComments {
     }
 
     /**
+     * Contar todos los registros en `QualityNomination_Comments`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `QualityNomination_Comments`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/QualityNominationLog.php
+++ b/frontend/server/src/DAO/Base/QualityNominationLog.php
@@ -132,6 +132,25 @@ abstract class QualityNominationLog {
     }
 
     /**
+     * Contar todos los registros en `QualityNomination_Log`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `QualityNomination_Log`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/QualityNominationReviewers.php
+++ b/frontend/server/src/DAO/Base/QualityNominationReviewers.php
@@ -84,6 +84,25 @@ abstract class QualityNominationReviewers {
     }
 
     /**
+     * Contar todos los registros en `QualityNomination_Reviewers`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `QualityNomination_Reviewers`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/QualityNominations.php
+++ b/frontend/server/src/DAO/Base/QualityNominations.php
@@ -132,6 +132,25 @@ abstract class QualityNominations {
     }
 
     /**
+     * Contar todos los registros en `QualityNominations`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `QualityNominations`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Roles.php
+++ b/frontend/server/src/DAO/Base/Roles.php
@@ -110,6 +110,25 @@ abstract class Roles {
     }
 
     /**
+     * Contar todos los registros en `Roles`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Roles`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/RolesPermissions.php
+++ b/frontend/server/src/DAO/Base/RolesPermissions.php
@@ -84,6 +84,25 @@ abstract class RolesPermissions {
     }
 
     /**
+     * Contar todos los registros en `Roles_Permissions`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Roles_Permissions`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/RunCounts.php
+++ b/frontend/server/src/DAO/Base/RunCounts.php
@@ -155,6 +155,25 @@ abstract class RunCounts {
     }
 
     /**
+     * Contar todos los registros en `Run_Counts`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Run_Counts`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -150,6 +150,25 @@ abstract class Runs {
     }
 
     /**
+     * Contar todos los registros en `Runs`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Runs`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/RunsGroups.php
+++ b/frontend/server/src/DAO/Base/RunsGroups.php
@@ -120,6 +120,25 @@ abstract class RunsGroups {
     }
 
     /**
+     * Contar todos los registros en `Runs_Groups`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Runs_Groups`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
@@ -131,6 +131,25 @@ abstract class SchoolOfTheMonth {
     }
 
     /**
+     * Contar todos los registros en `School_Of_The_Month`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `School_Of_The_Month`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Schools.php
+++ b/frontend/server/src/DAO/Base/Schools.php
@@ -123,6 +123,25 @@ abstract class Schools {
     }
 
     /**
+     * Contar todos los registros en `Schools`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Schools`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
@@ -121,6 +121,25 @@ abstract class SchoolsProblemsSolvedPerMonth {
     }
 
     /**
+     * Contar todos los registros en `Schools_Problems_Solved_Per_Month`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Schools_Problems_Solved_Per_Month`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/States.php
+++ b/frontend/server/src/DAO/Base/States.php
@@ -160,6 +160,25 @@ abstract class States {
     }
 
     /**
+     * Contar todos los registros en `States`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `States`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/SubmissionFeedback.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedback.php
@@ -140,6 +140,25 @@ abstract class SubmissionFeedback {
     }
 
     /**
+     * Contar todos los registros en `Submission_Feedback`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Submission_Feedback`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
@@ -126,6 +126,25 @@ abstract class SubmissionFeedbackThread {
     }
 
     /**
+     * Contar todos los registros en `Submission_Feedback_Thread`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Submission_Feedback_Thread`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/SubmissionLog.php
+++ b/frontend/server/src/DAO/Base/SubmissionLog.php
@@ -213,6 +213,25 @@ abstract class SubmissionLog {
     }
 
     /**
+     * Contar todos los registros en `Submission_Log`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Submission_Log`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -162,6 +162,25 @@ abstract class Submissions {
     }
 
     /**
+     * Contar todos los registros en `Submissions`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Submissions`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Tags.php
+++ b/frontend/server/src/DAO/Base/Tags.php
@@ -110,6 +110,25 @@ abstract class Tags {
     }
 
     /**
+     * Contar todos los registros en `Tags`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Tags`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/TeamGroups.php
+++ b/frontend/server/src/DAO/Base/TeamGroups.php
@@ -128,6 +128,25 @@ abstract class TeamGroups {
     }
 
     /**
+     * Contar todos los registros en `Team_Groups`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Team_Groups`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/TeamUsers.php
+++ b/frontend/server/src/DAO/Base/TeamUsers.php
@@ -84,6 +84,25 @@ abstract class TeamUsers {
     }
 
     /**
+     * Contar todos los registros en `Team_Users`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Team_Users`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Teams.php
+++ b/frontend/server/src/DAO/Base/Teams.php
@@ -118,6 +118,25 @@ abstract class Teams {
     }
 
     /**
+     * Contar todos los registros en `Teams`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Teams`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/TeamsGroupRoles.php
+++ b/frontend/server/src/DAO/Base/TeamsGroupRoles.php
@@ -89,6 +89,25 @@ abstract class TeamsGroupRoles {
     }
 
     /**
+     * Contar todos los registros en `Teams_Group_Roles`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Teams_Group_Roles`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -247,6 +247,25 @@ abstract class UserRank {
     }
 
     /**
+     * Contar todos los registros en `User_Rank`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `User_Rank`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/UserRoles.php
+++ b/frontend/server/src/DAO/Base/UserRoles.php
@@ -89,6 +89,25 @@ abstract class UserRoles {
     }
 
     /**
+     * Contar todos los registros en `User_Roles`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `User_Roles`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/Users.php
+++ b/frontend/server/src/DAO/Base/Users.php
@@ -223,6 +223,25 @@ abstract class Users {
     }
 
     /**
+     * Contar todos los registros en `Users`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Users`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/server/src/DAO/Base/UsersBadges.php
+++ b/frontend/server/src/DAO/Base/UsersBadges.php
@@ -119,6 +119,25 @@ abstract class UsersBadges {
     }
 
     /**
+     * Contar todos los registros en `Users_Badges`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Users_Badges`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en

--- a/frontend/tests/controllers/CertificatesTest.php
+++ b/frontend/tests/controllers/CertificatesTest.php
@@ -110,22 +110,25 @@ class CertificatesTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $this->assertEquals($certificatesCutoff, $contest->certificate_cutoff);
 
-        $certificates = \OmegaUp\DAO\Certificates::getAll();
-        $this->assertCount(0, $certificates);
-        $notifications = \OmegaUp\DAO\Notifications::getAll();
-        $this->assertCount(0, $notifications);
+        $certificates = \OmegaUp\DAO\Certificates::countAll();
+        $this->assertSame(0, $certificates);
+        $notifications = \OmegaUp\DAO\Notifications::countAll();
+        $this->assertSame(0, $notifications);
 
         //Adds the certificates only for one contest to the database,
         //so it must be called after each successful call to the API
         \OmegaUp\Test\Utils::runGenerateContestCertificates();
 
-        $certificates = \OmegaUp\DAO\Certificates::getAll();
+        $certificates = \OmegaUp\DAO\Certificates::countAll();
         //Should add one certificate per contestant
-        $this->assertCount($numOfIdentities, $certificates);
+        $this->assertSame($numOfIdentities, $certificates);
 
-        $notifications = \OmegaUp\DAO\Notifications::getAll();
+        $notifications = \OmegaUp\DAO\Notifications::countAll();
         //Should add one notification per contestant
-        $this->assertCount($numOfIdentities, $notifications);
+        $this->assertSame($numOfIdentities, $notifications);
+
+        $certificates = \OmegaUp\DAO\Certificates::getAll();
+        $notifications = \OmegaUp\DAO\Notifications::getAll();
 
         //Check the certificates data
         $verificationCodes = [];

--- a/stuff/dao_templates/dao.php
+++ b/stuff/dao_templates/dao.php
@@ -230,6 +230,25 @@ abstract class {{ table.class_name }} {
     }
 
     /**
+     * Contar todos los registros en `{{ table.name }}`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `{{ table.name }}`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
      * Eliminar registros.
      *
      * Este metodo eliminará el registro identificado por la llave primaria en


### PR DESCRIPTION

# Description

Se agrego el metodo `countAll()` a todos los DAO, esto por si se llega a requerir en un futuro. Actualmente, se usara solamente para la parte de `CertificatesTest.php`, que es el archivo del fix adjunto.

Fixes: #8269

# Comments

Aun creando el metodo, se requirio mandar a llamar una sola ves a `getAll()`, por el uso que este tiene al checar con los valores que arroja cada tabla.
