### PR TITLE
fix: pin alpine version in Dockerfile.frontend (#9207)

### DIFF
--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -53,7 +53,7 @@ define('OMEGAUP_ENVIRONMENT', 'production');\n\
 define('TEMPLATE_CACHE_DIR', '/var/lib/omegaup/templates');\n" > frontend/server/config.php
 RUN php frontend/server/cmd/CompileTemplatesCmd.php
 
-FROM alpine:latest AS frontend
+FROM alpine:3.23.3 AS frontend
 RUN apk add rsync
 RUN mkdir -p /var/lib/omegaup /opt/omegaup
 COPY --from=build /opt/omegaup /opt/omegaup


### PR DESCRIPTION
# Description

pin the intermediate frontend build stage from `alpine:latest` to `alpine:3.23.3` to ensure reproducible builds.

`latest` can silently update to a new major alpine version on `docker pull`, potentially breaking the build without any code changes.

Fixes: #9207

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.