### PR TITLE
Agregando indice para los campos alias y name de la tabla Team_Groups.

### DIFF
--- a/frontend/database/00252_add_index_team_alias_name.sql
+++ b/frontend/database/00252_add_index_team_alias_name.sql
@@ -1,0 +1,2 @@
+-- Add index to Team_Groups table on alias, name column
+CREATE INDEX idx_team_groups_alias_name ON Team_Groups (alias, name);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1163,6 +1163,7 @@ CREATE TABLE `Team_Groups` (
   KEY `acl_id` (`acl_id`),
   KEY `idx_create_time` (`create_time`),
   KEY `idx_team_groups_name` (`name`),
+  KEY `idx_team_groups_alias_name` (`alias`,`name`),
   CONSTRAINT `fk_tg_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
# Description

Se agrego el índice `idx_team_groups_alias_name` para los campos `alias` y `name` de la tabla `Team_Groups`.

Fixes: #8441

# Antes

| Table | Type   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| tg | ALL |  | Using where |

# Después

| Table | Type   | Possible Keys                      | Extra           |
|-------|--------|-----------------------------------|----------------|
| tg | index | idx_team_groups_alias_name | Using where; Using index |