### PR TITLE
fix(docs): fix broken mentor link in GSoC 2026 description

### DIFF
--- a/frontend/www/docs/Google-Summer-of-Code-2026.md
+++ b/frontend/www/docs/Google-Summer-of-Code-2026.md
@@ -210,7 +210,7 @@ A seamless end-to-end user experience where authors can create or edit problems 
 
 **Possible mentor**:
 
-[pabo99](https://github.com/pabo99), [heduenas](https://github.com/heduenas), Ankitsinghsisodya](https://github.com/Ankitsinghsisodya)
+[pabo99](https://github.com/pabo99), [heduenas](https://github.com/heduenas), [Ankitsinghsisodya](https://github.com/Ankitsinghsisodya)
 
 **Estimated size of project:**
 


### PR DESCRIPTION
# Description

Adds missing opening bracket to Ankitsinghsisodya's profile link in the GSoC 2026 documentation.

Fixes #8963

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.