### PR TITLE
Quitando log spam

### DIFF
--- a/frontend/server/src/Cache.php
+++ b/frontend/server/src/Cache.php
@@ -106,8 +106,6 @@ abstract class CacheAdapter {
             }
             return $returnValue;
         }
-        $log = \Monolog\Registry::omegaup()->withName('cache');
-
         // Get a lock to prevent multiple requests from trying to create the
         // same cache entry. The name of the lockfile is derived from the
         // provided lock group, not the full key, since it is still preferred
@@ -138,6 +136,7 @@ abstract class CacheAdapter {
             /** @var T */
             $returnValue = call_user_func($setFunc);
             $this->store($key, $returnValue, $timeout);
+
             if (!is_null($cacheUsed)) {
                 $cacheUsed = false;
             }


### PR DESCRIPTION
# Description

Quitando mensajes que solo contaminan el log. Fueron útiles hace muchos años cuando desarrollábamos la funcionalidad del Cache, pero ya ahorita no ayudan.

Debería facilitar el encontrar problemas reales en el log.

<img width="654" height="128" alt="image" src="https://github.com/user-attachments/assets/68e328a6-c4f9-476b-acca-864df064d130" />

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
