### PR TITLE
implemented keep-alive to preserve component state when switching tabs

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Edit.vue
+++ b/frontend/www/js/omegaup/components/contest/Edit.vue
@@ -125,7 +125,11 @@
 
     <keep-alive>
       <div class="tab-content mt-2">
-        <div v-show="showTab === 'new_form'" class="tab-pane" :class="{ active: showTab === 'new_form' }">
+        <div
+          v-show="showTab === 'new_form'"
+          class="tab-pane"
+          :class="{ active: showTab === 'new_form' }"
+        >
           <omegaup-contest-new-form
             :admission-mode="details.admission_mode"
             :default-show-all-contestants-in-scoreboard="
@@ -147,7 +151,9 @@
             :initial-show-scoreboard-after="details.show_scoreboard_after"
             :score-mode="details.score_mode"
             :initial-needs-basic-information="details.needs_basic_information"
-            :initial-requests-user-information="details.requests_user_information"
+            :initial-requests-user-information="
+              details.requests_user_information
+            "
             :all-languages="details.available_languages"
             :teams-group-alias="teamsGroupAlias"
             :contest-for-teams="details.contest_for_teams"
@@ -166,7 +172,11 @@
             "
           ></omegaup-contest-new-form>
         </div>
-        <div v-show="showTab === 'problems'" class="tab-pane" :class="{ active: showTab === 'problems' }">
+        <div
+          v-show="showTab === 'problems'"
+          class="tab-pane"
+          :class="{ active: showTab === 'problems' }"
+        >
           <omegaup-contest-add-problem
             :contest-alias="details.alias"
             :initial-points="details.score_mode !== 'all_or_nothing' ? 100 : 1"
@@ -187,7 +197,11 @@
           >
           </omegaup-contest-add-problem>
         </div>
-        <div v-show="showTab === 'publish'" class="tab-pane" :class="{ active: showTab === 'publish' }">
+        <div
+          v-show="showTab === 'publish'"
+          class="tab-pane"
+          :class="{ active: showTab === 'publish' }"
+        >
           <omegaup-common-publish
             :default-show-all-contestants-in-scoreboard="
               details.default_show_all_contestants_in_scoreboard
@@ -202,7 +216,11 @@
             "
           ></omegaup-common-publish>
         </div>
-        <div v-show="showTab === 'contestants'" class="tab-pane contestants" :class="{ active: showTab === 'contestants' }">
+        <div
+          v-show="showTab === 'contestants'"
+          class="tab-pane contestants"
+          :class="{ active: showTab === 'contestants' }"
+        >
           <omegaup-contest-add-contestant
             :contest="details"
             :users="users"
@@ -227,10 +245,16 @@
               (query) => $emit('update-search-result-groups', query)
             "
             @emit-add-group="(groupAlias) => $emit('add-group', groupAlias)"
-            @emit-remove-group="(groupAlias) => $emit('remove-group', groupAlias)"
+            @emit-remove-group="
+              (groupAlias) => $emit('remove-group', groupAlias)
+            "
           ></omegaup-contest-groups>
         </div>
-        <div v-show="showTab === 'groups'" class="tab-pane groups" :class="{ active: showTab === 'groups' }">
+        <div
+          v-show="showTab === 'groups'"
+          class="tab-pane groups"
+          :class="{ active: showTab === 'groups' }"
+        >
           <omegaup-contest-teams-groups
             :teams-group="teamsGroup"
             :search-result-teams-groups="searchResultTeamsGroups"
@@ -243,7 +267,11 @@
             "
           ></omegaup-contest-teams-groups>
         </div>
-        <div v-show="showTab === 'admins'" class="tab-pane" :class="{ active: showTab === 'admins' }">
+        <div
+          v-show="showTab === 'admins'"
+          class="tab-pane"
+          :class="{ active: showTab === 'admins' }"
+        >
           <omegaup-common-admins
             :admins="admins"
             :search-result-users="searchResultUsers"
@@ -268,7 +296,11 @@
             "
           ></omegaup-common-group-admins>
         </div>
-        <div v-show="showTab === 'links'" class="tab-pane" :class="{ active: showTab === 'links' }">
+        <div
+          v-show="showTab === 'links'"
+          class="tab-pane"
+          :class="{ active: showTab === 'links' }"
+        >
           <omegaup-contest-links
             :data="details"
             @download-csv-scoreboard="
