### PR TITLE
Optimize badge SQL: drop Runs join, use Submissions.verdict, fix non-sargable predicates

### DIFF
--- a/frontend/badges/100solvedProblems/query.sql
+++ b/frontend/badges/100solvedProblems/query.sql
@@ -1,17 +1,14 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id`
 INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-INNER JOIN
-    `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
-INNER JOIN
-    `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
+    `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND `s`.`type` = "normal"
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal'
 GROUP BY
     `u`.`user_id`
 HAVING

--- a/frontend/badges/cppExpert/query.sql
+++ b/frontend/badges/cppExpert/query.sql
@@ -1,20 +1,16 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id`
 INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-INNER JOIN
-    `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
-INNER JOIN
-    `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
+    `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND
-    `s`.`type` = "normal" AND
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal' AND
     `p`.`visibility` >= 2 AND
-    `s`.`language` REGEXP '^(cpp|c11)'
+    `s`.`language` IN ('cpp', 'cpp11', 'cpp11-gcc', 'cpp11-clang', 'cpp17-gcc', 'cpp17-clang', 'cpp20-gcc', 'cpp20-clang', 'c11-gcc', 'c11-clang')
 GROUP BY
     `u`.`user_id`
 HAVING

--- a/frontend/badges/javaExpert/query.sql
+++ b/frontend/badges/javaExpert/query.sql
@@ -1,20 +1,16 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id`
 INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-INNER JOIN
-    `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
-INNER JOIN
-    `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
+    `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND
-    `s`.`type` = "normal" AND
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal' AND
     `p`.`visibility` >= 2 AND
-    `s`.`language`= 'java'
+    `s`.`language` = 'java'
 GROUP BY
     `u`.`user_id`
 HAVING

--- a/frontend/badges/karelExpert/query.sql
+++ b/frontend/badges/karelExpert/query.sql
@@ -1,20 +1,16 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id`
 INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-INNER JOIN
-    `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
-INNER JOIN
-    `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
+    `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND
-    `s`.`type` = "normal" AND
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal' AND
     `p`.`visibility` >= 2 AND
-    FIND_IN_SET(`s`.`language`,'kj,kp')
+    `s`.`language` IN ('kj', 'kp')
 GROUP BY
     `u`.`user_id`
 HAVING

--- a/frontend/badges/legacyUser/query.sql
+++ b/frontend/badges/legacyUser/query.sql
@@ -29,11 +29,9 @@ FROM
       FROM
         `Submissions` AS `s`
       INNER JOIN
-        `Users` AS `u` ON `s`.`identity_id` = `u`.`main_identity_id`
-      INNER JOIN
-        `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
+        `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
       WHERE
-        `r`.`verdict` = 'AC'
+        `s`.`verdict` = 'AC'
     )
   ) AS `activity`
 WHERE

--- a/frontend/badges/pascalExpert/query.sql
+++ b/frontend/badges/pascalExpert/query.sql
@@ -1,18 +1,14 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id`
 INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-INNER JOIN
-    `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
-INNER JOIN
-    `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
+    `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND
-    `s`.`type` = "normal" AND
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal' AND
     `p`.`visibility` >= 2 AND
     `s`.`language` = 'pas'
 GROUP BY

--- a/frontend/badges/problemOfTheWeekWithOmegaUp/query.sql
+++ b/frontend/badges/problemOfTheWeekWithOmegaUp/query.sql
@@ -1,26 +1,20 @@
 SELECT
-    DISTINCT u.user_id
+    u.user_id
 FROM
-    Assignments a
+    Submissions s
 INNER JOIN
-    Problemsets ps ON a.problemset_id = ps.problemset_id
+    Assignments a ON a.problemset_id = s.problemset_id
 INNER JOIN
-    Problemset_Problems psp ON psp.problemset_id = ps.problemset_id
+    Problemset_Problems psp ON psp.problemset_id = a.problemset_id AND psp.problem_id = s.problem_id
 INNER JOIN
-    Submissions s ON s.problem_id = psp.problem_id AND
-    s.problemset_id = a.problemset_id
+    Identities i ON i.identity_id = s.identity_id AND i.user_id IS NOT NULL
 INNER JOIN
