### PR TITLE
Optimize javaExpert badge SQL query

### DIFF
--- a/frontend/badges/javaExpert/query.sql
+++ b/frontend/badges/javaExpert/query.sql
@@ -1,20 +1,17 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
-INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id` AND `p`.`visibility` >= 2
 INNER JOIN
     `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
 INNER JOIN
     `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND
-    `s`.`type` = "normal" AND
-    `p`.`visibility` >= 2 AND
-    `s`.`language`= 'java'
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal' AND
+    `s`.`language` = 'java'
 GROUP BY
     `u`.`user_id`
 HAVING


### PR DESCRIPTION
## Changes

1. **Removed Runs join**: Use `Submissions.verdict` directly. The verdict column is denormalized and kept in sync with the current run (see migration `00195_denormalize_submissions_datafix.sql`). This pattern is used elsewhere (Problems.php, Runs.php, coder_of_the_month.py).

2. **Removed redundant DISTINCT**: `GROUP BY user_id` already ensures unique user_ids.

3. **Reordered joins**: Start from Submissions with filters (verdict, type, language) as the driving table.

## Verification

- Badge tests (`frontend/tests/badges/BadgesTest.php`) cover javaExpert via `test.json` with `apicall` testType
- Same logical result: users with >10 distinct AC Java submissions on problems with visibility >= 2

Fixes #9099 