@@ -276,7 +308,11 @@
             "
           ></omegaup-contest-links>
         </div>
-        <div v-show="showTab === 'clone'" class="tab-pane" :class="{ active: showTab === 'clone' }">
+        <div
+          v-show="showTab === 'clone'"
+          class="tab-pane"
+          :class="{ active: showTab === 'clone' }"
+        >
           <omegaup-contest-clone
             @clone="
               ({ title, alias, description, startTime }) =>
@@ -284,7 +320,11 @@
             "
           ></omegaup-contest-clone>
         </div>
-        <div v-show="showTab === 'archive'" class="tab-pane" :class="{ active: showTab === 'archive' }">
+        <div
+          v-show="showTab === 'archive'"
+          class="tab-pane"
+          :class="{ active: showTab === 'archive' }"
+        >
           <omegaup-common-archive
             :already-archived="alreadyArchived"
             :archive-button-description="archiveButtonDescription"
@@ -294,7 +334,11 @@
             @archive="onArchiveContest"
           ></omegaup-common-archive>
         </div>
-        <div v-show="showTab === 'certificates'" class="tab-pane" :class="{ active: showTab === 'certificates' }">
+        <div
+          v-show="showTab === 'certificates'"
+          class="tab-pane"
+          :class="{ active: showTab === 'certificates' }"
+        >
           <omegaup-contest-certificates
             :certificates-details="certificatesDetails"
             @generate="

--- a/frontend/www/js/omegaup/components/course/Edit.vue
+++ b/frontend/www/js/omegaup/components/course/Edit.vue
@@ -91,20 +91,25 @@
 
     <keep-alive>
       <div class="tab-content mt-2">
-        <div v-show="showTab === 'course'" class="tab-pane" :class="{ active: showTab === 'course' }" role="tabpanel">
-        <omegaup-course-form
-          :update="true"
-          :course="data.course"
-          :all-languages="data.allLanguages"
-          :search-result-schools="searchResultSchools"
-          :read-only="readOnly"
-          @emit-cancel="onCancel"
-          @submit="(request) => $emit('submit-edit-course', request)"
-          @update-search-result-schools="
-            (query) => $emit('update-search-result-schools', query)
-          "
-        ></omegaup-course-form>
-      </div>
+        <div
+          v-show="showTab === 'course'"
+          class="tab-pane"
+          :class="{ active: showTab === 'course' }"
+          role="tabpanel"
+        >
+          <omegaup-course-form
+            :update="true"
+            :course="data.course"
+            :all-languages="data.allLanguages"
+            :search-result-schools="searchResultSchools"
+            :read-only="readOnly"
+            @emit-cancel="onCancel"
+            @submit="(request) => $emit('submit-edit-course', request)"
+            @update-search-result-schools="
+              (query) => $emit('update-search-result-schools', query)
+            "
+          ></omegaup-course-form>
+        </div>
 
         <div
           v-show="showTab === 'content'"
@@ -113,69 +118,71 @@
           :class="{ active: showTab === 'content' }"
           role="tabpanel"
         >
