### PR TITLE
Agregando indice para la columna `parental_verification_token`

### DIFF
--- a/frontend/database/00246_add_index_verification_users.sql
+++ b/frontend/database/00246_add_index_verification_users.sql
@@ -1,0 +1,2 @@
+-- Add index to Users table on parental_verification_token column
+CREATE INDEX idx_users_parental_verification ON Users(parental_verification_token);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1289,6 +1289,7 @@ CREATE TABLE `Users` (
   KEY `fk_parent_email_id` (`parent_email_id`),
   KEY `verification_id` (`verification_id`),
   KEY `idx_is_private` (`is_private`),
+  KEY `idx_users_parental_verification` (`parental_verification_token`),
   CONSTRAINT `fk_main_email_id` FOREIGN KEY (`main_email_id`) REFERENCES `Emails` (`email_id`),
   CONSTRAINT `fk_main_identity_id` FOREIGN KEY (`main_identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_parent_email_id` FOREIGN KEY (`parent_email_id`) REFERENCES `Emails` (`email_id`)


### PR DESCRIPTION

# Description

Agregando el índice `idx_users_parental_verification` para la columna `parental_verification_token` de la tabla de `Users`.

Fixes: #8432

# Antes

| Table | Type   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| u | ALL | fk_main_identity_id | Using where |
| i | eq_ref | PRIMARY | Using index |

# Después

| Table | Type   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| u | ref | fk_main_identity_id,idx_users_parental_verification | Using where |
| i | eq_ref | PRIMARY | Using index |
