### PR TITLE
remove libgconf from Cypress setup instructions

### DIFF
--- a/frontend/www/docs/How-to-use-Cypress-in-omegaUp.md
+++ b/frontend/www/docs/How-to-use-Cypress-in-omegaUp.md
@@ -1,11 +1,14 @@
 ## Preliminary Steps
+
 You need to have `node` installed to use `cypress`:
+
 ```bash
 sudo apt-get install nodejs
 sudo apt-get install npm
 ```
 
 If you still get:
+
 ```bash
 No version of Cypress is installed in: ~/.cache/Cypress/9.1.1/Cypress
 
@@ -22,11 +25,13 @@ Cypress Version: 9.1.1
 ```
 
 You need to install cypress as follows:
+
 ```bash
 ./node_modules/.bin/cypress install
 ```
 
 Other errors that may appear include:
+
 ```bash
 It looks like this is your first time using Cypress: 13.3.0
 
@@ -44,12 +49,15 @@ Please refer to the error below for more details.
 Platform: linux-x64 (Ubuntu - 22.04)
 Cypress Version: 13.3.0
 ```
+
 You need to install the following dependencies:
+
 ```bash
-sudo apt install libgconf-2-4 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm-dev libnss3-dev libxss-dev
+sudo apt install libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm-dev libnss3-dev libxss-dev
 ```
 
 Or the following error:
+
 ```bash
 It looks like this is your first time using Cypress: 13.3.0
 
@@ -71,27 +79,33 @@ Cypress Version: 13.3.0
 ```
 
 You need to install the dependency:
+
 ```bash
 sudo apt-get install libasound2
 ```
 
 If you are using Ubuntu 24.04 or a newer version, install the required dependency with:
+
 ```bash
 sudo apt install libasound2t64
 ```
 
 **Note:** If you encounter any unexpected errors, try running:
+
 ```bash
 sudo apt update
 ```
+
 and then try the process again.
 
 ## Introduction
+
 **Note:** Currently, tests are run outside of the Docker container.
 
 Everything related to Cypress is located inside the `./cypress` folder at the root directory.
 
 ## GUI
+
 To run Cypress, use one of the following commands:
 
 - To run the tests from the command line:
@@ -104,13 +118,14 @@ To run Cypress, use one of the following commands:
   # or
   ./node_modules/.bin/cypress open
   ```
-The GUI will open a window listing all available tests.
+  The GUI will open a window listing all available tests.
 
 ![image](https://github.com/user-attachments/assets/a3bf6b11-0e9a-4290-b5e5-fec6884be3e7)
 
 Click on the test you are interested in running.
 
 ### Test View
+
 ![image](https://github.com/user-attachments/assets/b1f615c1-e8f8-4259-ad97-52d6f1490478)
 
 Now you can see the test execution in real time, and if you hover over a command, you can see a `snapshot` of the page at that moment in the test. You can also open the console (right-click -> inspect element) and see the output of the page actions.
@@ -120,17 +135,21 @@ You can select an element with the selector tool to get the necessary command to
 ![image](https://github.com/user-attachments/assets/403b84b6-5516-4956-8123-ec60bd1b2b26)
 
 ## Headless
+
 If you don't want to run the test with GUI, you can use `npx cypress run` or `./node_modules/.bin cypress run` to execute the tests without an interface. A video will be created inside `./cypress/videos` so you can see how the test was performed.
 
 ## Writing Tests for Cypress
+
 The tests are contained within `./cypress/e2e` and have the filename format `name.cy.ts`. (Subfolders can be created if necessary.)
 
 For basic commands, refer to: https://docs.cypress.io/guides/getting-started/writing-your-first-test
 
 ### Commands
+
 One interesting feature of Cypress is **custom commands**. Custom commands are simply functions that contain Cypress commands for testing. For example, a custom command could be `login(username, password)`. This command would handle the login process so that it doesn't need to be rewritten in every test.
 
 These commands are declared in `./cypress/support/commands.js`:
+
 ```typescript
 Cypress.Commands.add('login', ({ username, password }: LoginOptions) => {
   const URL =
@@ -141,7 +160,9 @@ Cypress.Commands.add('login', ({ username, password }: LoginOptions) => {
   });
 });
 ```
+
 Since we are using TypeScript, it is necessary to add the command type inside `./cypress/support/cypress.d.ts`:
+
 ```typescript
 // <reference types="cypress"/>
 
@@ -158,9 +179,11 @@ declare global {
   }
 }
 ```
+
 https://docs.cypress.io/api/cypress-api/custom-commands
 
 ### Events
+
 Sometimes, we want to continue running a test even if an exception occurs. For that, Cypress events exist. These can be declared globally or locally. For example, when running Cypress, the Google Sign-In API did not recognize `127.0.0.1` (Docker IP) as a permitted host, which was breaking the tests. A global event can be added so that when this exception appears, the test does not stop and continues running.
 
 Global events are added in `./cypress/support/e2e.ts`. Local events are added within the test file.
@@ -175,13 +198,13 @@ Cypress.on('uncaught:exception', (err, runnable) => {
     return false;
   }
 });
-
 ```
+
 https://docs.cypress.io/api/events/catalog-of-events
 
 ### Cypress Studio
-The coolest way to write tests! If you open the Cypress GUI and go to any test, at the end, there is a button that allows you to record the test yourself. All interactions you make with the page will be added to the test you are modifying!
 
+The coolest way to write tests! If you open the Cypress GUI and go to any test, at the end, there is a button that allows you to record the test yourself. All interactions you make with the page will be added to the test you are modifying!
 
 ![](https://docs.cypress.io/_nuxt/img/extend-activate-studio.91d9bd8.png)
 
@@ -192,9 +215,11 @@ After recording, these interactions are saved in the respective file as commands
 **Note**: Since Studio saves your interactions as commands, there is no need to rush through actions, as the time between each interaction is not recorded.
 
 ### Important Plugins
+
 Currently, two plugins are installed in Cypress: WaitUntil and File-Upload.
 
 ## Github Actions
+
 Sometimes, your tests may work locally, but when you try to make a PR, the test fails in GitHub Actions. To see exactly what went wrong, go to the `Checks` tab inside the PR and then select `CI`.
 ![](https://i.imgur.com/6iu4w1L.png)
 
@@ -208,7 +233,7 @@ Scroll down on this screen and download the `cypress-screenshots-<run_attempt>` 
 
 Example:
 If the workflow URL ends with `/attempts/3`, the artifact name will be:
+
 - `cypress-screenshots-3`
 - `cypress-videos-3`
-There, you will find all the videos generated by the Cypress container running in GitHub Actions. You can see exactly what is happening with your test and debug it more effectively!
-
+  There, you will find all the videos generated by the Cypress container running in GitHub Actions. You can see exactly what is happening with your test and debug it more effectively!


### PR DESCRIPTION
# Description

Removes `libgconf-2-4` from the installation documentation command.

This package has been removed from the Ubuntu 24.04 repositories, causing the `sudo apt install` command to fail with an "Unable to locate package" error. I have verified that removing this dependency does not affect Cypress execution on WSL 2 (Ubuntu 24.04).

Fixes: #8597 

# Comments

This updates the documentation to support newer OS versions (specifically Ubuntu 24.04 LTS) where `libgconf-2-4` is deprecated.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.