### PR TITLE
fix: parameterize IN-clause SQL in coder_of_the_month

### DIFF
--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -499,15 +499,9 @@ def compute_points_for_user(
         logging.info('No eligible problems found.')
         return []
 
-    # Convert the list of identity IDs to a comma-separated string
-    identity_ids_str = ', '.join(map(str, identity_ids))
-
-    # Convert the list of problem IDs to a comma-separated string
-    problem_ids_str = ', '.join(map(str, problem_ids))
-
     user_problems = get_user_problems(cur_readonly,
-                                      identity_ids_str,
-                                      problem_ids_str,
+                                      identity_ids,
+                                      problem_ids,
                                       eligible_users,
                                       first_day_of_current_month,
                                       )


### PR DESCRIPTION
# description

`stuff/cron/database/coder_of_the_month.py` built SQL `IN` clauses by joining python id lists into raw strings and interpolating them directly via f-strings:

```python
identity_ids_str = ', '.join(map(str, identity_ids))
cur_readonly.execute(f'... WHERE s.identity_id IN ({identity_ids_str}) ...')
```

this bypasses the db driver's parameterization layer and is inconsistent with the rest of the codebase.

changed `get_user_problems()` and `get_problems_admins()` to:
- accept `List[int]` instead of pre-joined strings
- build `%s` placeholders dynamically for the `IN` clauses
- pass id tuples as params to `cur_readonly.execute()`

also removed the now-redundant string joins from `update_ranks.py`.

Fixes: #9203

# checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.