### PR TITLE
Fix statement preview box layout and alignment

### DIFF
--- a/frontend/www/js/omegaup/components/problem/StatementEdit.vue
+++ b/frontend/www/js/omegaup/components/problem/StatementEdit.vue
@@ -211,11 +211,17 @@ export default class ProblemStatementEdit extends Vue {
 @import '../../../../third_party/js/pagedown/demo/browser/demo.css';
 
 .wmd-preview,
+  
+.wmd-preview {
+  text-align: left;
+}
 .wmd-button-bar {
   background-color: var(--wmd-button-bar-background-color);
 }
 
 .row {
+    display: flex;
+    gap: 15px;
   .wmd-button-bar {
     flex-shrink: 0;
   }
@@ -232,7 +238,9 @@ export default class ProblemStatementEdit extends Vue {
   }
 
   [data-statement-edit-markdown] {
-    flex: 1;
+    flex: 0 0 auto;
+    max-width: 48%;
+      text-align: left;
     min-height: 400px;
     overflow-y: auto;
     border: 1px solid var(--markdown-preview-border-color);


### PR DESCRIPTION
CSS fixes for statement preview box:

- Set preview box max-width to 48% to prevent full-width layout
- Added text-align: left to preview content for proper alignment
- Set row to display: flex with gap for proper column spacing
- Fixed flex properties on preview element (flex: 0 0 auto) to prevent stretching

This creates a proper side-by-side layout with:
- Editor on the left (50% via col-md-6)
- Preview on the right (48% via max-width)
- Proper left alignment for content

# Description

Please include a description of the changes you have made. The text you put in this section will be used as the **commit message** when this PR is merged.

If you modify the **User Interface**, please include a screenshot or a video.

Fixes: #(issue)

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
