### PR TITLE
add Discord issue thread notification workflow

### DIFF
--- a/.github/workflows/discord-issue-notification.yml
+++ b/.github/workflows/discord-issue-notification.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Send Discord Notification
         if: steps.check-label.outputs.should_notify == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:


### PR DESCRIPTION
# Description

Implemented a GitHub Action workflow (`discord-issue-monitor.yml`) to automatically send notifications to a Discord channel when an issue is created or tagged with specific labels.

**Key changes:**
* **Workflow Trigger:** Listens for `issues` events (specifically `opened` and `labeled`).
* **Filtering Logic:** The workflow strictly checks if the issue contains priority labels ("GSoC" or "good first issue") before executing.
* **Implementation:** Used `actions/github-script` (Node.js) instead of shell scripts to ensure robust JSON handling (preventing errors with special characters in issue titles) and to support creating threads in Discord via Webhook.
* **Outcome:** Sends a rich embed message to Discord and initiates a thread for discussion.

Fixes: #8569 

# Comments

**Notes for Reviewers:**
1.  **Prerequisite:** This workflow requires a repository secret named `DISCORD_WEBHOOK_URL` to be configured in the repository settings.
2.  **Tech Choice:** I opted for `actions/github-script` over a `curl` bash script to handle edge cases where issue titles contain quotes, backslashes, or emojis, ensuring valid JSON payloads every time.
3.  **Logic:** The script handles two scenarios:
    * An issue is **opened** with the required label already selected.
    * An existing issue is **labeled** later with the required label.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed. (Verified workflow syntax and logic manually).
- [ ] If you are creating a feature, the new tests were added. (N/A - Infrastructure/Workflow change).
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.