### PR TITLE
feat: profile picture edit shortcut to Gravatar and test cases

### DIFF
--- a/frontend/www/js/omegaup/components/user/SidebarMainInfo.test.ts
+++ b/frontend/www/js/omegaup/components/user/SidebarMainInfo.test.ts
@@ -146,15 +146,6 @@ describe.each(rankingMapping)(`A user:`, (rank) => {
 });
 
 describe('Profile Picture Edit Feature', () => {
-  beforeEach(() => {
-    // Mock window.open
-    window.open = jest.fn();
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('Should display profile edit overlay when viewing own profile', () => {
     const wrapper = mount(user_SidebarMainInfo, {
       propsData: { profile, data },
@@ -163,12 +154,10 @@ describe('Profile Picture Edit Feature', () => {
     const profileContainer = wrapper.find('.profile-picture-container');
     const editOverlay = wrapper.find('.profile-edit-overlay');
     const pencilIcon = wrapper.find('.edit-icon');
-    const svgIcon = wrapper.find('.edit-icon svg');
 
     expect(profileContainer.exists()).toBeTruthy();
     expect(editOverlay.exists()).toBeTruthy();
     expect(pencilIcon.exists()).toBeTruthy();
-    expect(svgIcon.exists()).toBeTruthy();
   });
 
   it('Should not display profile edit overlay when viewing other user profile', () => {
@@ -195,32 +184,26 @@ describe('Profile Picture Edit Feature', () => {
     expect(profilePicture.attributes('class')).toContain('rounded-circle');
   });
 
-  it('Should call redirectToGravatar when clicking edit overlay', async () => {
+  it('Should have edit overlay as anchor link to Gravatar', () => {
     const wrapper = mount(user_SidebarMainInfo, {
       propsData: { profile, data },
     });
 
     const editOverlay = wrapper.find('.profile-edit-overlay');
-    await editOverlay.trigger('click');
-
-    expect(window.open).toHaveBeenCalledWith(
-      'https://www.gravatar.com',
-      '_blank',
-    );
+    expect(editOverlay.element.tagName).toBe('A');
+    expect(editOverlay.attributes('href')).toBe('https://www.gravatar.com');
+    expect(editOverlay.attributes('target')).toBe('_blank');
   });
 
-  it('Should call redirectToGravatar when clicking profile picture', async () => {
+  it('Should not have click handler on profile picture', () => {
     const wrapper = mount(user_SidebarMainInfo, {
       propsData: { profile, data },
     });
 
     const profilePicture = wrapper.find('.profile-picture');
-    await profilePicture.trigger('click');
-
-    expect(window.open).toHaveBeenCalledWith(
-      'https://www.gravatar.com',
-      '_blank',
-    );
+    expect(profilePicture.exists()).toBeTruthy();
+    // Verify there is no click handler on the image itself
+    expect(profilePicture.element.onclick).toBeNull();
   });
 
   it('Should have correct tooltip text', () => {
@@ -251,18 +234,18 @@ describe('Profile Picture Edit Feature', () => {
     expect(pencilIcon.classes()).toContain('edit-icon');
   });
 
-  it('Should display pencil SVG icon', () => {
+  it('Should display FontAwesome pencil icon', () => {
     const wrapper = mount(user_SidebarMainInfo, {
       propsData: { profile, data },
     });
 
-    const pencilIcon = wrapper.find('.edit-icon');
-    const svgIcon = wrapper.find('.edit-icon svg');
+    const editIconContainer = wrapper.find('.edit-icon');
+    const faIcon = wrapper.find('i.fa.fa-pencil-alt');
 
-    expect(pencilIcon.exists()).toBeTruthy();
-    expect(svgIcon.exists()).toBeTruthy();
-    expect(svgIcon.attributes('width')).toBe('20');
-    expect(svgIcon.attributes('height')).toBe('20');
+    expect(editIconContainer.exists()).toBeTruthy();
+    expect(faIcon.exists()).toBeTruthy();
+    expect(faIcon.classes()).toContain('fa');
+    expect(faIcon.classes()).toContain('fa-pencil-alt');
   });
 
   it('Should not show edit overlay for non-own profile even if clicked', async () => {

--- a/frontend/www/js/omegaup/components/user/SidebarMainInfo.vue
+++ b/frontend/www/js/omegaup/components/user/SidebarMainInfo.vue
@@ -6,28 +6,15 @@
           <img
             class="rounded-circle profile-picture"
             :src="profile.gravatar_92"
-            @click="redirectToGravatar"
           />
-          <div
+          <a
             class="profile-edit-overlay"
             :title="T.userEditProfileImage"
-            @click="redirectToGravatar"
+            href="https://www.gravatar.com"
+            target="_blank"
           >
-            <div class="edit-icon">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                  fill="white"
-                />
-              </svg>
-            </div>
-          </div>
+            <i class="fa fa-pencil-alt edit-icon"></i>
+          </a>
         </div>
         <img v-else class="rounded-circle" :src="profile.gravatar_92" />
       </div>
@@ -226,14 +213,18 @@ export default class UserSidebarMainInfo extends Vue {
       this.$emit('update:selectedTab', validTab);
     }
   }
-
-  redirectToGravatar(): void {
-    window.open('https://www.gravatar.com', '_blank');
-  }
 }
 </script>
 
 <style scoped>
+:root {
+  --overlay-bg-color: rgba(0, 0, 0, 0.6);
+  --icon-color: white;
+  --icon-font-size: 16px;
+  --image-opacity-hover: 0.8;
+  --shadow-color: rgba(0, 0, 0, 0.5);
+}
+
 .profile-picture-container {
   position: relative;
   display: inline-block;
@@ -253,13 +244,14 @@ export default class UserSidebarMainInfo extends Vue {
   left: 0;
   width: 92px;
   height: 92px;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--overlay-bg-color);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
+  text-decoration: none;
 }
 
 .profile-picture-container:hover .profile-edit-overlay {
@@ -267,21 +259,13 @@ export default class UserSidebarMainInfo extends Vue {
 }
 
 .profile-picture-container:hover .profile-picture {
-  opacity: 0.8;
+  opacity: var(--image-opacity-hover);
 }
 
 .edit-icon {
-  color: white;
-  font-size: 16px;
+  color: var(--icon-color);
+  font-size: var(--icon-font-size);
   z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.edit-icon svg {
-  width: 20px;
-  height: 20px;
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+  text-shadow: 0 1px 2px var(--shadow-color);
 }
 </style>


### PR DESCRIPTION
# Description

This PR introduces a UI enhancement that adds a profile picture edit shortcut in the sidebar for users viewing their own profile.

Previously, changing the profile picture required navigating to the Preferences section and locating the Gravatar link manually, which created unnecessary friction.

### Changes Made

- Added a pencil (✏️) icon overlay that appears on hover over the profile picture.
- Made both the profile picture and the overlay icon clickable.
- Clicking redirects the user directly to Gravatar in a new tab.
- Feature is conditionally rendered only when `profile.is_own_profile` is true.
- Implemented smooth hover transitions with a semi-transparent overlay.
- Added scoped CSS to preserve circular layout and visual consistency.
- Added unit tests to validate visibility, behavior, and conditional rendering.

This improves discoverability and significantly reduces the number of steps required for users to update their profile image while staying aligned with omegaUp’s decision to rely on Gravatar instead of native uploads.

### Screencast


https://github.com/user-attachments/assets/c1381465-d5d3-4290-bbf8-42405be3483d



Fixes: #8868 

# Comments

This change does not introduce any image upload capability and strictly works within the existing Gravatar-based flow.


# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [X] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
