### PR TITLE
fix: navbar item alignment and dropdown overflow

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -37,7 +37,7 @@
               @read="readNotifications"
             ></omegaup-notification-list>
           </div>
-          <ul v-if="!isLoggedIn" class="navbar-nav navbar-right d-lg-flex">
+          <ul v-if="!isLoggedIn" class="navbar-nav navbar-right d-lg-flex mr-2">
             <li class="nav-item d-flex align-items-center">
               <a
                 class="nav-link nav-login-text pr-0"

--- a/frontend/www/js/omegaup/components/common/NavbarItems.vue
+++ b/frontend/www/js/omegaup/components/common/NavbarItems.vue
@@ -260,3 +260,26 @@ export default class NavbarItems extends Vue {
   T = T;
 }
 </script>
+
+<style lang="scss" scoped>
+@media only screen and (max-width: 992px) {
+  .help-dropdown {
+    min-width: auto !important;
+    width: auto !important;
+    max-width: 85vw !important;
+    left: auto !important;
+    right: 0 !important;
+
+    .dropdown-item {
+      white-space: normal !important;
+      word-wrap: break-word !important;
+      overflow-wrap: break-word !important;
+      word-break: break-word !important;
+      line-height: 1.4 !important;
+      padding: 0.5rem 1rem !important;
+      max-width: 100% !important;
+      display: block !important;
+    }
+  }
+}
+</style>

--- a/frontend/www/js/omegaup/components/problem/SearchBar.vue
+++ b/frontend/www/js/omegaup/components/problem/SearchBar.vue
@@ -53,7 +53,7 @@
         </label>
       </div>
       <div class="form-group mr-2">
-        <label>
+        <label class="ml-4 large:ml-0">
           <input
             v-model="currentOnlyQualitySeal"
             name="only_quality_seal"


### PR DESCRIPTION
# Description
1. Added a right margin to the "log in / sign up".
<img width="609" height="584" alt="Screenshot from 2026-02-04 18-59-12" src="https://github.com/user-attachments/assets/2531dec2-531b-425b-8e74-c4b5be4ddd58" />

2. The Help menu items now wrap if the text is too long
<img width="609" height="584" alt="Screenshot from 2026-02-04 19-02-48" src="https://github.com/user-attachments/assets/13ace81a-19f2-46ee-855f-3fbdab0f0c16" />

3. Added a left margin to the quality label

 <img width="609" height="584" alt="Screenshot from 2026-02-04 19-04-15" src="https://github.com/user-attachments/assets/3091876a-4d7c-4ee0-99c4-71f21cc486ae" />

Fixes: #8976 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
