### PR TITLE
fix: migrate container registry from docker.pkg.github.com to ghcr.io

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Push containers to GitHub registry
         run: |
           echo "${{ github.token }}" | \
-            docker login https://docker.pkg.github.com "--username=${{ github.actor }}" --password-stdin
+            docker login ghcr.io "--username=${{ github.actor }}" --password-stdin
 
           for container in frontend frontend-sidecar nginx php ai-editorial-worker; do
             for tag in "latest-${{ steps.extract_branch.outputs.branch }}" "${{ github.sha }}"; do
-              container_name="docker.pkg.github.com/${{ github.repository }}/${container}:${tag}"
+              container_name="ghcr.io/${{ github.repository_owner }}/${container}:${tag}"
               docker tag "omegaup/${container}:${{ github.sha }}" "${container_name}"
               docker push "${container_name}"
             done


### PR DESCRIPTION


# Description

Migrate the GitHub container registry from the deprecated `docker.pkg.github.com` to `ghcr.io` in the Build containers workflow.

Since February 11, 2026, the workflow has been failing with `401 Unauthorized` errors when pushing Docker images because GitHub has migrated Docker images from the legacy Docker registry (`docker.pkg.github.com`) to the Container registry (`ghcr.io`).

### Changes:
- Updated `docker login` URL from `https://docker.pkg.github.com` to `ghcr.io`
- Updated image naming from `docker.pkg.github.com/${{ github.repository }}/IMAGE` to `ghcr.io/${{ github.repository_owner }}/IMAGE`

The `packages: write` permission was already present at the job level, so no permission changes were needed.

Reference: https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry

Fixes: #9176

# Comments

This is a minimal 2-line change in [.github/workflows/build-containers.yml](cci:7://file:///c:/Users/BIT/Desktop/omegaup/.github/workflows/build-containers.yml:0:0-0:0). The Docker Hub push step and k8s manifest update steps are unaffected.

# Checklist

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.