### PR TITLE
feat: use Throwable instead of Exception in exception type hints

### DIFF
--- a/frontend/server/src/Exceptions/ApiException.php
+++ b/frontend/server/src/Exceptions/ApiException.php
@@ -22,7 +22,7 @@ abstract class ApiException extends \Exception {
         string $message,
         string $header,
         int $code,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/frontend/server/src/Exceptions/CSRFException.php
+++ b/frontend/server/src/Exceptions/CSRFException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class CSRFException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'csrfException',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/DuplicatedEntryInArrayException.php
+++ b/frontend/server/src/Exceptions/DuplicatedEntryInArrayException.php
@@ -20,7 +20,7 @@ class DuplicatedEntryInArrayException extends \OmegaUp\Exceptions\ApiException {
         string $message,
         string $duplicatedItem,
         array $duplicatedItemsInArray,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/DuplicatedEntryInDatabaseException.php
+++ b/frontend/server/src/Exceptions/DuplicatedEntryInDatabaseException.php
@@ -3,7 +3,7 @@
 namespace OmegaUp\Exceptions;
 
 class DuplicatedEntryInDatabaseException extends \OmegaUp\Exceptions\ApiException {
-    public function __construct(string $message, ?\Exception $previous = null) {
+    public function __construct(string $message, ?\Throwable $previous = null) {
         parent::__construct(
             $message,
             'HTTP/1.1 400 BAD REQUEST',

--- a/frontend/server/src/Exceptions/ForbiddenAccessException.php
+++ b/frontend/server/src/Exceptions/ForbiddenAccessException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class ForbiddenAccessException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'userNotAllowed',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, 'HTTP/1.1 403 FORBIDDEN', 403, $previous);
     }

--- a/frontend/server/src/Exceptions/InternalServerErrorException.php
+++ b/frontend/server/src/Exceptions/InternalServerErrorException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class InternalServerErrorException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'generalError',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/InvalidFilesystemOperationException.php
+++ b/frontend/server/src/Exceptions/InvalidFilesystemOperationException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class InvalidFilesystemOperationException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'generalError',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/LoginDisabledException.php
+++ b/frontend/server/src/Exceptions/LoginDisabledException.php
@@ -3,7 +3,7 @@
 namespace OmegaUp\Exceptions;
 
 class LoginDisabledException extends \OmegaUp\Exceptions\ApiException {
-    public function __construct(string $message, ?\Exception $previous = null) {
+    public function __construct(string $message, ?\Throwable $previous = null) {
         parent::__construct(
             $message,
             'HTTP/1.1 400 BAD REQUEST',

--- a/frontend/server/src/Exceptions/MethodNotAllowedException.php
+++ b/frontend/server/src/Exceptions/MethodNotAllowedException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class MethodNotAllowedException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'methodNotAllowed',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/NotAllowedToSubmitException.php
+++ b/frontend/server/src/Exceptions/NotAllowedToSubmitException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class NotAllowedToSubmitException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message,
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, 'HTTP/1.1 403 FORBIDDEN', 403, $previous);
     }

--- a/frontend/server/src/Exceptions/NotFoundException.php
+++ b/frontend/server/src/Exceptions/NotFoundException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class NotFoundException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'resourceNotFound',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, 'HTTP/1.1 404 NOT FOUND', 404, $previous);
     }

--- a/frontend/server/src/Exceptions/PreconditionFailedException.php
+++ b/frontend/server/src/Exceptions/PreconditionFailedException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class PreconditionFailedException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'userNotAllowed',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/RateLimitExceededException.php
+++ b/frontend/server/src/Exceptions/RateLimitExceededException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class RateLimitExceededException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'apiTokenRateLimitExceeded',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/ServiceUnavailableException.php
+++ b/frontend/server/src/Exceptions/ServiceUnavailableException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class ServiceUnavailableException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'serviceUnavailable',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,

--- a/frontend/server/src/Exceptions/UnauthorizedException.php
+++ b/frontend/server/src/Exceptions/UnauthorizedException.php
@@ -5,7 +5,7 @@ namespace OmegaUp\Exceptions;
 class UnauthorizedException extends \OmegaUp\Exceptions\ApiException {
     public function __construct(
         string $message = 'loginRequired',
-        ?\Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $message,


### PR DESCRIPTION
Replace `?\Exception` previous type hints with `?\Throwable` previous in all exception constructors so that both [Exception](cci:2://file:///c:/Users/BIT/Desktop/omegaup/frontend/server/src/Exceptions/ApiException.php:7:0-91:1) and [Error](cci:1://file:///c:/Users/BIT/Desktop/omegaup/frontend/server/src/Exceptions/ProblemDeploymentFailedException.php:20:4-30:5) subclasses (e.g., `TypeError`, `ValueError`) can be passed as previous exceptions.

Fixes #9268

# Description

Replace `?\Exception $previous` type hints with `?\Throwable $previous` in 15 exception class constructors across `frontend/server/src/Exceptions/`.

**Why:** PHP's `\Exception::__construct` already accepts `?\Throwable $previous` since PHP 7.0. Using `?\Throwable` is more correct because it also catches `Error` subclasses (e.g., `TypeError`, `ValueError`), not just `Exception` subclasses. This is a fully backward-compatible widening of the type.

**Changed files (15):**
- `ApiException.php` (base class)
- `CSRFException.php`
- `DuplicatedEntryInArrayException.php`
- `DuplicatedEntryInDatabaseException.php`
- `ForbiddenAccessException.php`
- `InternalServerErrorException.php`
- `InvalidFilesystemOperationException.php`
- `LoginDisabledException.php`
- `MethodNotAllowedException.php`
- `NotAllowedToSubmitException.php`
- `NotFoundException.php`
- `PreconditionFailedException.php`
- `RateLimitExceededException.php`
- `ServiceUnavailableException.php`
- `UnauthorizedException.php`

**Not changed (9 files):** Exception classes without a `$previous` parameter in their constructor (`CaptchaVerificationFailedException`, `DatabaseOperationException`, `EmailNotVerifiedException`, `EmailVerificationSendException`, `ExitException`, `InvalidCredentialsException`, `InvalidParameterException`, `ProblemDeploymentFailedException`, `TokenValidateException`).

Fixes #9268

# Comments

Mechanical one-token change per file (`\Exception` → `\Throwable`). No behavioral change for existing callers since `Exception` implements `Throwable`.

# Checklist

- [x] The code follows the [coding guidelines](<https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding guidelines.md>) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.