-        <omegaup-course-assignment-list
-          :content="assignments"
-          :course-alias="data.course.alias"
-          :assignment-form-mode="assignmentFormMode"
-          @emit-new="onNewAssignment"
-          @emit-edit="(assignment) => onEditAssignment(assignment)"
-          @emit-add-problems="(assignment) => onAddProblems(assignment)"
-          @emit-delete="(assignment) => $emit('delete-assignment', assignment)"
-          @emit-sort-content="
-            (courseAlias, contentAliases) =>
-              $emit('sort-content', courseAlias, contentAliases)
-          "
-        ></omegaup-course-assignment-list>
-        <omegaup-course-assignment-details
-          ref="assignment-details"
-          :unlimited-duration-course="!data.course.finish_time"
-          :finish-time-course="data.course.finish_time"
-          :start-time-course="data.course.start_time"
-          :assignment="assignment"
-          :assignment-problems="assignmentProblems"
-          :tagged-problems="data.taggedProblems"
-          :invalid-parameter-name="invalidParameterName"
-          :assignment-form-mode.sync="assignmentFormMode"
-          :course-alias="data.course.alias"
-          :search-result-problems="searchResultProblems"
-          @update-search-result-problems="
-            (query) => $emit('update-search-result-problems', query)
-          "
-          @add-problem="
-            (assignment, problem) => $emit('add-problem', assignment, problem)
-          "
-          @emit-add-problem="
-            (assignment, problemAlias) =>
-              $emit('add-problem', assignment, problemAlias)
-          "
-          @emit-select-assignment="
-            (assignment) => $emit('select-assignment', assignment)
-          "
-          @remove-problem="
-            (assignment, problem) =>
-              $emit('remove-problem', assignment, problem)
-          "
-          @sort-problems="
-            (assignmentAlias, problemsAlias) =>
-              $emit('sort-problems', assignmentAlias, problemsAlias)
-          "
-          @cancel="onResetAssignmentForm"
-          @add-assignment="(params) => $emit('add-assignment', params)"
-          @update-assignment="(params) => $emit('update-assignment', params)"
-          @get-versions="(request) => $emit('get-versions', request)"
-        >
-          <template #page-header><span></span></template>
-          <template #cancel-button>
-            <button
-              class="btn btn-secondary"
-              type="reset"
-              @click.prevent="onResetAssignmentForm"
-            >
-              {{ T.wordsCancel }}
-            </button></template
-          ></omegaup-course-assignment-details
-        >
-      </div>
+          <omegaup-course-assignment-list
+            :content="assignments"
+            :course-alias="data.course.alias"
+            :assignment-form-mode="assignmentFormMode"
+            @emit-new="onNewAssignment"
+            @emit-edit="(assignment) => onEditAssignment(assignment)"
+            @emit-add-problems="(assignment) => onAddProblems(assignment)"
+            @emit-delete="
+              (assignment) => $emit('delete-assignment', assignment)
+            "
+            @emit-sort-content="
+              (courseAlias, contentAliases) =>
+                $emit('sort-content', courseAlias, contentAliases)
+            "
+          ></omegaup-course-assignment-list>
+          <omegaup-course-assignment-details
+            ref="assignment-details"
+            :unlimited-duration-course="!data.course.finish_time"
+            :finish-time-course="data.course.finish_time"
+            :start-time-course="data.course.start_time"
+            :assignment="assignment"
+            :assignment-problems="assignmentProblems"
+            :tagged-problems="data.taggedProblems"
+            :invalid-parameter-name="invalidParameterName"
+            :assignment-form-mode.sync="assignmentFormMode"
+            :course-alias="data.course.alias"
+            :search-result-problems="searchResultProblems"
+            @update-search-result-problems="
+              (query) => $emit('update-search-result-problems', query)
+            "
+            @add-problem="
+              (assignment, problem) => $emit('add-problem', assignment, problem)
+            "
+            @emit-add-problem="
+              (assignment, problemAlias) =>
+                $emit('add-problem', assignment, problemAlias)
+            "
+            @emit-select-assignment="
+              (assignment) => $emit('select-assignment', assignment)
+            "
+            @remove-problem="
+              (assignment, problem) =>
+                $emit('remove-problem', assignment, problem)
+            "
+            @sort-problems="
+              (assignmentAlias, problemsAlias) =>
+                $emit('sort-problems', assignmentAlias, problemsAlias)
+            "
+            @cancel="onResetAssignmentForm"
+            @add-assignment="(params) => $emit('add-assignment', params)"
+            @update-assignment="(params) => $emit('update-assignment', params)"
+            @get-versions="(request) => $emit('get-versions', request)"
+          >
+            <template #page-header><span></span></template>
+            <template #cancel-button>
+              <button
+                class="btn btn-secondary"
+                type="reset"
+                @click.prevent="onResetAssignmentForm"
+              >
+                {{ T.wordsCancel }}
+              </button></template
+            ></omegaup-course-assignment-details
+          >
+        </div>
 
         <div
           v-show="showTab === 'admission-mode'"
@@ -184,16 +191,16 @@
           :class="{ active: showTab === 'admission-mode' }"
           role="tabpanel"
         >
-        <omegaup-course-admision-mode
-          :admission-mode="data.course.admission_mode"
-          :should-show-public-option="data.course.is_curator"
-          :course-alias="data.course.alias"
-          :show-in-public-courses-list="data.course.recommended"
-          @update-admission-mode="
-            (request) => $emit('update-admission-mode', request)
-          "
-        ></omegaup-course-admision-mode>
-      </div>
+          <omegaup-course-admision-mode
+            :admission-mode="data.course.admission_mode"
+            :should-show-public-option="data.course.is_curator"
+            :course-alias="data.course.alias"
+            :show-in-public-courses-list="data.course.recommended"
+            @update-admission-mode="
+              (request) => $emit('update-admission-mode', request)
+            "
+          ></omegaup-course-admision-mode>
+        </div>
 
         <div
           v-show="showTab === 'students'"