-    Runs r ON r.run_id = s.current_run_id
-INNER JOIN
-    Identities i ON i.identity_id = s.identity_id
-INNER JOIN
-    Users AS u ON u.main_identity_id = i.identity_id
+    Users u ON u.main_identity_id = i.identity_id
 INNER JOIN
     Courses c ON c.course_id = a.course_id
 WHERE
     c.alias = 'ResolviendoProblemas2021' AND
-    r.verdict = 'AC' AND
-    i.user_id IS NOT NULL
+    s.verdict = 'AC'
 GROUP BY
     u.user_id
 HAVING

--- a/frontend/badges/pythonExpert/query.sql
+++ b/frontend/badges/pythonExpert/query.sql
@@ -1,20 +1,16 @@
 SELECT
-    DISTINCT `u`.`user_id`
+    `u`.`user_id`
 FROM
-    `Problems` AS `p`
+    `Submissions` AS `s`
 INNER JOIN
-    `Submissions` AS `s` ON `p`.`problem_id` = `s`.`problem_id`
+    `Problems` AS `p` ON `p`.`problem_id` = `s`.`problem_id`
 INNER JOIN
-    `Runs` AS `r` ON `r`.`run_id` = `s`.`current_run_id`
-INNER JOIN
-    `Identities` AS `i` ON `s`.`identity_id` = `i`.`identity_id`
-INNER JOIN
-    `Users` AS `u` ON `u`.`main_identity_id` = `i`.`identity_id`
+    `Users` AS `u` ON `u`.`main_identity_id` = `s`.`identity_id`
 WHERE
-    `r`.`verdict` = "AC" AND
-    `s`.`type` = "normal" AND
+    `s`.`verdict` = 'AC' AND
+    `s`.`type` = 'normal' AND
     `p`.`visibility` >= 2 AND
-    FIND_IN_SET(`s`.`language`,'py2,py3')
+    `s`.`language` IN ('py2', 'py3')
 GROUP BY
     `u`.`user_id`
 HAVING


### PR DESCRIPTION
## Problem
Badge assignment queries were slow, with EXPLAIN showing `type=ALL`, `Using temporary`, and `Using filesort`. The main causes were unnecessary joins (Runs, Identities), non-sargable predicates, and a suboptimal join order.

## Solution
Query-only changes (no schema changes):

### 1. Use `Submissions.verdict` instead of joining `Runs`
`Submissions` stores a denormalized verdict (migrations 00193, 00195). Filtering by `s.verdict = 'AC'` removes the Runs join and lets MySQL use indexes like `verdict_type_time` and `idx_submissions_identity_verdict_type_problem`.

### 2. Remove `Identities` join (Expert badges)
Join directly: `Users u ON u.main_identity_id = s.identity_id`, since we only need users whose main identity submitted.

### 3. Replace non-sargable predicates with `IN()`
- **karelExpert**: `FIND_IN_SET(s.language,'kj,kp')` → `s.language IN ('kj','kp')`
- **pythonExpert**: `FIND_IN_SET(s.language,'py2,py3')` → `s.language IN ('py2','py3')`
- **cppExpert**: `REGEXP '^(cpp|c11)'` → `s.language IN ('cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','c11-gcc','c11-clang')`

### 4. Restructure to start from `Submissions`
Begin with Submissions (the most filtered table), then join Problems and Users. This helps reduce intermediate rows and improve plan choices.

### 5. Other cleanups
- **legacyUser**: Drop Runs join; normalize join: `u.main_identity_id = s.identity_id`
- **problemOfTheWeekWithOmegaUp**: Drop Runs join; start from Submissions; remove unused Problemsets join; move `i.user_id IS NOT NULL` into the Identities join condition
- Remove redundant `DISTINCT` where `GROUP BY u.user_id` already enforces uniqueness

## Affected badges
| Badge | Changes |
|-------|---------|
| karelExpert | Runs/Identities removed, FIND_IN_SET→IN, s.verdict |
| pythonExpert | Same pattern |
| cppExpert | Same pattern, REGEXP→IN |
| javaExpert | Runs/Identities removed, s.verdict |
| pascalExpert | Same pattern |
| 100solvedProblems | Runs/Identities removed, s.verdict |
| legacyUser | Runs removed, s.verdict |
| problemOfTheWeekWithOmegaUp | Runs removed, restructured, s.verdict |

Fixes #9170