### PR TITLE
[BUG] Fix arena contest list creating extra browser history entries on tab/filter/sort changes

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_listv2.ts
+++ b/frontend/www/js/omegaup/arena/contest_listv2.ts
@@ -165,19 +165,15 @@ OmegaUp.on('ready', () => {
             urlObj: URL;
           }) => {
             for (const [key, value] of Object.entries(params)) {
-              if (key === 'replaceState') continue; // Don't add flag to URL
               if (value) {
                 urlObj.searchParams.set(key, value.toString());
               } else {
                 urlObj.searchParams.delete(key);
               }
             }
-            // Use replaceState for browser navigation to avoid corrupting history
-            if (params.replaceState) {
-              window.history.replaceState({}, '', urlObj);
-            } else {
-              window.history.pushState({}, '', urlObj);
-            }
+            // Always use replaceState to avoid polluting browser history
+            // with in-page state changes (tab switches, filter, sort order)
+            window.history.replaceState({}, '', urlObj);
             await contestStore.dispatch('fetchContestList', {
               requestParams: params,
               name: params.tab_name,

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -459,7 +459,6 @@ export interface UrlParams {
   query: string;
   sort_order: ContestOrder;
   filter: ContestFilter;
-  replaceState?: boolean; // When true, use replaceState instead of pushState (for browser navigation)
 }
 
 @Component({
@@ -496,9 +495,6 @@ class ArenaContestList extends Vue {
   refreshing: boolean = false;
   isScrollLoading: boolean = false;
   hasMore: boolean = true;
-  // Flag to track if state change came from browser navigation (back/forward button)
-  // When true, we should use replaceState instead of pushState to avoid corrupting history
-  isFromBrowserNavigation: boolean = false;
 
   titleLinkClass(tab: ContestTab) {
     if (this.currentTab === tab) {
@@ -535,14 +531,11 @@ class ArenaContestList extends Vue {
       query: this.currentQuery,
       sort_order: this.currentOrder,
       filter: this.currentFilter,
-      replaceState: this.isFromBrowserNavigation,
     };
     // Reset the contest list for this tab to avoid stale data
     Vue.set(this.contests, this.currentTab, []);
     this.currentPage = 1;
     this.hasMore = true;
-    // Reset the navigation flag after using it
-    this.isFromBrowserNavigation = false;
     this.fetchPage(params, urlObj);
   }
   mounted() {
@@ -666,28 +659,23 @@ class ArenaContestList extends Vue {
   }
 
   // Watchers for props - sync internal state when parent updates props (e.g., via popstate)
-  // Set isFromBrowserNavigation flag to prevent pushState from corrupting history
   @Watch('tab')
   onTabPropChanged(newValue: ContestTab) {
-    this.isFromBrowserNavigation = true;
     this.currentTab = newValue;
   }
 
   @Watch('sortOrder')
   onSortOrderPropChanged(newValue: ContestOrder) {
-    this.isFromBrowserNavigation = true;
     this.currentOrder = newValue;
   }
 
   @Watch('filter')
   onFilterPropChanged(newValue: ContestFilter) {
-    this.isFromBrowserNavigation = true;
     this.currentFilter = newValue;
   }
 
   @Watch('page')
   onPagePropChanged(newValue: number) {
-    this.isFromBrowserNavigation = true;
     this.currentPage = newValue;
   }
 


### PR DESCRIPTION
# Description

Fix arena contest list creating extra browser history entries when switching tabs, changing sort order, or applying filters. Previously, every in-page state change used `history.pushState()`, which added a new entry to the browser history stack. This caused the browser Back button to cycle through each tab/filter/sort state instead of navigating to the actual previous page.

The fix replaces `pushState()` with `replaceState()` for all in-page state changes, and removes the partial `isFromBrowserNavigation` workaround that was only applied during browser back/forward navigation.

### Changes made:

**[ContestListv2.vue](cci:7://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/arena/ContestListv2.vue:0:0-0:0):**
- Removed `replaceState` optional field from [UrlParams](cci:2://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/arena/ContestListv2.vue:455:0-461:1) interface (no longer needed)
- Removed `isFromBrowserNavigation` flag and its related logic
- Simplified [fetchInitialContests()](cci:1://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/arena/ContestListv2.vue:525:2-539:3) by removing conditional `replaceState` usage
- Cleaned up prop watchers by removing `isFromBrowserNavigation` flag assignments

**[contest_listv2.ts](cci:7://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/arena/contest_listv2.ts:0:0-0:0):**
- Simplified `fetch-page` event handler to always use `history.replaceState()`
- Removed conditional `pushState`/`replaceState` branching
- Removed the `replaceState` key skip in URL parameter iteration

Fixes: #9110

# Comments

This issue was identified by @pabo99 during the review of PR #8776. The original PR added browser back/forward button support for contest filters, but introduced a side effect where every tab/filter/sort change created a new history entry. This PR addresses that side effect with a minimal, focused fix.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.


https://github.com/user-attachments/assets/2d88a84c-dc0c-4748-a84d-4d69856cf06d