@@ -202,22 +209,22 @@
           :class="{ active: showTab === 'students' }"
           role="tabpanel"
         >
-        <omegaup-course-add-students
-          :students="data.students"
-          :course-alias="data.course.alias"
-          :identity-requests="data.identityRequests"
-          :search-result-users="searchResultUsers"
-          @emit-add-student="
-            (participants) => $emit('add-student', participants)
-          "
-          @emit-remove-student="(student) => $emit('remove-student', student)"
-          @accept-request="(request) => $emit('accept-request', request)"
-          @deny-request="(request) => $emit('deny-request', request)"
-          @update-search-result-users="
-            (query) => $emit('update-search-result-users', query)
-          "
-        ></omegaup-course-add-students>
-      </div>
+          <omegaup-course-add-students
+            :students="data.students"
+            :course-alias="data.course.alias"
+            :identity-requests="data.identityRequests"
+            :search-result-users="searchResultUsers"
+            @emit-add-student="
+              (participants) => $emit('add-student', participants)
+            "
+            @emit-remove-student="(student) => $emit('remove-student', student)"
+            @accept-request="(request) => $emit('accept-request', request)"
+            @deny-request="(request) => $emit('deny-request', request)"
+            @update-search-result-users="
+              (query) => $emit('update-search-result-users', query)
+            "
+          ></omegaup-course-add-students>
+        </div>
 
         <div
           v-show="showTab === 'admins'"
@@ -225,97 +232,108 @@
           :class="{ active: showTab === 'admins' }"
           role="tabpanel"
         >
-        <div class="col-md-6">
-          <omegaup-common-admins
-            :admins="data.admins"
-            :search-result-users="searchResultUsers"
-            @add-admin="(username) => $emit('add-admin', username)"
-            @remove-admin="(username) => $emit('remove-admin', username)"
-            @update-search-result-users="
-              (query) => $emit('update-search-result-users', query)
-            "
-          ></omegaup-common-admins>
-        </div>
-        <div class="col-md-6">
-          <omegaup-common-groupadmins
-            :group-admins="data.groupsAdmins"
-            :search-result-groups="searchResultGroups"
-            @add-group-admin="
-              (groupAlias) => $emit('add-group-admin', groupAlias)
-            "
-            @remove-group-admin="
-              (groupAlias) => $emit('remove-group-admin', groupAlias)
-            "
-            @update-search-result-groups="
-              (query) => $emit('update-search-result-groups', query)
-            "
-          ></omegaup-common-groupadmins>
-        </div>
-        <div class="col-md-6">
-          <omegaup-common-teaching-assistants
-            :teaching-assistants="data.teachingAssistants"
-            :search-result-users="searchResultUsers"
-            @add-teaching-assistant="
-              (username) => $emit('add-teaching-assistant', username)
-            "
-            @remove-teaching-assistant="
-              (username) => $emit('remove-teaching-assistant', username)
-            "
-            @update-search-result-users="
-              (query) => $emit('update-search-result-users', query)
-            "
-          ></omegaup-common-teaching-assistants>
-        </div>
-        <div class="col-md-6">
-          <omegaup-common-group-teaching-assistants
-            :group-teaching-assistants="data.groupsTeachingAssistants"
-            :search-result-groups="searchResultGroups"
-            @add-group-teaching-assistant="
-              (groupAlias) => $emit('add-group-teaching-assistant', groupAlias)
-            "
-            @remove-group-teaching-assistant="
-              (groupAlias) =>
-                $emit('remove-group-teaching-assistant', groupAlias)
-            "
-            @update-search-result-groups="
-              (query) => $emit('update-search-result-groups', query)
-            "
-          ></omegaup-common-group-teaching-assistants>
-        </div>
-      </div>
-
-        <div v-show="showTab === 'clone'" class="tab-pane" :class="{ active: showTab === 'clone' }" role="tabpanel">
-        <div class="card">
-          <div class="card-body">
-            <omegaup-course-clone
-              class="mb-4"
-              :initial-alias="data.course.alias"
-              :initial-name="data.course.name"
-              @clone="
-                (alias, name, startTime) =>
-                  $emit('clone', alias, name, startTime)
+          <div class="col-md-6">
+            <omegaup-common-admins
+              :admins="data.admins"
+              :search-result-users="searchResultUsers"
+              @add-admin="(username) => $emit('add-admin', username)"
+              @remove-admin="(username) => $emit('remove-admin', username)"
+              @update-search-result-users="
+                (query) => $emit('update-search-result-users', query)
               "
