### PR TITLE
Added DAO layer for System_Settings table

### DIFF
--- a/frontend/server/src/DAO/SystemSettings.php
+++ b/frontend/server/src/DAO/SystemSettings.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * SystemSettings Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\SystemSettings}.
+ */
+class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
+    /**
+     * Get a system setting by key.
+     *
+     * @param string $key The setting key
+     * @return \OmegaUp\DAO\VO\SystemSettings|null The setting object or null if not found
+     */
+    public static function getByKey(string $key): ?\OmegaUp\DAO\VO\SystemSettings {
+        $fields = join(
+            ', ',
+            array_keys(
+                \OmegaUp\DAO\VO\SystemSettings::FIELD_NAMES
+            )
+        );
+        $sql = "SELECT {$fields} FROM System_Settings WHERE setting_key = ? LIMIT 1;";
+        /** @var array{created_at: \OmegaUp\Timestamp, setting_description: null|string, setting_id: int, setting_key: string, setting_value: null|string, updated_at: \OmegaUp\Timestamp}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$key]);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\SystemSettings($row);
+    }
+
+    /**
+     * Get a boolean system setting value.
+     *
+     * @param string $key The setting key
+     * @param bool $default Default value if setting not found
+     * @return bool The boolean setting value
+     */
+    public static function getBooleanSetting(
+        string $key,
+        bool $default = true
+    ): bool {
+        $setting = self::getByKey($key);
+        if (is_null($setting)) {
+            return $default;
+        }
+        return intval($setting->setting_value) === 1;
+    }
+
+    /**
+     * Set a boolean system setting value.
+     *
+     * @param string $key The setting key
+     * @param bool $value The value to set
+     * @return int Number of affected rows
+     */
+    public static function setBooleanSetting(
+        string $key,
+        bool $value
+    ): int {
+        $setting = self::getByKey($key);
+        if (is_null($setting)) {
+            $newSetting = new \OmegaUp\DAO\VO\SystemSettings([
+                'setting_key' => $key,
+                'setting_value' => $value ? '1' : '0',
+                'setting_description' => '',
+            ]);
+            return self::create($newSetting);
+        }
+        $setting->setting_value = $value ? '1' : '0';
+        return self::update($setting);
+    }
+
+    /**
+     * Get a string system setting value.
+     *
+     * @param string $key The setting key
+     * @param string $default Default value if setting not found
+     * @return string The string setting value
+     */
+    public static function getStringSetting(
+        string $key,
+        string $default = ''
+    ): string {
+        $setting = self::getByKey($key);
+        if (is_null($setting)) {
+            return $default;
+        }
+        return strval($setting->setting_value);
+    }
+
+    /**
+     * Set a string system setting value.
+     *
+     * @param string $key The setting key
+     * @param string $value The value to set
+     * @return int Number of affected rows
+     */
+    public static function setStringSetting(
+        string $key,
+        string $value
+    ): int {
+        $setting = self::getByKey($key);
+        if (is_null($setting)) {
+            $newSetting = new \OmegaUp\DAO\VO\SystemSettings([
+                'setting_key' => $key,
+                'setting_value' => $value,
+                'setting_description' => '',
+            ]);
+            return self::create($newSetting);
+        }
+        $setting->setting_value = $value;
+        return self::update($setting);
+    }
+}

--- a/frontend/tests/controllers/SystemSettingsDAOTest.php
+++ b/frontend/tests/controllers/SystemSettingsDAOTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\SystemSettings data access object.
+ */
+class SystemSettingsDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    public function testGetByKeyReturnsSeededSetting() {
+        $setting = \OmegaUp\DAO\SystemSettings::getByKey(
+            'ephemeral_grader_enabled'
+        );
+
+        $this->assertNotNull($setting);
+        $this->assertSame('ephemeral_grader_enabled', $setting->setting_key);
+        $this->assertSame('1', $setting->setting_value);
+    }
+
+    public function testGetByKeyReturnsNullForUnknownKey() {
+        $this->assertNull(
+            \OmegaUp\DAO\SystemSettings::getByKey(
+                \OmegaUp\Test\Utils::createRandomString()
+            )
+        );
+    }
+
+    public function testGetBooleanSettingReadsSeededValue() {
+        $this->assertTrue(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting(
+                'ephemeral_grader_enabled'
+            )
+        );
+    }
+
+    public function testGetBooleanSettingReturnsDefaultWhenMissing() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        $this->assertFalse(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, false)
+        );
+        $this->assertTrue(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, true)
+        );
+    }
+
+    public function testSetBooleanSettingCreatesThenUpdates() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        \OmegaUp\DAO\SystemSettings::setBooleanSetting($key, true);
+        $this->assertTrue(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, false)
+        );
+
+        \OmegaUp\DAO\SystemSettings::setBooleanSetting($key, false);
+        $this->assertFalse(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, true)
+        );
+    }
+
+    public function testGetStringSettingReturnsDefaultWhenMissing() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        $this->assertSame(
+            'fallback',
+            \OmegaUp\DAO\SystemSettings::getStringSetting($key, 'fallback')
+        );
+    }
+
+    public function testSetStringSettingCreatesThenUpdates() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        \OmegaUp\DAO\SystemSettings::setStringSetting($key, 'first');
+        $this->assertSame(
+            'first',
+            \OmegaUp\DAO\SystemSettings::getStringSetting($key)
+        );
+
+        \OmegaUp\DAO\SystemSettings::setStringSetting($key, 'second');
+        $this->assertSame(
+            'second',
+            \OmegaUp\DAO\SystemSettings::getStringSetting($key)
+        );
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces the **DAO/VO layer** for the `System_Settings` table and refactors existing code to use it,keeping omegaup’s standard database access patterns.

All database access related to system settings is now centralized in the DAO layer instead of using direct SQL queries.

This PR is a **dependency for PR #8906**, which implements the backend logic for system settings.

Fixes: #8319 

# Comments
- This PR only adds the DAO/VO layer and does not introduce user-facing changes.
- It should be **merged before PR #8906** to keep the feature split clean and reviewable.

 Depends on
- Waiting for **PR #8905**
# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.
