### PR TITLE
fix: relax mysql timeout values in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,8 +131,8 @@ services:
       MYSQL_TCP_PORT: 13306
     command:
       - --max_execution_time=30000
-      - --lock_wait_timeout=10
-      - --wait_timeout=20
+      - --lock_wait_timeout=60
+      - --wait_timeout=300
     expose:
       - '13306'
     volumes:


### PR DESCRIPTION
# description

`docker-compose.yml` sets very aggressive MySQL timeout values - `wait_timeout=20` (20 seconds) and `lock_wait_timeout=10` (10 seconds). these cause intermittent "MySQL server has gone away" and deadlock errors during normal development.

increased both to practical dev-environment values:
- `wait_timeout`: 20s to 300s
- `lock_wait_timeout`: 10s to 60s

Fixes: #9208

# checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.