### PR TITLE
refactor: standardize null checks in DAO

### DIFF
--- a/frontend/server/src/DAO/AIEditorialJobs.php
+++ b/frontend/server/src/DAO/AIEditorialJobs.php
@@ -34,13 +34,9 @@ class AIEditorialJobs extends \OmegaUp\DAO\Base\AIEditorialJobs {
         \OmegaUp\DAO\VO\AIEditorialJobs $AI_Editorial_Jobs
     ): int {
         if (
-            is_null(
-                $AI_Editorial_Jobs->job_id
-            ) || is_null(
-                self::getByPK(
+            $AI_Editorial_Jobs->job_id === null || self::getByPK(
                     $AI_Editorial_Jobs->job_id
-                )
-            )
+                ) === null
         ) {
             return AIEditorialJobs::create($AI_Editorial_Jobs);
         }
@@ -81,15 +77,15 @@ class AIEditorialJobs extends \OmegaUp\DAO\Base\AIEditorialJobs {
         ?bool $isRetriable = null
     ): void {
         $job = self::getByPK($jobId);
-        if (is_null($job)) {
+        if ($job === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
         }
 
         $job->status = $status;
-        if (!is_null($errorMessage)) {
+        if ($errorMessage !== null) {
             $job->error_message = $errorMessage;
         }
-        if (!is_null($isRetriable)) {
+        if ($isRetriable !== null) {
             $job->is_retriable = $isRetriable;
         }
 
@@ -107,20 +103,20 @@ class AIEditorialJobs extends \OmegaUp\DAO\Base\AIEditorialJobs {
         ?string $validationVerdict = null
     ): void {
         $job = self::getByPK($jobId);
-        if (is_null($job)) {
+        if ($job === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
         }
 
-        if (!is_null($mdEn)) {
+        if ($mdEn !== null) {
             $job->md_en = $mdEn;
         }
-        if (!is_null($mdEs)) {
+        if ($mdEs !== null) {
             $job->md_es = $mdEs;
         }
-        if (!is_null($mdPt)) {
+        if ($mdPt !== null) {
             $job->md_pt = $mdPt;
         }
-        if (!is_null($validationVerdict)) {
+        if ($validationVerdict !== null) {
             $job->validation_verdict = $validationVerdict;
         }
 
@@ -172,7 +168,7 @@ class AIEditorialJobs extends \OmegaUp\DAO\Base\AIEditorialJobs {
             $sql,
             [$problemId]
         );
-        if (is_null($rs)) {
+        if ($rs === null) {
             return null;
         }
 

--- a/frontend/server/src/DAO/APITokens.php
+++ b/frontend/server/src/DAO/APITokens.php
@@ -41,7 +41,7 @@ class APITokens extends \OmegaUp\DAO\Base\APITokens {
                 at.token = ?
         ";
         $params = [$apiToken];
-        if (!is_null($username)) {
+        if ($username !== null) {
             $sql .= "
                 UNION
                 SELECT
@@ -65,7 +65,7 @@ class APITokens extends \OmegaUp\DAO\Base\APITokens {
 
         /** @var list<array{apitoken_id: int, classname: string, country_id: null|string, current_identity_school_id: int|null, gender: null|string, identity_id: int, is_main_identity: int, language_id: int|null, name: null|string, password: null|string, state_id: null|string, user_id: int|null, username: string}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
-        if (count($rs) === 1 && is_null($username)) {
+        if (count($rs) === 1 && $username === null) {
             $apiTokenId = $rs[0]['apitoken_id'];
             unset($rs[0]['apitoken_id'], $rs[0]['is_main_identity']);
             return [
@@ -74,7 +74,7 @@ class APITokens extends \OmegaUp\DAO\Base\APITokens {
                 'apiTokenId' => $apiTokenId,
             ];
         }
-        if (count($rs) !== 2 || is_null($username)) {
+        if (count($rs) !== 2 || $username === null) {
             return null;
         }
         // Put the main user identity first.
@@ -128,7 +128,7 @@ class APITokens extends \OmegaUp\DAO\Base\APITokens {
                 ',
                 [$apiTokenId],
             );
-            if (is_null($rs)) {
+            if ($rs === null) {
                 \OmegaUp\DAO\DAO::transRollback();
                 return null;
             }

--- a/frontend/server/src/DAO/Assignments.php
+++ b/frontend/server/src/DAO/Assignments.php
@@ -218,7 +218,7 @@ class Assignments extends \OmegaUp\DAO\Base\Assignments {
     }
 
     public static function getAssignmentForProblemset(?int $problemsetId): ?\OmegaUp\DAO\VO\Assignments {
-        if (is_null($problemsetId)) {
+        if ($problemsetId === null) {
             return null;
         }
 

--- a/frontend/server/src/DAO/Base/ACLs.php
+++ b/frontend/server/src/DAO/Base/ACLs.php
@@ -39,7 +39,7 @@ abstract class ACLs {
                 );';
         $params = [
             (
-                is_null($ACLs->owner_id) ?
+                $ACLs->owner_id === null ?
                 null :
                 intval($ACLs->owner_id)
             ),
@@ -213,7 +213,7 @@ abstract class ACLs {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -258,7 +258,7 @@ abstract class ACLs {
                 );';
         $params = [
             (
-                is_null($ACLs->owner_id) ?
+                $ACLs->owner_id === null ?
                 null :
                 intval($ACLs->owner_id)
             ),

--- a/frontend/server/src/DAO/Base/AIEditorialJobs.php
+++ b/frontend/server/src/DAO/Base/AIEditorialJobs.php
@@ -75,12 +75,12 @@ abstract class AIEditorialJobs {
         $params = [
             $AI_Editorial_Jobs->job_id,
             (
-                !is_null($AI_Editorial_Jobs->problem_id) ?
+                $AI_Editorial_Jobs->problem_id !== null ?
                 intval($AI_Editorial_Jobs->problem_id) :
                 null
             ),
             (
-                !is_null($AI_Editorial_Jobs->user_id) ?
+                $AI_Editorial_Jobs->user_id !== null ?
                 intval($AI_Editorial_Jobs->user_id) :
                 null
             ),
@@ -131,12 +131,12 @@ abstract class AIEditorialJobs {
                 );';
         $params = [
             (
-                is_null($AI_Editorial_Jobs->problem_id) ?
+                $AI_Editorial_Jobs->problem_id === null ?
                 null :
                 intval($AI_Editorial_Jobs->problem_id)
             ),
             (
-                is_null($AI_Editorial_Jobs->user_id) ?
+                $AI_Editorial_Jobs->user_id === null ?
                 null :
                 intval($AI_Editorial_Jobs->user_id)
             ),
@@ -341,7 +341,7 @@ abstract class AIEditorialJobs {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -409,12 +409,12 @@ abstract class AIEditorialJobs {
         $params = [
             $AI_Editorial_Jobs->job_id,
             (
-                is_null($AI_Editorial_Jobs->problem_id) ?
+                $AI_Editorial_Jobs->problem_id === null ?
                 null :
                 intval($AI_Editorial_Jobs->problem_id)
             ),
             (
-                is_null($AI_Editorial_Jobs->user_id) ?
+                $AI_Editorial_Jobs->user_id === null ?
                 null :
                 intval($AI_Editorial_Jobs->user_id)
             ),

--- a/frontend/server/src/DAO/Base/APITokens.php
+++ b/frontend/server/src/DAO/Base/APITokens.php
@@ -44,7 +44,7 @@ abstract class APITokens {
                 );';
         $params = [
             (
-                is_null($API_Tokens->user_id) ?
+                $API_Tokens->user_id === null ?
                 null :
                 intval($API_Tokens->user_id)
             ),
@@ -237,7 +237,7 @@ abstract class APITokens {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -292,7 +292,7 @@ abstract class APITokens {
                 );';
         $params = [
             (
-                is_null($API_Tokens->user_id) ?
+                $API_Tokens->user_id === null ?
                 null :
                 intval($API_Tokens->user_id)
             ),

--- a/frontend/server/src/DAO/Base/Announcement.php
+++ b/frontend/server/src/DAO/Base/Announcement.php
@@ -41,7 +41,7 @@ abstract class Announcement {
                 );';
         $params = [
             (
-                is_null($Announcement->user_id) ?
+                $Announcement->user_id === null ?
                 null :
                 intval($Announcement->user_id)
             ),
@@ -223,7 +223,7 @@ abstract class Announcement {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -272,7 +272,7 @@ abstract class Announcement {
                 );';
         $params = [
             (
-                is_null($Announcement->user_id) ?
+                $Announcement->user_id === null ?
                 null :
                 intval($Announcement->user_id)
             ),

--- a/frontend/server/src/DAO/Base/Assignments.php
+++ b/frontend/server/src/DAO/Base/Assignments.php
@@ -50,17 +50,17 @@ abstract class Assignments {
                 );';
         $params = [
             (
-                is_null($Assignments->course_id) ?
+                $Assignments->course_id === null ?
                 null :
                 intval($Assignments->course_id)
             ),
             (
-                is_null($Assignments->problemset_id) ?
+                $Assignments->problemset_id === null ?
                 null :
                 intval($Assignments->problemset_id)
             ),
             (
-                is_null($Assignments->acl_id) ?
+                $Assignments->acl_id === null ?
                 null :
                 intval($Assignments->acl_id)
             ),
@@ -68,7 +68,7 @@ abstract class Assignments {
             $Assignments->description,
             $Assignments->alias,
             (
-                is_null($Assignments->publish_time_delay) ?
+                $Assignments->publish_time_delay === null ?
                 null :
                 intval($Assignments->publish_time_delay)
             ),
@@ -273,7 +273,7 @@ abstract class Assignments {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -340,17 +340,17 @@ abstract class Assignments {
                 );';
         $params = [
             (
-                is_null($Assignments->course_id) ?
+                $Assignments->course_id === null ?
                 null :
                 intval($Assignments->course_id)
             ),
             (
-                is_null($Assignments->problemset_id) ?
+                $Assignments->problemset_id === null ?
                 null :
                 intval($Assignments->problemset_id)
             ),
             (
-                is_null($Assignments->acl_id) ?
+                $Assignments->acl_id === null ?
                 null :
                 intval($Assignments->acl_id)
             ),
@@ -358,7 +358,7 @@ abstract class Assignments {
             $Assignments->description,
             $Assignments->alias,
             (
-                is_null($Assignments->publish_time_delay) ?
+                $Assignments->publish_time_delay === null ?
                 null :
                 intval($Assignments->publish_time_delay)
             ),

--- a/frontend/server/src/DAO/Base/AuthTokens.php
+++ b/frontend/server/src/DAO/Base/AuthTokens.php
@@ -60,17 +60,17 @@ abstract class AuthTokens {
                 );';
         $params = [
             (
-                !is_null($Auth_Tokens->user_id) ?
+                $Auth_Tokens->user_id !== null ?
                 intval($Auth_Tokens->user_id) :
                 null
             ),
             (
-                !is_null($Auth_Tokens->identity_id) ?
+                $Auth_Tokens->identity_id !== null ?
                 intval($Auth_Tokens->identity_id) :
                 null
             ),
             (
-                !is_null($Auth_Tokens->acting_identity_id) ?
+                $Auth_Tokens->acting_identity_id !== null ?
                 intval($Auth_Tokens->acting_identity_id) :
                 null
             ),
@@ -107,17 +107,17 @@ abstract class AuthTokens {
                 );';
         $params = [
             (
-                is_null($Auth_Tokens->user_id) ?
+                $Auth_Tokens->user_id === null ?
                 null :
                 intval($Auth_Tokens->user_id)
             ),
             (
-                is_null($Auth_Tokens->identity_id) ?
+                $Auth_Tokens->identity_id === null ?
                 null :
                 intval($Auth_Tokens->identity_id)
             ),
             (
-                is_null($Auth_Tokens->acting_identity_id) ?
+                $Auth_Tokens->acting_identity_id === null ?
                 null :
                 intval($Auth_Tokens->acting_identity_id)
             ),
@@ -300,7 +300,7 @@ abstract class AuthTokens {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -353,17 +353,17 @@ abstract class AuthTokens {
                 );';
         $params = [
             (
-                is_null($Auth_Tokens->user_id) ?
+                $Auth_Tokens->user_id === null ?
                 null :
                 intval($Auth_Tokens->user_id)
             ),
             (
-                is_null($Auth_Tokens->identity_id) ?
+                $Auth_Tokens->identity_id === null ?
                 null :
                 intval($Auth_Tokens->identity_id)
             ),
             (
-                is_null($Auth_Tokens->acting_identity_id) ?
+                $Auth_Tokens->acting_identity_id === null ?
                 null :
                 intval($Auth_Tokens->acting_identity_id)
             ),

--- a/frontend/server/src/DAO/Base/CarouselItems.php
+++ b/frontend/server/src/DAO/Base/CarouselItems.php
@@ -57,7 +57,7 @@ abstract class CarouselItems {
             ),
             $Carousel_Items->status,
             (
-                is_null($Carousel_Items->user_id) ?
+                $Carousel_Items->user_id === null ?
                 null :
                 intval($Carousel_Items->user_id)
             ),
@@ -255,7 +255,7 @@ abstract class CarouselItems {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -327,7 +327,7 @@ abstract class CarouselItems {
             ),
             $Carousel_Items->status,
             (
-                is_null($Carousel_Items->user_id) ?
+                $Carousel_Items->user_id === null ?
                 null :
                 intval($Carousel_Items->user_id)
             ),

--- a/frontend/server/src/DAO/Base/Certificates.php
+++ b/frontend/server/src/DAO/Base/Certificates.php
@@ -46,7 +46,7 @@ abstract class Certificates {
                 );';
         $params = [
             (
-                is_null($Certificates->identity_id) ?
+                $Certificates->identity_id === null ?
                 null :
                 intval($Certificates->identity_id)
             ),
@@ -55,23 +55,23 @@ abstract class Certificates {
             ),
             $Certificates->certificate_type,
             (
-                is_null($Certificates->course_id) ?
+                $Certificates->course_id === null ?
                 null :
                 intval($Certificates->course_id)
             ),
             (
-                is_null($Certificates->contest_id) ?
+                $Certificates->contest_id === null ?
                 null :
                 intval($Certificates->contest_id)
             ),
             (
-                is_null($Certificates->coder_of_the_month_id) ?
+                $Certificates->coder_of_the_month_id === null ?
                 null :
                 intval($Certificates->coder_of_the_month_id)
             ),
             $Certificates->verification_code,
             (
-                is_null($Certificates->contest_place) ?
+                $Certificates->contest_place === null ?
                 null :
                 intval($Certificates->contest_place)
             ),
@@ -259,7 +259,7 @@ abstract class Certificates {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -318,7 +318,7 @@ abstract class Certificates {
                 );';
         $params = [
             (
-                is_null($Certificates->identity_id) ?
+                $Certificates->identity_id === null ?
                 null :
                 intval($Certificates->identity_id)
             ),
@@ -327,23 +327,23 @@ abstract class Certificates {
             ),
             $Certificates->certificate_type,
             (
-                is_null($Certificates->course_id) ?
+                $Certificates->course_id === null ?
                 null :
                 intval($Certificates->course_id)
             ),
             (
-                is_null($Certificates->contest_id) ?
+                $Certificates->contest_id === null ?
                 null :
                 intval($Certificates->contest_id)
             ),
             (
-                is_null($Certificates->coder_of_the_month_id) ?
+                $Certificates->coder_of_the_month_id === null ?
                 null :
                 intval($Certificates->coder_of_the_month_id)
             ),
             $Certificates->verification_code,
             (
-                is_null($Certificates->contest_place) ?
+                $Certificates->contest_place === null ?
                 null :
                 intval($Certificates->contest_place)
             ),

--- a/frontend/server/src/DAO/Base/Clarifications.php
+++ b/frontend/server/src/DAO/Base/Clarifications.php
@@ -46,12 +46,12 @@ abstract class Clarifications {
                 );';
         $params = [
             (
-                is_null($Clarifications->author_id) ?
+                $Clarifications->author_id === null ?
                 null :
                 intval($Clarifications->author_id)
             ),
             (
-                is_null($Clarifications->receiver_id) ?
+                $Clarifications->receiver_id === null ?
                 null :
                 intval($Clarifications->receiver_id)
             ),
@@ -61,12 +61,12 @@ abstract class Clarifications {
                 $Clarifications->time
             ),
             (
-                is_null($Clarifications->problem_id) ?
+                $Clarifications->problem_id === null ?
                 null :
                 intval($Clarifications->problem_id)
             ),
             (
-                is_null($Clarifications->problemset_id) ?
+                $Clarifications->problemset_id === null ?
                 null :
                 intval($Clarifications->problemset_id)
             ),
@@ -255,7 +255,7 @@ abstract class Clarifications {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -314,12 +314,12 @@ abstract class Clarifications {
                 );';
         $params = [
             (
-                is_null($Clarifications->author_id) ?
+                $Clarifications->author_id === null ?
                 null :
                 intval($Clarifications->author_id)
             ),
             (
-                is_null($Clarifications->receiver_id) ?
+                $Clarifications->receiver_id === null ?
                 null :
                 intval($Clarifications->receiver_id)
             ),
@@ -329,12 +329,12 @@ abstract class Clarifications {
                 $Clarifications->time
             ),
             (
-                is_null($Clarifications->problem_id) ?
+                $Clarifications->problem_id === null ?
                 null :
                 intval($Clarifications->problem_id)
             ),
             (
-                is_null($Clarifications->problemset_id) ?
+                $Clarifications->problemset_id === null ?
                 null :
                 intval($Clarifications->problemset_id)
             ),

--- a/frontend/server/src/DAO/Base/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/CoderOfTheMonth.php
@@ -49,7 +49,7 @@ abstract class CoderOfTheMonth {
                 );';
         $params = [
             (
-                is_null($Coder_Of_The_Month->user_id) ?
+                $Coder_Of_The_Month->user_id === null ?
                 null :
                 intval($Coder_Of_The_Month->user_id)
             ),
@@ -57,17 +57,17 @@ abstract class CoderOfTheMonth {
             $Coder_Of_The_Month->time,
             $Coder_Of_The_Month->interview_url,
             (
-                is_null($Coder_Of_The_Month->ranking) ?
+                $Coder_Of_The_Month->ranking === null ?
                 null :
                 intval($Coder_Of_The_Month->ranking)
             ),
             (
-                is_null($Coder_Of_The_Month->selected_by) ?
+                $Coder_Of_The_Month->selected_by === null ?
                 null :
                 intval($Coder_Of_The_Month->selected_by)
             ),
             (
-                is_null($Coder_Of_The_Month->school_id) ?
+                $Coder_Of_The_Month->school_id === null ?
                 null :
                 intval($Coder_Of_The_Month->school_id)
             ),
@@ -265,7 +265,7 @@ abstract class CoderOfTheMonth {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -330,7 +330,7 @@ abstract class CoderOfTheMonth {
                 );';
         $params = [
             (
-                is_null($Coder_Of_The_Month->user_id) ?
+                $Coder_Of_The_Month->user_id === null ?
                 null :
                 intval($Coder_Of_The_Month->user_id)
             ),
@@ -338,17 +338,17 @@ abstract class CoderOfTheMonth {
             $Coder_Of_The_Month->time,
             $Coder_Of_The_Month->interview_url,
             (
-                is_null($Coder_Of_The_Month->ranking) ?
+                $Coder_Of_The_Month->ranking === null ?
                 null :
                 intval($Coder_Of_The_Month->ranking)
             ),
             (
-                is_null($Coder_Of_The_Month->selected_by) ?
+                $Coder_Of_The_Month->selected_by === null ?
                 null :
                 intval($Coder_Of_The_Month->selected_by)
             ),
             (
-                is_null($Coder_Of_The_Month->school_id) ?
+                $Coder_Of_The_Month->school_id === null ?
                 null :
                 intval($Coder_Of_The_Month->school_id)
             ),

--- a/frontend/server/src/DAO/Base/ContestLog.php
+++ b/frontend/server/src/DAO/Base/ContestLog.php
@@ -43,12 +43,12 @@ abstract class ContestLog {
                 );';
         $params = [
             (
-                is_null($Contest_Log->contest_id) ?
+                $Contest_Log->contest_id === null ?
                 null :
                 intval($Contest_Log->contest_id)
             ),
             (
-                is_null($Contest_Log->user_id) ?
+                $Contest_Log->user_id === null ?
                 null :
                 intval($Contest_Log->user_id)
             ),
@@ -235,7 +235,7 @@ abstract class ContestLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -288,12 +288,12 @@ abstract class ContestLog {
                 );';
         $params = [
             (
-                is_null($Contest_Log->contest_id) ?
+                $Contest_Log->contest_id === null ?
                 null :
                 intval($Contest_Log->contest_id)
             ),
             (
-                is_null($Contest_Log->user_id) ?
+                $Contest_Log->user_id === null ?
                 null :
                 intval($Contest_Log->user_id)
             ),

--- a/frontend/server/src/DAO/Base/Contests.php
+++ b/frontend/server/src/DAO/Base/Contests.php
@@ -69,12 +69,12 @@ abstract class Contests {
                 );';
         $params = [
             (
-                is_null($Contests->problemset_id) ?
+                $Contests->problemset_id === null ?
                 null :
                 intval($Contests->problemset_id)
             ),
             (
-                is_null($Contests->acl_id) ?
+                $Contests->acl_id === null ?
                 null :
                 intval($Contests->acl_id)
             ),
@@ -90,12 +90,12 @@ abstract class Contests {
                 $Contests->last_updated
             ),
             (
-                is_null($Contests->window_length) ?
+                $Contests->window_length === null ?
                 null :
                 intval($Contests->window_length)
             ),
             (
-                is_null($Contests->rerun_id) ?
+                $Contests->rerun_id === null ?
                 null :
                 intval($Contests->rerun_id)
             ),
@@ -115,7 +115,7 @@ abstract class Contests {
             intval($Contests->recommended),
             intval($Contests->archived),
             (
-                is_null($Contests->certificate_cutoff) ?
+                $Contests->certificate_cutoff === null ?
                 null :
                 intval($Contests->certificate_cutoff)
             ),
@@ -355,7 +355,7 @@ abstract class Contests {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -460,12 +460,12 @@ abstract class Contests {
                 );';
         $params = [
             (
-                is_null($Contests->problemset_id) ?
+                $Contests->problemset_id === null ?
                 null :
                 intval($Contests->problemset_id)
             ),
             (
-                is_null($Contests->acl_id) ?
+                $Contests->acl_id === null ?
                 null :
                 intval($Contests->acl_id)
             ),
@@ -481,12 +481,12 @@ abstract class Contests {
                 $Contests->last_updated
             ),
             (
-                is_null($Contests->window_length) ?
+                $Contests->window_length === null ?
                 null :
                 intval($Contests->window_length)
             ),
             (
-                is_null($Contests->rerun_id) ?
+                $Contests->rerun_id === null ?
                 null :
                 intval($Contests->rerun_id)
             ),
@@ -506,7 +506,7 @@ abstract class Contests {
             intval($Contests->recommended),
             intval($Contests->archived),
             (
-                is_null($Contests->certificate_cutoff) ?
+                $Contests->certificate_cutoff === null ?
                 null :
                 intval($Contests->certificate_cutoff)
             ),

--- a/frontend/server/src/DAO/Base/Countries.php
+++ b/frontend/server/src/DAO/Base/Countries.php
@@ -251,7 +251,7 @@ abstract class Countries {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/CourseCloneLog.php
+++ b/frontend/server/src/DAO/Base/CourseCloneLog.php
@@ -46,12 +46,12 @@ abstract class CourseCloneLog {
         $params = [
             $Course_Clone_Log->ip,
             (
-                is_null($Course_Clone_Log->course_id) ?
+                $Course_Clone_Log->course_id === null ?
                 null :
                 intval($Course_Clone_Log->course_id)
             ),
             (
-                is_null($Course_Clone_Log->new_course_id) ?
+                $Course_Clone_Log->new_course_id === null ?
                 null :
                 intval($Course_Clone_Log->new_course_id)
             ),
@@ -60,7 +60,7 @@ abstract class CourseCloneLog {
                 $Course_Clone_Log->timestamp
             ),
             (
-                is_null($Course_Clone_Log->user_id) ?
+                $Course_Clone_Log->user_id === null ?
                 null :
                 intval($Course_Clone_Log->user_id)
             ),
@@ -247,7 +247,7 @@ abstract class CourseCloneLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -305,12 +305,12 @@ abstract class CourseCloneLog {
         $params = [
             $Course_Clone_Log->ip,
             (
-                is_null($Course_Clone_Log->course_id) ?
+                $Course_Clone_Log->course_id === null ?
                 null :
                 intval($Course_Clone_Log->course_id)
             ),
             (
-                is_null($Course_Clone_Log->new_course_id) ?
+                $Course_Clone_Log->new_course_id === null ?
                 null :
                 intval($Course_Clone_Log->new_course_id)
             ),
@@ -319,7 +319,7 @@ abstract class CourseCloneLog {
                 $Course_Clone_Log->timestamp
             ),
             (
-                is_null($Course_Clone_Log->user_id) ?
+                $Course_Clone_Log->user_id === null ?
                 null :
                 intval($Course_Clone_Log->user_id)
             ),

--- a/frontend/server/src/DAO/Base/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequest.php
@@ -75,18 +75,18 @@ abstract class CourseIdentityRequest {
                 $Course_Identity_Request->last_update
             ),
             (
-                !is_null($Course_Identity_Request->accepted) ?
+                $Course_Identity_Request->accepted !== null ?
                 intval($Course_Identity_Request->accepted) :
                 null
             ),
             $Course_Identity_Request->extra_note,
             (
-                !is_null($Course_Identity_Request->accept_teacher) ?
+                $Course_Identity_Request->accept_teacher !== null ?
                 intval($Course_Identity_Request->accept_teacher) :
                 null
             ),
             (
-                !is_null($Course_Identity_Request->share_user_information) ?
+                $Course_Identity_Request->share_user_information !== null ?
                 intval($Course_Identity_Request->share_user_information) :
                 null
             ),
@@ -128,28 +128,28 @@ abstract class CourseIdentityRequest {
                 $Course_Identity_Request->last_update
             ),
             (
-                is_null($Course_Identity_Request->accepted) ?
+                $Course_Identity_Request->accepted === null ?
                 null :
                 intval($Course_Identity_Request->accepted)
             ),
             $Course_Identity_Request->extra_note,
             (
-                is_null($Course_Identity_Request->accept_teacher) ?
+                $Course_Identity_Request->accept_teacher === null ?
                 null :
                 intval($Course_Identity_Request->accept_teacher)
             ),
             (
-                is_null($Course_Identity_Request->share_user_information) ?
+                $Course_Identity_Request->share_user_information === null ?
                 null :
                 intval($Course_Identity_Request->share_user_information)
             ),
             (
-                is_null($Course_Identity_Request->identity_id) ?
+                $Course_Identity_Request->identity_id === null ?
                 null :
                 intval($Course_Identity_Request->identity_id)
             ),
             (
-                is_null($Course_Identity_Request->course_id) ?
+                $Course_Identity_Request->course_id === null ?
                 null :
                 intval($Course_Identity_Request->course_id)
             ),
@@ -340,7 +340,7 @@ abstract class CourseIdentityRequest {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -399,12 +399,12 @@ abstract class CourseIdentityRequest {
                 );';
         $params = [
             (
-                is_null($Course_Identity_Request->identity_id) ?
+                $Course_Identity_Request->identity_id === null ?
                 null :
                 intval($Course_Identity_Request->identity_id)
             ),
             (
-                is_null($Course_Identity_Request->course_id) ?
+                $Course_Identity_Request->course_id === null ?
                 null :
                 intval($Course_Identity_Request->course_id)
             ),
@@ -415,18 +415,18 @@ abstract class CourseIdentityRequest {
                 $Course_Identity_Request->last_update
             ),
             (
-                is_null($Course_Identity_Request->accepted) ?
+                $Course_Identity_Request->accepted === null ?
                 null :
                 intval($Course_Identity_Request->accepted)
             ),
             $Course_Identity_Request->extra_note,
             (
-                is_null($Course_Identity_Request->accept_teacher) ?
+                $Course_Identity_Request->accept_teacher === null ?
                 null :
                 intval($Course_Identity_Request->accept_teacher)
             ),
             (
-                is_null($Course_Identity_Request->share_user_information) ?
+                $Course_Identity_Request->share_user_information === null ?
                 null :
                 intval($Course_Identity_Request->share_user_information)
             ),

--- a/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/CourseIdentityRequestHistory.php
@@ -43,12 +43,12 @@ abstract class CourseIdentityRequestHistory {
                 );';
         $params = [
             (
-                is_null($Course_Identity_Request_History->identity_id) ?
+                $Course_Identity_Request_History->identity_id === null ?
                 null :
                 intval($Course_Identity_Request_History->identity_id)
             ),
             (
-                is_null($Course_Identity_Request_History->course_id) ?
+                $Course_Identity_Request_History->course_id === null ?
                 null :
                 intval($Course_Identity_Request_History->course_id)
             ),
@@ -56,12 +56,12 @@ abstract class CourseIdentityRequestHistory {
                 $Course_Identity_Request_History->time
             ),
             (
-                is_null($Course_Identity_Request_History->accepted) ?
+                $Course_Identity_Request_History->accepted === null ?
                 null :
                 intval($Course_Identity_Request_History->accepted)
             ),
             (
-                is_null($Course_Identity_Request_History->admin_id) ?
+                $Course_Identity_Request_History->admin_id === null ?
                 null :
                 intval($Course_Identity_Request_History->admin_id)
             ),
@@ -243,7 +243,7 @@ abstract class CourseIdentityRequestHistory {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -296,12 +296,12 @@ abstract class CourseIdentityRequestHistory {
                 );';
         $params = [
             (
-                is_null($Course_Identity_Request_History->identity_id) ?
+                $Course_Identity_Request_History->identity_id === null ?
                 null :
                 intval($Course_Identity_Request_History->identity_id)
             ),
             (
-                is_null($Course_Identity_Request_History->course_id) ?
+                $Course_Identity_Request_History->course_id === null ?
                 null :
                 intval($Course_Identity_Request_History->course_id)
             ),
@@ -309,12 +309,12 @@ abstract class CourseIdentityRequestHistory {
                 $Course_Identity_Request_History->time
             ),
             (
-                is_null($Course_Identity_Request_History->accepted) ?
+                $Course_Identity_Request_History->accepted === null ?
                 null :
                 intval($Course_Identity_Request_History->accepted)
             ),
             (
-                is_null($Course_Identity_Request_History->admin_id) ?
+                $Course_Identity_Request_History->admin_id === null ?
                 null :
                 intval($Course_Identity_Request_History->admin_id)
             ),

--- a/frontend/server/src/DAO/Base/Courses.php
+++ b/frontend/server/src/DAO/Base/Courses.php
@@ -62,12 +62,12 @@ abstract class Courses {
             $Courses->objective,
             $Courses->alias,
             (
-                is_null($Courses->group_id) ?
+                $Courses->group_id === null ?
                 null :
                 intval($Courses->group_id)
             ),
             (
-                is_null($Courses->acl_id) ?
+                $Courses->acl_id === null ?
                 null :
                 intval($Courses->acl_id)
             ),
@@ -80,7 +80,7 @@ abstract class Courses {
             ),
             $Courses->admission_mode,
             (
-                is_null($Courses->school_id) ?
+                $Courses->school_id === null ?
                 null :
                 intval($Courses->school_id)
             ),
@@ -90,7 +90,7 @@ abstract class Courses {
             $Courses->languages,
             intval($Courses->archived),
             (
-                is_null($Courses->minimum_progress_for_certificate) ?
+                $Courses->minimum_progress_for_certificate === null ?
                 null :
                 intval($Courses->minimum_progress_for_certificate)
             ),
@@ -305,7 +305,7 @@ abstract class Courses {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -392,12 +392,12 @@ abstract class Courses {
             $Courses->objective,
             $Courses->alias,
             (
-                is_null($Courses->group_id) ?
+                $Courses->group_id === null ?
                 null :
                 intval($Courses->group_id)
             ),
             (
-                is_null($Courses->acl_id) ?
+                $Courses->acl_id === null ?
                 null :
                 intval($Courses->acl_id)
             ),
@@ -410,7 +410,7 @@ abstract class Courses {
             ),
             $Courses->admission_mode,
             (
-                is_null($Courses->school_id) ?
+                $Courses->school_id === null ?
                 null :
                 intval($Courses->school_id)
             ),
@@ -420,7 +420,7 @@ abstract class Courses {
             $Courses->languages,
             intval($Courses->archived),
             (
-                is_null($Courses->minimum_progress_for_certificate) ?
+                $Courses->minimum_progress_for_certificate === null ?
                 null :
                 intval($Courses->minimum_progress_for_certificate)
             ),

--- a/frontend/server/src/DAO/Base/Emails.php
+++ b/frontend/server/src/DAO/Base/Emails.php
@@ -41,7 +41,7 @@ abstract class Emails {
         $params = [
             $Emails->email,
             (
-                is_null($Emails->user_id) ?
+                $Emails->user_id === null ?
                 null :
                 intval($Emails->user_id)
             ),
@@ -217,7 +217,7 @@ abstract class Emails {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -265,7 +265,7 @@ abstract class Emails {
         $params = [
             $Emails->email,
             (
-                is_null($Emails->user_id) ?
+                $Emails->user_id === null ?
                 null :
                 intval($Emails->user_id)
             ),

--- a/frontend/server/src/DAO/Base/Favorites.php
+++ b/frontend/server/src/DAO/Base/Favorites.php
@@ -188,7 +188,7 @@ abstract class Favorites {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -235,12 +235,12 @@ abstract class Favorites {
                 );';
         $params = [
             (
-                is_null($Favorites->user_id) ?
+                $Favorites->user_id === null ?
                 null :
                 intval($Favorites->user_id)
             ),
             (
-                is_null($Favorites->problem_id) ?
+                $Favorites->problem_id === null ?
                 null :
                 intval($Favorites->problem_id)
             ),

--- a/frontend/server/src/DAO/Base/GroupRoles.php
+++ b/frontend/server/src/DAO/Base/GroupRoles.php
@@ -196,7 +196,7 @@ abstract class GroupRoles {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -245,17 +245,17 @@ abstract class GroupRoles {
                 );';
         $params = [
             (
-                is_null($Group_Roles->group_id) ?
+                $Group_Roles->group_id === null ?
                 null :
                 intval($Group_Roles->group_id)
             ),
             (
-                is_null($Group_Roles->role_id) ?
+                $Group_Roles->role_id === null ?
                 null :
                 intval($Group_Roles->role_id)
             ),
             (
-                is_null($Group_Roles->acl_id) ?
+                $Group_Roles->acl_id === null ?
                 null :
                 intval($Group_Roles->acl_id)
             ),

--- a/frontend/server/src/DAO/Base/Groups.php
+++ b/frontend/server/src/DAO/Base/Groups.php
@@ -43,7 +43,7 @@ abstract class Groups {
                 );';
         $params = [
             (
-                is_null($Groups_->acl_id) ?
+                $Groups_->acl_id === null ?
                 null :
                 intval($Groups_->acl_id)
             ),
@@ -231,7 +231,7 @@ abstract class Groups {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -284,7 +284,7 @@ abstract class Groups {
                 );';
         $params = [
             (
-                is_null($Groups_->acl_id) ?
+                $Groups_->acl_id === null ?
                 null :
                 intval($Groups_->acl_id)
             ),

--- a/frontend/server/src/DAO/Base/GroupsIdentities.php
+++ b/frontend/server/src/DAO/Base/GroupsIdentities.php
@@ -65,17 +65,17 @@ abstract class GroupsIdentities {
             $Groups_Identities->group_id,
             $Groups_Identities->identity_id,
             (
-                !is_null($Groups_Identities->share_user_information) ?
+                $Groups_Identities->share_user_information !== null ?
                 intval($Groups_Identities->share_user_information) :
                 null
             ),
             (
-                !is_null($Groups_Identities->privacystatement_consent_id) ?
+                $Groups_Identities->privacystatement_consent_id !== null ?
                 intval($Groups_Identities->privacystatement_consent_id) :
                 null
             ),
             (
-                !is_null($Groups_Identities->accept_teacher) ?
+                $Groups_Identities->accept_teacher !== null ?
                 intval($Groups_Identities->accept_teacher) :
                 null
             ),
@@ -110,28 +110,28 @@ abstract class GroupsIdentities {
                 );';
         $params = [
             (
-                is_null($Groups_Identities->share_user_information) ?
+                $Groups_Identities->share_user_information === null ?
                 null :
                 intval($Groups_Identities->share_user_information)
             ),
             (
-                is_null($Groups_Identities->privacystatement_consent_id) ?
+                $Groups_Identities->privacystatement_consent_id === null ?
                 null :
                 intval($Groups_Identities->privacystatement_consent_id)
             ),
             (
-                is_null($Groups_Identities->accept_teacher) ?
+                $Groups_Identities->accept_teacher === null ?
                 null :
                 intval($Groups_Identities->accept_teacher)
             ),
             intval($Groups_Identities->is_invited),
             (
-                is_null($Groups_Identities->group_id) ?
+                $Groups_Identities->group_id === null ?
                 null :
                 intval($Groups_Identities->group_id)
             ),
             (
-                is_null($Groups_Identities->identity_id) ?
+                $Groups_Identities->identity_id === null ?
                 null :
                 intval($Groups_Identities->identity_id)
             ),
@@ -318,7 +318,7 @@ abstract class GroupsIdentities {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -373,27 +373,27 @@ abstract class GroupsIdentities {
                 );';
         $params = [
             (
-                is_null($Groups_Identities->group_id) ?
+                $Groups_Identities->group_id === null ?
                 null :
                 intval($Groups_Identities->group_id)
             ),
             (
-                is_null($Groups_Identities->identity_id) ?
+                $Groups_Identities->identity_id === null ?
                 null :
                 intval($Groups_Identities->identity_id)
             ),
             (
-                is_null($Groups_Identities->share_user_information) ?
+                $Groups_Identities->share_user_information === null ?
                 null :
                 intval($Groups_Identities->share_user_information)
             ),
             (
-                is_null($Groups_Identities->privacystatement_consent_id) ?
+                $Groups_Identities->privacystatement_consent_id === null ?
                 null :
                 intval($Groups_Identities->privacystatement_consent_id)
             ),
             (
-                is_null($Groups_Identities->accept_teacher) ?
+                $Groups_Identities->accept_teacher === null ?
                 null :
                 intval($Groups_Identities->accept_teacher)
             ),

--- a/frontend/server/src/DAO/Base/GroupsScoreboards.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboards.php
@@ -43,7 +43,7 @@ abstract class GroupsScoreboards {
                 );';
         $params = [
             (
-                is_null($Groups_Scoreboards->group_id) ?
+                $Groups_Scoreboards->group_id === null ?
                 null :
                 intval($Groups_Scoreboards->group_id)
             ),
@@ -231,7 +231,7 @@ abstract class GroupsScoreboards {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -284,7 +284,7 @@ abstract class GroupsScoreboards {
                 );';
         $params = [
             (
-                is_null($Groups_Scoreboards->group_id) ?
+                $Groups_Scoreboards->group_id === null ?
                 null :
                 intval($Groups_Scoreboards->group_id)
             ),

--- a/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
+++ b/frontend/server/src/DAO/Base/GroupsScoreboardsProblemsets.php
@@ -92,12 +92,12 @@ abstract class GroupsScoreboardsProblemsets {
             intval($Groups_Scoreboards_Problemsets->only_ac),
             intval($Groups_Scoreboards_Problemsets->weight),
             (
-                is_null($Groups_Scoreboards_Problemsets->group_scoreboard_id) ?
+                $Groups_Scoreboards_Problemsets->group_scoreboard_id === null ?
                 null :
                 intval($Groups_Scoreboards_Problemsets->group_scoreboard_id)
             ),
             (
-                is_null($Groups_Scoreboards_Problemsets->problemset_id) ?
+                $Groups_Scoreboards_Problemsets->problemset_id === null ?
                 null :
                 intval($Groups_Scoreboards_Problemsets->problemset_id)
             ),
@@ -280,7 +280,7 @@ abstract class GroupsScoreboardsProblemsets {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -331,12 +331,12 @@ abstract class GroupsScoreboardsProblemsets {
                 );';
         $params = [
             (
-                is_null($Groups_Scoreboards_Problemsets->group_scoreboard_id) ?
+                $Groups_Scoreboards_Problemsets->group_scoreboard_id === null ?
                 null :
                 intval($Groups_Scoreboards_Problemsets->group_scoreboard_id)
             ),
             (
-                is_null($Groups_Scoreboards_Problemsets->problemset_id) ?
+                $Groups_Scoreboards_Problemsets->problemset_id === null ?
                 null :
                 intval($Groups_Scoreboards_Problemsets->problemset_id)
             ),

--- a/frontend/server/src/DAO/Base/Identities.php
+++ b/frontend/server/src/DAO/Base/Identities.php
@@ -50,12 +50,12 @@ abstract class Identities {
             $Identities->password,
             $Identities->name,
             (
-                is_null($Identities->user_id) ?
+                $Identities->user_id === null ?
                 null :
                 intval($Identities->user_id)
             ),
             (
-                is_null($Identities->language_id) ?
+                $Identities->language_id === null ?
                 null :
                 intval($Identities->language_id)
             ),
@@ -63,7 +63,7 @@ abstract class Identities {
             $Identities->state_id,
             $Identities->gender,
             (
-                is_null($Identities->current_identity_school_id) ?
+                $Identities->current_identity_school_id === null ?
                 null :
                 intval($Identities->current_identity_school_id)
             ),
@@ -253,7 +253,7 @@ abstract class Identities {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -317,12 +317,12 @@ abstract class Identities {
             $Identities->password,
             $Identities->name,
             (
-                is_null($Identities->user_id) ?
+                $Identities->user_id === null ?
                 null :
                 intval($Identities->user_id)
             ),
             (
-                is_null($Identities->language_id) ?
+                $Identities->language_id === null ?
                 null :
                 intval($Identities->language_id)
             ),
@@ -330,7 +330,7 @@ abstract class Identities {
             $Identities->state_id,
             $Identities->gender,
             (
-                is_null($Identities->current_identity_school_id) ?
+                $Identities->current_identity_school_id === null ?
                 null :
                 intval($Identities->current_identity_school_id)
             ),

--- a/frontend/server/src/DAO/Base/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/Base/IdentitiesSchools.php
@@ -43,12 +43,12 @@ abstract class IdentitiesSchools {
                 );';
         $params = [
             (
-                is_null($Identities_Schools->identity_id) ?
+                $Identities_Schools->identity_id === null ?
                 null :
                 intval($Identities_Schools->identity_id)
             ),
             (
-                is_null($Identities_Schools->school_id) ?
+                $Identities_Schools->school_id === null ?
                 null :
                 intval($Identities_Schools->school_id)
             ),
@@ -237,7 +237,7 @@ abstract class IdentitiesSchools {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -290,12 +290,12 @@ abstract class IdentitiesSchools {
                 );';
         $params = [
             (
-                is_null($Identities_Schools->identity_id) ?
+                $Identities_Schools->identity_id === null ?
                 null :
                 intval($Identities_Schools->identity_id)
             ),
             (
-                is_null($Identities_Schools->school_id) ?
+                $Identities_Schools->school_id === null ?
                 null :
                 intval($Identities_Schools->school_id)
             ),

--- a/frontend/server/src/DAO/Base/IdentityLoginLog.php
+++ b/frontend/server/src/DAO/Base/IdentityLoginLog.php
@@ -64,7 +64,7 @@ abstract class IdentityLoginLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -113,12 +113,12 @@ abstract class IdentityLoginLog {
                 );';
         $params = [
             (
-                is_null($Identity_Login_Log->identity_id) ?
+                $Identity_Login_Log->identity_id === null ?
                 null :
                 intval($Identity_Login_Log->identity_id)
             ),
             (
-                is_null($Identity_Login_Log->ip) ?
+                $Identity_Login_Log->ip === null ?
                 null :
                 intval($Identity_Login_Log->ip)
             ),

--- a/frontend/server/src/DAO/Base/Interviews.php
+++ b/frontend/server/src/DAO/Base/Interviews.php
@@ -44,12 +44,12 @@ abstract class Interviews {
                 );';
         $params = [
             (
-                is_null($Interviews->problemset_id) ?
+                $Interviews->problemset_id === null ?
                 null :
                 intval($Interviews->problemset_id)
             ),
             (
-                is_null($Interviews->acl_id) ?
+                $Interviews->acl_id === null ?
                 null :
                 intval($Interviews->acl_id)
             ),
@@ -57,7 +57,7 @@ abstract class Interviews {
             $Interviews->title,
             $Interviews->description,
             (
-                is_null($Interviews->window_length) ?
+                $Interviews->window_length === null ?
                 null :
                 intval($Interviews->window_length)
             ),
@@ -241,7 +241,7 @@ abstract class Interviews {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -296,12 +296,12 @@ abstract class Interviews {
                 );';
         $params = [
             (
-                is_null($Interviews->problemset_id) ?
+                $Interviews->problemset_id === null ?
                 null :
                 intval($Interviews->problemset_id)
             ),
             (
-                is_null($Interviews->acl_id) ?
+                $Interviews->acl_id === null ?
                 null :
                 intval($Interviews->acl_id)
             ),
@@ -309,7 +309,7 @@ abstract class Interviews {
             $Interviews->title,
             $Interviews->description,
             (
-                is_null($Interviews->window_length) ?
+                $Interviews->window_length === null ?
                 null :
                 intval($Interviews->window_length)
             ),

--- a/frontend/server/src/DAO/Base/Languages.php
+++ b/frontend/server/src/DAO/Base/Languages.php
@@ -213,7 +213,7 @@ abstract class Languages {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/Messages.php
+++ b/frontend/server/src/DAO/Base/Messages.php
@@ -44,12 +44,12 @@ abstract class Messages {
         $params = [
             intval($Messages->read),
             (
-                is_null($Messages->sender_id) ?
+                $Messages->sender_id === null ?
                 null :
                 intval($Messages->sender_id)
             ),
             (
-                is_null($Messages->recipient_id) ?
+                $Messages->recipient_id === null ?
                 null :
                 intval($Messages->recipient_id)
             ),
@@ -235,7 +235,7 @@ abstract class Messages {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -289,12 +289,12 @@ abstract class Messages {
         $params = [
             intval($Messages->read),
             (
-                is_null($Messages->sender_id) ?
+                $Messages->sender_id === null ?
                 null :
                 intval($Messages->sender_id)
             ),
             (
-                is_null($Messages->recipient_id) ?
+                $Messages->recipient_id === null ?
                 null :
                 intval($Messages->recipient_id)
             ),

--- a/frontend/server/src/DAO/Base/Notifications.php
+++ b/frontend/server/src/DAO/Base/Notifications.php
@@ -42,7 +42,7 @@ abstract class Notifications {
                 );';
         $params = [
             (
-                is_null($Notifications->user_id) ?
+                $Notifications->user_id === null ?
                 null :
                 intval($Notifications->user_id)
             ),
@@ -227,7 +227,7 @@ abstract class Notifications {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -278,7 +278,7 @@ abstract class Notifications {
                 );';
         $params = [
             (
-                is_null($Notifications->user_id) ?
+                $Notifications->user_id === null ?
                 null :
                 intval($Notifications->user_id)
             ),

--- a/frontend/server/src/DAO/Base/Permissions.php
+++ b/frontend/server/src/DAO/Base/Permissions.php
@@ -213,7 +213,7 @@ abstract class Permissions {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/Plagiarisms.php
+++ b/frontend/server/src/DAO/Base/Plagiarisms.php
@@ -44,27 +44,27 @@ abstract class Plagiarisms {
                 );';
         $params = [
             (
-                is_null($Plagiarisms->contest_id) ?
+                $Plagiarisms->contest_id === null ?
                 null :
                 intval($Plagiarisms->contest_id)
             ),
             (
-                is_null($Plagiarisms->submission_id_1) ?
+                $Plagiarisms->submission_id_1 === null ?
                 null :
                 intval($Plagiarisms->submission_id_1)
             ),
             (
-                is_null($Plagiarisms->submission_id_2) ?
+                $Plagiarisms->submission_id_2 === null ?
                 null :
                 intval($Plagiarisms->submission_id_2)
             ),
             (
-                is_null($Plagiarisms->score_1) ?
+                $Plagiarisms->score_1 === null ?
                 null :
                 intval($Plagiarisms->score_1)
             ),
             (
-                is_null($Plagiarisms->score_2) ?
+                $Plagiarisms->score_2 === null ?
                 null :
                 intval($Plagiarisms->score_2)
             ),
@@ -249,7 +249,7 @@ abstract class Plagiarisms {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -304,27 +304,27 @@ abstract class Plagiarisms {
                 );';
         $params = [
             (
-                is_null($Plagiarisms->contest_id) ?
+                $Plagiarisms->contest_id === null ?
                 null :
                 intval($Plagiarisms->contest_id)
             ),
             (
-                is_null($Plagiarisms->submission_id_1) ?
+                $Plagiarisms->submission_id_1 === null ?
                 null :
                 intval($Plagiarisms->submission_id_1)
             ),
             (
-                is_null($Plagiarisms->submission_id_2) ?
+                $Plagiarisms->submission_id_2 === null ?
                 null :
                 intval($Plagiarisms->submission_id_2)
             ),
             (
-                is_null($Plagiarisms->score_1) ?
+                $Plagiarisms->score_1 === null ?
                 null :
                 intval($Plagiarisms->score_1)
             ),
             (
-                is_null($Plagiarisms->score_2) ?
+                $Plagiarisms->score_2 === null ?
                 null :
                 intval($Plagiarisms->score_2)
             ),

--- a/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatementConsentLog.php
@@ -41,12 +41,12 @@ abstract class PrivacyStatementConsentLog {
                 );';
         $params = [
             (
-                is_null($PrivacyStatement_Consent_Log->identity_id) ?
+                $PrivacyStatement_Consent_Log->identity_id === null ?
                 null :
                 intval($PrivacyStatement_Consent_Log->identity_id)
             ),
             (
-                is_null($PrivacyStatement_Consent_Log->privacystatement_id) ?
+                $PrivacyStatement_Consent_Log->privacystatement_id === null ?
                 null :
                 intval($PrivacyStatement_Consent_Log->privacystatement_id)
             ),
@@ -227,7 +227,7 @@ abstract class PrivacyStatementConsentLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -276,12 +276,12 @@ abstract class PrivacyStatementConsentLog {
                 );';
         $params = [
             (
-                is_null($PrivacyStatement_Consent_Log->identity_id) ?
+                $PrivacyStatement_Consent_Log->identity_id === null ?
                 null :
                 intval($PrivacyStatement_Consent_Log->identity_id)
             ),
             (
-                is_null($PrivacyStatement_Consent_Log->privacystatement_id) ?
+                $PrivacyStatement_Consent_Log->privacystatement_id === null ?
                 null :
                 intval($PrivacyStatement_Consent_Log->privacystatement_id)
             ),

--- a/frontend/server/src/DAO/Base/PrivacyStatements.php
+++ b/frontend/server/src/DAO/Base/PrivacyStatements.php
@@ -213,7 +213,7 @@ abstract class PrivacyStatements {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/ProblemBookmarks.php
+++ b/frontend/server/src/DAO/Base/ProblemBookmarks.php
@@ -91,12 +91,12 @@ abstract class ProblemBookmarks {
                 $Problem_Bookmarks->created_at
             ),
             (
-                is_null($Problem_Bookmarks->identity_id) ?
+                $Problem_Bookmarks->identity_id === null ?
                 null :
                 intval($Problem_Bookmarks->identity_id)
             ),
             (
-                is_null($Problem_Bookmarks->problem_id) ?
+                $Problem_Bookmarks->problem_id === null ?
                 null :
                 intval($Problem_Bookmarks->problem_id)
             ),
@@ -277,7 +277,7 @@ abstract class ProblemBookmarks {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -326,12 +326,12 @@ abstract class ProblemBookmarks {
                 );';
         $params = [
             (
-                is_null($Problem_Bookmarks->identity_id) ?
+                $Problem_Bookmarks->identity_id === null ?
                 null :
                 intval($Problem_Bookmarks->identity_id)
             ),
             (
-                is_null($Problem_Bookmarks->problem_id) ?
+                $Problem_Bookmarks->problem_id === null ?
                 null :
                 intval($Problem_Bookmarks->problem_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
+++ b/frontend/server/src/DAO/Base/ProblemOfTheWeek.php
@@ -41,7 +41,7 @@ abstract class ProblemOfTheWeek {
                 );';
         $params = [
             (
-                is_null($Problem_Of_The_Week->problem_id) ?
+                $Problem_Of_The_Week->problem_id === null ?
                 null :
                 intval($Problem_Of_The_Week->problem_id)
             ),
@@ -221,7 +221,7 @@ abstract class ProblemOfTheWeek {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -270,7 +270,7 @@ abstract class ProblemOfTheWeek {
                 );';
         $params = [
             (
-                is_null($Problem_Of_The_Week->problem_id) ?
+                $Problem_Of_The_Week->problem_id === null ?
                 null :
                 intval($Problem_Of_The_Week->problem_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemViewed.php
+++ b/frontend/server/src/DAO/Base/ProblemViewed.php
@@ -91,12 +91,12 @@ abstract class ProblemViewed {
                 $Problem_Viewed->view_time
             ),
             (
-                is_null($Problem_Viewed->problem_id) ?
+                $Problem_Viewed->problem_id === null ?
                 null :
                 intval($Problem_Viewed->problem_id)
             ),
             (
-                is_null($Problem_Viewed->identity_id) ?
+                $Problem_Viewed->identity_id === null ?
                 null :
                 intval($Problem_Viewed->identity_id)
             ),
@@ -277,7 +277,7 @@ abstract class ProblemViewed {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -326,12 +326,12 @@ abstract class ProblemViewed {
                 );';
         $params = [
             (
-                is_null($Problem_Viewed->problem_id) ?
+                $Problem_Viewed->problem_id === null ?
                 null :
                 intval($Problem_Viewed->problem_id)
             ),
             (
-                is_null($Problem_Viewed->identity_id) ?
+                $Problem_Viewed->identity_id === null ?
                 null :
                 intval($Problem_Viewed->identity_id)
             ),

--- a/frontend/server/src/DAO/Base/Problems.php
+++ b/frontend/server/src/DAO/Base/Problems.php
@@ -61,7 +61,7 @@ abstract class Problems {
                 );';
         $params = [
             (
-                is_null($Problems->acl_id) ?
+                $Problems->acl_id === null ?
                 null :
                 intval($Problems->acl_id)
             ),
@@ -76,7 +76,7 @@ abstract class Problems {
             intval($Problems->submissions),
             intval($Problems->accepted),
             (
-                is_null($Problems->difficulty) ?
+                $Problems->difficulty === null ?
                 null :
                 floatval($Problems->difficulty)
             ),
@@ -88,7 +88,7 @@ abstract class Problems {
             intval($Problems->deprecated),
             intval($Problems->email_clarifications),
             (
-                is_null($Problems->quality) ?
+                $Problems->quality === null ?
                 null :
                 floatval($Problems->quality)
             ),
@@ -311,7 +311,7 @@ abstract class Problems {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -400,7 +400,7 @@ abstract class Problems {
                 );';
         $params = [
             (
-                is_null($Problems->acl_id) ?
+                $Problems->acl_id === null ?
                 null :
                 intval($Problems->acl_id)
             ),
@@ -415,7 +415,7 @@ abstract class Problems {
             intval($Problems->submissions),
             intval($Problems->accepted),
             (
-                is_null($Problems->difficulty) ?
+                $Problems->difficulty === null ?
                 null :
                 floatval($Problems->difficulty)
             ),
@@ -427,7 +427,7 @@ abstract class Problems {
             intval($Problems->deprecated),
             intval($Problems->email_clarifications),
             (
-                is_null($Problems->quality) ?
+                $Problems->quality === null ?
                 null :
                 floatval($Problems->quality)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsForfeited.php
+++ b/frontend/server/src/DAO/Base/ProblemsForfeited.php
@@ -91,12 +91,12 @@ abstract class ProblemsForfeited {
                 $Problems_Forfeited->forfeited_date
             ),
             (
-                is_null($Problems_Forfeited->user_id) ?
+                $Problems_Forfeited->user_id === null ?
                 null :
                 intval($Problems_Forfeited->user_id)
             ),
             (
-                is_null($Problems_Forfeited->problem_id) ?
+                $Problems_Forfeited->problem_id === null ?
                 null :
                 intval($Problems_Forfeited->problem_id)
             ),
@@ -277,7 +277,7 @@ abstract class ProblemsForfeited {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -326,12 +326,12 @@ abstract class ProblemsForfeited {
                 );';
         $params = [
             (
-                is_null($Problems_Forfeited->user_id) ?
+                $Problems_Forfeited->user_id === null ?
                 null :
                 intval($Problems_Forfeited->user_id)
             ),
             (
-                is_null($Problems_Forfeited->problem_id) ?
+                $Problems_Forfeited->problem_id === null ?
                 null :
                 intval($Problems_Forfeited->problem_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsLanguages.php
+++ b/frontend/server/src/DAO/Base/ProblemsLanguages.php
@@ -188,7 +188,7 @@ abstract class ProblemsLanguages {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -235,12 +235,12 @@ abstract class ProblemsLanguages {
                 );';
         $params = [
             (
-                is_null($Problems_Languages->problem_id) ?
+                $Problems_Languages->problem_id === null ?
                 null :
                 intval($Problems_Languages->problem_id)
             ),
             (
-                is_null($Problems_Languages->language_id) ?
+                $Problems_Languages->language_id === null ?
                 null :
                 intval($Problems_Languages->language_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsTags.php
+++ b/frontend/server/src/DAO/Base/ProblemsTags.php
@@ -87,12 +87,12 @@ abstract class ProblemsTags {
         $params = [
             $Problems_Tags->source,
             (
-                is_null($Problems_Tags->problem_id) ?
+                $Problems_Tags->problem_id === null ?
                 null :
                 intval($Problems_Tags->problem_id)
             ),
             (
-                is_null($Problems_Tags->tag_id) ?
+                $Problems_Tags->tag_id === null ?
                 null :
                 intval($Problems_Tags->tag_id)
             ),
@@ -273,7 +273,7 @@ abstract class ProblemsTags {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -322,12 +322,12 @@ abstract class ProblemsTags {
                 );';
         $params = [
             (
-                is_null($Problems_Tags->problem_id) ?
+                $Problems_Tags->problem_id === null ?
                 null :
                 intval($Problems_Tags->problem_id)
             ),
             (
-                is_null($Problems_Tags->tag_id) ?
+                $Problems_Tags->tag_id === null ?
                 null :
                 intval($Problems_Tags->tag_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
+++ b/frontend/server/src/DAO/Base/ProblemsetAccessLog.php
@@ -65,7 +65,7 @@ abstract class ProblemsetAccessLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -116,17 +116,17 @@ abstract class ProblemsetAccessLog {
                 );';
         $params = [
             (
-                is_null($Problemset_Access_Log->problemset_id) ?
+                $Problemset_Access_Log->problemset_id === null ?
                 null :
                 intval($Problemset_Access_Log->problemset_id)
             ),
             (
-                is_null($Problemset_Access_Log->identity_id) ?
+                $Problemset_Access_Log->identity_id === null ?
                 null :
                 intval($Problemset_Access_Log->identity_id)
             ),
             (
-                is_null($Problemset_Access_Log->ip) ?
+                $Problemset_Access_Log->ip === null ?
                 null :
                 intval($Problemset_Access_Log->ip)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentities.php
@@ -79,12 +79,12 @@ abstract class ProblemsetIdentities {
             intval($Problemset_Identities->score),
             intval($Problemset_Identities->time),
             (
-                !is_null($Problemset_Identities->share_user_information) ?
+                $Problemset_Identities->share_user_information !== null ?
                 intval($Problemset_Identities->share_user_information) :
                 null
             ),
             (
-                !is_null($Problemset_Identities->privacystatement_consent_id) ?
+                $Problemset_Identities->privacystatement_consent_id !== null ?
                 intval($Problemset_Identities->privacystatement_consent_id) :
                 null
             ),
@@ -130,23 +130,23 @@ abstract class ProblemsetIdentities {
             intval($Problemset_Identities->score),
             intval($Problemset_Identities->time),
             (
-                is_null($Problemset_Identities->share_user_information) ?
+                $Problemset_Identities->share_user_information === null ?
                 null :
                 intval($Problemset_Identities->share_user_information)
             ),
             (
-                is_null($Problemset_Identities->privacystatement_consent_id) ?
+                $Problemset_Identities->privacystatement_consent_id === null ?
                 null :
                 intval($Problemset_Identities->privacystatement_consent_id)
             ),
             intval($Problemset_Identities->is_invited),
             (
-                is_null($Problemset_Identities->identity_id) ?
+                $Problemset_Identities->identity_id === null ?
                 null :
                 intval($Problemset_Identities->identity_id)
             ),
             (
-                is_null($Problemset_Identities->problemset_id) ?
+                $Problemset_Identities->problemset_id === null ?
                 null :
                 intval($Problemset_Identities->problemset_id)
             ),
@@ -339,7 +339,7 @@ abstract class ProblemsetIdentities {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -400,12 +400,12 @@ abstract class ProblemsetIdentities {
                 );';
         $params = [
             (
-                is_null($Problemset_Identities->identity_id) ?
+                $Problemset_Identities->identity_id === null ?
                 null :
                 intval($Problemset_Identities->identity_id)
             ),
             (
-                is_null($Problemset_Identities->problemset_id) ?
+                $Problemset_Identities->problemset_id === null ?
                 null :
                 intval($Problemset_Identities->problemset_id)
             ),
@@ -418,12 +418,12 @@ abstract class ProblemsetIdentities {
             intval($Problemset_Identities->score),
             intval($Problemset_Identities->time),
             (
-                is_null($Problemset_Identities->share_user_information) ?
+                $Problemset_Identities->share_user_information === null ?
                 null :
                 intval($Problemset_Identities->share_user_information)
             ),
             (
-                is_null($Problemset_Identities->privacystatement_consent_id) ?
+                $Problemset_Identities->privacystatement_consent_id === null ?
                 null :
                 intval($Problemset_Identities->privacystatement_consent_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequest.php
@@ -71,7 +71,7 @@ abstract class ProblemsetIdentityRequest {
                 $Problemset_Identity_Request->last_update
             ),
             (
-                !is_null($Problemset_Identity_Request->accepted) ?
+                $Problemset_Identity_Request->accepted !== null ?
                 intval($Problemset_Identity_Request->accepted) :
                 null
             ),
@@ -112,18 +112,18 @@ abstract class ProblemsetIdentityRequest {
                 $Problemset_Identity_Request->last_update
             ),
             (
-                is_null($Problemset_Identity_Request->accepted) ?
+                $Problemset_Identity_Request->accepted === null ?
                 null :
                 intval($Problemset_Identity_Request->accepted)
             ),
             $Problemset_Identity_Request->extra_note,
             (
-                is_null($Problemset_Identity_Request->identity_id) ?
+                $Problemset_Identity_Request->identity_id === null ?
                 null :
                 intval($Problemset_Identity_Request->identity_id)
             ),
             (
-                is_null($Problemset_Identity_Request->problemset_id) ?
+                $Problemset_Identity_Request->problemset_id === null ?
                 null :
                 intval($Problemset_Identity_Request->problemset_id)
             ),
@@ -310,7 +310,7 @@ abstract class ProblemsetIdentityRequest {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -365,12 +365,12 @@ abstract class ProblemsetIdentityRequest {
                 );';
         $params = [
             (
-                is_null($Problemset_Identity_Request->identity_id) ?
+                $Problemset_Identity_Request->identity_id === null ?
                 null :
                 intval($Problemset_Identity_Request->identity_id)
             ),
             (
-                is_null($Problemset_Identity_Request->problemset_id) ?
+                $Problemset_Identity_Request->problemset_id === null ?
                 null :
                 intval($Problemset_Identity_Request->problemset_id)
             ),
@@ -381,7 +381,7 @@ abstract class ProblemsetIdentityRequest {
                 $Problemset_Identity_Request->last_update
             ),
             (
-                is_null($Problemset_Identity_Request->accepted) ?
+                $Problemset_Identity_Request->accepted === null ?
                 null :
                 intval($Problemset_Identity_Request->accepted)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
+++ b/frontend/server/src/DAO/Base/ProblemsetIdentityRequestHistory.php
@@ -43,12 +43,12 @@ abstract class ProblemsetIdentityRequestHistory {
                 );';
         $params = [
             (
-                is_null($Problemset_Identity_Request_History->identity_id) ?
+                $Problemset_Identity_Request_History->identity_id === null ?
                 null :
                 intval($Problemset_Identity_Request_History->identity_id)
             ),
             (
-                is_null($Problemset_Identity_Request_History->problemset_id) ?
+                $Problemset_Identity_Request_History->problemset_id === null ?
                 null :
                 intval($Problemset_Identity_Request_History->problemset_id)
             ),
@@ -56,12 +56,12 @@ abstract class ProblemsetIdentityRequestHistory {
                 $Problemset_Identity_Request_History->time
             ),
             (
-                is_null($Problemset_Identity_Request_History->accepted) ?
+                $Problemset_Identity_Request_History->accepted === null ?
                 null :
                 intval($Problemset_Identity_Request_History->accepted)
             ),
             (
-                is_null($Problemset_Identity_Request_History->admin_id) ?
+                $Problemset_Identity_Request_History->admin_id === null ?
                 null :
                 intval($Problemset_Identity_Request_History->admin_id)
             ),
@@ -243,7 +243,7 @@ abstract class ProblemsetIdentityRequestHistory {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -296,12 +296,12 @@ abstract class ProblemsetIdentityRequestHistory {
                 );';
         $params = [
             (
-                is_null($Problemset_Identity_Request_History->identity_id) ?
+                $Problemset_Identity_Request_History->identity_id === null ?
                 null :
                 intval($Problemset_Identity_Request_History->identity_id)
             ),
             (
-                is_null($Problemset_Identity_Request_History->problemset_id) ?
+                $Problemset_Identity_Request_History->problemset_id === null ?
                 null :
                 intval($Problemset_Identity_Request_History->problemset_id)
             ),
@@ -309,12 +309,12 @@ abstract class ProblemsetIdentityRequestHistory {
                 $Problemset_Identity_Request_History->time
             ),
             (
-                is_null($Problemset_Identity_Request_History->accepted) ?
+                $Problemset_Identity_Request_History->accepted === null ?
                 null :
                 intval($Problemset_Identity_Request_History->accepted)
             ),
             (
-                is_null($Problemset_Identity_Request_History->admin_id) ?
+                $Problemset_Identity_Request_History->admin_id === null ?
                 null :
                 intval($Problemset_Identity_Request_History->admin_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblemOpened.php
@@ -96,17 +96,17 @@ abstract class ProblemsetProblemOpened {
                 $Problemset_Problem_Opened->open_time
             ),
             (
-                is_null($Problemset_Problem_Opened->problemset_id) ?
+                $Problemset_Problem_Opened->problemset_id === null ?
                 null :
                 intval($Problemset_Problem_Opened->problemset_id)
             ),
             (
-                is_null($Problemset_Problem_Opened->problem_id) ?
+                $Problemset_Problem_Opened->problem_id === null ?
                 null :
                 intval($Problemset_Problem_Opened->problem_id)
             ),
             (
-                is_null($Problemset_Problem_Opened->identity_id) ?
+                $Problemset_Problem_Opened->identity_id === null ?
                 null :
                 intval($Problemset_Problem_Opened->identity_id)
             ),
@@ -295,7 +295,7 @@ abstract class ProblemsetProblemOpened {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -346,17 +346,17 @@ abstract class ProblemsetProblemOpened {
                 );';
         $params = [
             (
-                is_null($Problemset_Problem_Opened->problemset_id) ?
+                $Problemset_Problem_Opened->problemset_id === null ?
                 null :
                 intval($Problemset_Problem_Opened->problemset_id)
             ),
             (
-                is_null($Problemset_Problem_Opened->problem_id) ?
+                $Problemset_Problem_Opened->problem_id === null ?
                 null :
                 intval($Problemset_Problem_Opened->problem_id)
             ),
             (
-                is_null($Problemset_Problem_Opened->identity_id) ?
+                $Problemset_Problem_Opened->identity_id === null ?
                 null :
                 intval($Problemset_Problem_Opened->identity_id)
             ),

--- a/frontend/server/src/DAO/Base/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/Base/ProblemsetProblems.php
@@ -107,12 +107,12 @@ abstract class ProblemsetProblems {
             intval($Problemset_Problems->order),
             intval($Problemset_Problems->is_extra_problem),
             (
-                is_null($Problemset_Problems->problemset_id) ?
+                $Problemset_Problems->problemset_id === null ?
                 null :
                 intval($Problemset_Problems->problemset_id)
             ),
             (
-                is_null($Problemset_Problems->problem_id) ?
+                $Problemset_Problems->problem_id === null ?
                 null :
                 intval($Problemset_Problems->problem_id)
             ),
@@ -301,7 +301,7 @@ abstract class ProblemsetProblems {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -358,12 +358,12 @@ abstract class ProblemsetProblems {
                 );';
         $params = [
             (
-                is_null($Problemset_Problems->problemset_id) ?
+                $Problemset_Problems->problemset_id === null ?
                 null :
                 intval($Problemset_Problems->problemset_id)
             ),
             (
-                is_null($Problemset_Problems->problem_id) ?
+                $Problemset_Problems->problem_id === null ?
                 null :
                 intval($Problemset_Problems->problem_id)
             ),

--- a/frontend/server/src/DAO/Base/Problemsets.php
+++ b/frontend/server/src/DAO/Base/Problemsets.php
@@ -49,7 +49,7 @@ abstract class Problemsets {
                 );';
         $params = [
             (
-                is_null($Problemsets->acl_id) ?
+                $Problemsets->acl_id === null ?
                 null :
                 intval($Problemsets->acl_id)
             ),
@@ -61,17 +61,17 @@ abstract class Problemsets {
             $Problemsets->scoreboard_url_admin,
             $Problemsets->type,
             (
-                is_null($Problemsets->contest_id) ?
+                $Problemsets->contest_id === null ?
                 null :
                 intval($Problemsets->contest_id)
             ),
             (
-                is_null($Problemsets->assignment_id) ?
+                $Problemsets->assignment_id === null ?
                 null :
                 intval($Problemsets->assignment_id)
             ),
             (
-                is_null($Problemsets->interview_id) ?
+                $Problemsets->interview_id === null ?
                 null :
                 intval($Problemsets->interview_id)
             ),
@@ -265,7 +265,7 @@ abstract class Problemsets {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -330,7 +330,7 @@ abstract class Problemsets {
                 );';
         $params = [
             (
-                is_null($Problemsets->acl_id) ?
+                $Problemsets->acl_id === null ?
                 null :
                 intval($Problemsets->acl_id)
             ),
@@ -342,17 +342,17 @@ abstract class Problemsets {
             $Problemsets->scoreboard_url_admin,
             $Problemsets->type,
             (
-                is_null($Problemsets->contest_id) ?
+                $Problemsets->contest_id === null ?
                 null :
                 intval($Problemsets->contest_id)
             ),
             (
-                is_null($Problemsets->assignment_id) ?
+                $Problemsets->assignment_id === null ?
                 null :
                 intval($Problemsets->assignment_id)
             ),
             (
-                is_null($Problemsets->interview_id) ?
+                $Problemsets->interview_id === null ?
                 null :
                 intval($Problemsets->interview_id)
             ),

--- a/frontend/server/src/DAO/Base/QualityNominationComments.php
+++ b/frontend/server/src/DAO/Base/QualityNominationComments.php
@@ -43,12 +43,12 @@ abstract class QualityNominationComments {
                 );';
         $params = [
             (
-                is_null($QualityNomination_Comments->qualitynomination_id) ?
+                $QualityNomination_Comments->qualitynomination_id === null ?
                 null :
                 intval($QualityNomination_Comments->qualitynomination_id)
             ),
             (
-                is_null($QualityNomination_Comments->user_id) ?
+                $QualityNomination_Comments->user_id === null ?
                 null :
                 intval($QualityNomination_Comments->user_id)
             ),
@@ -56,7 +56,7 @@ abstract class QualityNominationComments {
                 $QualityNomination_Comments->time
             ),
             (
-                is_null($QualityNomination_Comments->vote) ?
+                $QualityNomination_Comments->vote === null ?
                 null :
                 intval($QualityNomination_Comments->vote)
             ),
@@ -239,7 +239,7 @@ abstract class QualityNominationComments {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -292,12 +292,12 @@ abstract class QualityNominationComments {
                 );';
         $params = [
             (
-                is_null($QualityNomination_Comments->qualitynomination_id) ?
+                $QualityNomination_Comments->qualitynomination_id === null ?
                 null :
                 intval($QualityNomination_Comments->qualitynomination_id)
             ),
             (
-                is_null($QualityNomination_Comments->user_id) ?
+                $QualityNomination_Comments->user_id === null ?
                 null :
                 intval($QualityNomination_Comments->user_id)
             ),
@@ -305,7 +305,7 @@ abstract class QualityNominationComments {
                 $QualityNomination_Comments->time
             ),
             (
-                is_null($QualityNomination_Comments->vote) ?
+                $QualityNomination_Comments->vote === null ?
                 null :
                 intval($QualityNomination_Comments->vote)
             ),

--- a/frontend/server/src/DAO/Base/QualityNominationLog.php
+++ b/frontend/server/src/DAO/Base/QualityNominationLog.php
@@ -44,7 +44,7 @@ abstract class QualityNominationLog {
                 );';
         $params = [
             (
-                is_null($QualityNomination_Log->qualitynomination_id) ?
+                $QualityNomination_Log->qualitynomination_id === null ?
                 null :
                 intval($QualityNomination_Log->qualitynomination_id)
             ),
@@ -52,7 +52,7 @@ abstract class QualityNominationLog {
                 $QualityNomination_Log->time
             ),
             (
-                is_null($QualityNomination_Log->user_id) ?
+                $QualityNomination_Log->user_id === null ?
                 null :
                 intval($QualityNomination_Log->user_id)
             ),
@@ -239,7 +239,7 @@ abstract class QualityNominationLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -294,7 +294,7 @@ abstract class QualityNominationLog {
                 );';
         $params = [
             (
-                is_null($QualityNomination_Log->qualitynomination_id) ?
+                $QualityNomination_Log->qualitynomination_id === null ?
                 null :
                 intval($QualityNomination_Log->qualitynomination_id)
             ),
@@ -302,7 +302,7 @@ abstract class QualityNominationLog {
                 $QualityNomination_Log->time
             ),
             (
-                is_null($QualityNomination_Log->user_id) ?
+                $QualityNomination_Log->user_id === null ?
                 null :
                 intval($QualityNomination_Log->user_id)
             ),

--- a/frontend/server/src/DAO/Base/QualityNominationReviewers.php
+++ b/frontend/server/src/DAO/Base/QualityNominationReviewers.php
@@ -188,7 +188,7 @@ abstract class QualityNominationReviewers {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -235,12 +235,12 @@ abstract class QualityNominationReviewers {
                 );';
         $params = [
             (
-                is_null($QualityNomination_Reviewers->qualitynomination_id) ?
+                $QualityNomination_Reviewers->qualitynomination_id === null ?
                 null :
                 intval($QualityNomination_Reviewers->qualitynomination_id)
             ),
             (
-                is_null($QualityNomination_Reviewers->user_id) ?
+                $QualityNomination_Reviewers->user_id === null ?
                 null :
                 intval($QualityNomination_Reviewers->user_id)
             ),

--- a/frontend/server/src/DAO/Base/QualityNominations.php
+++ b/frontend/server/src/DAO/Base/QualityNominations.php
@@ -44,12 +44,12 @@ abstract class QualityNominations {
                 );';
         $params = [
             (
-                is_null($QualityNominations->user_id) ?
+                $QualityNominations->user_id === null ?
                 null :
                 intval($QualityNominations->user_id)
             ),
             (
-                is_null($QualityNominations->problem_id) ?
+                $QualityNominations->problem_id === null ?
                 null :
                 intval($QualityNominations->problem_id)
             ),
@@ -239,7 +239,7 @@ abstract class QualityNominations {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -294,12 +294,12 @@ abstract class QualityNominations {
                 );';
         $params = [
             (
-                is_null($QualityNominations->user_id) ?
+                $QualityNominations->user_id === null ?
                 null :
                 intval($QualityNominations->user_id)
             ),
             (
-                is_null($QualityNominations->problem_id) ?
+                $QualityNominations->problem_id === null ?
                 null :
                 intval($QualityNominations->problem_id)
             ),

--- a/frontend/server/src/DAO/Base/Roles.php
+++ b/frontend/server/src/DAO/Base/Roles.php
@@ -213,7 +213,7 @@ abstract class Roles {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/RolesPermissions.php
+++ b/frontend/server/src/DAO/Base/RolesPermissions.php
@@ -188,7 +188,7 @@ abstract class RolesPermissions {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -235,12 +235,12 @@ abstract class RolesPermissions {
                 );';
         $params = [
             (
-                is_null($Roles_Permissions->role_id) ?
+                $Roles_Permissions->role_id === null ?
                 null :
                 intval($Roles_Permissions->role_id)
             ),
             (
-                is_null($Roles_Permissions->permission_id) ?
+                $Roles_Permissions->permission_id === null ?
                 null :
                 intval($Roles_Permissions->permission_id)
             ),

--- a/frontend/server/src/DAO/Base/RunCounts.php
+++ b/frontend/server/src/DAO/Base/RunCounts.php
@@ -258,7 +258,7 @@ abstract class RunCounts {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/Runs.php
+++ b/frontend/server/src/DAO/Base/Runs.php
@@ -50,7 +50,7 @@ abstract class Runs {
                 );';
         $params = [
             (
-                is_null($Runs->submission_id) ?
+                $Runs->submission_id === null ?
                 null :
                 intval($Runs->submission_id)
             ),
@@ -63,7 +63,7 @@ abstract class Runs {
             intval($Runs->memory),
             floatval($Runs->score),
             (
-                is_null($Runs->contest_score) ?
+                $Runs->contest_score === null ?
                 null :
                 floatval($Runs->contest_score)
             ),
@@ -263,7 +263,7 @@ abstract class Runs {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -330,7 +330,7 @@ abstract class Runs {
                 );';
         $params = [
             (
-                is_null($Runs->submission_id) ?
+                $Runs->submission_id === null ?
                 null :
                 intval($Runs->submission_id)
             ),
@@ -343,7 +343,7 @@ abstract class Runs {
             intval($Runs->memory),
             floatval($Runs->score),
             (
-                is_null($Runs->contest_score) ?
+                $Runs->contest_score === null ?
                 null :
                 floatval($Runs->contest_score)
             ),

--- a/frontend/server/src/DAO/Base/RunsGroups.php
+++ b/frontend/server/src/DAO/Base/RunsGroups.php
@@ -42,7 +42,7 @@ abstract class RunsGroups {
                 );';
         $params = [
             (
-                is_null($Runs_Groups->run_id) ?
+                $Runs_Groups->run_id === null ?
                 null :
                 intval($Runs_Groups->run_id)
             ),
@@ -225,7 +225,7 @@ abstract class RunsGroups {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -276,7 +276,7 @@ abstract class RunsGroups {
                 );';
         $params = [
             (
-                is_null($Runs_Groups->run_id) ?
+                $Runs_Groups->run_id === null ?
                 null :
                 intval($Runs_Groups->run_id)
             ),

--- a/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolOfTheMonth.php
@@ -43,18 +43,18 @@ abstract class SchoolOfTheMonth {
                 );';
         $params = [
             (
-                is_null($School_Of_The_Month->school_id) ?
+                $School_Of_The_Month->school_id === null ?
                 null :
                 intval($School_Of_The_Month->school_id)
             ),
             $School_Of_The_Month->time,
             (
-                is_null($School_Of_The_Month->ranking) ?
+                $School_Of_The_Month->ranking === null ?
                 null :
                 intval($School_Of_The_Month->ranking)
             ),
             (
-                is_null($School_Of_The_Month->selected_by) ?
+                $School_Of_The_Month->selected_by === null ?
                 null :
                 intval($School_Of_The_Month->selected_by)
             ),
@@ -237,7 +237,7 @@ abstract class SchoolOfTheMonth {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -290,18 +290,18 @@ abstract class SchoolOfTheMonth {
                 );';
         $params = [
             (
-                is_null($School_Of_The_Month->school_id) ?
+                $School_Of_The_Month->school_id === null ?
                 null :
                 intval($School_Of_The_Month->school_id)
             ),
             $School_Of_The_Month->time,
             (
-                is_null($School_Of_The_Month->ranking) ?
+                $School_Of_The_Month->ranking === null ?
                 null :
                 intval($School_Of_The_Month->ranking)
             ),
             (
-                is_null($School_Of_The_Month->selected_by) ?
+                $School_Of_The_Month->selected_by === null ?
                 null :
                 intval($School_Of_The_Month->selected_by)
             ),

--- a/frontend/server/src/DAO/Base/Schools.php
+++ b/frontend/server/src/DAO/Base/Schools.php
@@ -46,7 +46,7 @@ abstract class Schools {
             $Schools->state_id,
             $Schools->name,
             (
-                is_null($Schools->ranking) ?
+                $Schools->ranking === null ?
                 null :
                 intval($Schools->ranking)
             ),
@@ -229,7 +229,7 @@ abstract class Schools {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -285,7 +285,7 @@ abstract class Schools {
             $Schools->state_id,
             $Schools->name,
             (
-                is_null($Schools->ranking) ?
+                $Schools->ranking === null ?
                 null :
                 intval($Schools->ranking)
             ),

--- a/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
+++ b/frontend/server/src/DAO/Base/SchoolsProblemsSolvedPerMonth.php
@@ -41,13 +41,13 @@ abstract class SchoolsProblemsSolvedPerMonth {
                 );';
         $params = [
             (
-                is_null($Schools_Problems_Solved_Per_Month->school_id) ?
+                $Schools_Problems_Solved_Per_Month->school_id === null ?
                 null :
                 intval($Schools_Problems_Solved_Per_Month->school_id)
             ),
             $Schools_Problems_Solved_Per_Month->time,
             (
-                is_null($Schools_Problems_Solved_Per_Month->problems_solved) ?
+                $Schools_Problems_Solved_Per_Month->problems_solved === null ?
                 null :
                 intval($Schools_Problems_Solved_Per_Month->problems_solved)
             ),
@@ -225,7 +225,7 @@ abstract class SchoolsProblemsSolvedPerMonth {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -274,13 +274,13 @@ abstract class SchoolsProblemsSolvedPerMonth {
                 );';
         $params = [
             (
-                is_null($Schools_Problems_Solved_Per_Month->school_id) ?
+                $Schools_Problems_Solved_Per_Month->school_id === null ?
                 null :
                 intval($Schools_Problems_Solved_Per_Month->school_id)
             ),
             $Schools_Problems_Solved_Per_Month->time,
             (
-                is_null($Schools_Problems_Solved_Per_Month->problems_solved) ?
+                $Schools_Problems_Solved_Per_Month->problems_solved === null ?
                 null :
                 intval($Schools_Problems_Solved_Per_Month->problems_solved)
             ),

--- a/frontend/server/src/DAO/Base/States.php
+++ b/frontend/server/src/DAO/Base/States.php
@@ -265,7 +265,7 @@ abstract class States {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/SubmissionFeedback.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedback.php
@@ -44,12 +44,12 @@ abstract class SubmissionFeedback {
                 );';
         $params = [
             (
-                is_null($Submission_Feedback->identity_id) ?
+                $Submission_Feedback->identity_id === null ?
                 null :
                 intval($Submission_Feedback->identity_id)
             ),
             (
-                is_null($Submission_Feedback->submission_id) ?
+                $Submission_Feedback->submission_id === null ?
                 null :
                 intval($Submission_Feedback->submission_id)
             ),
@@ -58,12 +58,12 @@ abstract class SubmissionFeedback {
                 $Submission_Feedback->date
             ),
             (
-                is_null($Submission_Feedback->range_bytes_start) ?
+                $Submission_Feedback->range_bytes_start === null ?
                 null :
                 intval($Submission_Feedback->range_bytes_start)
             ),
             (
-                is_null($Submission_Feedback->range_bytes_end) ?
+                $Submission_Feedback->range_bytes_end === null ?
                 null :
                 intval($Submission_Feedback->range_bytes_end)
             ),
@@ -247,7 +247,7 @@ abstract class SubmissionFeedback {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -302,12 +302,12 @@ abstract class SubmissionFeedback {
                 );';
         $params = [
             (
-                is_null($Submission_Feedback->identity_id) ?
+                $Submission_Feedback->identity_id === null ?
                 null :
                 intval($Submission_Feedback->identity_id)
             ),
             (
-                is_null($Submission_Feedback->submission_id) ?
+                $Submission_Feedback->submission_id === null ?
                 null :
                 intval($Submission_Feedback->submission_id)
             ),
@@ -316,12 +316,12 @@ abstract class SubmissionFeedback {
                 $Submission_Feedback->date
             ),
             (
-                is_null($Submission_Feedback->range_bytes_start) ?
+                $Submission_Feedback->range_bytes_start === null ?
                 null :
                 intval($Submission_Feedback->range_bytes_start)
             ),
             (
-                is_null($Submission_Feedback->range_bytes_end) ?
+                $Submission_Feedback->range_bytes_end === null ?
                 null :
                 intval($Submission_Feedback->range_bytes_end)
             ),

--- a/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
+++ b/frontend/server/src/DAO/Base/SubmissionFeedbackThread.php
@@ -42,12 +42,12 @@ abstract class SubmissionFeedbackThread {
                 );';
         $params = [
             (
-                is_null($Submission_Feedback_Thread->submission_feedback_id) ?
+                $Submission_Feedback_Thread->submission_feedback_id === null ?
                 null :
                 intval($Submission_Feedback_Thread->submission_feedback_id)
             ),
             (
-                is_null($Submission_Feedback_Thread->identity_id) ?
+                $Submission_Feedback_Thread->identity_id === null ?
                 null :
                 intval($Submission_Feedback_Thread->identity_id)
             ),
@@ -231,7 +231,7 @@ abstract class SubmissionFeedbackThread {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -282,12 +282,12 @@ abstract class SubmissionFeedbackThread {
                 );';
         $params = [
             (
-                is_null($Submission_Feedback_Thread->submission_feedback_id) ?
+                $Submission_Feedback_Thread->submission_feedback_id === null ?
                 null :
                 intval($Submission_Feedback_Thread->submission_feedback_id)
             ),
             (
-                is_null($Submission_Feedback_Thread->identity_id) ?
+                $Submission_Feedback_Thread->identity_id === null ?
                 null :
                 intval($Submission_Feedback_Thread->identity_id)
             ),

--- a/frontend/server/src/DAO/Base/SubmissionLog.php
+++ b/frontend/server/src/DAO/Base/SubmissionLog.php
@@ -62,23 +62,23 @@ abstract class SubmissionLog {
                 );';
         $params = [
             (
-                !is_null($Submission_Log->problemset_id) ?
+                $Submission_Log->problemset_id !== null ?
                 intval($Submission_Log->problemset_id) :
                 null
             ),
             $Submission_Log->submission_id,
             (
-                !is_null($Submission_Log->user_id) ?
+                $Submission_Log->user_id !== null ?
                 intval($Submission_Log->user_id) :
                 null
             ),
             (
-                !is_null($Submission_Log->identity_id) ?
+                $Submission_Log->identity_id !== null ?
                 intval($Submission_Log->identity_id) :
                 null
             ),
             (
-                !is_null($Submission_Log->ip) ?
+                $Submission_Log->ip !== null ?
                 intval($Submission_Log->ip) :
                 null
             ),
@@ -115,22 +115,22 @@ abstract class SubmissionLog {
                 );';
         $params = [
             (
-                is_null($Submission_Log->problemset_id) ?
+                $Submission_Log->problemset_id === null ?
                 null :
                 intval($Submission_Log->problemset_id)
             ),
             (
-                is_null($Submission_Log->user_id) ?
+                $Submission_Log->user_id === null ?
                 null :
                 intval($Submission_Log->user_id)
             ),
             (
-                is_null($Submission_Log->identity_id) ?
+                $Submission_Log->identity_id === null ?
                 null :
                 intval($Submission_Log->identity_id)
             ),
             (
-                is_null($Submission_Log->ip) ?
+                $Submission_Log->ip === null ?
                 null :
                 intval($Submission_Log->ip)
             ),
@@ -138,7 +138,7 @@ abstract class SubmissionLog {
                 $Submission_Log->time
             ),
             (
-                is_null($Submission_Log->submission_id) ?
+                $Submission_Log->submission_id === null ?
                 null :
                 intval($Submission_Log->submission_id)
             ),
@@ -319,7 +319,7 @@ abstract class SubmissionLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -374,27 +374,27 @@ abstract class SubmissionLog {
                 );';
         $params = [
             (
-                is_null($Submission_Log->problemset_id) ?
+                $Submission_Log->problemset_id === null ?
                 null :
                 intval($Submission_Log->problemset_id)
             ),
             (
-                is_null($Submission_Log->submission_id) ?
+                $Submission_Log->submission_id === null ?
                 null :
                 intval($Submission_Log->submission_id)
             ),
             (
-                is_null($Submission_Log->user_id) ?
+                $Submission_Log->user_id === null ?
                 null :
                 intval($Submission_Log->user_id)
             ),
             (
-                is_null($Submission_Log->identity_id) ?
+                $Submission_Log->identity_id === null ?
                 null :
                 intval($Submission_Log->identity_id)
             ),
             (
-                is_null($Submission_Log->ip) ?
+                $Submission_Log->ip === null ?
                 null :
                 intval($Submission_Log->ip)
             ),

--- a/frontend/server/src/DAO/Base/Submissions.php
+++ b/frontend/server/src/DAO/Base/Submissions.php
@@ -50,22 +50,22 @@ abstract class Submissions {
                 );';
         $params = [
             (
-                is_null($Submissions->current_run_id) ?
+                $Submissions->current_run_id === null ?
                 null :
                 intval($Submissions->current_run_id)
             ),
             (
-                is_null($Submissions->identity_id) ?
+                $Submissions->identity_id === null ?
                 null :
                 intval($Submissions->identity_id)
             ),
             (
-                is_null($Submissions->problem_id) ?
+                $Submissions->problem_id === null ?
                 null :
                 intval($Submissions->problem_id)
             ),
             (
-                is_null($Submissions->problemset_id) ?
+                $Submissions->problemset_id === null ?
                 null :
                 intval($Submissions->problemset_id)
             ),
@@ -79,7 +79,7 @@ abstract class Submissions {
             intval($Submissions->submit_delay),
             $Submissions->type,
             (
-                is_null($Submissions->school_id) ?
+                $Submissions->school_id === null ?
                 null :
                 intval($Submissions->school_id)
             ),
@@ -275,7 +275,7 @@ abstract class Submissions {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -342,22 +342,22 @@ abstract class Submissions {
                 );';
         $params = [
             (
-                is_null($Submissions->current_run_id) ?
+                $Submissions->current_run_id === null ?
                 null :
                 intval($Submissions->current_run_id)
             ),
             (
-                is_null($Submissions->identity_id) ?
+                $Submissions->identity_id === null ?
                 null :
                 intval($Submissions->identity_id)
             ),
             (
-                is_null($Submissions->problem_id) ?
+                $Submissions->problem_id === null ?
                 null :
                 intval($Submissions->problem_id)
             ),
             (
-                is_null($Submissions->problemset_id) ?
+                $Submissions->problemset_id === null ?
                 null :
                 intval($Submissions->problemset_id)
             ),
@@ -371,7 +371,7 @@ abstract class Submissions {
             intval($Submissions->submit_delay),
             $Submissions->type,
             (
-                is_null($Submissions->school_id) ?
+                $Submissions->school_id === null ?
                 null :
                 intval($Submissions->school_id)
             ),

--- a/frontend/server/src/DAO/Base/SystemSettings.php
+++ b/frontend/server/src/DAO/Base/SystemSettings.php
@@ -229,7 +229,7 @@ abstract class SystemSettings {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/Tags.php
+++ b/frontend/server/src/DAO/Base/Tags.php
@@ -213,7 +213,7 @@ abstract class Tags {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .

--- a/frontend/server/src/DAO/Base/TeamGroups.php
+++ b/frontend/server/src/DAO/Base/TeamGroups.php
@@ -44,7 +44,7 @@ abstract class TeamGroups {
                 );';
         $params = [
             (
-                is_null($Team_Groups->acl_id) ?
+                $Team_Groups->acl_id === null ?
                 null :
                 intval($Team_Groups->acl_id)
             ),
@@ -235,7 +235,7 @@ abstract class TeamGroups {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -290,7 +290,7 @@ abstract class TeamGroups {
                 );';
         $params = [
             (
-                is_null($Team_Groups->acl_id) ?
+                $Team_Groups->acl_id === null ?
                 null :
                 intval($Team_Groups->acl_id)
             ),

--- a/frontend/server/src/DAO/Base/TeamUsers.php
+++ b/frontend/server/src/DAO/Base/TeamUsers.php
@@ -188,7 +188,7 @@ abstract class TeamUsers {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -235,12 +235,12 @@ abstract class TeamUsers {
                 );';
         $params = [
             (
-                is_null($Team_Users->team_id) ?
+                $Team_Users->team_id === null ?
                 null :
                 intval($Team_Users->team_id)
             ),
             (
-                is_null($Team_Users->identity_id) ?
+                $Team_Users->identity_id === null ?
                 null :
                 intval($Team_Users->identity_id)
             ),

--- a/frontend/server/src/DAO/Base/Teams.php
+++ b/frontend/server/src/DAO/Base/Teams.php
@@ -40,12 +40,12 @@ abstract class Teams {
                 );';
         $params = [
             (
-                is_null($Teams->team_group_id) ?
+                $Teams->team_group_id === null ?
                 null :
                 intval($Teams->team_group_id)
             ),
             (
-                is_null($Teams->identity_id) ?
+                $Teams->identity_id === null ?
                 null :
                 intval($Teams->identity_id)
             ),
@@ -221,7 +221,7 @@ abstract class Teams {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -268,12 +268,12 @@ abstract class Teams {
                 );';
         $params = [
             (
-                is_null($Teams->team_group_id) ?
+                $Teams->team_group_id === null ?
                 null :
                 intval($Teams->team_group_id)
             ),
             (
-                is_null($Teams->identity_id) ?
+                $Teams->identity_id === null ?
                 null :
                 intval($Teams->identity_id)
             ),

--- a/frontend/server/src/DAO/Base/TeamsGroupRoles.php
+++ b/frontend/server/src/DAO/Base/TeamsGroupRoles.php
@@ -196,7 +196,7 @@ abstract class TeamsGroupRoles {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -245,17 +245,17 @@ abstract class TeamsGroupRoles {
                 );';
         $params = [
             (
-                is_null($Teams_Group_Roles->team_group_id) ?
+                $Teams_Group_Roles->team_group_id === null ?
                 null :
                 intval($Teams_Group_Roles->team_group_id)
             ),
             (
-                is_null($Teams_Group_Roles->role_id) ?
+                $Teams_Group_Roles->role_id === null ?
                 null :
                 intval($Teams_Group_Roles->role_id)
             ),
             (
-                is_null($Teams_Group_Roles->acl_id) ?
+                $Teams_Group_Roles->acl_id === null ?
                 null :
                 intval($Teams_Group_Roles->acl_id)
             ),

--- a/frontend/server/src/DAO/Base/UserRank.php
+++ b/frontend/server/src/DAO/Base/UserRank.php
@@ -77,7 +77,7 @@ abstract class UserRank {
         $params = [
             $User_Rank->user_id,
             (
-                !is_null($User_Rank->ranking) ?
+                $User_Rank->ranking !== null ?
                 intval($User_Rank->ranking) :
                 null
             ),
@@ -88,13 +88,13 @@ abstract class UserRank {
             $User_Rank->country_id,
             $User_Rank->state_id,
             (
-                !is_null($User_Rank->school_id) ?
+                $User_Rank->school_id !== null ?
                 intval($User_Rank->school_id) :
                 null
             ),
             floatval($User_Rank->author_score),
             (
-                !is_null($User_Rank->author_ranking) ?
+                $User_Rank->author_ranking !== null ?
                 intval($User_Rank->author_ranking) :
                 null
             ),
@@ -139,7 +139,7 @@ abstract class UserRank {
                 );';
         $params = [
             (
-                is_null($User_Rank->ranking) ?
+                $User_Rank->ranking === null ?
                 null :
                 intval($User_Rank->ranking)
             ),
@@ -150,13 +150,13 @@ abstract class UserRank {
             $User_Rank->country_id,
             $User_Rank->state_id,
             (
-                is_null($User_Rank->school_id) ?
+                $User_Rank->school_id === null ?
                 null :
                 intval($User_Rank->school_id)
             ),
             floatval($User_Rank->author_score),
             (
-                is_null($User_Rank->author_ranking) ?
+                $User_Rank->author_ranking === null ?
                 null :
                 intval($User_Rank->author_ranking)
             ),
@@ -165,7 +165,7 @@ abstract class UserRank {
                 $User_Rank->timestamp
             ),
             (
-                is_null($User_Rank->user_id) ?
+                $User_Rank->user_id === null ?
                 null :
                 intval($User_Rank->user_id)
             ),
@@ -360,7 +360,7 @@ abstract class UserRank {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -429,12 +429,12 @@ abstract class UserRank {
                 );';
         $params = [
             (
-                is_null($User_Rank->user_id) ?
+                $User_Rank->user_id === null ?
                 null :
                 intval($User_Rank->user_id)
             ),
             (
-                is_null($User_Rank->ranking) ?
+                $User_Rank->ranking === null ?
                 null :
                 intval($User_Rank->ranking)
             ),
@@ -445,13 +445,13 @@ abstract class UserRank {
             $User_Rank->country_id,
             $User_Rank->state_id,
             (
-                is_null($User_Rank->school_id) ?
+                $User_Rank->school_id === null ?
                 null :
                 intval($User_Rank->school_id)
             ),
             floatval($User_Rank->author_score),
             (
-                is_null($User_Rank->author_ranking) ?
+                $User_Rank->author_ranking === null ?
                 null :
                 intval($User_Rank->author_ranking)
             ),

--- a/frontend/server/src/DAO/Base/UserRankCutoffs.php
+++ b/frontend/server/src/DAO/Base/UserRankCutoffs.php
@@ -64,7 +64,7 @@ abstract class UserRankCutoffs {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -113,12 +113,12 @@ abstract class UserRankCutoffs {
                 );';
         $params = [
             (
-                is_null($User_Rank_Cutoffs->score) ?
+                $User_Rank_Cutoffs->score === null ?
                 null :
                 floatval($User_Rank_Cutoffs->score)
             ),
             (
-                is_null($User_Rank_Cutoffs->percentile) ?
+                $User_Rank_Cutoffs->percentile === null ?
                 null :
                 floatval($User_Rank_Cutoffs->percentile)
             ),

--- a/frontend/server/src/DAO/Base/UserReadmeReportLog.php
+++ b/frontend/server/src/DAO/Base/UserReadmeReportLog.php
@@ -91,12 +91,12 @@ abstract class UserReadmeReportLog {
                 $User_Readme_Report_Log->report_time
             ),
             (
-                is_null($User_Readme_Report_Log->readme_id) ?
+                $User_Readme_Report_Log->readme_id === null ?
                 null :
                 intval($User_Readme_Report_Log->readme_id)
             ),
             (
-                is_null($User_Readme_Report_Log->reporter_user_id) ?
+                $User_Readme_Report_Log->reporter_user_id === null ?
                 null :
                 intval($User_Readme_Report_Log->reporter_user_id)
             ),
@@ -277,7 +277,7 @@ abstract class UserReadmeReportLog {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -326,12 +326,12 @@ abstract class UserReadmeReportLog {
                 );';
         $params = [
             (
-                is_null($User_Readme_Report_Log->readme_id) ?
+                $User_Readme_Report_Log->readme_id === null ?
                 null :
                 intval($User_Readme_Report_Log->readme_id)
             ),
             (
-                is_null($User_Readme_Report_Log->reporter_user_id) ?
+                $User_Readme_Report_Log->reporter_user_id === null ?
                 null :
                 intval($User_Readme_Report_Log->reporter_user_id)
             ),

--- a/frontend/server/src/DAO/Base/UserReadmes.php
+++ b/frontend/server/src/DAO/Base/UserReadmes.php
@@ -44,7 +44,7 @@ abstract class UserReadmes {
                 );';
         $params = [
             (
-                is_null($User_Readmes->user_id) ?
+                $User_Readmes->user_id === null ?
                 null :
                 intval($User_Readmes->user_id)
             ),
@@ -235,7 +235,7 @@ abstract class UserReadmes {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -290,7 +290,7 @@ abstract class UserReadmes {
                 );';
         $params = [
             (
-                is_null($User_Readmes->user_id) ?
+                $User_Readmes->user_id === null ?
                 null :
                 intval($User_Readmes->user_id)
             ),

--- a/frontend/server/src/DAO/Base/UserRoles.php
+++ b/frontend/server/src/DAO/Base/UserRoles.php
@@ -196,7 +196,7 @@ abstract class UserRoles {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -245,17 +245,17 @@ abstract class UserRoles {
                 );';
         $params = [
             (
-                is_null($User_Roles->user_id) ?
+                $User_Roles->user_id === null ?
                 null :
                 intval($User_Roles->user_id)
             ),
             (
-                is_null($User_Roles->role_id) ?
+                $User_Roles->role_id === null ?
                 null :
                 intval($User_Roles->role_id)
             ),
             (
-                is_null($User_Roles->acl_id) ?
+                $User_Roles->acl_id === null ?
                 null :
                 intval($User_Roles->acl_id)
             ),

--- a/frontend/server/src/DAO/Base/Users.php
+++ b/frontend/server/src/DAO/Base/Users.php
@@ -68,32 +68,32 @@ abstract class Users {
             $Users->facebook_user_id,
             $Users->git_token,
             (
-                is_null($Users->main_email_id) ?
+                $Users->main_email_id === null ?
                 null :
                 intval($Users->main_email_id)
             ),
             (
-                is_null($Users->main_identity_id) ?
+                $Users->main_identity_id === null ?
                 null :
                 intval($Users->main_identity_id)
             ),
             (
-                is_null($Users->has_learning_objective) ?
+                $Users->has_learning_objective === null ?
                 null :
                 intval($Users->has_learning_objective)
             ),
             (
-                is_null($Users->has_teaching_objective) ?
+                $Users->has_teaching_objective === null ?
                 null :
                 intval($Users->has_teaching_objective)
             ),
             (
-                is_null($Users->has_scholar_objective) ?
+                $Users->has_scholar_objective === null ?
                 null :
                 intval($Users->has_scholar_objective)
             ),
             (
-                is_null($Users->has_competitive_objective) ?
+                $Users->has_competitive_objective === null ?
                 null :
                 intval($Users->has_competitive_objective)
             ),
@@ -107,7 +107,7 @@ abstract class Users {
                 $Users->reset_sent_at
             ),
             (
-                is_null($Users->hide_problem_tags) ?
+                $Users->hide_problem_tags === null ?
                 null :
                 intval($Users->hide_problem_tags)
             ),
@@ -115,7 +115,7 @@ abstract class Users {
             intval($Users->is_private),
             $Users->preferred_language,
             (
-                is_null($Users->parent_verified) ?
+                $Users->parent_verified === null ?
                 null :
                 intval($Users->parent_verified)
             ),
@@ -130,7 +130,7 @@ abstract class Users {
                 $Users->parent_email_verification_deadline
             ),
             (
-                is_null($Users->parent_email_id) ?
+                $Users->parent_email_id === null ?
                 null :
                 intval($Users->parent_email_id)
             ),
@@ -361,7 +361,7 @@ abstract class Users {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -462,32 +462,32 @@ abstract class Users {
             $Users->facebook_user_id,
             $Users->git_token,
             (
-                is_null($Users->main_email_id) ?
+                $Users->main_email_id === null ?
                 null :
                 intval($Users->main_email_id)
             ),
             (
-                is_null($Users->main_identity_id) ?
+                $Users->main_identity_id === null ?
                 null :
                 intval($Users->main_identity_id)
             ),
             (
-                is_null($Users->has_learning_objective) ?
+                $Users->has_learning_objective === null ?
                 null :
                 intval($Users->has_learning_objective)
             ),
             (
-                is_null($Users->has_teaching_objective) ?
+                $Users->has_teaching_objective === null ?
                 null :
                 intval($Users->has_teaching_objective)
             ),
             (
-                is_null($Users->has_scholar_objective) ?
+                $Users->has_scholar_objective === null ?
                 null :
                 intval($Users->has_scholar_objective)
             ),
             (
-                is_null($Users->has_competitive_objective) ?
+                $Users->has_competitive_objective === null ?
                 null :
                 intval($Users->has_competitive_objective)
             ),
@@ -501,7 +501,7 @@ abstract class Users {
                 $Users->reset_sent_at
             ),
             (
-                is_null($Users->hide_problem_tags) ?
+                $Users->hide_problem_tags === null ?
                 null :
                 intval($Users->hide_problem_tags)
             ),
@@ -509,7 +509,7 @@ abstract class Users {
             intval($Users->is_private),
             $Users->preferred_language,
             (
-                is_null($Users->parent_verified) ?
+                $Users->parent_verified === null ?
                 null :
                 intval($Users->parent_verified)
             ),
@@ -524,7 +524,7 @@ abstract class Users {
                 $Users->parent_email_verification_deadline
             ),
             (
-                is_null($Users->parent_email_id) ?
+                $Users->parent_email_id === null ?
                 null :
                 intval($Users->parent_email_id)
             ),

--- a/frontend/server/src/DAO/Base/UsersBadges.php
+++ b/frontend/server/src/DAO/Base/UsersBadges.php
@@ -41,7 +41,7 @@ abstract class UsersBadges {
                 );';
         $params = [
             (
-                is_null($Users_Badges->user_id) ?
+                $Users_Badges->user_id === null ?
                 null :
                 intval($Users_Badges->user_id)
             ),
@@ -223,7 +223,7 @@ abstract class UsersBadges {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -272,7 +272,7 @@ abstract class UsersBadges {
                 );';
         $params = [
             (
-                is_null($Users_Badges->user_id) ?
+                $Users_Badges->user_id === null ?
                 null :
                 intval($Users_Badges->user_id)
             ),

--- a/frontend/server/src/DAO/Base/UsersExperiments.php
+++ b/frontend/server/src/DAO/Base/UsersExperiments.php
@@ -63,7 +63,7 @@ abstract class UsersExperiments {
             ORDER BY
                 `{$sanitizedOrder}` {$tipoDeOrden}
         ";
-        if (!is_null($pagina)) {
+        if ($pagina !== null) {
             $sql .= (
                 ' LIMIT ' .
                 (($pagina - 1) * $filasPorPagina) .
@@ -110,7 +110,7 @@ abstract class UsersExperiments {
                 );';
         $params = [
             (
-                is_null($Users_Experiments->user_id) ?
+                $Users_Experiments->user_id === null ?
                 null :
                 intval($Users_Experiments->user_id)
             ),

--- a/frontend/server/src/DAO/Clarifications.php
+++ b/frontend/server/src/DAO/Clarifications.php
@@ -23,7 +23,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         ?int $offset,
         int $rowcount
     ): array {
-        if (!is_null($contest)) {
+        if ($contest !== null) {
             $sqlProblemsets = '
             SELECT
                 problemset_id,
@@ -34,7 +34,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
                 contest_id = ?
             ';
             $params = [$contest->contest_id];
-        } elseif (!is_null($course)) {
+        } elseif ($course !== null) {
             $sqlProblemsets = '
             SELECT
                 problemset_id,
@@ -105,7 +105,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         $countQuery = $sqlCount . $sqlFrom;
 
         $sqlLimit = '';
-        if (!is_null($offset)) {
+        if ($offset !== null) {
             $sqlLimit = 'LIMIT ?, ?';
             $params[] = max(0, $offset - 1) * $rowcount;
             $params[] = $rowcount;
@@ -122,7 +122,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         // If we didn't get an offset, we know the total number of rows
         // already, no need to query the database for it.
         $totalRows = count($clarifications);
-        if (!is_null($offset) && $offset != 0) {
+        if ($offset !== null && $offset != 0) {
             if ($totalRows != $rowcount) {
                 // If we did get an offset, but the number of rows we got is
                 // less than what we allowed, we've already reached the end
@@ -201,7 +201,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
             c.clarification_id DESC
         ';
 
-        if (!is_null($offset)) {
+        if ($offset !== null) {
             $sql .= 'LIMIT ?, ?';
             $params[] = max(0, $offset);
             $params[] = $rowcount;
@@ -275,7 +275,7 @@ class Clarifications extends \OmegaUp\DAO\Base\Clarifications {
         }
 
         $sql .= 'ORDER BY c.answer IS NULL DESC, c.clarification_id DESC ';
-        if (!is_null($offset)) {
+        if ($offset !== null) {
             $sql .= 'LIMIT ?, ?';
             $val[] = max(0, $offset);
             $val[] = $rowcount;

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -96,7 +96,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $contests = [];
         foreach ($rs as $row) {
             $contest = new \OmegaUp\DAO\VO\Contests($row);
-            if (!is_null($contest->contest_id)) {
+            if ($contest->contest_id !== null) {
                 $contests[$contest->contest_id] = $contest;
             }
         }
@@ -253,7 +253,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     public static function getPrivateContestsCount(
         \OmegaUp\DAO\VO\Users $user
     ): int {
-        if (is_null($user->user_id)) {
+        if ($user->user_id === null) {
             return 0;
         }
         $sql = 'SELECT
@@ -434,13 +434,13 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             WHERE
                 archived = ?";
 
-        if (!is_null($order)) {
+        if ($order !== null) {
             $sql .= ' ORDER BY `Contests`.`' . \OmegaUp\MySQLConnection::getInstance()->escape(
                 $order
             ) . '` ' .
                 ($orderType == 'DESC' ? 'DESC' : 'ASC');
         }
-        if (!is_null($page)) {
+        if ($page !== null) {
             $sql .= ' LIMIT ' . (($page - 1) * $pageSize) . ', ' . intval(
                 $pageSize
             );
@@ -717,7 +717,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         ?\OmegaUp\DAO\VO\Identities $identity,
         ?int $dayLimit = 15
     ) {
-        if (is_null($identity) || is_null($identity->identity_id)) {
+        if ($identity === null || $identity->identity_id === null) {
             return null;
         }
 
@@ -728,7 +728,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             \OmegaUp\DAO\Enum\ActiveStatus::FUTURE
         );
         $withinDayLimitCondition = 'TRUE';
-        if (!is_null($dayLimit)) {
+        if ($dayLimit !== null) {
             $withinDayLimitCondition = "DATEDIFF(start_time, NOW()) < $dayLimit";
         }
 
@@ -819,7 +819,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params
         );
 
-        if (!is_null($contest)) {
+        if ($contest !== null) {
             $contest['participating'] = true;
         }
 
@@ -1368,7 +1368,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
     }
 
     public static function getContestForProblemset(?int $problemsetId): ?\OmegaUp\DAO\VO\Contests {
-        if (is_null($problemsetId)) {
+        if ($problemsetId === null) {
             return null;
         }
 
@@ -1447,7 +1447,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
      * Check if contest is virtual contest
      */
     public static function isVirtual(\OmegaUp\DAO\VO\Contests $contest): bool {
-        return !is_null($contest->rerun_id);
+        return $contest->rerun_id !== null;
     }
 
     /**

--- a/frontend/server/src/DAO/CourseIdentityRequest.php
+++ b/frontend/server/src/DAO/CourseIdentityRequest.php
@@ -87,7 +87,7 @@ class CourseIdentityRequest extends \OmegaUp\DAO\Base\CourseIdentityRequest {
         );
 
         return array_map(function ($request) {
-            if (!is_null($request['admin_username'])) {
+            if ($request['admin_username'] !== null) {
                 $request['admin'] = [
                     'name' => $request['admin_name'],
                     'username' => $request['admin_username'],

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -65,7 +65,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
 
         $openedCondition = 'false AS opened';
         $args = [];
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             $openedCondition = '
                 EXISTS(
                     SELECT
@@ -216,7 +216,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
         $courses = [];
         foreach ($rs as $row) {
             $row['assignments'] = [];
-            $row['is_open'] = !is_null($row['accept_teacher']);
+            $row['is_open'] = $row['accept_teacher'] !== null;
             $row['counts'] = \OmegaUp\DAO\Assignments::getAssignmentCountsForCourse(
                 $row['course_id']
             );
@@ -268,7 +268,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                 $row['course_id']
             );
             $row['is_open'] = boolval($row['is_open']);
-            $row['accept_teacher'] = !is_null($row['accept_teacher'])
+            $row['accept_teacher'] = $row['accept_teacher'] !== null
               ? boolval($row['accept_teacher'])
               : null;
             unset($row['course_id']);
@@ -847,8 +847,8 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
              * @param array{assignments: array<string, array{problems: array<string, array{progress: float, score: float}>, progress: float, score: float}>, classname: string, country_id: null|string, courseProgress: float, courseScore: float, name: null|string, username: string} $b
              */
             fn (array $a, array $b) => strcasecmp(
-                !is_null($a['name']) ? $a['name'] : $a['username'],
-                !is_null($b['name']) ? $b['name'] : $b['username']
+                $a['name'] !== null ? $a['name'] : $a['username'],
+                $b['name'] !== null ? $b['name'] : $b['username']
             )
         );
 
@@ -1087,7 +1087,7 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
                 $row['course_id']
             );
             $row['is_open'] = boolval($row['is_open']);
-            $row['accept_teacher'] = !is_null($row['accept_teacher'])
+            $row['accept_teacher'] = $row['accept_teacher'] !== null
               ? boolval($row['accept_teacher'])
               : null;
             unset($row['course_id']);

--- a/frontend/server/src/DAO/DAO.php
+++ b/frontend/server/src/DAO/DAO.php
@@ -37,7 +37,7 @@ final class DAO {
      * @return string|null the timestamp in MySQL format.
      */
     final public static function toMySQLTimestamp($timestamp): ?string {
-        if (is_null($timestamp)) {
+        if ($timestamp === null) {
             return null;
         }
         // Temporary migration code to allow the timestamps to be in either

--- a/frontend/server/src/DAO/Enum/StatusBase.php
+++ b/frontend/server/src/DAO/Enum/StatusBase.php
@@ -77,7 +77,7 @@ class StatusBase {
         ?string $field,
         int $defaultValue
     ): int {
-        if (is_null($field)) {
+        if ($field === null) {
             return $defaultValue;
         }
         $index = array_search($field, static::NAME_FOR_STATUS);
@@ -88,7 +88,7 @@ class StatusBase {
             );
         }
         $convertedValue = static::getIntValue($index);
-        if (is_null($convertedValue)) {
+        if ($convertedValue === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterInvalid',
                 $fieldName

--- a/frontend/server/src/DAO/Identities.php
+++ b/frontend/server/src/DAO/Identities.php
@@ -152,7 +152,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
         string $usernameOrEmail,
         \OmegaUp\DAO\VO\Identities $currentIdentity
     ): ?\OmegaUp\DAO\VO\Identities {
-        if (is_null($currentIdentity->identity_id)) {
+        if ($currentIdentity->identity_id === null) {
             return null;
         }
         $sql = '(
@@ -203,7 +203,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
 
         /** @var array{country_id: null|string, current_identity_school_id: int|null, gender: null|string, identity_id: int, language_id: int|null, name: null|string, password: null|string, state_id: null|string, user_id: int|null, username: string}|null $rs */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $args);
-        if (is_null($rs)) {
+        if ($rs === null) {
             return null;
         }
 
@@ -272,7 +272,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
         }
         return [
             'within_last_day' => (
-                !is_null($rs['reset_sent_at']) &&
+                $rs['reset_sent_at'] !== null &&
                 (
                     \OmegaUp\Time::get() - intval($rs['reset_sent_at']->time)
                 ) < 60 * 60 * 24
@@ -313,7 +313,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
      * @return array{birth_date: \OmegaUp\Timestamp|null, classname: string, country: string, email: null|string, gender: null|string, graduation_date: \OmegaUp\Timestamp|null, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, locale: null|string, scholar_degree: null|string, school: null|string, state: null|string, verified: bool|null}|null
      */
     final public static function getExtendedProfileDataByPk(?int $identityId): ?array {
-        if (is_null($identityId)) {
+        if ($identityId === null) {
             return null;
         }
         $sql = 'SELECT
@@ -360,7 +360,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
             $sql,
             [$identityId]
         );
-        if (is_null($identity)) {
+        if ($identity === null) {
             return null;
         }
 
@@ -449,7 +449,7 @@ class Identities extends \OmegaUp\DAO\Base\Identities {
     public static function getAssociatedIdentities(
         \OmegaUp\DAO\VO\Identities $identity
     ): array {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return [];
         }
         $sql = '

--- a/frontend/server/src/DAO/IdentitiesSchools.php
+++ b/frontend/server/src/DAO/IdentitiesSchools.php
@@ -17,11 +17,11 @@ class IdentitiesSchools extends \OmegaUp\DAO\Base\IdentitiesSchools {
         ?string $graduationDate
     ): \OmegaUp\DAO\VO\IdentitiesSchools {
         // First get the current IdentitySchool and update its end_time
-        if (!is_null($identity->current_identity_school_id)) {
+        if ($identity->current_identity_school_id !== null) {
             $identitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
                 $identity->current_identity_school_id
             );
-            if (!is_null($identitySchool)) {
+            if ($identitySchool !== null) {
                 $identitySchool->end_time = new \OmegaUp\Timestamp(
                     \OmegaUp\Time::get()
                 );
@@ -34,7 +34,7 @@ class IdentitiesSchools extends \OmegaUp\DAO\Base\IdentitiesSchools {
             'school_id' => $schoolId,
         ]);
 
-        if (!is_null($graduationDate)) {
+        if ($graduationDate !== null) {
             $newIdentitySchool->graduation_date = $graduationDate;
         }
 
@@ -47,7 +47,7 @@ class IdentitiesSchools extends \OmegaUp\DAO\Base\IdentitiesSchools {
         \OmegaUp\DAO\VO\Identities $identity,
         int $schoolId
     ): ?\OmegaUp\DAO\VO\IdentitiesSchools {
-        if (is_null($identity->identity_id)) {
+        if ($identity->identity_id === null) {
             return null;
         }
         $sql = 'SELECT
@@ -68,7 +68,7 @@ class IdentitiesSchools extends \OmegaUp\DAO\Base\IdentitiesSchools {
         /** @var array{creation_time: \OmegaUp\Timestamp, end_time: \OmegaUp\Timestamp|null, graduation_date: null|string, identity_id: int, identity_school_id: int, school_id: int}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $args);
 
-        if (is_null($rs)) {
+        if ($rs === null) {
             return null;
         }
 

--- a/frontend/server/src/DAO/Notifications.php
+++ b/frontend/server/src/DAO/Notifications.php
@@ -78,7 +78,7 @@ class Notifications extends \OmegaUp\DAO\Base\Notifications {
         foreach ($notifications as $notification) {
             $rowPlaceholders[] = '(?, ?, ?, ?)';
             $params[] = (
-                is_null($notification->user_id) ?
+                $notification->user_id === null ?
                 null :
                 intval($notification->user_id)
             );

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -58,7 +58,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             $args[] = count($tags);
         }
 
-        if ($identityType === IDENTITY_NORMAL && !is_null($identityId)) {
+        if ($identityType === IDENTITY_NORMAL && $identityId !== null) {
             array_push(
                 $clauses,
                 [
@@ -84,7 +84,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         ?int $identityId,
         ?int $userId
     ): array {
-        if (is_null($identityId) || is_null($userId)) {
+        if ($identityId === null || $userId === null) {
             return [];
         }
 
@@ -173,7 +173,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         }
 
         $languageJoin = '';
-        if (!is_null($language) && $language !== 'all') {
+        if ($language !== null && $language !== 'all') {
             $languageJoin = '
                 INNER JOIN
                     Problems_Languages ON Problems_Languages.problem_id = p.problem_id
@@ -186,7 +186,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         $clauses = [];
 
         $levelJoin = '';
-        if (!is_null($level)) {
+        if ($level !== null) {
             $levelJoin = '
             INNER JOIN
                 Problems_Tags pt ON p.problem_id = pt.problem_id
@@ -215,7 +215,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         }
 
         // Convert the difficulty in text form to a range
-        if (is_null($difficultyRange)) {
+        if ($difficultyRange === null) {
             $difficultyRange = [];
             switch ($difficulty) {
                 case 'easy':
@@ -289,7 +289,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             ];
         }
 
-        if (!is_null($query)) {
+        if ($query !== null) {
             if (is_numeric($query)) {
                 $clauses[] = [
                     "(
@@ -337,8 +337,8 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 'p.visibility > ?',
                 [\OmegaUp\ProblemParams::VISIBILITY_DELETED],
             ];
-        } elseif ($identityType === IDENTITY_NORMAL && !is_null($identityId)) {
-            $userKey = is_null($userId) ? 'null' : $userId;
+        } elseif ($identityType === IDENTITY_NORMAL && $identityId !== null) {
+            $userKey = $userId === null ? 'null' : $userId;
             $callback = /** @return list<int> */ fn (): array =>
                 self::getAccessibleAclIds($identityId, $userId);
             $cacheKey = "{$identityId}-{$userKey}";
@@ -536,7 +536,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                 showUserTags: $row['allow_user_add_tags']
             );
             $difficultyHistogram = [];
-            if (!is_null($row['difficulty_histogram'])) {
+            if ($row['difficulty_histogram'] !== null) {
                 /** @var list<int> */
                 $difficultyHistogram = json_decode(
                     $row['difficulty_histogram']
@@ -551,7 +551,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             $problem['difficulty_histogram'] = $difficultyHistogram;
 
             $qualityHistogram = [];
-            if (!is_null($row['quality_histogram'])) {
+            if ($row['quality_histogram'] !== null) {
                 /** @var list<int> */
                 $qualityHistogram = json_decode(
                     $row['quality_histogram']
@@ -617,7 +617,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         $problems = [];
         foreach ($rs as $row) {
             $problem = new \OmegaUp\DAO\VO\Problems($row);
-            if (is_null($problem->alias)) {
+            if ($problem->alias === null) {
                 continue;
             }
             $problems[$problem->alias] = $problem;
@@ -657,7 +657,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
 
         /** @var array{accepted: int, acl_id: int, alias: string, allow_user_add_tags: bool, commit: string, creation_date: \OmegaUp\Timestamp, current_version: string, deprecated: bool, difficulty: float|null, difficulty_histogram: null|string, email_clarifications: bool, input_limit: int, languages: string, order: string, problem_id: int, quality: float|null, quality_histogram: null|string, quality_seal: bool, show_diff: string, source: null|string, submissions: int, title: string, visibility: int, visits: int}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
-        if (is_null($rs)) {
+        if ($rs === null) {
                 return null;
         }
         return new \OmegaUp\DAO\VO\Problems($rs);
@@ -1046,7 +1046,7 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
     }
 
     public static function getPrivateCount(\OmegaUp\DAO\VO\Users $user): ?int {
-        if (is_null($user->user_id)) {
+        if ($user->user_id === null) {
             return 0;
         }
         $sql = 'SELECT
@@ -1402,12 +1402,12 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             \OmegaUp\DAO\VO\Problems::FIELD_NAMES,
             'Problems'
         ) . ' from Problems p where `visibility` > ? ';
-        if (!is_null($order)) {
+        if ($order !== null) {
             $sql .= ' ORDER BY `' . \OmegaUp\MySQLConnection::getInstance()->escape(
                 $order
             ) . '` ' . ($orderType == 'DESC' ? 'DESC' : 'ASC');
         }
-        if (!is_null($page)) {
+        if ($page !== null) {
             $sql .= ' LIMIT ' . (($page - 1) * $colsPerPage) . ', ' . intval(
                 $colsPerPage
             );

--- a/frontend/server/src/DAO/ProblemsetIdentities.php
+++ b/frontend/server/src/DAO/ProblemsetIdentities.php
@@ -33,14 +33,14 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
             $identity->identity_id,
             intval($container->problemset_id)
         );
-        if (is_null($problemsetIdentity)) {
+        if ($problemsetIdentity === null) {
             // Identities that were added through a group are still considered
             // to be granted access.
             $problemset = \OmegaUp\DAO\Problemsets::getByPK(
                 intval($container->problemset_id)
             );
             $isInvited = (
-                !is_null($problemset) &&
+                $problemset !== null &&
                 \OmegaUp\DAO\GroupRoles::isContestant(
                     intval($identity->identity_id),
                     intval($problemset->acl_id)
@@ -59,7 +59,7 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
                 'share_user_information' => $shareUserInformation,
             ]);
         }
-        if (is_null($problemsetIdentity->access_time)) {
+        if ($problemsetIdentity->access_time === null) {
             // If its set to default time, update it
             $problemsetIdentity->access_time = new \OmegaUp\Timestamp(
                 $currentTime
@@ -78,7 +78,7 @@ class ProblemsetIdentities extends \OmegaUp\DAO\Base\ProblemsetIdentities {
             if (
                 !empty($windowLength) &&
                 (
-                    is_null($finishTime) ||
+                    $finishTime === null ||
                     $finishTime->time > $currentTime + $windowLength
                 )
             ) {

--- a/frontend/server/src/DAO/ProblemsetProblems.php
+++ b/frontend/server/src/DAO/ProblemsetProblems.php
@@ -75,7 +75,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
                     'problems' => [],
                 ];
             }
-            if (is_null($assignment['problem_alias'])) {
+            if ($assignment['problem_alias'] === null) {
                 continue;
             }
             $result[$assignmentAlias]['problems'][] = [
@@ -254,7 +254,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
         foreach ($rs as &$problem) {
             // There are languages in problemset table, so we can get the list
             // directly from that table
-            if (!is_null($problem['problemset_languages'])) {
+            if ($problem['problemset_languages'] !== null) {
                 $problem['languages'] = join(',', array_intersect(
                     explode(',', $problem['problemset_languages']),
                     explode(',', $problem['languages'])
@@ -526,7 +526,7 @@ class ProblemsetProblems extends \OmegaUp\DAO\Base\ProblemsetProblems {
             $identity = \OmegaUp\DAO\Identities::getByPK(
                 intval($user->main_identity_id)
             );
-            if (is_null($identity)) {
+            if ($identity === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
             }
             $problemsets = array_filter(

--- a/frontend/server/src/DAO/Problemsets.php
+++ b/frontend/server/src/DAO/Problemsets.php
@@ -16,7 +16,7 @@ class Problemsets extends \OmegaUp\DAO\Base\Problemsets {
      * @return null|\OmegaUp\DAO\VO\Contests|\OmegaUp\DAO\VO\Assignments
      */
     public static function getProblemsetContainer(?int $problemsetId) {
-        if (is_null($problemsetId)) {
+        if ($problemsetId === null) {
             return null;
         }
 
@@ -25,14 +25,14 @@ class Problemsets extends \OmegaUp\DAO\Base\Problemsets {
         $contest = \OmegaUp\DAO\Contests::getContestForProblemset(
             $problemsetId
         );
-        if (!is_null($contest)) {
+        if ($contest !== null) {
             return $contest;
         }
 
         $assignment = \OmegaUp\DAO\Assignments::getAssignmentForProblemset(
             $problemsetId
         );
-        if (!is_null($assignment)) {
+        if ($assignment !== null) {
             return $assignment;
         }
 
@@ -54,8 +54,8 @@ class Problemsets extends \OmegaUp\DAO\Base\Problemsets {
             return false;
         }
         if (
-            !is_null($problemsetIdentity) &&
-            !is_null($problemsetIdentity->end_time)
+            $problemsetIdentity !== null &&
+            $problemsetIdentity->end_time !== null
         ) {
             return (
                 \OmegaUp\Time::get() > $problemsetIdentity->end_time->time

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -31,7 +31,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             'dismissedBeforeAc' => false,
         ];
 
-        if (is_null($userId)) {
+        if ($userId === null) {
             return $response;
         }
 
@@ -51,7 +51,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             $sql,
             [$problemId, $userId]
         );
-        if (!is_null($suggestion)) {
+        if ($suggestion !== null) {
             $response['nominated'] = true;
             /** @var array{before_ac?: mixed} */
             $suggestionContents = json_decode(
@@ -83,7 +83,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             $sql,
             [$problemId, $userId]
         );
-        if (!is_null($dismissal)) {
+        if ($dismissal !== null) {
             $response['dismissed'] = true;
             /** @var array $dismissalContents */
             $dismissalContents = json_decode(
@@ -332,7 +332,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         $params = [];
         $conditions = [];
 
-        if (!is_null($assigneeUserId)) {
+        if ($assigneeUserId !== null) {
             $sqlFrom .= '
             INNER JOIN
                 QualityNomination_Reviewers qnr
@@ -356,12 +356,12 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
                 ) . '")';
         }
 
-        if (!is_null($nominatorUserId)) {
+        if ($nominatorUserId !== null) {
             $conditions[] = ' qn.user_id = ?';
             $params[] = $nominatorUserId;
         }
 
-        if (!is_null($query) && !is_null($column)) {
+        if ($query !== null && $column !== null) {
             // Some columns are renamed in the query.
             if ($column == 'author_username') {
                 $column = 'authorIdentity.username';
@@ -383,7 +383,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
                 ' AND ',
                 $conditions
             );
-            if (!is_null($query)) {
+            if ($query !== null) {
                 $sqlFrom .= " AND {$sqlSearch} ";
             }
         } else {
@@ -476,7 +476,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             $sql,
             [$qualitynomination_id]
         );
-        if (is_null($result)) {
+        if ($result === null) {
             return null;
         }
         return self::processNomination($result);

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -220,7 +220,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         $suggestionsCountField = '0 AS suggestions';
         $suggestionsJoin = '';
 
-        if (!is_null($problemsetId)) {
+        if ($problemsetId !== null) {
             $cteSubmissionsFeedback = self::$ctesubmissionFeedbackForProblemset;
 
             $suggestionsCountField = 'IFNULL(ssff.suggestions, 0) AS suggestions';
@@ -229,24 +229,24 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             $where[] = 's.problemset_id = ?';
             $val[] = $problemsetId;
         }
-        if (!is_null($problemId)) {
+        if ($problemId !== null) {
             $where[] = 's.problem_id = ?';
             $val[] = $problemId;
         }
-        if (!is_null($language)) {
+        if ($language !== null) {
             $where[] = 's.language = ?';
             $val[] = $language;
         }
-        if (!is_null($identityId)) {
+        if ($identityId !== null) {
             $where[] = 's.identity_id = ?';
             $val[] = $identityId;
         }
 
-        if (!is_null($status)) {
+        if ($status !== null) {
             $where[] = 's.status = ?';
             $val[] = $status;
         }
-        if (!is_null($verdict)) {
+        if ($verdict !== null) {
             if ($verdict === 'NO-AC') {
                 $where[] = 's.verdict <> ?';
                 $val[] = 'AC';
@@ -255,7 +255,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 $val[] = $verdict;
             }
         } else {
-            if (!is_null($execution)) {
+            if ($execution !== null) {
                 $executionArgs = \OmegaUp\Controllers\Run::EXECUTION[$execution];
                 $placeholders = array_fill(0, count($executionArgs), '?');
                 $placeholders = join(',', $placeholders);
@@ -263,7 +263,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 $val = array_merge($val, $executionArgs);
             }
 
-            if (!is_null($output)) {
+            if ($output !== null) {
                 $outputArgs = \OmegaUp\Controllers\Run::OUTPUT[$output];
                 $placeholders = array_fill(0, count($outputArgs), '?');
                 $placeholders = join(',', $placeholders);
@@ -288,10 +288,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             $val,
         );
 
-        if (is_null($offset) || $offset < 0) {
+        if ($offset === null || $offset < 0) {
             $offset = 0;
         }
-        if (is_null($rowCount)) {
+        if ($rowCount === null) {
             $rowCount = 100;
         }
 
@@ -527,7 +527,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             ) AS classname';
         // Build SQL statement
         if ($showAllRuns) {
-            if (is_null($groupId)) {
+            if ($groupId === null) {
                 $sql = "
                     SELECT
                         i.identity_id,
@@ -641,7 +641,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
             }
         } else {
             $val = [$problemsetId];
-            if (is_null($filterUsersBy)) {
+            if ($filterUsersBy === null) {
                 $sqlUserFilter = '';
             } else {
                 $sqlUserFilter = ' AND i.username LIKE ?';
@@ -947,7 +947,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         /** @var array{commit: string, contest_score: float|null, execution: string, judged_by: null|string, memory: int, output: string, penalty: int, run_id: int, runtime: int, score: float, status: string, status_memory: string, status_runtime: string, submission_id: int, time: \OmegaUp\Timestamp, verdict: string, version: string}|null */
         $run = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$guid]);
 
-        if (is_null($run)) {
+        if ($run === null) {
             return null;
         }
 
@@ -1001,7 +1001,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         $whereClause = '';
         $params = [$problemId, $identityId];
 
-        if (!is_null($problemsetId)) {
+        if ($problemsetId !== null) {
             $cteSubmissionsFeedback = self::$ctesubmissionFeedbackForProblemset;
             $suggestionsCountField = 'IFNULL(ssff.suggestions, 0) AS suggestions';
             $suggestionsJoin = 'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
@@ -1084,7 +1084,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 $record['score_by_group'] ?? '',
                 associative: true
             );
-            if (is_null($record['score_by_group'])) {
+            if ($record['score_by_group'] === null) {
                 unset($record['score_by_group']);
             }
             $runs[] = $record;
@@ -1182,7 +1182,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 s.problem_id = ? AND s.identity_id = ?
         ';
         $params = [$problemId, $identityId];
-        if (!is_null($problemsetId)) {
+        if ($problemsetId !== null) {
             $sql .= ' AND s.problemset_id = ?';
             $params[] = $problemsetId;
         }
@@ -1200,7 +1200,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         ?\OmegaUp\Timestamp $lastSubmissionTime = null
     ): \OmegaUp\Timestamp {
         $submissionGap = \OmegaUp\Controllers\Run::$defaultSubmissionGap;
-        if (!is_null($contest)) {
+        if ($contest !== null) {
             // Get submissions gap
             $submissionGap = max(
                 $submissionGap,
@@ -1232,7 +1232,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         int $initialGap,
         ?\OmegaUp\Timestamp $lastActivityTime = null
     ): \OmegaUp\Timestamp {
-        if (is_null($lastActivityTime)) {
+        if ($lastActivityTime === null) {
             return new \OmegaUp\Timestamp(\OmegaUp\Time::get());
         }
 
@@ -1548,7 +1548,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         $clauses = ['s.problem_id = ?'];
         $params[] = $problem->problem_id;
 
-        if (is_null($problemsetId)) {
+        if ($problemsetId === null) {
             $clauses[] = 's.problemset_id IS NULL';
         } else {
             $clauses[] = 's.problemset_id = ?';

--- a/frontend/server/src/DAO/RunsGroups.php
+++ b/frontend/server/src/DAO/RunsGroups.php
@@ -26,7 +26,7 @@ class RunsGroups extends \OmegaUp\DAO\Base\RunsGroups {
             $penaltyQuery = 'SUM(mspg.penalty) AS penalty';
         }
         $params = [$problemsetId];
-        if (!is_null($scoreboardTimeLimit)) {
+        if ($scoreboardTimeLimit !== null) {
             $timeQuery = 'mspg.`time` < ?';
             $params[] = $scoreboardTimeLimit;
         }

--- a/frontend/server/src/DAO/SchoolOfTheMonth.php
+++ b/frontend/server/src/DAO/SchoolOfTheMonth.php
@@ -20,7 +20,7 @@ class SchoolOfTheMonth extends \OmegaUp\DAO\Base\SchoolOfTheMonth {
         int $rowcount = 100,
         string $firstDayOfMonth = null
     ): array {
-        if (is_null($firstDayOfMonth)) {
+        if ($firstDayOfMonth === null) {
             $currentDate = date('Y-m-d', \OmegaUp\Time::get());
             $date = new \DateTimeImmutable($currentDate);
             $firstDayOfMonth = $date->modify(

--- a/frontend/server/src/DAO/SubmissionFeedback.php
+++ b/frontend/server/src/DAO/SubmissionFeedback.php
@@ -75,15 +75,7 @@ class SubmissionFeedback extends \OmegaUp\DAO\Base\SubmissionFeedback {
                 ];
             }
             if (
-                !is_null(
-                    $row['feedback_thread']
-                ) && !is_null(
-                    $row['author_thread']
-                ) && !is_null(
-                    $row['date_thread']
-                ) && !is_null(
-                    $row['submission_feedback_thread_id']
-                )
+                $row['feedback_thread'] !== null && $row['author_thread'] !== null && $row['date_thread'] !== null && $row['submission_feedback_thread_id'] !== null
             ) {
                 $feedback[$row['submission_feedback_id']]['feedback_thread'][] = [
                     'author' => $row['author_thread'],
@@ -123,7 +115,7 @@ class SubmissionFeedback extends \OmegaUp\DAO\Base\SubmissionFeedback {
         );
         $params = [$guid];
         $clause = 'AND sf.range_bytes_start IS NULL';
-        if (!is_null($rangeBytesStart)) {
+        if ($rangeBytesStart !== null) {
             $clause = 'AND sf.range_bytes_start = ?';
             $params[] = $rangeBytesStart;
         }
@@ -141,7 +133,7 @@ class SubmissionFeedback extends \OmegaUp\DAO\Base\SubmissionFeedback {
 
         /** @var array{date: \OmegaUp\Timestamp, feedback: string, identity_id: int, range_bytes_end: int|null, range_bytes_start: int|null, submission_feedback_id: int, submission_id: int}|null */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
-        if (is_null($rs)) {
+        if ($rs === null) {
             return null;
         }
         return new \OmegaUp\DAO\VO\SubmissionFeedback($rs);

--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -230,7 +230,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
         $problemsetIdFilter = '';
         $val = [$identityId, $problemId];
 
-        if (!is_null($problemsetId)) {
+        if ($problemsetId !== null) {
             $problemsetIdFilter = 'AND s.problemset_id = ?';
             $val[] = $problemsetId;
         }
@@ -252,12 +252,12 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
             $sql,
             $val
         );
-        if (is_null($lastRunTime)) {
+        if ($lastRunTime === null) {
             return true;
         }
 
         $submissionGap = \OmegaUp\Controllers\Run::$defaultSubmissionGap;
-        if (!is_null($contest)) {
+        if ($contest !== null) {
             // Get submissions gap
             $submissionGap = max(
                 $submissionGap,
@@ -297,7 +297,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
         ?int $rowsPerPage = 100,
     ): array {
         $limitDate = gmdate('Y-m-d H:i:s', time() - 24 * 3600);
-        if (is_null($identityId)) {
+        if ($identityId === null) {
             $indexHint = 'USE INDEX(PRIMARY)';
         } else {
             $indexHint = '';
@@ -350,7 +350,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
         ";
         $params = [$limitDate, \OmegaUp\ProblemParams::VISIBILITY_PUBLIC];
 
-        if (!is_null($identityId)) {
+        if ($identityId !== null) {
             $sql .= '
                     AND i.identity_id = ?
             ';
@@ -439,7 +439,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
             $username,
             $contestAlias,
         ];
-        if (!is_null($problemAlias)) {
+        if ($problemAlias !== null) {
             $clause = 'AND p.alias = ?';
             $params[] = $problemAlias;
         }

--- a/frontend/server/src/DAO/Teams.php
+++ b/frontend/server/src/DAO/Teams.php
@@ -53,7 +53,7 @@ class Teams extends \OmegaUp\DAO\Base\Teams {
             $sql,
             [$identityId]
         );
-        if (is_null($row)) {
+        if ($row === null) {
             return null;
         }
         return new \OmegaUp\DAO\VO\Teams($row);

--- a/frontend/server/src/DAO/UserRank.php
+++ b/frontend/server/src/DAO/UserRank.php
@@ -57,7 +57,7 @@ class UserRank extends \OmegaUp\DAO\Base\UserRank {
                 $filteredBy
             ) . '_id` = ?';
         }
-        if (!is_null($order)) {
+        if ($order !== null) {
             $sqlFrom .= ' ORDER BY `ur`.`' . \OmegaUp\MySQLConnection::getInstance()->escape(
                 $order
             ) . '` ' . ($orderType === 'DESC' ? 'DESC' : 'ASC');

--- a/frontend/server/src/DAO/Users.php
+++ b/frontend/server/src/DAO/Users.php
@@ -81,7 +81,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
      */
     public static function FindResetInfoByEmail(string $email): ?array {
         $user = self::findByEmail($email);
-        if (is_null($user)) {
+        if ($user === null) {
             return null;
         }
         return [
@@ -138,7 +138,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
             [$userId]
         );
 
-        if (is_null($user)) {
+        if ($user === null) {
             return null;
         }
 
@@ -156,7 +156,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
      * @return array{classname: string, country_id: string, email: null|string}
      */
     final public static function getBasicProfileDataByPk(?int $userId): array {
-        if (is_null($userId)) {
+        if ($userId === null) {
             return [
                 'classname' => 'user-rank-unranked',
                 'country_id' => 'xx',
@@ -185,7 +185,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
             [$userId]
         );
 
-        if (is_null($user)) {
+        if ($user === null) {
             return [
                 'classname' => 'user-rank-unranked',
                 'country_id' => 'xx',
@@ -197,7 +197,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
     }
 
     public static function getPreferredLanguage(?int $userId): ?string {
-        if (is_null($userId)) {
+        if ($userId === null) {
             return null;
         }
         $sql = 'SELECT
@@ -216,7 +216,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
     }
 
     public static function getHideTags(?int $identityId): bool {
-        if (is_null($identityId)) {
+        if ($identityId === null) {
             return false;
         }
         $sql = '
@@ -242,7 +242,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
     }
 
     public static function getRankingClassName(?int $userId): string {
-        if (is_null($userId)) {
+        if ($userId === null) {
             return 'user-rank-unranked';
         }
         $sql = 'SELECT
@@ -486,7 +486,7 @@ class Users extends \OmegaUp\DAO\Base\Users {
             $sql,
             [$token]
         );
-        if (is_null($result)) {
+        if ($result === null) {
             return null;
         }
         return new \OmegaUp\DAO\VO\Users($result);


### PR DESCRIPTION
# Description

Replace all `is_null($x)` calls with `$x === null` and `!is_null($x)` with `$x !== null` in `frontend/server/src/DAO/` (including `DAO/Base/`).

This is **Sub-PR B** of 3 for issue #9270. The strict comparison (`=== null`) is slightly faster and is the more common modern PHP convention.

**Changes:** 105 files, ~578 insertions, ~590 deletions.

Fixes #9270 (partial)

# Comments

This is a purely mechanical find-and-replace with no logic changes. Split into 3 PRs as recommended in the issue:
- **Sub-PR A:** `Controllers/` → see companion PR
- **Sub-PR B (this one):** `DAO/`
- **Sub-PR C:** Core `src/` files → see companion PR

# Checklist

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.