### PR TITLE
Fix contest list "Show more results" pagination behavior

### DIFF
--- a/frontend/www/js/omegaup/arena/contestStore.ts
+++ b/frontend/www/js/omegaup/arena/contestStore.ts
@@ -87,7 +87,10 @@ export const contestStoreConfig = {
         return;
       }
       commit('setLoading', true);
-      api.Contest.list(payload.requestParams)
+      api.Contest.list({
+        ...payload.requestParams,
+        page_size: 3,
+      })
         .then((response) => {
           commit('updateList', {
             name: payload.name,
@@ -103,7 +106,9 @@ export const contestStoreConfig = {
 };
 
 function generateCacheKey(params: UrlParams) {
-  return `${params.tab_name}-${params.filter}-${params.sort_order}-${params.query}-${params.page}`;
+  return `${params.tab_name}-${params.filter}-${params.sort_order}-${
+    params.query
+  }-${params.page}-${(params as any).page_size || ''}`;
 }
 
 export default new Vuex.Store<ContestState>(contestStoreConfig);

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -205,7 +205,7 @@
             </div>
             <div v-else class="d-flex">
               <div
-                v-for="contestItem in getContestsForTab(tab).slice(0, 10)"
+                v-for="contestItem in getContestsForTab(tab).slice(0, 3)"
                 :key="contestItem.contest_id"
                 class="mr-3"
                 style="min-width: 300px; max-width: 300px"
@@ -417,6 +417,13 @@
         "
         class="text-center mb-2"
       >
+        <button
+          class="btn btn-outline-primary w-100"
+          :disabled="isScrollLoading"
+          @click="loadMoreContests"
+        >
+          {{ showMoreContestButtonText }}
+        </button>
         <button
           class="btn btn-outline-primary w-100"
           :disabled="isScrollLoading"

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -479,7 +479,7 @@ class ArenaContestList extends Vue {
   @Prop({ default: ContestOrder.None }) sortOrder!: ContestOrder;
   @Prop({ default: ContestFilter.All }) filter!: ContestFilter;
   @Prop() page!: number;
-  @Prop({ default: 10 }) pageSize!: number;
+  @Prop({ default: 3 }) pageSize!: number;
   @Prop({ default: false }) loading!: boolean;
 
   T = T;


### PR DESCRIPTION
# Description

Fix contest list pagination so that the "Show more results" button properly loads additional contests instead of showing all contests immediately.

Fixes: #8800 


# Comments

Before: 

https://github.com/user-attachments/assets/e4f4e36a-b1e8-4779-b7bb-0f5d23fb3cb9

After:


https://github.com/user-attachments/assets/556e4196-a6ee-491a-a931-0da3db5ac359


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
