### PR TITLE
fix(cypress): dismiss IntroJS overlay on signup tab in registerSingleUser test

### DIFF
--- a/cypress/support/pageObjects/loginPage.ts
+++ b/cypress/support/pageObjects/loginPage.ts
@@ -31,6 +31,7 @@ export class LoginPage {
     cy.get('[data-login-button]').click();
     cy.get('.introjs-skipbutton').click();
     cy.get('a[href="#signup"]').click();
+    cy.get('.introjs-skipbutton').click();
     cy.get('[data-signup-username]').type(loginOptions.username);
     cy.get('[data-signup-password]').type(loginOptions.password);
     cy.get('[data-signup-repeat-password]').type(loginOptions.password);


### PR DESCRIPTION
# Description

The Cypress test `Should register a user` in [basic_commands.cy.ts](cci:7://file:///c:/Users/BIT/Desktop/omegaup/cypress/e2e/basic_commands.cy.ts:0:0-0:0) fails on every PR because the [registerSingleUser()](cci:1://file:///c:/Users/BIT/Desktop/omegaup/cypress/support/pageObjects/loginPage.ts:29:2-40:3) method in [loginPage.ts](cci:7://file:///c:/Users/BIT/Desktop/omegaup/cypress/support/pageObjects/loginPage.ts:0:0-0:0) does not dismiss the IntroJS overlay that appears when switching to the signup tab.

**Root Cause:** The [Signup.vue](cci:7://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/login/Signup.vue:0:0-0:0) component has a `@Watch('activeTab')` watcher that triggers [maybeStartIntro()](cci:1://file:///c:/Users/BIT/Desktop/omegaup/frontend/www/js/omegaup/components/login/Signup.vue:307:2-369:3), launching a second IntroJS tour when the tab switches to signup. The test was only dismissing the Login tab's IntroJS tour, leaving the Signup tab's overlay covering the form inputs and causing `cy.type()` to fail.

**Fix:** Added a second `cy.get('.introjs-skipbutton').click()` call after switching to the signup tab, dismissing the overlay before interacting with form elements.

If you modify the **User Interface**, please include a screenshot or a video.

Fixes: #9162

# Comments

This is a one-line fix in [cypress/support/pageObjects/loginPage.ts](cci:7://file:///c:/Users/BIT/Desktop/omegaup/cypress/support/pageObjects/loginPage.ts:0:0-0:0). The [loginByGUI()](cci:1://file:///c:/Users/BIT/Desktop/omegaup/cypress/support/pageObjects/loginPage.ts:49:2-55:3) method in the same file already follows this pattern (dismiss IntroJS after navigating to the login page), this fix makes [registerSingleUser()](cci:1://file:///c:/Users/BIT/Desktop/omegaup/cypress/support/pageObjects/loginPage.ts:29:2-40:3) consistent with that approach.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split in various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.