### PR TITLE
Refactor Tags.vue emitted events to use object payloads

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Edit.vue
+++ b/frontend/www/js/omegaup/components/problem/Edit.vue
@@ -207,17 +207,10 @@
           @emit-update-problem-level="
             (levelTag) => $emit('update-problem-level', levelTag)
           "
-          @emit-add-tag="
-            (alias, tagname, isPublic) =>
-              $emit('add-tag', alias, tagname, isPublic)
-          "
-          @emit-remove-tag="
-            (alias, tagname, isPublic) =>
-              $emit('remove-tag', alias, tagname, isPublic)
-          "
+          @emit-add-tag="(payload) => $emit('add-tag', payload)"
+          @emit-remove-tag="(payload) => $emit('remove-tag', payload)"
           @emit-change-allow-user-add-tag="
-            (alias, title, allowTags) =>
-              $emit('change-allow-user-add-tag', alias, title, allowTags)
+            (payload) => $emit('change-allow-user-add-tag', payload)
           "
         ></omegaup-problem-tags>
       </div>

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -633,15 +633,20 @@ export default class ProblemForm extends Vue {
       .map((tag) => tag.tagname);
   }
 
-  addTag(alias: string, tagname: string, isPublic: boolean): void {
+  addTag(payload: { alias: string; tagname: string; isPublic: boolean }): void {
+    const { tagname, isPublic } = payload;
     this.selectedTags.push({
-      tagname: tagname,
+      tagname,
       public: isPublic,
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  removeTag(alias: string, tagname: string, isPublic: boolean): void {
+  removeTag(payload: {
+    alias: string;
+    tagname: string;
+    isPublic: boolean;
+  }): void {
+    const { tagname } = payload;
     this.selectedTags = this.selectedTags.filter(
       (tag) => tag.tagname !== tagname,
     );

--- a/frontend/www/js/omegaup/components/problem/Tags.vue
+++ b/frontend/www/js/omegaup/components/problem/Tags.vue
@@ -205,7 +205,11 @@ export default class ProblemTags extends Vue {
 
   addPublicTag(tag: string): void {
     if (this.canAddNewTags && !this.selectedPublicTags.includes(tag)) {
-      this.$emit('emit-add-tag', this.alias, tag, true);
+      this.$emit('emit-add-tag', {
+        alias: this.alias,
+        tagname: tag,
+        isPublic: true,
+      });
     }
     this.newPublicTag = '';
   }
@@ -216,14 +220,22 @@ export default class ProblemTags extends Vue {
       this.newPrivateTag !== '' &&
       !this.selectedPrivateTags.includes(this.newPrivateTag)
     ) {
-      this.$emit('emit-add-tag', this.alias, this.newPrivateTag, false);
+      this.$emit('emit-add-tag', {
+        alias: this.alias,
+        tagname: this.newPrivateTag,
+        isPublic: false,
+      });
       this.newPrivateTag = '';
     }
   }
 
   removeTag(tag: string, isPublic: boolean): void {
     if (this.canAddNewTags) {
-      this.$emit('emit-remove-tag', this.alias, tag, isPublic);
+      this.$emit('emit-remove-tag', {
+        alias: this.alias,
+        tagname: tag,
+        isPublic,
+      });
     }
   }
 
@@ -256,12 +268,11 @@ export default class ProblemTags extends Vue {
     if (!this.canAddNewTags) {
       return;
     }
-    this.$emit(
-      'emit-change-allow-user-add-tag',
-      this.alias,
-      this.title,
-      newValue,
-    );
+    this.$emit('emit-change-allow-user-add-tag', {
+      alias: this.alias,
+      title: this.title,
+      allowTags: newValue,
+    });
   }
 }
 </script>

--- a/frontend/www/js/omegaup/problem/edit.ts
+++ b/frontend/www/js/omegaup/problem/edit.ts
@@ -157,52 +157,60 @@ OmegaUp.on('ready', () => {
                 });
             }
           },
-          'add-tag': (alias: string, tagname: string, isPublic: boolean) => {
+          'add-tag': (payload: {
+            alias: string;
+            tagname: string;
+            isPublic: boolean;
+          }) => {
             api.Problem.addTag({
-              problem_alias: alias,
-              name: tagname,
-              public: isPublic,
+              problem_alias: payload.alias,
+              name: payload.tagname,
+              public: payload.isPublic,
             })
               .then(() => {
                 ui.success(T.tagAdded);
-                if (isPublic) {
-                  this.selectedPublicTags.push(tagname);
+                if (payload.isPublic) {
+                  this.selectedPublicTags.push(payload.tagname);
                 } else {
-                  this.selectedPrivateTags.push(tagname);
+                  this.selectedPrivateTags.push(payload.tagname);
                 }
               })
               .catch(ui.apiError);
           },
-          'remove-tag': (alias: string, tagname: string, isPublic: boolean) => {
+          'remove-tag': (payload: {
+            alias: string;
+            tagname: string;
+            isPublic: boolean;
+          }) => {
             api.Problem.removeTag({
-              problem_alias: alias,
-              name: tagname,
+              problem_alias: payload.alias,
+              name: payload.tagname,
             })
               .then(() => {
                 ui.success(T.tagRemoved);
                 // FIXME: For some reason this is not being reactive
-                if (isPublic) {
+                if (payload.isPublic) {
                   this.selectedPublicTags = this.selectedPublicTags.filter(
-                    (tag) => tag !== tagname,
+                    (tag) => tag !== payload.tagname,
                   );
                 } else {
                   this.selectedPrivateTags = this.selectedPrivateTags.filter(
-                    (tag) => tag !== tagname,
+                    (tag) => tag !== payload.tagname,
                   );
                 }
               })
               .catch(ui.apiError);
           },
-          'change-allow-user-add-tag': (
-            alias: string,
-            title: string,
-            allowTags: boolean,
-          ) => {
+          'change-allow-user-add-tag': (payload: {
+            alias: string;
+            title: string;
+            allowTags: boolean;
+          }) => {
             api.Problem.update({
-              problem_alias: alias,
-              title: title,
-              allow_user_add_tags: allowTags,
-              message: `${T.problemEditFormAllowUserAddTags}: ${allowTags}`,
+              problem_alias: payload.alias,
+              title: payload.title,
+              allow_user_add_tags: payload.allowTags,
+              message: `${T.problemEditFormAllowUserAddTags}: ${payload.allowTags}`,
             })
               .then(() => {
                 ui.success(T.problemEditUpdatedSuccessfully);


### PR DESCRIPTION
## Summary

This PR refactors emitted events in `Tags.vue` to use a single object payload instead of multiple positional parameters, following the frontend coding guidelines.

## What changed

- Updated `Tags.vue` to emit object payloads:
  - `{ alias, tagname, isPublic }` for add/remove tag
  - `{ alias, title, allowTags }` for allow-user-add-tags
- Updated `Edit.vue` to forward these payloads directly.
- Updated `edit.ts` handlers to accept object parameters and use named fields.
- Updated `Form.vue` (`addTag` / `removeTag`) to consume the new payload shape.

No behavior changes, this is a refactor only.

Fixes #8911
