### PR TITLE
fix: pin redis and rabbitmq image versions in docker-compose (#9206)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
       - SYS_NICE
 
   rabbitmq:
-    image: rabbitmq:3-management-alpine
+    image: rabbitmq:4.0-management-alpine
     restart: always
     environment:
       RABBITMQ_DEFAULT_USER: 'omegaup'
@@ -167,7 +167,7 @@ services:
         mode: host
 
   redis:
-    image: redis
+    image: redis:7.4-alpine
     restart: always
     command: ['redis-server', '/etc/redis/redis.conf']
     expose:


### PR DESCRIPTION
# Description

pin docker image versions in `docker-compose.yml` to avoid silent updates:

- `redis` → `redis:7.4-alpine` (7.4 LTS, confirmed on Docker Hub)
- `rabbitmq:3-management-alpine` → `rabbitmq:4.0-management-alpine` (latest stable)

using `redis` (implicit `latest`) and `rabbitmq:3-management-alpine` (major only) can silently pull a newer major version on `docker compose pull`, potentially breaking the dev environment.

Fixes: #9206

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.