### PR TITLE
revert: remove paths filter from CI workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,76 +2,10 @@ name: CI
 
 on:
   workflow_call: # make this workflow reusable
-  pull_request:
-    paths:
-      # Source code
-      - 'frontend/**'
-      - 'stuff/**'
-      - 'cypress/**'
-      - 'bin/**'
-      # Dependencies
-      - 'composer.json'
-      - 'composer.lock'
-      - 'package.json'
-      - 'yarn.lock'
-      # Build & TypeScript config
-      - 'tsconfig.json'
-      - 'webpack.config*.js'
-      - '.babelrc'
-      # Test config
-      - 'jest.config.js'
-      - 'cypress.config.ts'
-      # Linter configs
-      - '.eslintrc.js'
-      - '.prettierrc.json'
-      - '.stylelintrc.yml'
-      - '.flake8'
-      - '.pylintrc'
-      - '.lint.config.json'
-      - 'psalm.xml'
-      - 'setup.cfg'
-      # Docker
-      - 'Dockerfile'
-      - 'docker-compose*.yml'
-      # Git & CI
-      - '.gitmodules'
-      - '.github/workflows/**'
+  pull_request: {}
   push:
     branches:
       - main
-    paths:
-      # Source code
-      - 'frontend/**'
-      - 'stuff/**'
-      - 'cypress/**'
-      - 'bin/**'
-      # Dependencies
-      - 'composer.json'
-      - 'composer.lock'
-      - 'package.json'
-      - 'yarn.lock'
-      # Build & TypeScript config
-      - 'tsconfig.json'
-      - 'webpack.config*.js'
-      - '.babelrc'
-      # Test config
-      - 'jest.config.js'
-      - 'cypress.config.ts'
-      # Linter configs
-      - '.eslintrc.js'
-      - '.prettierrc.json'
-      - '.stylelintrc.yml'
-      - '.flake8'
-      - '.pylintrc'
-      - '.lint.config.json'
-      - 'psalm.xml'
-      - 'setup.cfg'
-      # Docker
-      - 'Dockerfile'
-      - 'docker-compose*.yml'
-      # Git & CI
-      - '.gitmodules'
-      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
The paths filter causes required checks to be skipped for PRs that only modify files not in the filter (e.g., documentation). Since GitHub still expects required checks to pass, this blocks merging those PRs.

Reverts the path optimization while we design a better solution.

Related to #8566 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
