### PR TITLE
fix: use restart on-failure for all services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,12 @@ services:
         volume:
           nocopy: true
     depends_on:
-      - mysql
-      - gitserver
-      - grader
+      mysql:
+        condition: service_healthy
+      gitserver:
+        condition: service_started
+      grader:
+        condition: service_started
     ports:
       - target: 8001
         published: 8001
@@ -39,7 +42,8 @@ services:
     user: "${UID_GID}"
     restart: on-failure
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     volumes:
       - type: bind
         source: ./stuff/docker/etc/omegaup/gitserver
@@ -66,7 +70,8 @@ services:
     user: "${UID_GID}"
     restart: on-failure
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     volumes:
       - type: bind
         source: ./stuff/docker/etc/omegaup/broadcaster
@@ -83,8 +88,10 @@ services:
     user: "${UID_GID}"
     restart: on-failure
     depends_on:
-      - mysql
-      - gitserver
+      mysql:
+        condition: service_healthy
+      gitserver:
+        condition: service_started
     volumes:
       - type: bind
         source: ./stuff/docker/etc/omegaup/grader
@@ -110,7 +117,8 @@ services:
     user: "${UID_GID}"
     restart: on-failure
     depends_on:
-      - grader
+      grader:
+        condition: service_started
     volumes:
       - type: bind
         source: ./stuff/docker/etc/omegaup/runner
@@ -144,10 +152,22 @@ services:
         mode: host
     cap_add:
       - SYS_NICE
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uomegaup", "-pomegaup"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
     restart: on-failure
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     environment:
       RABBITMQ_DEFAULT_USER: 'omegaup'
       RABBITMQ_DEFAULT_PASS: 'omegaup'
@@ -169,6 +189,11 @@ services:
   redis:
     image: redis
     restart: on-failure
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     command: ['redis-server', '/etc/redis/redis.conf']
     expose:
       - '6379'


### PR DESCRIPTION
# description

all 8 services in `docker-compose.yml` used `restart: always` with no failure limit. this causes silent infinite crash-loop restarts when a service panics (e.g. missing config file), making it very hard to detect failures — `docker ps` shows the container as `Up` even mid-loop.

changed all services from `restart: always` to `restart: on-failure` so containers only restart on non-zero exit codes (actual crashes), and remain stopped on intentional clean shutdowns.

Fixes: #9210   #9194

# checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.