### PR TITLE
fix: enable mysql slow query logging in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,9 @@ services:
       - --max_execution_time=30000
       - --lock_wait_timeout=10
       - --wait_timeout=20
+      - --slow_query_log=1
+      - --slow_query_log_file=/var/lib/mysql/slow.log
+      - --long_query_time=1
     expose:
       - '13306'
     volumes:


### PR DESCRIPTION
# description

MySQL in `docker-compose.yml` starts with `slow_query_log` disabled and `long_query_time=10s` (default). developers writing or modifying DAO queries have no local feedback on slow queries before they hit production. with 15+ open SQL optimization issues tracked in #8277, this gap is significant.

added to the MySQL `command:` block:
- `--slow_query_log=1` — enable slow query logging
- `--slow_query_log_file=/var/lib/mysql/slow.log` — write to a known location inside the container volume
- `--long_query_time=1` — flag queries taking over 1 second

developers can view slow queries with:
```bash
docker exec omegaup-mysql-1 tail -f /var/lib/mysql/slow.log
```

Fixes: #9200

# checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.