### PR TITLE
Agregando una actualización a la documentación de Cypress.

### DIFF
--- a/frontend/www/docs/How-to-use-Cypress-in-omegaUp.md
+++ b/frontend/www/docs/How-to-use-Cypress-in-omegaUp.md
@@ -92,7 +92,19 @@ and then try the process again.
 Everything related to Cypress is located inside the `./cypress` folder at the root directory.
 
 ## GUI
-To run the Cypress GUI (which is great), use `npx cypress run` `./node_modules/.bin/cypress open`. This will open a screen with all available tests.
+To run Cypress, use one of the following commands:
+
+- To run the tests from the command line:
+  ```bash
+  npx cypress run
+  ```
+- To open the Cypress GUI:
+  ```bash
+  npx cypress open
+  # or
+  ./node_modules/.bin/cypress open
+  ```
+The GUI will open a window listing all available tests.
 
 ![image](https://github.com/user-attachments/assets/a3bf6b11-0e9a-4290-b5e5-fec6884be3e7)
 


### PR DESCRIPTION
# Description

Se agrego a la documentación el comando `sudo apt install libasound2t64` para versiones más actualizadas de Ubuntu.

Fixes: #8510
