### PR TITLE
Arreglando errores de claves indefinidas en arrays para NewRelic

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -202,7 +202,7 @@ class ApiCaller {
         //                       ^
         $args = preg_split('/[\/?]/', $apiAsUrl);
 
-        if ($args === false || count($args) < 2) {
+        if ($args === false || count($args) < 4) {
             self::$log->error(
                 'Api called with URI with less args than expected: ' . count(
                     $args

--- a/frontend/server/src/ArrayHelper.php
+++ b/frontend/server/src/ArrayHelper.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * Helper class for safe array access to prevent undefined key errors
+ */
+class ArrayHelper {
+    /**
+     * Safely get array value with default fallback
+     *
+     * @template T
+     * @param array<string|int, mixed> $array
+     * @param string|int $key
+     * @param T $default
+     * @return mixed|T
+     */
+    public static function get(array $array, $key, $default = null) {
+        return array_key_exists($key, $array) ? $array[$key] : $default;
+    }
+
+    /**
+     * Safely get string from array with default fallback
+     *
+     * @param array<string|int, mixed> $array
+     * @param string|int $key
+     * @param string $default
+     * @return string
+     */
+    public static function getString(
+        array $array,
+        $key,
+        string $default = ''
+    ): string {
+        $value = self::get($array, $key, $default);
+        return is_string($value) ? $value : $default;
+    }
+
+    /**
+     * Safely get integer from array with default fallback
+     *
+     * @param array<string|int, mixed> $array
+     * @param string|int $key
+     * @param int $default
+     * @return int
+     */
+    public static function getInt(array $array, $key, int $default = 0): int {
+        $value = self::get($array, $key, $default);
+        return is_numeric($value) ? intval($value) : $default;
+    }
+
+    /**
+     * Safely get float from array with default fallback
+     *
+     * @param array<string|int, mixed> $array
+     * @param string|int $key
+     * @param float $default
+     * @return float
+     */
+    public static function getFloat(
+        array $array,
+        $key,
+        float $default = 0.0
+    ): float {
+        $value = self::get($array, $key, $default);
+        return is_numeric($value) ? floatval($value) : $default;
+    }
+
+    /**
+     * Safely get boolean from array with default fallback
+     *
+     * @param array<string|int, mixed> $array
+     * @param string|int $key
+     * @param bool $default
+     * @return bool
+     */
+    public static function getBool(
+        array $array,
+        $key,
+        bool $default = false
+    ): bool {
+        $value = self::get($array, $key, $default);
+        return is_bool($value) ? $value : boolval($value);
+    }
+
+    /**
+     * Check if array has all required keys
+     *
+     * @param array<string|int, mixed> $array
+     * @param array<string|int> $requiredKeys
+     * @return bool
+     */
+    public static function hasKeys(array $array, array $requiredKeys): bool {
+        foreach ($requiredKeys as $key) {
+            if (!array_key_exists($key, $array)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Safely access nested array values
+     *
+     * @template T
+     * @param array<string|int, mixed> $array
+     * @param array<string|int> $keys Path to the value (e.g., ['user', 'profile', 'score'])
+     * @param T $default
+     * @return mixed|T
+     */
+    public static function getPath(array $array, array $keys, $default = null) {
+        $current = $array;
+
+        foreach ($keys as $key) {
+            if (!is_array($current) || !array_key_exists($key, $current)) {
+                return $default;
+            }
+            $current = $current[$key];
+        }
+
+        return $current;
+    }
+}

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -236,13 +236,20 @@ class Identity extends \OmegaUp\Controllers\Controller {
                 ) ? null : strval(
                     $identity['state_id']
                 );
+                if (!array_key_exists('gender', $identity)) {
+                    throw new \OmegaUp\Exceptions\InvalidParameterException(
+                        'parameterEmpty',
+                        'gender'
+                    );
+                }
+                $gender = $identity['gender'];
                 $newIdentity = self::createIdentity(
                     $identity['username'],
                     $identity['name'],
                     $identity['password'],
                     $countryId,
                     $stateId,
-                    $identity['gender'],
+                    $gender,
                     $group->alias
                 );
 
@@ -409,13 +416,20 @@ class Identity extends \OmegaUp\Controllers\Controller {
                 ) ? null : strval(
                     $teamIdentity['state_id']
                 );
+                if (!array_key_exists('gender', $teamIdentity)) {
+                    throw new \OmegaUp\Exceptions\InvalidParameterException(
+                        'parameterEmpty',
+                        'gender'
+                    );
+                }
+                $gender = $teamIdentity['gender'];
                 $newIdentity = self::createIdentityTeam(
                     $teamIdentity['username'],
                     $teamIdentity['name'],
                     $teamIdentity['password'],
                     $countryId,
                     $stateId,
-                    $teamIdentity['gender'],
+                    $gender,
                     $teamGroup->alias
                 );
 

--- a/frontend/server/src/Controllers/Problemset.php
+++ b/frontend/server/src/Controllers/Problemset.php
@@ -300,8 +300,10 @@ class Problemset extends \OmegaUp\Controllers\Controller {
                 count($r['tokens']) >= 4
             ) {
                 /** @psalm-suppress MixedArrayAccess $r['tokens'] is definitely an array here. */
-                $token = strval($r['tokens'][3]);
-                $request['token'] = $token;
+                $token = \OmegaUp\ArrayHelper::getString($r['tokens'], 3, '');
+                if (!empty($token)) {
+                    $request['token'] = $token;
+                }
             }
             $response = \OmegaUp\Controllers\Contest::validateDetails(
                 $problemset['contest_alias'],

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -4381,10 +4381,10 @@ Gets a list of tags
 
 ### Parameters
 
-| Name    | Type    | Description |
-| ------- | ------- | ----------- |
-| `query` | `mixed` |             |
-| `term`  | `mixed` |             |
+| Name    | Type           | Description |
+| ------- | -------------- | ----------- |
+| `query` | `null\|string` |             |
+| `term`  | `null\|string` |             |
 
 ### Returns
 

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -1442,8 +1442,12 @@ class Run extends \OmegaUp\Controllers\Controller {
             $details['contest_score'] = 0.0;
             $details['score'] = 0.0;
         } else {
-            $details['contest_score'] = floatval($details['contest_score']);
-            $details['score'] = floatval($details['score']);
+            $details['contest_score'] = floatval(
+                \OmegaUp\ArrayHelper::getFloat($details, 'contest_score', 0.0)
+            );
+            $details['score'] = floatval(
+                \OmegaUp\ArrayHelper::getFloat($details, 'score', 0.0)
+            );
         }
         if (!OMEGAUP_LOCKDOWN && $showDetails) {
             $response['details'] = $details;

--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -19,17 +19,20 @@ class Tag extends \OmegaUp\Controllers\Controller {
     /**
      * Gets a list of tags
      *
-     * @omegaup-request-param mixed $query
-     * @omegaup-request-param mixed $term
+     * @omegaup-request-param null|string $query
+     * @omegaup-request-param null|string $term
      *
      * @return list<array{name: string}>
      */
     public static function apiList(\OmegaUp\Request $r) {
         $param = '';
-        if (is_string($r['term'])) {
-            $param = $r['term'];
-        } elseif (is_string($r['query'])) {
-            $param = $r['query'];
+        $term = $r->ensureOptionalString('term');
+        $query = $r->ensureOptionalString('query');
+
+        if (!is_null($term)) {
+            $param = $term;
+        } elseif (!is_null($query)) {
+            $param = $query;
         } else {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterEmpty',

--- a/frontend/tests/controllers/ArrayKeyErrorTest.php
+++ b/frontend/tests/controllers/ArrayKeyErrorTest.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * Tests for undefined array key errors prevention
+ */
+class ArrayKeyErrorTest extends \OmegaUp\Test\ControllerTestCase {
+    /**
+     * Test that ArrayHelper prevents undefined array key errors
+     */
+    public function testArrayHelperPreventsErrors() {
+        $emptyArray = [];
+
+        // These should not throw "Undefined array key" errors
+        $result1 = \OmegaUp\ArrayHelper::get(
+            $emptyArray,
+            'missing_key',
+            'default'
+        );
+        $this->assertSame('default', $result1);
+
+        $result2 = \OmegaUp\ArrayHelper::getString(
+            $emptyArray,
+            'missing_key',
+            'default_string'
+        );
+        $this->assertSame('default_string', $result2);
+
+        $result3 = \OmegaUp\ArrayHelper::getInt($emptyArray, 'missing_key', 42);
+        $this->assertSame(42, $result3);
+
+        $result4 = \OmegaUp\ArrayHelper::getFloat(
+            $emptyArray,
+            'missing_key',
+            3.14
+        );
+        $this->assertSame(3.14, $result4);
+    }
+
+    /**
+     * Test scoreboard group score handling with empty keys
+     */
+    public function testScoreboardEmptyGroupKeys() {
+        // Simulate the scoreboard scenario that caused the NewRelic error
+        $scoreByGroupArray = [
+            '' => 50.0,  // Empty key that causes "Undefined array key" error
+            'group1' => 75.0,
+            'group2' => 90.0
+        ];
+
+        // Test that ArrayHelper handles empty keys safely
+        $emptyKeyScore = \OmegaUp\ArrayHelper::getFloat(
+            $scoreByGroupArray,
+            '',
+            0.0
+        );
+        $this->assertSame(50.0, $emptyKeyScore);
+
+        $missingKeyScore = \OmegaUp\ArrayHelper::getFloat(
+            $scoreByGroupArray,
+            'missing',
+            0.0
+        );
+        $this->assertSame(0.0, $missingKeyScore);
+
+        $normalKeyScore = \OmegaUp\ArrayHelper::getFloat(
+            $scoreByGroupArray,
+            'group1',
+            0.0
+        );
+        $this->assertSame(75.0, $normalKeyScore);
+    }
+
+    /**
+     * Test that demonstrates score key errors in run details
+     *
+     * This test simulates the error: Undefined array key "score"
+     * that appears in /api/run.details
+     */
+    public function testRunDetailsScoreUndefinedKeyError() {
+        // Simulate run data without score field (causes the original error)
+        $runData = [
+            'verdict' => 'AC',
+            'runtime' => 1500,
+            'memory' => 2048
+            // Missing 'score' key - this causes the error
+        ];
+
+        $score = \OmegaUp\ArrayHelper::getFloat($runData, 'score', 0.0);
+        $this->assertSame(0.0, $score);
+
+        // Test with actual score present
+        $runDataWithScore = [
+            'verdict' => 'AC',
+            'runtime' => 1500,
+            'memory' => 2048,
+            'score' => 85.5
+        ];
+
+        $actualScore = \OmegaUp\ArrayHelper::getFloat(
+            $runDataWithScore,
+            'score',
+            default: 0.0
+        );
+        $this->assertSame(85.5, $actualScore);
+    }
+
+    /**
+     * Test that demonstrates gender key errors in identity bulk create
+     *
+     * This test simulates the error: Undefined array key "gender"
+     * that appears in /api/identity.bulkcreate
+     */
+    public function testIdentityBulkCreateGenderUndefinedKeyError() {
+        // Simulate identity data without gender field
+        $identityData = [
+            'username' => 'testuser',
+            'name' => 'Test User',
+            'password' => 'password123'
+            // Missing 'gender' key - this causes the error
+        ];
+
+        // Using our ArrayHelper should provide safe access
+        $gender = \OmegaUp\ArrayHelper::getString(
+            $identityData,
+            key: 'gender',
+            default: 'decline'
+        );
+        $this->assertSame('decline', $gender);
+
+        // Test with gender present
+        $identityDataWithGender = [
+            'username' => 'testuser',
+            'name' => 'Test User',
+            'password' => 'password123',
+            'gender' => 'male'
+        ];
+
+        $actualGender = \OmegaUp\ArrayHelper::getString(
+            $identityDataWithGender,
+            key: 'gender',
+            default: 'decline'
+        );
+        $this->assertSame('male', $actualGender);
+    }
+
+    /**
+     * Test Identity bulk create proper validation approach
+     *
+     * This tests the corrected approach: Instead of silently using ArrayHelper defaults,
+     * we should validate user input and throw proper parameter errors.
+     */
+    public function testIdentityBulkCreateProperValidation() {
+        // Test identity data without gender field
+        // Should now properly validate and indicate missing required field
+        $identityWithoutGender = [
+            'username' => 'testuser',
+            'name' => 'Test User',
+            'password' => 'password123'
+            // Missing 'gender' key - should be validated as required
+        ];
+
+        // Test validation logic (simulating what Identity controller should do)
+        $hasGender = array_key_exists('gender', $identityWithoutGender);
+        $this->assertFalse(
+            $hasGender,
+            'Missing gender should be detected for proper validation'
+        );
+
+        // Test identity data with gender field
+        $identityWithGender = [
+            'username' => 'testuser',
+            'name' => 'Test User',
+            'password' => 'password123',
+            'gender' => 'female'
+        ];
+
+        $hasGenderPresent = array_key_exists('gender', $identityWithGender);
+        $this->assertTrue(
+            $hasGenderPresent,
+            'Present gender should be detected'
+        );
+
+        if ($hasGenderPresent) {
+            $gender = $identityWithGender['gender'];
+            $this->assertSame('female', $gender);
+        }
+    }
+
+    /**
+     * Test Run controller score/contest_score undefined key errors
+     *
+     * This test simulates the error: "Undefined array key 'score'" and
+     * "Undefined array key 'contest_score'" that appear in Run::getOptionalRunDetails
+     */
+    public function testRunOptionalDetailsScoreUndefinedKeys() {
+        // Simulate run details data without score fields (causes the original errors)
+        $incompleteRunDetails = [
+            'verdict' => 'AC',
+            'judged_by' => 'grader',
+            'memory' => 2048,
+            'time' => 1.5
+            // Missing 'score' and 'contest_score' keys - these cause the errors
+        ];
+
+        // Test safe access to missing score field
+        $score = \OmegaUp\ArrayHelper::getFloat(
+            $incompleteRunDetails,
+            'score',
+            0.0
+        );
+        $this->assertSame(0.0, $score);
+
+        // Test safe access to missing contest_score field
+        $contestScore = \OmegaUp\ArrayHelper::getFloat(
+            $incompleteRunDetails,
+            'contest_score',
+            0.0
+        );
+        $this->assertSame(0.0, $contestScore);
+
+        // Test with complete data
+        $completeRunDetails = [
+            'verdict' => 'AC',
+            'judged_by' => 'grader',
+            'memory' => 2048,
+            'time' => 1.5,
+            'score' => 85.5,
+            'contest_score' => 90.0
+        ];
+
+        $actualScore = \OmegaUp\ArrayHelper::getFloat(
+            $completeRunDetails,
+            'score',
+            0.0
+        );
+        $this->assertSame(85.5, $actualScore);
+
+        $actualContestScore = \OmegaUp\ArrayHelper::getFloat(
+            $completeRunDetails,
+            'contest_score',
+            0.0
+        );
+        $this->assertSame(90.0, $actualContestScore);
+    }
+
+    /**
+     * Test that Tag controller handles missing request parameters safely
+     *
+     * This test simulates the potential "Undefined array key 'term'" or
+     * "Undefined array key 'query'" errors in Tag::apiList
+     */
+    public function testTagControllerSafeParameterAccess() {
+        // This test verifies that the Tag controller uses ensureOptionalString
+        // instead of direct array access which would cause "Undefined array key" errors
+
+        // We can't easily test the controller directly without full setup,
+        // but we can verify that the pattern we're trying to prevent is handled
+        // by our ArrayHelper for similar cases
+
+        $mockRequestData = []; // Empty request - no 'term' or 'query' keys
+
+        // Test safe access to missing keys (simulating what Tag controller should do)
+        $term = \OmegaUp\ArrayHelper::get($mockRequestData, 'term', null);
+        $this->assertNull($term);
+
+        $query = \OmegaUp\ArrayHelper::get($mockRequestData, 'query', null);
+        $this->assertNull($query);
+
+        // Test with actual values
+        $mockRequestDataWithTerm = ['term' => 'algorithm'];
+        $actualTerm = \OmegaUp\ArrayHelper::get(
+            $mockRequestDataWithTerm,
+            'term',
+            null
+        );
+        $this->assertSame('algorithm', $actualTerm);
+
+        $mockRequestDataWithQuery = ['query' => 'dynamic programming'];
+        $actualQuery = \OmegaUp\ArrayHelper::get(
+            $mockRequestDataWithQuery,
+            'query',
+            null
+        );
+        $this->assertSame('dynamic programming', $actualQuery);
+    }
+
+    /**
+     * Test getPath method for safe nested array access
+     */
+    public function testArrayHelperGetPathMethod() {
+        $nestedData = [
+            'user' => [
+                'profile' => [
+                    'score' => 1500,
+                    'rank' => 42
+                ]
+            ]
+        ];
+
+        // Test successful nested access
+        $score = \OmegaUp\ArrayHelper::getPath(
+            $nestedData,
+            keys: ['user', 'profile', 'score'],
+            default: 0
+        );
+        $this->assertSame(1500, $score);
+
+        // Test missing nested key (should return default)
+        $missing = \OmegaUp\ArrayHelper::getPath(
+            $nestedData,
+            keys: ['user', 'profile', 'missing'],
+            default: 'default'
+        );
+        $this->assertSame('default', $missing);
+
+        // Test completely wrong path
+        $wrongPath = \OmegaUp\ArrayHelper::getPath(
+            $nestedData,
+            keys: ['nonexistent', 'path'],
+            default: 'fallback'
+        );
+        $this->assertSame('fallback', $wrongPath);
+    }
+}


### PR DESCRIPTION
# Description

Después de revisar los errores que aparecen en New Relic, uno muy común es el de claves indefinidas de arrays.

En este PR se arregla lo siguiente:

- Agrega clase ArrayHelper con métodos seguros de acceso a arrays
- Corrige claves indefinidas score/contest_score en controlador Run
- Corrige acceso a parámetros term/query en controlador Tag
- Corrige validación de gender en Identity (excepciones apropiadas)
- Corrige validación de parsing URI en ApiCaller
- Corrige acceso a array tokens en Problemset


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
