### PR TITLE
fixed the 403 error on size labeler PR

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: PR Size Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
Currently, the size labeler workflow is giving 403 error as I saw on the latest PR. I have included the fix for that in this PR.