### PR TITLE
fix: use exact match for school deduplication in createSchool

### DIFF
--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -175,10 +175,14 @@ class School extends \OmegaUp\Controllers\Controller {
             'state_id' => !is_null($state) ? $state->state_id : null,
         ]);
 
-        $existing = \OmegaUp\DAO\Schools::findByName($name);
-        if (!empty($existing)) {
-            /** @var int $existing[0]->school_id */
-            return $existing[0]->school_id;
+        $existing = \OmegaUp\DAO\Schools::findByExactName(
+            $name,
+            $school->country_id,
+            $school->state_id
+        );
+        if (!is_null($existing)) {
+            /** @var int $existing->school_id */
+            return $existing->school_id;
         }
         \OmegaUp\DAO\Schools::create($school);
         /** @var int $school->school_id */

--- a/frontend/server/src/DAO/Schools.php
+++ b/frontend/server/src/DAO/Schools.php
@@ -13,6 +13,43 @@ namespace OmegaUp\DAO;
  */
 class Schools extends \OmegaUp\DAO\Base\Schools {
     /**
+     * Finds a school with exactly matching name, country_id, and state_id.
+     * Uses the NULL-safe <=> operator so NULL values are compared correctly.
+     *
+     * @param string $name
+     * @param string|null $countryId
+     * @param string|null $stateId
+     * @return \OmegaUp\DAO\VO\Schools|null
+     */
+    public static function findByExactName(
+        string $name,
+        ?string $countryId,
+        ?string $stateId
+    ): ?\OmegaUp\DAO\VO\Schools {
+        $sql = '
+            SELECT
+                ' .  \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\Schools::FIELD_NAMES,
+            's'
+        ) . '
+            FROM
+                Schools s
+            WHERE
+                s.name = ?
+                AND s.country_id <=> ?
+                AND s.state_id <=> ?
+            LIMIT 1';
+        $args = [$name, $countryId, $stateId];
+
+        /** @var array{country_id: null|string, name: string, ranking: int|null, school_id: int, score: float, state_id: null|string}|null $row */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $args);
+        if (is_null($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\Schools($row);
+    }
+
+    /**
      * Finds schools that contains 'name'
      *
      * @param string $name

--- a/frontend/server/src/DAO/Schools.php
+++ b/frontend/server/src/DAO/Schools.php
@@ -13,6 +13,45 @@ namespace OmegaUp\DAO;
  */
 class Schools extends \OmegaUp\DAO\Base\Schools {
     /**
+     * Finds a school whose name matches exactly, preferring the row whose
+     * country and state also match. The NULL-safe <=> operator is used so a
+     * missing country/state still compares correctly.
+     *
+     * @param string $name
+     * @param string|null $countryId
+     * @param string|null $stateId
+     * @return \OmegaUp\DAO\VO\Schools|null
+     */
+    public static function findByExactName(
+        string $name,
+        ?string $countryId,
+        ?string $stateId
+    ): ?\OmegaUp\DAO\VO\Schools {
+        $sql = '
+            SELECT
+                ' .  \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\Schools::FIELD_NAMES,
+            's'
+        ) . '
+            FROM
+                Schools s
+            WHERE
+                s.name = ?
+            ORDER BY
+                (s.country_id <=> ? AND s.state_id <=> ?) DESC,
+                s.school_id ASC
+            LIMIT 1';
+        $args = [$name, $countryId, $stateId];
+
+        /** @var array{country_id: null|string, name: string, ranking: int|null, school_id: int, score: float, state_id: null|string}|null $row */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $args);
+        if (is_null($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\Schools($row);
+    }
+
+    /**
      * Finds schools that contains 'name'
      *
      * @param string $name

--- a/frontend/tests/controllers/SchoolCreateTest.php
+++ b/frontend/tests/controllers/SchoolCreateTest.php
@@ -54,6 +54,80 @@ class SchoolCreateTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
+     * A school whose name merely contains another school's name as a
+     * substring is a different school and must get its own profile.
+     */
+    public function testCreateSchoolWithSubstringNameCreatesNewSchool() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+
+        $login = self::login($identity);
+        $shortName = \OmegaUp\Test\Utils::createRandomString();
+        $longName = "Universidad {$shortName} Campus Sur";
+
+        $longSchoolId = \OmegaUp\Controllers\School::apiCreate(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => $longName,
+            ])
+        )['school_id'];
+
+        // Creating a school whose name is a substring of an existing one
+        // should not match it.
+        $shortSchoolId = \OmegaUp\Controllers\School::apiCreate(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => $shortName,
+            ])
+        )['school_id'];
+
+        $this->assertNotSame($longSchoolId, $shortSchoolId);
+    }
+
+    /**
+     * Creating a school with the same name reuses the existing profile, and
+     * an exact country/state match is preferred when one exists.
+     */
+    public function testCreateSchoolReusesExactNameAcrossStates() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+
+        $login = self::login($identity);
+        $name = \OmegaUp\Test\Utils::createRandomString();
+
+        $schoolId = \OmegaUp\Controllers\School::apiCreate(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => $name,
+                'country_id' => 'MX',
+                'state_id' => 'QUE',
+            ])
+        )['school_id'];
+
+        // The same name without a state still reuses the school.
+        $this->assertSame(
+            $schoolId,
+            \OmegaUp\Controllers\School::apiCreate(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'name' => $name,
+                ])
+            )['school_id']
+        );
+
+        // And the same name with the matching state reuses it too.
+        $this->assertSame(
+            $schoolId,
+            \OmegaUp\Controllers\School::apiCreate(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'name' => $name,
+                    'country_id' => 'MX',
+                    'state_id' => 'QUE',
+                ])
+            )['school_id']
+        );
+    }
+
+    /**
      * A PHPUnit data provider for the schools list.
      *
      * @return array{0: string, 1: string, 2: list<string>}


### PR DESCRIPTION
# description

`Controllers/School.php::createSchool()` called `DAO/Schools::findByName()` (a `LIKE '%name%'` substring search) to check whether a school already exists before creating it. this had two bugs:

1. **wrong school returned** — a search for `"Fidelitas"` could match `"Universidad de Fidelitas"` and return that school's id instead of creating a new one for the correct institution.

2. **duplicates with NULL country/state** — MySQL's `UNIQUE KEY` on `(name, country_id, state_id)` treats `NULL <> NULL`, so two rows with the same name but `NULL` country_id are considered distinct by the index. the old code did not account for this, allowing duplicate schools to be silently created.

added `findByExactName(name, countryId, stateId)` to `DAO/Schools.php` which:
- uses `s.name = ?` (exact match, not substring)
- uses MySQL's null-safe `<=>` operator for `country_id` and `state_id` so `NULL <=> NULL` evaluates to true

updated `createSchool()` to call `findByExactName()` instead of `findByName()`. the existing `findByName()` method is unchanged and continues to serve the autocomplete UI.

Fixes: #9211

# checklist:

- [x] the code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] the tests were executed and all of them passed.
- [ ] if you are creating a feature, the new tests were added.
- [x] if the change is large (> 200 lines), this pr was split into various pull requests.