### PR TITLE
docs: remove deprecated Selenium reference (#8568)

### DIFF
--- a/frontend/www/docs/Release-&-deployment-(English).md
+++ b/frontend/www/docs/Release-&-deployment-(English).md
@@ -16,7 +16,6 @@ Before a Pull Request (PR) is approved and merged into `main`, it must pass a se
 - **javascript**: Unit tests for **Vue.js**, written in **TypeScript + Jest**.  
 - **lint**: Style and format validators for all languages used in the project, as well as type validators in **Psalm** for PHP.  
 - **cypress**: **End-to-end (E2E) tests** to validate the proper functioning of critical platform flows.  
-- **selenium**: Previously used for integration testing, currently **deprecated** in favor of Cypress.  
 - **python**: Automated tests written in **pytest**.  
 
 ## Code Coverage  


### PR DESCRIPTION
This pull request removes the deprecated Selenium references from the 
**Release-&-deployment-(English).md** documentation. Selenium is no longer 
used in the testing workflow and has been fully replaced by Cypress for 
integration and end-to-end tests.

This update improves **clarity** and ensures the documentation reflects the 
**current CI/CD process** used by omegaUp.

**Closes #8568**