### PR TITLE
Implemented cache in the workflows

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -18,6 +18,17 @@ jobs:
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('docker-compose.k8s.yml', '**/Dockerfile*') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build docker containers
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
@@ -26,6 +37,8 @@ jobs:
         run: |
           docker compose --file=docker-compose.k8s.yml build \
             --build-arg BRANCH=${{ steps.extract_branch.outputs.branch }} \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to type=local,dest=/tmp/.buildx-cache,mode=max \
             frontend \
             frontend-sidecar \
             nginx \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
+          cache: 'pip'
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.local/lib/python3.8
+            ~/.local/bin
+          key: ${{ runner.os }}-python-${{ hashFiles('stuff/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Add mysql as alias to localhost
         run: |
@@ -179,6 +199,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.yarn/cache
+            ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install yarn dependencies
         run: yarn install
 
@@ -215,11 +246,41 @@ jobs:
           define('OMEGAUP_LOG_FILE', 'php://stderr');
           EOF
 
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.yarn/cache
+            ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install yarn dependencies
         run: yarn install
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-progress
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.local/lib/python3.8
+            ~/.local/bin
+          key: ${{ runner.os }}-python-yapf-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
 
       - name: Install Python dependencies
         run: python3 -m pip install --user yapf==0.30.0
@@ -288,6 +349,14 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install -y wait-for-it
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('docker-compose.yml', '**/Dockerfile*') }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+
       - name: Download the Docker containers
         run: |
           docker compose pull
@@ -353,12 +422,36 @@ jobs:
           password=omegaup
           EOF
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.local/lib/python3.8
+            ~/.local/bin
+          key: ${{ runner.os }}-python-${{ hashFiles('stuff/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
+
       - name: Install Python dependencies
         run: |
           python3 -m pip install --user setuptools
           python3 -m pip install --user wheel
           python3 -m pip install --user \
             -r stuff/requirements.txt
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-progress
@@ -375,6 +468,17 @@ jobs:
             python3 -m pip install wheel && \
             python3 -m pip install -r /opt/omegaup/stuff/requirements.txt"
           docker compose exec -T frontend python3 stuff/bootstrap-environment.py --purge --verbose
+
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.yarn/cache
+            ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Install yarn dependencies
         run: yarn install
@@ -429,6 +533,14 @@ jobs:
       - name: Install retry
         run: |
           sudo apt-get update -y && sudo apt-get install -y retry
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('docker-compose.yml', '**/Dockerfile*') }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
 
       - name: Download the Docker containers
         run: |
@@ -548,6 +660,14 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install -y wait-for-it
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('docker-compose.yml', '**/Dockerfile*') }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+
       - name: Download the Docker containers
         run: |
           docker compose pull
@@ -613,6 +733,23 @@ jobs:
           password=omegaup
           EOF
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.local/lib/python3.8
+            ~/.local/bin
+          key: ${{ runner.os }}-python-ta-${{ hashFiles('stuff/requirements.txt', 'stuff/teaching_assistant/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-python-ta-
+            ${{ runner.os }}-python-
+
       - name: Install Python dependencies
         run: |
           python3 -m pip install --user setuptools
@@ -621,6 +758,14 @@ jobs:
             -r stuff/requirements.txt
           python3 -m pip install --user \
             -r stuff/teaching_assistant/requirements.txt
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-progress

--- a/.github/workflows/libomegaup.yml
+++ b/.github/workflows/libomegaup.yml
@@ -16,6 +16,18 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
+          cache: 'pip'
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.local/lib/python3.9
+            ~/.local/bin
+          key: ${{ runner.os }}-python-yapf-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-python-
 
       - name: Use PHP 8.1
         run: |
@@ -24,6 +36,14 @@ jobs:
           echo 'apc.enable_cli=1' | sudo tee --append /etc/php/8.1/cli/conf.d/20-apcu.ini >/dev/null
           # Enable coverage for XDebug so that codecov can do its magic.
           echo 'xdebug.mode=coverage' | sudo tee --append /etc/php/8.1/cli/conf.d/20-xdebug.ini >/dev/null
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-progress


### PR DESCRIPTION
This PR adds caching for dependencies in CI workflows to reduce build times.
What's cached:
Composer dependencies — PHP packages (vendor/) cached based on composer.lock
Yarn dependencies — JavaScript packages (node_modules/) cached based on yarn.lock
Python packages — pip-installed packages cached based on requirements files
Docker layers — Docker image layers cached to speed up pulls and builds

Impact:
Faster CI runs when dependencies haven't changed
Reduced time spent downloading and installing dependencies
Lower CI costs from shorter job durations

Fixes #8563