### PR TITLE
fix: lazy import boto3 in db-migrate.py

### DIFF
--- a/stuff/db-migrate.py
+++ b/stuff/db-migrate.py
@@ -31,8 +31,6 @@ import sys
 import time
 from typing import Iterator, List, Optional, Sequence, Tuple
 
-import boto3  # type: ignore
-
 import database_utils
 
 OMEGAUP_ROOT = os.path.abspath(os.path.join(__file__, '..', '..'))
@@ -99,6 +97,7 @@ def _set_aws_rds_timeout(args: argparse.Namespace,
                          auth: Sequence[str],
                          timeout: Optional[int] = None) -> None:
     '''Set the MySQL through AWS RDS timeouts.'''
+    import boto3  # type: ignore  # pylint: disable=import-outside-toplevel
     del auth  # unused
     rds = boto3.client('rds')
 


### PR DESCRIPTION
# description

`boto3` was imported unconditionally at the top level of `stuff/db-migrate.py`. this caused an `ImportError` crash even when running basic commands like `--help` or `migrate` in non-aws environments where `boto3` is not installed.

moved the import inside `_set_aws_rds_timeout()` so it is only loaded when aws rds functionality is actually used.

Fixes: #9198

# checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.