### PR TITLE
fix(problem_runs): Apply filters when show_all is false

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3654,9 +3654,22 @@ class Problem extends \OmegaUp\Controllers\Controller {
             intval($r->identity->identity_id)
         );
 
+        $verdict = $r->ensureOptionalString('verdict');
+        $status = $r->ensureOptionalString('status');
+        $language = $r->ensureOptionalString('language');
+
         // Add each filtered run to an array
         $result = [];
         foreach ($runsArray as $run) {
+            if (!is_null($verdict) && $run['verdict'] !== $verdict) {
+                continue;
+            }
+            if (!is_null($status) && $run['status'] !== $status) {
+                continue;
+            }
+            if (!is_null($language) && $run['language'] !== $language) {
+                continue;
+            }
             $run['alias'] = strval($problem->alias);
             $run['country'] = 'xx';
             $result[] = $run;


### PR DESCRIPTION
## Description

Fixes #8054

When fetching runs via `/api/problem/runs` with `show_all` set to `false`, the controller (`src/Controllers/Problem.php`) ignored all filtering criteria like `verdict`, `status`, and `language`. As a result, users would see all their runs regardless of the applied filters in the UI.

This PR fixes this by correctly applying the `verdict`, `status`, and `language` filters to the resulting array in `apiRuns` after calling `\OmegaUp\DAO\Runs::getForProblemDetails`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually tested the `/api/problem/runs` endpoint by filtering submissions with `verdict=AC` and verifying that the results only contain accepted runs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes