### PR TITLE
[FEATURE] Add character limit indicators for Contest form fields

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Form.vue
+++ b/frontend/www/js/omegaup/components/contest/Form.vue
@@ -93,9 +93,16 @@
                     type="text"
                     required
                     :disabled="isSubmitting"
+                    :maxlength="MAX_LENGTH.title"
                     @blur="validateField(FieldName.Title)"
                     @input="clearFieldError(FieldName.Title)"
                   />
+                  <small
+                    class="character-counter"
+                    :class="{ 'text-danger': isExceedingTitle }"
+                  >
+                    {{ title.length }}/{{ MAX_LENGTH.title }}
+                  </small>
                   <div
                     v-if="
                       invalidParameterName === FieldName.Title ||
@@ -139,9 +146,16 @@
                     :disabled="update || isSubmitting"
                     type="text"
                     required
+                    :maxlength="MAX_LENGTH.alias"
                     @blur="validateField(FieldName.Alias)"
                     @input="clearFieldError(FieldName.Alias)"
                   />
+                  <small
+                    class="character-counter"
+                    :class="{ 'text-danger': isExceedingAlias }"
+                  >
+                    {{ alias.length }}/{{ MAX_LENGTH.alias }}
+                  </small>
                   <div
                     v-if="
                       invalidParameterName === FieldName.Alias ||
@@ -238,9 +252,16 @@
                     rows="10"
                     required
                     :disabled="isSubmitting"
+                    :maxlength="MAX_LENGTH.description"
                     @blur="validateField(FieldName.Description)"
                     @input="clearFieldError(FieldName.Description)"
                   ></textarea>
+                  <small
+                    class="character-counter"
+                    :class="{ 'text-danger': isExceedingDescription }"
+                  >
+                    {{ description.length }}/{{ MAX_LENGTH.description }}
+                  </small>
                   <div
                     v-if="
                       invalidParameterName === FieldName.Description ||
@@ -1009,6 +1030,14 @@ const CONTEST_PRESETS: Record<PresetType, PresetConfig> = {
   },
 };
 
+const MAX_LENGTH = {
+  title: 256,
+  alias: 32,
+  description: 255,
+};
+
+const DANGER_THRESHOLD_PERCENTAGE = 0.8;
+
 @Component({
   components: {
     'omegaup-common-typeahead': common_Typeahead,
@@ -1028,6 +1057,7 @@ export default class Form extends Vue {
   PresetType = PresetType;
   FieldName = FieldName;
   SectionName = SectionName;
+  MAX_LENGTH = MAX_LENGTH;
 
   @Prop() update!: boolean;
   @Prop() allLanguages!: string[];
@@ -1406,6 +1436,22 @@ export default class Form extends Vue {
     return false;
   }
 
+  // Computed properties for character limit danger thresholds
+  get isExceedingTitle(): boolean {
+    return this.title.length > MAX_LENGTH.title * DANGER_THRESHOLD_PERCENTAGE;
+  }
+
+  get isExceedingAlias(): boolean {
+    return this.alias.length > MAX_LENGTH.alias * DANGER_THRESHOLD_PERCENTAGE;
+  }
+
+  get isExceedingDescription(): boolean {
+    return (
+      this.description.length >
+      MAX_LENGTH.description * DANGER_THRESHOLD_PERCENTAGE
+    );
+  }
+
   onRemove(language: string) {
     if (this.catLanguageBlocked && language == 'cat') {
       this.$emit('language-remove-blocked', language);
@@ -1468,5 +1514,13 @@ export default class Form extends Vue {
 /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
 .is-invalid-wrapper ::v-deep .multiselect__tags {
   border-color: var(--form-input-error-color);
+}
+
+.character-counter {
+  display: block;
+  text-align: right;
+  color: var(--form-character-counter-color, #6c757d);
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
 }
 </style>


### PR DESCRIPTION
## Description

This PR adds character limit indicators and frontend validation for the Contest creation/edit form fields (title, alias, and description) to prevent users from entering data that exceeds database limits.

### Changes Made:
- **Title field**: Added `maxlength="256"` attribute and character counter (matches `VARCHAR(256)` database limit)
- **Alias field**: Added `maxlength="32"` attribute and character counter (matches `VARCHAR(32)` database limit)
- **Description field**: Added `maxlength="255"` attribute and character counter (matches `TINYTEXT` database limit)
- Added `MAX_LENGTH` constant and `DANGER_THRESHOLD_PERCENTAGE` (80%) for reusability
- Added computed properties ([isExceedingTitle](cci:1://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/contest/Form.vue:1438:2-1441:3), [isExceedingAlias](cci:1://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/contest/Form.vue:1443:2-1445:3), [isExceedingDescription](cci:1://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/contest/Form.vue:1447:2-1452:3)) to detect when approaching limit
- Added CSS styles for `.character-counter` with danger styling when threshold is exceeded

### Visual Behavior:
- Character counters display in the format `current/max` (e.g., `25/256`)
- Counter turns red (`text-danger`) when input exceeds 80% of the limit
- `maxlength` attribute prevents users from typing beyond the limit

Fixes #8966

## Comments

This implementation follows the same pattern used in the Course form (PR #8937). Only frontend changes are included as the `maxlength` HTML attribute prevents users from entering data beyond the limit.

## Checklist

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.


https://github.com/user-attachments/assets/f1272f28-999d-42c3-889c-bc265cdb4745
