### PR TITLE
Allow contestants to access printable problem statements

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -2183,6 +2183,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         if ($statementType === 'printable') {
             if (!is_null($problemset) && isset($problemset['contest'])) {
+                if (is_null($identity)) {
+                    throw new \OmegaUp\Exceptions\UnauthorizedException(
+                        'userNotAllowed'
+                    );
+                }
                 if (
                     !\OmegaUp\Authorization::isAdmin(
                         $identity,

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -33,6 +33,17 @@
         class="tab-pane fade py-4 p-lg-4"
         :class="{ 'show active': selectedTab === 'problems' }"
       >
+        <div class="d-flex justify-content-end mb-3">
+          <a
+            :href="printableUrl"
+            target="_blank"
+            class="btn btn-secondary btn-sm"
+            :title="T.problemPrintableVersion"
+          >
+            <font-awesome-icon :icon="['fas', 'print']" />
+            {{ T.problemPrintableVersion }}
+          </a>
+        </div>
         <omegaup-problem-settings-summary
           :problem="problem"
           :show-visibility-indicators="showVisibilityIndicators"
@@ -415,6 +426,7 @@ import {
   faEyeSlash,
   faBan,
   faExternalLinkAlt,
+  faPrint,
 } from '@fortawesome/free-solid-svg-icons';
 import { SubmissionRequest } from '../../arena/submissions';
 import { ArenaCourseFeedback } from '../arena/Feedback.vue';
@@ -424,6 +436,7 @@ library.add(
   faEyeSlash,
   faBan,
   faExternalLinkAlt,
+  faPrint,
 );
 
 export interface Tab {
@@ -523,6 +536,13 @@ export default class ProblemDetails extends Vue {
   hasUnreadClarifications =
     this.clarifications?.length > 0 && this.activeTab !== 'clarifications';
   currentRunDetailsData = this.runDetailsData;
+
+  get printableUrl(): string {
+    if (this.contestAlias) {
+      return `/arena/${this.contestAlias}/problem/${this.problem.alias}/print/`;
+    }
+    return `/arena/problem/${this.problem.alias}/print/`;
+  }
 
   get availableTabs(): Tab[] {
     const tabs = [


### PR DESCRIPTION
# Description

This change enables access to the existing **printable version of problem statements** for users who can view a problem (including contestants), instead of restricting it only to problemsetters.  

The authorization logic for printable statements was updated to use `canViewProblem`, while preserving contest integrity by blocking printable access during an active contest for non-admin users. Problem artifact downloads (ZIP with tests and configs) remain restricted to problemsetters only.

No new APIs or UI elements were added; the existing printable infrastructure is reused.

Fixes: #8754

# Comments

- This PR only adjusts permission checks for the printable statement path.
- Contest problems remain protected while the contest is running; admins can still access printable versions at all times.
- No changes were made to artifact, run, or contest download APIs.

# Checklist:

- [x] The code follows the coding guidelines of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.
