### PR TITLE
feat: prevent image dragging across the site

### DIFF
--- a/frontend/www/js/omegaup/components/CountryFlag.vue
+++ b/frontend/www/js/omegaup/components/CountryFlag.vue
@@ -1,6 +1,6 @@
 <template>
   <span v-if="country && country !== ''" class="pr-1">
-    <img height="11" :src="flagUrl" :title="displayTitle" width="16" />
+    <img height="11" :src="flagUrl" :title="displayTitle" width="16" draggable="false" />
   </span>
 </template>
 

--- a/frontend/www/js/omegaup/components/common/Footer.vue
+++ b/frontend/www/js/omegaup/components/common/Footer.vue
@@ -7,6 +7,7 @@
             class="footer-logo d-block mx-auto mb-1 mt-n6"
             width="120"
             src="/media/logo-main-white.svg"
+            draggable="false"
           />
           <div class="slogan mx-auto">
             {{ T.frontPageFooter }}
@@ -77,6 +78,7 @@
                   src="/media/homepage/airbnb_logo.svg"
                   alt="AirbnbLogo"
                   width="100"
+                  draggable="false"
                 />
               </a>
             </li>

--- a/frontend/www/js/omegaup/components/homepage/CoderOfTheMonth.vue
+++ b/frontend/www/js/omegaup/components/homepage/CoderOfTheMonth.vue
@@ -20,7 +20,7 @@
         v-if="!coderOfTheMonth.is_private"
         :href="`/profile/${coderOfTheMonth.username}/`"
       >
-        <img :src="coderOfTheMonth.gravatar_92" height="80" />
+        <img :src="coderOfTheMonth.gravatar_92" height="80" draggable="false" />
       </a>
       <h5 class="card-title">
         <omegaup-user-username

--- a/frontend/www/js/omegaup/components/homepage/Section.vue
+++ b/frontend/www/js/omegaup/components/homepage/Section.vue
@@ -5,7 +5,7 @@
       class="p-3 col-md-6 mt-2 mt-md-0"
       :class="{ 'order-md-2': imageToRight }"
     >
-      <img class="img-fluid" :src="imageSrc" />
+      <img class="img-fluid" :src="imageSrc" draggable="false" />
     </div>
     <div class="col-md-6 mt-2 mt-md-0" :class="{ 'order-md-1': imageToRight }">
       <p class="section-description">{{ description }}</p>

--- a/frontend/www/js/omegaup/components/homepage/Slide.vue
+++ b/frontend/www/js/omegaup/components/homepage/Slide.vue
@@ -17,7 +17,12 @@
         </a>
       </div>
       <div>
-        <img class="d-block image-width" height="320" :src="imageSrc" />
+        <img
+          class="d-block image-width"
+          height="320"
+          :src="imageSrc"
+          draggable="false"
+        />
       </div>
     </div>
   </div>

--- a/frontend/www/js/omegaup/components/homepage/Sponsors.vue
+++ b/frontend/www/js/omegaup/components/homepage/Sponsors.vue
@@ -7,7 +7,12 @@
       class="p-3 mt-2 mt-md-0 sponsor-logo-container"
     >
       <a :href="logo.href" target="_blank">
-        <img :class="logo.class" :src="logo.src" :alt="logo.alt" />
+        <img
+          :class="logo.class"
+          :src="logo.src"
+          :alt="logo.alt"
+          draggable="false"
+        />
       </a>
     </div>
   </div>

--- a/frontend/www/js/omegaup/omegaup.ts
+++ b/frontend/www/js/omegaup/omegaup.ts
@@ -532,3 +532,9 @@ export namespace omegaup {
 }
 
 export const OmegaUp = new omegaup.OmegaUp();
+// Prevent image dragging for better UX
+document.addEventListener('dragstart', (event) => {
+  if (event.target instanceof HTMLImageElement) {
+    event.preventDefault();
+  }
+});

--- a/frontend/www/sass/main.scss
+++ b/frontend/www/sass/main.scss
@@ -8,3 +8,8 @@
 @import 'components/_markdown';
 @import 'components/_buttons.scss';
 @import 'components/_navbar.scss'; // added
+// Prevent image dragging across the site for better UX
+img {
+  user-select: none;
+  -webkit-user-drag: none;
+}


### PR DESCRIPTION
## Description
Prevent images from being accidentally dragged on the omegaUp website for improved user experience.

## Problem (Issue #9144)
Users were able to accidentally drag images around the page causing poor UX and unintended layout shifts.

## Solution
Implemented three layers of safeguards:
1. CSS rules (user-select, -webkit-user-drag)
2. JavaScript dragstart event listener
3. HTML draggable="false" attributes on all image components

## Files Changed
- frontend/www/sass/main.scss
- frontend/www/js/omegaup/omegaup.ts
- 6 Vue components (Slide, Section, Sponsors, CoderOfTheMonth, Footer, CountryFlag)

Fixes #9144