### PR TITLE
fix(Username): Scope css to fix breadcrumbs regression

### DIFF
--- a/frontend/www/js/omegaup/components/user/Username.vue
+++ b/frontend/www/js/omegaup/components/user/Username.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :class="classname" :title="username">
+  <span :class="['username', classname]" :title="username">
     <omegaup-countryflag
       v-if="country != null"
       :country="country"
@@ -60,14 +60,14 @@ export default class Username extends Vue {
 <style lang="scss" scope>
 @import '../../../../sass/main.scss';
 
-span {
+span.username {
   display: inline-block;
   max-width: 100%;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
-span a {
+span.username a {
   display: inline-block;
   max-width: 100%;
   white-space: normal;


### PR DESCRIPTION
Fixes #9174

This PR resolves the breadcrumbs styling regression introduced in #9020 by applying scoped CSS correctly. Instead of leaking generic `span` styles, the component now uses the `.username` class selector to constraint its layout rules exclusively within `Username.vue`.