### PR TITLE
Optimize Problems list query when filtering by tags

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -36,19 +36,16 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 FROM
                     Problems_Tags pt
                 INNER JOIN
-                    Problems pp
-                ON
-                    pp.problem_id = pt.problem_id
-                INNER JOIN
                     Tags t
                 ON
                     pt.tag_id = t.tag_id
-                WHERE pt.tag_id IN (
-                    SELECT t.tag_id
-                    FROM Tags t
-                    WHERE t.name in ($placeholders)
-                )
-                AND (pp.allow_user_add_tags = '1' OR pt.source <> 'voted')
+                    AND t.name IN ($placeholders)
+                INNER JOIN
+                    Problems pp
+                ON
+                    pp.problem_id = pt.problem_id
+                WHERE
+                    (pp.allow_user_add_tags = '1' OR pt.source <> 'voted')
                 GROUP BY
                     pt.problem_id
                 {$havingClause}


### PR DESCRIPTION
## Changes

- Removed the redundant `WHERE pt.tag_id IN (SELECT t.tag_id FROM Tags t WHERE t.name IN (...))` subquery
- Moved the tag name filter into the JOIN condition: `Tags t ON pt.tag_id = t.tag_id AND t.name IN ($placeholders)`
- Reordered joins in the ptp subquery: Tags → Problems_Tags → Problems (filter by tag names first, then join to Problems)

## Rationale

- The Tags table was already joined, so the nested SELECT was unnecessary
- Filtering on t.name during the join lets MySQL use the Tags.tag_name index
- Reduces subquery executions and can improve the query plan

Fixes #9157