### PR TITLE
Fix: Hide 'Students’ progress' button when no students are enrolled (#8524)

### DIFF
--- a/frontend/www/js/omegaup/components/course/AddStudents.vue
+++ b/frontend/www/js/omegaup/components/course/AddStudents.vue
@@ -81,7 +81,7 @@
           </tr>
         </tbody>
       </table>
-      <div class="float-right">
+      <div v-if="students.length > 0" class="float-right">
         <a class="btn btn-primary" :href="studentsProgressUrl()">
           {{ T.courseStudentsProgress }}
         </a>


### PR DESCRIPTION
# Description

This PR fixes the UI issue where the **“Students’ progress”** button appeared even when no students were enrolled in a course.

A conditional check was added:

v-if="students.length > 0"

This ensures the button is only shown when at least one student is enrolled, improving clarity and preventing an unusable action.

**Fixes: #8524**

---

### Before (0 students — incorrectly visible)
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/d92ef938-7a49-4bab-8ea3-ae9d76653cd6" />

### After (0 students — correctly hidden)
<img width="1920" height="1080" alt="Screenshot from 2025-11-13 12-15-12" src="https://github.com/user-attachments/assets/8b34402c-3217-40b8-ace5-82c295cebb1e" />

### After (1+ students — correctly visible)
<img width="1920" height="1080" alt="Screenshot from 2025-11-13 12-16-31" src="https://github.com/user-attachments/assets/6b8e8add-5491-46d8-ad55-b65c6b771d00" />

---

# Comments

This follows the suggested approach to hide the button when no students are enrolled.  
Both empty and non-empty student states were verified manually.

---

# Checklist:

- [x] The code follows the coding guidelines.  
- [x] The tests were executed and all of them passed.  
- [x] UI was tested manually to confirm the visibility fix.  
- [x] Change is small (UI-only, <200 lines), so no split PR is required.