-            ></omegaup-course-clone>
-            <omegaup-course-generate-link-clone
-              v-if="data.course.admission_mode !== admissionMode.Public"
-              :alias="data.course.alias"
-              :token="token"
-              @generate-link="(alias) => $emit('generate-link', alias)"
-            ></omegaup-course-generate-link-clone>
+            ></omegaup-common-admins>
+          </div>
+          <div class="col-md-6">
+            <omegaup-common-groupadmins
+              :group-admins="data.groupsAdmins"
+              :search-result-groups="searchResultGroups"
+              @add-group-admin="
+                (groupAlias) => $emit('add-group-admin', groupAlias)
+              "
+              @remove-group-admin="
+                (groupAlias) => $emit('remove-group-admin', groupAlias)
+              "
+              @update-search-result-groups="
+                (query) => $emit('update-search-result-groups', query)
+              "
+            ></omegaup-common-groupadmins>
+          </div>
+          <div class="col-md-6">
+            <omegaup-common-teaching-assistants
+              :teaching-assistants="data.teachingAssistants"
+              :search-result-users="searchResultUsers"
+              @add-teaching-assistant="
+                (username) => $emit('add-teaching-assistant', username)
+              "
+              @remove-teaching-assistant="
+                (username) => $emit('remove-teaching-assistant', username)
+              "
+              @update-search-result-users="
+                (query) => $emit('update-search-result-users', query)
+              "
+            ></omegaup-common-teaching-assistants>
+          </div>
+          <div class="col-md-6">
+            <omegaup-common-group-teaching-assistants
+              :group-teaching-assistants="data.groupsTeachingAssistants"
+              :search-result-groups="searchResultGroups"
+              @add-group-teaching-assistant="
+                (groupAlias) =>
+                  $emit('add-group-teaching-assistant', groupAlias)
+              "
+              @remove-group-teaching-assistant="
+                (groupAlias) =>
+                  $emit('remove-group-teaching-assistant', groupAlias)
+              "
+              @update-search-result-groups="
+                (query) => $emit('update-search-result-groups', query)
+              "
+            ></omegaup-common-group-teaching-assistants>
           </div>
         </div>
-      </div>
-        <div v-show="showTab === 'archive'" class="tab-pane" :class="{ active: showTab === 'archive' }" role="tabpanel">
-        <omegaup-common-archive
-          :already-archived="alreadyArchived"
-          :archive-button-description="
-            alreadyArchived ? T.wordsUnarchiveCourse : T.wordsArchiveCourse
-          "
-          :archive-confirm-text="T.courseArchiveConfirmText"
-          :archive-header-title="T.wordsArchiveCourse"
-          :archive-help-text="T.courseArchiveHelpText"
-          @archive="onArchiveCourse"
-        ></omegaup-common-archive>
+
+        <div
+          v-show="showTab === 'clone'"
+          class="tab-pane"
+          :class="{ active: showTab === 'clone' }"
+          role="tabpanel"
+        >
+          <div class="card">
+            <div class="card-body">
+              <omegaup-course-clone
+                class="mb-4"
+                :initial-alias="data.course.alias"
+                :initial-name="data.course.name"
+                @clone="
+                  (alias, name, startTime) =>
+                    $emit('clone', alias, name, startTime)
+                "
+              ></omegaup-course-clone>
+              <omegaup-course-generate-link-clone
+                v-if="data.course.admission_mode !== admissionMode.Public"
+                :alias="data.course.alias"
+                :token="token"
+                @generate-link="(alias) => $emit('generate-link', alias)"
+              ></omegaup-course-generate-link-clone>
+            </div>
+          </div>
+        </div>
+        <div
+          v-show="showTab === 'archive'"
+          class="tab-pane"
+          :class="{ active: showTab === 'archive' }"
+          role="tabpanel"
+        >
+          <omegaup-common-archive
+            :already-archived="alreadyArchived"
+            :archive-button-description="
+              alreadyArchived ? T.wordsUnarchiveCourse : T.wordsArchiveCourse
+            "
+            :archive-confirm-text="T.courseArchiveConfirmText"
+            :archive-header-title="T.wordsArchiveCourse"
+            :archive-help-text="T.courseArchiveHelpText"
+            @archive="onArchiveCourse"
+          ></omegaup-common-archive>
         </div>
       </div>
     </keep-alive>

