### PR TITLE
fix: pin kustomize to v5.8.1 with sha256 checksum

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -67,8 +67,12 @@ jobs:
       - name: Update k8s sandbox manifests
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
+          KUSTOMIZE_VERSION=5.8.1
+          curl -sLo /tmp/kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          echo "029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d  /tmp/kustomize.tar.gz" | sha256sum -c
+          tar -xzf /tmp/kustomize.tar.gz -C /tmp/
+          sudo mv /tmp/kustomize /usr/local/bin/
 
           git clone --depth=1 https://omegaup-bot:${{ secrets.OMEGAUPBOT_RELEASE_TOKEN }}@github.com/omegaup/prod /tmp/prod
           TAG=${{ github.sha }}
@@ -89,8 +93,12 @@ jobs:
       - name: Update k8s manifests
         if: ${{ github.ref == 'refs/heads/release' }}
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
+          KUSTOMIZE_VERSION=5.8.1
+          curl -sLo /tmp/kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          echo "029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d  /tmp/kustomize.tar.gz" | sha256sum -c
+          tar -xzf /tmp/kustomize.tar.gz -C /tmp/
+          sudo mv /tmp/kustomize /usr/local/bin/
 
           git clone --depth=1 https://omegaup-bot:${{ secrets.OMEGAUPBOT_RELEASE_TOKEN }}@github.com/omegaup/prod /tmp/prod
           TAG=${{ github.sha }}


### PR DESCRIPTION
# Description

`build-containers.yml` installed kustomize by piping a remote shell script from the `master` branch directly into bash — no version pin, no integrity check:

```yaml
curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
```

this happened twice (sandbox deploy at line 70, production deploy at line 92). the installer fetched from a mutable ref, meaning its behavior could change silently between runs.

replaced both occurrences with a direct download of the pinned v5.8.1 release binary from the official github releases page, with SHA256 checksum verification before extraction. verified locally.

Fixes: #9204

# Checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.