### PR TITLE
Add User_Code_Templates database migration

### DIFF
--- a/frontend/database/00262_user_code_templates.sql
+++ b/frontend/database/00262_user_code_templates.sql
@@ -1,0 +1,15 @@
+-- User_Code_Templates
+CREATE TABLE IF NOT EXISTS `User_Code_Templates` (
+  `template_id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL COMMENT 'Identificador del usuario',
+  `language` varchar(70) NOT NULL COMMENT 'Lenguaje de programación del template',
+  `template_name` varchar(100) NOT NULL COMMENT 'Nombre del template definido por el usuario',
+  `code` mediumtext NOT NULL COMMENT 'Código del template',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Fecha de creación del template',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Fecha de última actualización',
+  PRIMARY KEY (`template_id`),
+  UNIQUE KEY `user_language_name` (`user_id`, `language`, `template_name`),
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_language` (`language`),
+  CONSTRAINT `fk_uct_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Templates de código personalizados por usuario y lenguaje';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1287,6 +1287,23 @@ CREATE TABLE `Teams_Group_Roles` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `User_Code_Templates` (
+  `template_id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL COMMENT 'Identificador del usuario',
+  `language` varchar(70) NOT NULL COMMENT 'Lenguaje de programación del template',
+  `template_name` varchar(100) NOT NULL COMMENT 'Nombre del template definido por el usuario',
+  `code` mediumtext NOT NULL COMMENT 'Código del template',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Fecha de creación del template',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Fecha de última actualización',
+  PRIMARY KEY (`template_id`),
+  UNIQUE KEY `user_language_name` (`user_id`,`language`,`template_name`),
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_language` (`language`),
+  CONSTRAINT `fk_uct_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Templates de código personalizados por usuario y lenguaje';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `User_Rank` (
   `user_id` int NOT NULL,
   `ranking` int DEFAULT NULL,


### PR DESCRIPTION
# Description

Adds database migration `00262_user_code_templates.sql` to create the `User_Code_Templates` table and updates `schema.sql` accordingly.

The new table stores per-user, per-language code templates with columns: `template_id`, `user_id`, `language`, `template_name`, `code`, `created_at`, `updated_at`.

Includes a unique constraint on `(user_id, language, template_name)` and a foreign key reference to `Users`.

This is Part 1 of 3 for #9044.

Fixes: #9044 (Part 1)

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.