### PR TITLE
remove runs join and push date filter in legacyUser badge query

### DIFF
--- a/frontend/badges/legacyUser/query.sql
+++ b/frontend/badges/legacyUser/query.sql
@@ -10,6 +10,8 @@ FROM
         `Contests` AS `c`
       INNER JOIN
         `ACLs` AS `a` ON `a`.`acl_id` = `c`.`acl_id`
+      WHERE
+        `c`.`last_updated` >= CONCAT(YEAR(NOW()) - 2, '-01-01 00:00:00')
     )
     UNION DISTINCT
     (
@@ -20,6 +22,8 @@ FROM
         `Problems` AS `p`
       INNER JOIN
         `ACLs` AS `a` ON `p`.`acl_id` = `a`.`acl_id`
+      WHERE
+        `p`.`creation_date` >= CONCAT(YEAR(NOW()) - 2, '-01-01 00:00:00')
     )
     UNION DISTINCT
     (
@@ -30,10 +34,9 @@ FROM
         `Submissions` AS `s`
       INNER JOIN
         `Users` AS `u` ON `s`.`identity_id` = `u`.`main_identity_id`
-      INNER JOIN
-        `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
       WHERE
-        `r`.`verdict` = 'AC'
+        `s`.`verdict` = 'AC'
+        AND `s`.`time` >= CONCAT(YEAR(NOW()) - 2, '-01-01 00:00:00')
     )
   ) AS `activity`
 WHERE


### PR DESCRIPTION
## Changes
- **Remove Runs join**: `Submissions.verdict` is denormalized (migrations 00193/00195), so the join to `Runs` for `r.verdict = 'AC'` is no longer needed
- **Push date filter into subqueries**: Add date-range filters (`>= CONCAT(YEAR(NOW()) - 2, '-01-01 00:00:00')`) inside each UNION branch for Contests, Problems, and Submissions to reduce rows before materialization

## EXPLAIN Impact
- Before: ALL scan on Runs.PRIMARY, materialization of full result sets
- After: No Runs access; fewer rows in each subquery before UNION

Fixes #9159