### PR TITLE
Optimize Problems typeahead SQL query in byIdentityTypeForTypeahead

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -1745,7 +1745,6 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                         FROM Problems p
                         WHERE MATCH(alias, title) AGAINST (? IN BOOLEAN MODE)
                         AND p.visibility >= ?";
-                $argsForBranches[] = [$curatedQuery, $curatedQuery, $visibilityArg];
             }
 
             $args = array_merge(
@@ -1754,7 +1753,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 $argsForBranches[2]
             );
             if ($hasFulltextQuery) {
-                $args = array_merge($args, $argsForBranches[3]);
+                $args = array_merge($args, [$curatedQuery, $curatedQuery, $visibilityArg]);
             }
 
             $sql = 'FROM (' . implode(' UNION ALL ', $branches) . ') AS p';


### PR DESCRIPTION
## Changes

1. **Add visibility filter** to all branches: `p.visibility >= ?` using the existing `minVisibility` parameter (default: `VISIBILITY_PUBLIC`). Fixes the case where private/banned problems could appear in the typeahead.

2. **Skip FULLTEXT branch when curated query is too short**: After `preg_replace('/\W+/', ' ', $query)`, if the result has length < 3, the FULLTEXT branch is omitted. This avoids unnecessary fulltext index scans for very short or punctuation-only inputs (e.g., `"a"`, `"!!"`).

## Why not a single-table scan?

A single query with OR across different index types (alias, title, LIKE, FULLTEXT) would likely force a full table scan. The UNION ALL approach lets each branch use its optimal index:
- Branch 1 (alias): `problems_alias` unique index
- Branch 2 (title): `idx_problems_title`
- Branch 3 (LIKE): full scan required (LIKE '%...%' cannot use B-tree indexes)
- Branch 4 (FULLTEXT): `ft_alias_title`

Fixes #9149 