### PR TITLE
docs: add local setup video guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Para configurar el entorno de desarrollo localmente, consulta la [Guía de Confi
 
 ### Inicio Rápido
 
+### Video de demostración
+🎥 https://youtu.be/08rFcs6TV9U
+
+Este video explica los pasos para configurar el proyecto localmente y cómo ejecutarlo.
+
+
 ```bash
 # Clonar con submódulos
 git clone --recurse-submodules https://github.com/TU_USUARIO/omegaup
@@ -80,6 +86,12 @@ See the [Issue Assignment Workflow](frontend/www/docs/Issue-Assignment-Workflow.
 To set up the development environment locally, see the [Development Environment Setup Guide](frontend/www/docs/Development-Environment-Setup-Process.md).
 
 ### Quick Start
+
+### Demo Video
+🎥 https://youtu.be/08rFcs6TV9U
+
+This video explains the local setup steps and how to run the project.
+
 
 ```bash
 # Clone with submodules
@@ -176,6 +188,12 @@ Para configurar o ambiente de desenvolvimento localmente, consulte o [Guia de Co
 
 ### Início Rápido
 
+### Vídeo de demonstração
+🎥 https://youtu.be/08rFcs6TV9U
+
+Este vídeo explica os passos para configurar o projeto localmente e como executá-lo.
+
+
 ```bash
 # Clonar com submódulos
 git clone --recurse-submodules https://github.com/SEUUSUARIO/omegaup
@@ -236,6 +254,12 @@ Questo include anche tutti i browser basati su Blink/WebKit le cui versioni sono
 Per configurare l'ambiente di sviluppo localmente, consulta la [Guida alla Configurazione dell'Ambiente di Sviluppo](frontend/www/docs/Development-Environment-Setup-Process.md).
 
 ### Avvio Rapido
+
+### Video dimostrativo
+🎥 https://youtu.be/08rFcs6TV9U
+
+Questo video spiega i passaggi per configurare il progetto localmente e come eseguirlo.
+
 
 ```bash
 # Clonare con i submodule


### PR DESCRIPTION
## Description
This PR adds a step-by-step video guide for setting up the omegaup repository locally.
The video helps beginners understand how to clone the repo, install dependencies (yarn),
run tests, and start the development server.

## Demo Video
🎥 https://youtu.be/08rFcs6TV9U

## Fixes
Fixes #8686

## Checklist
- [x] Documentation updated
- [x] No code changes
- [x] Video tested and accessible