--- a/frontend/www/js/omegaup/components/problem/Edit.vue
+++ b/frontend/www/js/omegaup/components/problem/Edit.vue
@@ -103,7 +103,11 @@
 
     <keep-alive>
       <div class="tab-content mt-2">
-        <div v-show="showTab === 'edit'" class="tab-pane" :class="{ active: showTab === 'edit' }">
+        <div
+          v-show="showTab === 'edit'"
+          class="tab-pane"
+          :class="{ active: showTab === 'edit' }"
+        >
           <omegaup-problem-form
             :data="data"
             :original-visibility="data.originalVisibility"
@@ -111,7 +115,11 @@
           ></omegaup-problem-form>
         </div>
 
-        <div v-show="showTab === 'markdown'" class="tab-pane" :class="{ active: showTab === 'markdown' }">
+        <div
+          v-show="showTab === 'markdown'"
+          class="tab-pane"
+          :class="{ active: showTab === 'markdown' }"
+        >
           <omegaup-problem-statementedit
             :statement="currentStatement"
             markdown-type="statements"
@@ -132,7 +140,11 @@
           ></omegaup-problem-statementedit>
         </div>
 
-        <div v-show="showTab === 'version'" class="tab-pane" :class="{ active: showTab === 'version' }">
+        <div
+          v-show="showTab === 'version'"
+          class="tab-pane"
+          :class="{ active: showTab === 'version' }"
+        >
           <omegaup-problem-versions
             :log="data.log"
             :published-revision="data.publishedRevision"
@@ -149,7 +161,11 @@
           ></omegaup-problem-versions>
         </div>
 
-        <div v-show="showTab === 'solution'" class="tab-pane" :class="{ active: showTab === 'solution' }">
+        <div
+          v-show="showTab === 'solution'"
+          class="tab-pane"
+          :class="{ active: showTab === 'solution' }"
+        >
           <omegaup-problem-statementedit
             :statement="
               data.solution || { markdown: '', language: 'es', images: {} }
@@ -169,7 +185,11 @@
           ></omegaup-problem-statementedit>
         </div>
 
-        <div v-show="showTab === 'admins'" class="tab-pane" :class="{ active: showTab === 'admins' }">
+        <div
+          v-show="showTab === 'admins'"
+          class="tab-pane"
+          :class="{ active: showTab === 'admins' }"
+        >
           <omegaup-common-admins
             :admins="admins"
             :search-result-users="searchResultUsers"
@@ -194,7 +214,11 @@
           ></omegaup-common-groupadmins>
         </div>
 
-        <div v-show="showTab === 'tags'" class="tab-pane" :class="{ active: showTab === 'tags' }">
+        <div
+          v-show="showTab === 'tags'"
+          class="tab-pane"
+          :class="{ active: showTab === 'tags' }"
+        >
           <omegaup-problem-tags
             :alias="data.alias"
             :title="data.title"
@@ -223,7 +247,11 @@
           ></omegaup-problem-tags>
         </div>
 
-        <div v-show="showTab === 'download'" class="tab-pane" :class="{ active: showTab === 'download' }">
+        <div
+          v-show="showTab === 'download'"
+          class="tab-pane"
+          :class="{ active: showTab === 'download' }"
+        >
           <div class="card">
             <div class="card-body">
               <form class="form" @submit.prevent="onDownload">
@@ -244,7 +272,11 @@
           </div>
         </div>
 
-        <div v-show="showTab === 'delete'" class="tab-pane" :class="{ active: showTab === 'delete' }">
+        <div
+          v-show="showTab === 'delete'"
+          class="tab-pane"
+          :class="{ active: showTab === 'delete' }"
+        >
           <div class="card">
             <div class="card-body">
               <div class="form-group">


### PR DESCRIPTION
Implemented keep-alive to preserve component state when switching tabs in the contest, problem, and course edit pages.

I have tested it locally(Below is an example from editing a problem preserving state while switching tabs, the title and problem source content didnt change):
<img width="891" height="228" alt="image" src="https://github.com/user-attachments/assets/1e7dcf21-caac-4b8a-a588-37d2fe90fe2c" />

Fixes #7566 