### PR TITLE
Agregando un tipo requerido  a `CourseDetails` en las pruebas de `Jest`

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Build docker containers

--- a/frontend/www/js/omegaup/components/arena/Course.test.ts
+++ b/frontend/www/js/omegaup/components/arena/Course.test.ts
@@ -59,6 +59,7 @@ describe('Course.vue', () => {
     start_time: new Date(),
     student_count: 1,
     unlimited_duration: false,
+    teaching_assistant_enabled: false,
   };
 
   const scoreboard: types.Scoreboard = {

--- a/frontend/www/js/omegaup/components/course/CloneWithToken.test.ts
+++ b/frontend/www/js/omegaup/components/course/CloneWithToken.test.ts
@@ -32,6 +32,7 @@ describe('CloneWithToken.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: false,
+          teaching_assistant_enabled: false,
         } as types.CourseDetails,
         username: 'omegaup',
         classname: 'user-rank-unranked',

--- a/frontend/www/js/omegaup/components/course/Details.test.ts
+++ b/frontend/www/js/omegaup/components/course/Details.test.ts
@@ -33,6 +33,7 @@ describe('Details.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: false,
+          teaching_assistant_enabled: false,
         } as types.CourseDetails,
         progress: {} as types.AssignmentProgress,
       },
@@ -74,6 +75,7 @@ describe('Details.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: false,
+          teaching_assistant_enabled: false,
         } as types.CourseDetails,
         progress: {} as types.AssignmentProgress,
       },
@@ -130,6 +132,7 @@ describe('Details.vue', () => {
           start_time: new Date(),
           student_count: 1,
           unlimited_duration: true,
+          teaching_assistant_enabled: false,
         } as types.CourseDetails,
         progress: {
           'test-assignment': {

--- a/frontend/www/js/omegaup/components/course/Edit.test.ts
+++ b/frontend/www/js/omegaup/components/course/Edit.test.ts
@@ -53,6 +53,7 @@ describe('Edit.vue', () => {
             start_time: new Date(),
             student_count: 1,
             unlimited_duration: false,
+            teaching_assistant_enabled: false,
           },
           allLanguages: { kp: 'Karel Pascal', kj: 'Karel Java' },
           assignmentProblems: [],

--- a/frontend/www/js/omegaup/components/course/Form.test.ts
+++ b/frontend/www/js/omegaup/components/course/Form.test.ts
@@ -31,6 +31,7 @@ const baseCourseFormProps = {
     student_count: 3,
     unlimited_duration: false,
     languages: ['py2'],
+    teaching_assistant_enabled: false,
   } as types.CourseDetails,
   update: true,
   searchResultSchools: [

--- a/frontend/www/js/omegaup/components/course/Intro.test.ts
+++ b/frontend/www/js/omegaup/components/course/Intro.test.ts
@@ -27,6 +27,7 @@ const courseDetails: types.CourseDetails = {
   start_time: new Date(),
   student_count: 1,
   unlimited_duration: false,
+  teaching_assistant_enabled: false,
 };
 
 const statements: {


### PR DESCRIPTION
# Description

Después de aprobarse el PR #8398 aún faltaban actualizar algunos tipos en las pruebas de Jest y esto ocasionó que el deploy automático fallara.

Con este cambio se arreglan los errores y permite que el deploy se pueda hacer de manera correcta


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
