### PR TITLE
Optimizes the problem list query when filtering by tags by removing redundant subquery

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -28,6 +28,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         $havingClause = $requireAllTags ? 'HAVING (COUNT(pt.tag_id) = ?)' : '';
         $placeholders = array_fill(0, count($tags), '?');
         $placeholders = join(',', $placeholders);
+        // Use direct JOIN on Tags by name to avoid redundant subquery;
+        // Tags.name has UNIQUE index so the lookup is efficient.
         $sql .= "
             INNER JOIN (
                 SELECT
@@ -43,12 +45,9 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                     Tags t
                 ON
                     pt.tag_id = t.tag_id
-                WHERE pt.tag_id IN (
-                    SELECT t.tag_id
-                    FROM Tags t
-                    WHERE t.name in ($placeholders)
-                )
-                AND (pp.allow_user_add_tags = '1' OR pt.source <> 'voted')
+                    AND t.name IN ($placeholders)
+                WHERE
+                    (pp.allow_user_add_tags = '1' OR pt.source <> 'voted')
                 GROUP BY
                     pt.problem_id
                 {$havingClause}


### PR DESCRIPTION
## Changes
- **`frontend/server/src/DAO/Problems.php`**: Replaced `WHERE pt.tag_id IN (SELECT t.tag_id FROM Tags t WHERE t.name in (...))` with `AND t.name IN (...)` in the existing `Tags` join.

## Rationale
- The `IN (subquery)` form was redundant because we already join `Tags t` on `pt.tag_id = t.tag_id`.
- Filtering by `t.name IN (...)` uses the `Tags.tag_name` (UNIQUE) index directly.
- Reduces work done for the tag filter in `Problems::byIdentityType`.

Fixes #9093 