### PR TITLE
fix: resolve Docker frontend build failure due to APCu in CLI mode

### DIFF
--- a/stuff/docker/Dockerfile.frontend
+++ b/stuff/docker/Dockerfile.frontend
@@ -12,6 +12,7 @@ RUN apt-get update -y && \
         curl \
         git \
         gnupg2 \
+        php8.1-apcu \
         php8.1-cli \
         php8.1-curl \
         php8.1-gmp \
@@ -37,7 +38,7 @@ RUN curl -sL https://getcomposer.org/download/2.1.14/composer.phar -o /usr/bin/c
     chmod +x /usr/bin/composer
 
 RUN useradd --create-home --shell=/bin/bash ubuntu
-RUN mkdir -p /opt/omegaup /var/lib/omegaup /var/log/omegaup && chown -R ubuntu /opt/omegaup /var/lib/omegaup /var/log/omegaup
+RUN mkdir -p /opt/omegaup /var/lib/omegaup/templates /var/log/omegaup && chown -R ubuntu /opt/omegaup /var/lib/omegaup /var/log/omegaup
 USER ubuntu
 WORKDIR /opt/omegaup
 ARG BRANCH=release
@@ -50,12 +51,13 @@ RUN yarn install && yarn build
 RUN composer install --no-dev --classmap-authoritative
 RUN printf "<?php\n\
 define('OMEGAUP_ENVIRONMENT', 'production');\n\
+define('OMEGAUP_CACHE_IMPLEMENTATION', 'none');\n\
 define('TEMPLATE_CACHE_DIR', '/var/lib/omegaup/templates');\n" > frontend/server/config.php
 RUN php frontend/server/cmd/CompileTemplatesCmd.php
 
 FROM alpine:latest AS frontend
 RUN apk add rsync
-RUN mkdir -p /var/lib/omegaup /opt/omegaup
+RUN mkdir -p /var/lib/omegaup/templates /opt/omegaup
 COPY --from=build /opt/omegaup /opt/omegaup
 COPY --from=build /opt/omegaup/frontend/www/rekarel/. /opt/omegaup/frontend/www/rekarel/
 COPY --from=build /var/lib/omegaup /var/lib/omegaup


### PR DESCRIPTION
What was broken:
The Docker frontend build failed with exit code 255 during execution of CompileTemplatesCmd.php. BuildKit suppressed the error output, making it difficult to debug.

Why it was broken:
Cache.php attempts to use the APCu cache adapter during template compilation. config.default.php sets OMEGAUP_CACHE_IMPLEMENTATION to 'apcu' by default. However, APCu is disabled in PHP CLI mode unless explicitly enabled via apc.enable_cli=1, causing the script to fail when initializing the cache during the Docker build phase.

How it was fixed:
1. Added php8.1-apcu to the build stage apt dependencies.
2. Created /var/lib/omegaup/templates directory with proper ownership in both the build and frontend stages.
3. Set define('OMEGAUP_CACHE_IMPLEMENTATION', 'none') in the build-time config.php so CompileTemplatesCmd.php uses InProcessCacheAdapter, which has no APCu dependency, during the build phase.

# Description

Please include a description of the changes you have made. The text you put in this section will be used as the **commit message** when this PR is merged.

If you modify the **User Interface**, please include a screenshot or a video.

Fixes: #9237 

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
