### PR TITLE
Add watcher for selectedYear to update heatmap on year change

### DIFF
--- a/frontend/www/js/omegaup/components/user/UserHeatmap.vue
+++ b/frontend/www/js/omegaup/components/user/UserHeatmap.vue
@@ -129,6 +129,16 @@ export default class UserHeatmap extends Vue {
     }
   }
 
+  @Watch('selectedYear')
+  onSelectedYearChange(): void {
+    this.hasRendered = false;
+    this.$nextTick(() => {
+      if (this.data?.length) {
+        this.renderHeatmap();
+      }
+    });
+  }
+
   onYearChange(): void {
     this.$emit('year-changed', this.selectedYear);
   }


### PR DESCRIPTION
# Description

The component was missing a watcher for selectedYear. Watchers existed for data, isLoading, and availableYears, but not for selectedYear. The onYearChange method only emitted an event and did not trigger a re-render.

**Solution**

`Added a @Watch('selectedYear') watcher that re-renders the heatmap when the year changes.`

Fixes #8723 

Video:


https://github.com/user-attachments/assets/89cd2a29-215d-474d-942f-042426637651




# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
