### PR TITLE
refactor: standardize null checks in Controllers

### DIFF
--- a/frontend/server/src/Controllers/ACL.php
+++ b/frontend/server/src/Controllers/ACL.php
@@ -91,13 +91,7 @@ class ACL extends \OmegaUp\Controllers\Controller {
         $roleMap = [];
         foreach (\OmegaUp\DAO\Roles::getAll() as $role) {
             if (
-                is_null(
-                    $role->role_id
-                ) || is_null(
-                    $role->name
-                ) || is_null(
-                    $role->description
-                )
+                $role->role_id === null || $role->name === null || $role->description === null
             ) {
                 continue;
             }
@@ -114,7 +108,7 @@ class ACL extends \OmegaUp\Controllers\Controller {
                 $userRoles,
                 'user_id'
             ),
-            fn($id) => !is_null($id)
+            fn($id) => $id !== null
         );
         /** @var list<int> $userIds */
         $userIds = array_values(array_unique($userIds));

--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -209,23 +209,17 @@ class Admin extends \OmegaUp\Controllers\Controller {
         $enabled = boolval($cacheEnabled->get());
 
         $cacheMessageEs = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_ES_KEY);
-        $messageEs = is_null(
-            $cacheMessageEs->get()
-        ) ? null : strval(
+        $messageEs = $cacheMessageEs->get() === null ? null : strval(
             $cacheMessageEs->get()
         );
 
         $cacheMessageEn = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_EN_KEY);
-        $messageEn = is_null(
-            $cacheMessageEn->get()
-        ) ? null : strval(
+        $messageEn = $cacheMessageEn->get() === null ? null : strval(
             $cacheMessageEn->get()
         );
 
         $cacheMessagePt = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_PT_KEY);
-        $messagePt = is_null(
-            $cacheMessagePt->get()
-        ) ? null : strval(
+        $messagePt = $cacheMessagePt->get() === null ? null : strval(
             $cacheMessagePt->get()
         );
 

--- a/frontend/server/src/Controllers/AiEditorial.php
+++ b/frontend/server/src/Controllers/AiEditorial.php
@@ -45,7 +45,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
         }
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -57,13 +57,13 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
         }
 
         // Validate required fields for job creation
-        if (is_null($problem->problem_id)) {
+        if ($problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
         }
 
-        if (is_null($r->identity->user_id)) {
+        if ($r->identity->user_id === null) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException(
                 'userNotAllowed'
             );
@@ -88,7 +88,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
                 $problem->problem_id
             );
 
-            if (!is_null($lastJob)) {
+            if ($lastJob !== null) {
                 $cooldownEnd = $lastJob->created_at->time + (self::COOLDOWN_MINUTES * 60);
                 if (time() < $cooldownEnd) {
                     throw new \OmegaUp\Exceptions\RateLimitExceededException(
@@ -102,7 +102,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
         $currentSession = \OmegaUp\Controllers\Session::getCurrentSession($r);
         $sessionAuthToken = $currentSession['auth_token'];
 
-        if (is_null($sessionAuthToken)) {
+        if ($sessionAuthToken === null) {
             throw new \OmegaUp\Exceptions\UnauthorizedException(
                 'userNotAllowed'
             );
@@ -228,16 +228,16 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
         $jobId = $r->ensureString('job_id');
 
         $job = \OmegaUp\DAO\AIEditorialJobs::getByPK($jobId);
-        if (is_null($job)) {
+        if ($job === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
         }
 
         // Get problem to check permissions
-        if (is_null($job->problem_id)) {
+        if ($job->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problem = \OmegaUp\DAO\Problems::getByPK($job->problem_id);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -289,16 +289,16 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
         }
 
         $job = \OmegaUp\DAO\AIEditorialJobs::getByPK($jobId);
-        if (is_null($job)) {
+        if ($job === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
         }
 
         // Get problem to check permissions
-        if (is_null($job->problem_id)) {
+        if ($job->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problem = \OmegaUp\DAO\Problems::getByPK($job->problem_id);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -325,18 +325,18 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
 
             // Publish the editorial using existing Problem API
             $solutionMarkdown = null;
-            if ($language === 'en' && !is_null($job->md_en)) {
+            if ($language === 'en' && $job->md_en !== null) {
                 $solutionMarkdown = $job->md_en;
-            } elseif ($language === 'es' && !is_null($job->md_es)) {
+            } elseif ($language === 'es' && $job->md_es !== null) {
                 $solutionMarkdown = $job->md_es;
-            } elseif ($language === 'pt' && !is_null($job->md_pt)) {
+            } elseif ($language === 'pt' && $job->md_pt !== null) {
                 $solutionMarkdown = $job->md_pt;
             } else {
                 // Default to English if no language specified or content not found
                 $solutionMarkdown = $job->md_en ?? $job->md_es ?? $job->md_pt;
             }
 
-            if (!is_null($solutionMarkdown)) {
+            if ($solutionMarkdown !== null) {
                 // Skip publishing in test environment to avoid gitserver dependencies
                 // Check if we're in a test environment by looking for PHPUnit class
                 if (class_exists('\PHPUnit\Framework\TestCase', false)) {
@@ -434,16 +434,16 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
         }
 
         $job = \OmegaUp\DAO\AIEditorialJobs::getByPK($jobId);
-        if (is_null($job)) {
+        if ($job === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('resourceNotFound');
         }
 
         // Get problem to check permissions
-        if (is_null($job->problem_id)) {
+        if ($job->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problem = \OmegaUp\DAO\Problems::getByPK($job->problem_id);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -465,15 +465,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
 
         // Update job content if provided
         if (
-            !is_null(
-                $mdEn
-            ) || !is_null(
-                $mdEs
-            ) || !is_null(
-                $mdPt
-            ) || !is_null(
-                $validationVerdict
-            )
+            $mdEn !== null || $mdEs !== null || $mdPt !== null || $validationVerdict !== null
         ) {
             \OmegaUp\DAO\AIEditorialJobs::updateJobContent(
                 $jobId,

--- a/frontend/server/src/Controllers/Authorization.php
+++ b/frontend/server/src/Controllers/Authorization.php
@@ -39,7 +39,7 @@ class Authorization extends \OmegaUp\Controllers\Controller {
         );
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 

--- a/frontend/server/src/Controllers/Badge.php
+++ b/frontend/server/src/Controllers/Badge.php
@@ -53,7 +53,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
     public static function apiMyList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
         return [
-            'badges' => is_null($r->user) ?
+            'badges' => $r->user === null ?
                 [] :
                 \OmegaUp\DAO\UsersBadges::getUserOwnedBadges($r->user),
         ];
@@ -72,7 +72,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
             'target_username'
         );
         $user = \OmegaUp\DAO\Users::FindByUsername($r['target_username']);
-        if (is_null($user)) {
+        if ($user === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         return [
@@ -99,7 +99,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
             self::getAllBadges()
         );
         return [
-            'assignation_time' => is_null($r->user) ?
+            'assignation_time' => $r->user === null ?
                 null :
                 \OmegaUp\DAO\UsersBadges::getUserBadgeAssignationTime(
                     $r->user,
@@ -187,7 +187,7 @@ class Badge extends \OmegaUp\Controllers\Controller {
         );
 
         $details = self::getBadgeDetails($badgeAlias);
-        if (!is_null($r->user)) {
+        if ($r->user !== null) {
             $details['assignation_time'] = \OmegaUp\DAO\UsersBadges::getUserBadgeAssignationTime(
                 $r->user,
                 $badgeAlias

--- a/frontend/server/src/Controllers/CarouselItems.php
+++ b/frontend/server/src/Controllers/CarouselItems.php
@@ -35,7 +35,7 @@ class CarouselItems extends \OmegaUp\Controllers\Controller {
             'image_url' => $r->ensureString('image_url'),
             'link' => $r->ensureString('link'),
             'button_title' => $r->ensureString('buttonTitle'),
-            'expiration_date' => is_null($expiration)
+            'expiration_date' => $expiration === null
                 ? null
                 : new \OmegaUp\Timestamp(strtotime($expiration)),
             'status' => $r->ensureBool('status') ? 'active' : 'inactive',
@@ -62,7 +62,7 @@ class CarouselItems extends \OmegaUp\Controllers\Controller {
         $carouselItem = \OmegaUp\DAO\Base\CarouselItems::getByPK(
             $carouselItemId
         );
-        if (is_null($carouselItem)) {
+        if ($carouselItem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'carouselItemNotFound'
             );
@@ -97,7 +97,7 @@ class CarouselItems extends \OmegaUp\Controllers\Controller {
         $carouselItem = \OmegaUp\DAO\Base\CarouselItems::getByPK(
             $r->ensureInt('carousel_item_id')
         );
-        if (is_null($carouselItem)) {
+        if ($carouselItem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'carouselItemNotFound'
             );

--- a/frontend/server/src/Controllers/Certificate.php
+++ b/frontend/server/src/Controllers/Certificate.php
@@ -62,7 +62,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
     public static function getCertificateListMineForTypeScript(\OmegaUp\Request $r) {
         $r->ensureIdentity();
         $certificates = [];
-        if (!is_null($r->identity->user_id)) {
+        if ($r->identity->user_id !== null) {
             $certificates = \OmegaUp\DAO\Certificates::getUserCertificates(
                 $r->identity->user_id
             );
@@ -398,12 +398,12 @@ class Certificate extends \OmegaUp\Controllers\Controller {
             $verificationCode
         );
 
-        if (is_null($certificateData)) {
+        if ($certificateData === null) {
             return null;
         }
 
         $translator = \OmegaUp\Translations::getInstance();
-        if (!is_null($certificateData['contest_place'])) {
+        if ($certificateData['contest_place'] !== null) {
             $placeNumber = intval($certificateData['contest_place']);
             $title = \OmegaUp\ApiUtils::convertUTFToISO(
                 $placeNumber
@@ -440,7 +440,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
             $verificationCode
         );
 
-        if (is_null($certificateData)) {
+        if ($certificateData === null) {
             return null;
         }
 
@@ -477,7 +477,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
             $verificationCode
         );
 
-        if (is_null($certificateData)) {
+        if ($certificateData === null) {
             return null;
         }
 
@@ -575,9 +575,9 @@ class Certificate extends \OmegaUp\Controllers\Controller {
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
 
         if (
-            is_null($contest)
-            || is_null($contest->problemset_id)
-            || is_null($contest->alias)
+            $contest === null
+            || $contest->problemset_id === null
+            || $contest->alias === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
@@ -586,7 +586,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
             $contest->problemset_id
         );
 
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -620,7 +620,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
         $certificateCutoff = $r->ensureOptionalInt('certificates_cutoff');
 
         // add certificates_cutoff value to the contest
-        if (!is_null($certificateCutoff)) {
+        if ($certificateCutoff !== null) {
             $contest->certificate_cutoff = $certificateCutoff;
 
             // update contest with the new value
@@ -632,7 +632,7 @@ class Certificate extends \OmegaUp\Controllers\Controller {
             $contest->alias
         );
 
-        if (is_null($contestExtraInformation)) {
+        if ($contestExtraInformation === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 

--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -15,7 +15,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
      * Creates an instance of Broadcaster if not already created
      */
     private static function getBroadcasterInstance(): \OmegaUp\Broadcaster {
-        if (is_null(self::$broadcaster)) {
+        if (self::$broadcaster === null) {
             // Create new grader
             self::$broadcaster = new \OmegaUp\Broadcaster();
         }
@@ -44,7 +44,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
 
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -68,7 +68,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         $contest = null;
         $problemsetId = null;
         $admins = [];
-        if (is_null($contestAlias)) {
+        if ($contestAlias === null) {
             // Clarification for course assignment
             $courseAlias = $r->ensureString(
                 'course_alias',
@@ -82,7 +82,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
 
             $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
 
-            if (is_null($course)) {
+            if ($course === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'courseNotFound'
                 );
@@ -108,7 +108,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
                 $assignmentAlias
             );
 
-            if (is_null($problemset)) {
+            if ($problemset === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemsetNotFound'
                 );
@@ -130,7 +130,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         } else {
             // Clarification for contest
             $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-            if (is_null($contest)) {
+            if ($contest === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
@@ -153,19 +153,17 @@ class Clarification extends \OmegaUp\Controllers\Controller {
 
         // Is the combination problemset_id and problem_id valid?
         if (
-            is_null(
-                \OmegaUp\DAO\ProblemsetProblems::getByPK(
+            \OmegaUp\DAO\ProblemsetProblems::getByPK(
                     $problemsetId,
                     $problem->problem_id
-                )
-            )
+                ) === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFoundInProblemset'
             );
         }
 
-        $receiver = !is_null($username) ?
+        $receiver = $username !== null ?
         \OmegaUp\DAO\Identities::findByUsername($username) : null;
         $receiverId = $receiver ? $receiver->identity_id : null;
 
@@ -181,7 +179,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
 
         \OmegaUp\DAO\Clarifications::create($clarification);
 
-        if (!is_null($contest)) {
+        if ($contest !== null) {
             self::clarificationUpdated(
                 $r,
                 $clarification,
@@ -235,7 +233,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         $clarification = \OmegaUp\DAO\Clarifications::getByPK(
             intval($r['clarification_id'])
         );
-        if (is_null($clarification)) {
+        if ($clarification === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'clarificationNotFound'
             );
@@ -293,7 +291,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         $clarification = \OmegaUp\DAO\Clarifications::GetByPK(
             $r->ensureInt('clarification_id')
         );
-        if (is_null($clarification)) {
+        if ($clarification === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'clarificationNotFound'
             );
@@ -309,15 +307,15 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         }
 
         // Update clarification
-        if (!is_null($public)) {
+        if ($public !== null) {
             $clarification->public = $public;
         }
 
-        if (!is_null($message)) {
+        if ($message !== null) {
             $clarification->message = $message;
         }
 
-        if (!is_null($answer)) {
+        if ($answer !== null) {
             $clarification->answer = $answer;
         }
 
@@ -326,7 +324,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
                 $clarification->author_id
             )
         );
-        if (is_null($author)) {
+        if ($author === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -335,7 +333,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::GetByPK(
             intval($clarification->problem_id)
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -346,11 +344,11 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         );
         $assignment = null;
         $course = null;
-        if (is_null($contest)) {
+        if ($contest === null) {
             $assignment = \OmegaUp\DAO\Assignments::getByProblemset(
                 intval($clarification->problemset_id)
             );
-            if (is_null($assignment)) {
+            if ($assignment === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'assignmentNotFound'
                 );
@@ -358,7 +356,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
             $course = \OmegaUp\DAO\Courses::getByPK(
                 intval($assignment->course_id)
             );
-            if (is_null($course)) {
+            if ($course === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'courseNotFound'
                 );
@@ -370,7 +368,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\Clarifications::update($clarification);
 
         // Send notification to author
-        if (!is_null($author->user_id) && !is_null($answer)) {
+        if ($author->user_id !== null && $answer !== null) {
             if ($contest) {
                 \OmegaUp\Controllers\Notification::setCommonNotification(
                     [$author->user_id],
@@ -422,29 +420,29 @@ class Clarification extends \OmegaUp\Controllers\Controller {
         ?\OmegaUp\DAO\VO\Contests $contest
     ): void {
         try {
-            if (is_null($problem)) {
+            if ($problem === null) {
                 $problem = \OmegaUp\DAO\Problems::GetByPK(
                     intval($clarification->problem_id)
                 );
-                if (is_null($problem)) {
+                if ($problem === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemNotFound'
                     );
                 }
             }
             if (
-                is_null($contest) &&
-                !is_null($clarification->problemset_id)
+                $contest === null &&
+                $clarification->problemset_id !== null
             ) {
                 $contest = \OmegaUp\DAO\Contests::getByProblemset(
                     $clarification->problemset_id
                 );
             }
-            if (is_null($identity)) {
+            if ($identity === null) {
                 $identity = \OmegaUp\DAO\Identities::GetByPK(
                     intval($clarification->author_id)
                 );
-                if (is_null($identity)) {
+                if ($identity === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'userNotExist'
                     );

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -156,9 +156,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         // admission mode status in contest is public
-        $public = (!is_null($admissionMode) && self::isPublic($admissionMode));
+        $public = ($admissionMode !== null && self::isPublic($admissionMode));
 
-        if (is_null($participating)) {
+        if ($participating === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterInvalid',
                 'participating'
@@ -222,7 +222,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     ) {
         $identityId = $identity?->identity_id ?? 0;
         $cacheKey = "01-{$identityId}-{$activeContests}-{$recommended}-{$participating}-{$page}-{$pageSize}";
-        if (is_null($identity) || is_null($identity->identity_id)) {
+        if ($identity === null || $identity->identity_id === null) {
             // Get all public contests
             $callback =
             /** @return array{contests: list<ContestListItem>, count: int} */
@@ -316,9 +316,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
         $addedContests = [];
         foreach ($contests as $contestInfo) {
-            $contestInfo['duration_minutes'] = (is_null(
-                $contestInfo['window_length']
-            ) ?
+            $contestInfo['duration_minutes'] = ($contestInfo['window_length'] === null ?
                 $contestInfo['finish_time']->time - $contestInfo['start_time']->time : ($contestInfo['window_length'] * 60)
             );
 
@@ -516,7 +514,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Contests $contest,
         \OmegaUp\DAO\VO\Identities $identity
     ): bool {
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         if ($contest->admission_mode === 'private') {
@@ -547,7 +545,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $identity->identity_id,
                 $contest->problemset_id
             );
-            if (is_null($req) || !$req->accepted) {
+            if ($req === null || !$req->accepted) {
                 return false;
             }
         }
@@ -566,7 +564,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $contestProblemset = \OmegaUp\DAO\Contests::getByAliasWithExtraInformation(
             $contestAlias
         );
-        if (is_null($contestProblemset)) {
+        if ($contestProblemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         return [
@@ -595,7 +593,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         string $contestAlias
     ): \OmegaUp\DAO\VO\Contests {
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest)) {
+        if ($contest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         return $contest;
@@ -609,7 +607,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
      */
     public static function validateContestWithDirector(string $contestAlias) {
         $contest = \OmegaUp\DAO\Contests::getByAliasWithDirector($contestAlias);
-        if (is_null($contest)) {
+        if ($contest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -631,7 +629,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Contests $contest,
         \OmegaUp\DAO\VO\Identities $identity
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
         return self::isPublic($contest->admission_mode) ||
@@ -651,7 +649,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         bool $isPracticeMode = false
     ): array {
-        if (is_null($identity->identity_id)) {
+        if ($identity->identity_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -664,7 +662,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             isPracticeMode: $isPracticeMode
         );
 
-        if (is_null($problemset->problemset_id)) {
+        if ($problemset->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -783,7 +781,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problems = [];
         foreach ($details['problems'] as $index => $problem) {
             $problemDetails = $problemsMap[$problem['alias']] ?? null;
-            if (is_null($problemDetails)) {
+            if ($problemDetails === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -841,7 +839,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'contestWithDirector' => $contestWithDirector,
         ] = self::validateContestWithDirector($contestAlias);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -871,7 +869,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         if (
             $startFresh
-            && !is_null($r->identity)
+            && $r->identity !== null
             && !self::canAccessContest($contest, $r->identity)
             && $contest->admission_mode === 'private'
         ) {
@@ -893,14 +891,14 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'contest_admin' => $contestAdmin,
                 'problemset' => $problemset,
             ] = self::validateDetails($contestAlias, $r->identity);
-            if (is_null($contest->problemset_id)) {
+            if ($contest->problemset_id === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
             }
             $shouldShowFirstAssociatedIdentityRunWarning = (
-                !is_null($r->identity) &&
-                !is_null($r->user) &&
+                $r->identity !== null &&
+                $r->user !== null &&
                 !\OmegaUp\Controllers\User::isMainIdentity(
                     $r->user,
                     $r->identity
@@ -909,7 +907,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $r->user
                 )
             );
-            if (is_null($r->identity)) {
+            if ($r->identity === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'userNotExist'
                 );
@@ -965,11 +963,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $contest->rerun_id
                 );
                 if (
-                    is_null(
-                        $originalContest
-                    ) || is_null(
-                        $originalContest->problemset_id
-                    )
+                    $originalContest === null || $originalContest->problemset_id === null
                 ) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'contestNotFound'
@@ -978,7 +972,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $originalProblemset = \OmegaUp\DAO\Problemsets::getByPK(
                     $contest->problemset_id
                 );
-                if (is_null($originalProblemset)) {
+                if ($originalProblemset === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'contestNotFound'
                     );
@@ -1003,7 +997,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             return $result;
         }
 
-        if (is_null($r->identity)) {
+        if ($r->identity === null) {
             return $result;
         }
 
@@ -1019,9 +1013,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         ];
 
         $needsBasicInformation = $needsBasicInformation && (
-            is_null($userBasicInformation['country']) ||
-            is_null($userBasicInformation['state']) ||
-            is_null($userBasicInformation['school'])
+            $userBasicInformation['country'] === null ||
+            $userBasicInformation['state'] === null ||
+            $userBasicInformation['school'] === null
         );
 
         $result['templateProperties']['payload']['requestsUserInformation'] = $requestsUserInformation;
@@ -1034,7 +1028,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest',
             $requestsUserInformation
         );
-        if (!is_null($privacyStatementMarkdown)) {
+        if ($privacyStatementMarkdown !== null) {
             $statementType = "contest_{$requestsUserInformation}_consent";
             $result['templateProperties']['payload']['privacyStatement'] = [
                 'markdown' => $privacyStatementMarkdown,
@@ -1043,7 +1037,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $statement = \OmegaUp\DAO\PrivacyStatements::getLatestPublishedStatement(
                 $statementType
             );
-            if (!is_null($statement)) {
+            if ($statement !== null) {
                 $result['templateProperties']['payload']['privacyStatement']['gitObjectId'] = $statement['git_object_id'];
             }
         }
@@ -1084,7 +1078,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest_admin' => $contestAdmin,
             'problemset' => $problemset,
         ] = self::validateDetails($contestAlias, $r->identity);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         $commonDetails = self::getCommonDetails(
@@ -1103,7 +1097,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'payload' => array_merge(
                     [
                         'shouldShowFirstAssociatedIdentityRunWarning' => (
-                            !is_null($r->user) &&
+                            $r->user !== null &&
                             !\OmegaUp\Controllers\User::isMainIdentity(
                                 $r->user,
                                 $r->identity
@@ -1159,7 +1153,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         foreach ($validContestIds as $contestID) {
             try {
                 $contest = $contestsMap[$contestID] ?? null;
-                if (is_null($contest)) {
+                if ($contest === null) {
                     $contestants[$contestID] = 0;
                     continue;
                 }
@@ -1167,9 +1161,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 // Only validate access when user is logged in and the admission
                 // mode for the contest is not public
                 if (
-                    !is_null(
-                        $r->identity
-                    ) && $contest->admission_mode !== 'public'
+                    $r->identity !== null && $contest->admission_mode !== 'public'
                 ) {
                     self::validateAccessContest($contest, $r->identity);
                 }
@@ -1432,7 +1424,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'contest_admin' => $contestAdmin,
         ] = self::validateDetails($contestAlias, $r->identity);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'contestNotFound'
             );
@@ -1444,7 +1436,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         $originalContest = null;
-        if (!is_null($contest->rerun_id)) {
+        if ($contest->rerun_id !== null) {
             $originalContest = \OmegaUp\DAO\Contests::getByPK(
                 $contest->rerun_id
             );
@@ -1453,7 +1445,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             $contest->problemset_id
         );
-        if (is_null($problemset) || is_null($problemset->problemset_id)) {
+        if ($problemset === null || $problemset->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -1568,7 +1560,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Contests $contest
     ): bool {
         try {
-            if (is_null($identity)) {
+            if ($identity === null) {
                 // No session, show the intro (if public), so that they can login.
                 return self::isPublic($contest->admission_mode);
             }
@@ -1590,7 +1582,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             // Could not access contest. Private contests must not be leaked, so
             // unless they were manually added beforehand, show them a 404 error.
             if (
-                is_null($identity) ||
+                $identity === null ||
                 !self::isInvitedToContest($contest, $identity)
             ) {
                 throw $e;
@@ -1604,7 +1596,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $identity->identity_id,
             $contest->problemset_id
         );
-        if (!is_null($contestOpened) && !is_null($contestOpened->access_time)) {
+        if ($contestOpened !== null && $contestOpened->access_time !== null) {
             self::$log->debug(
                 'No intro because you already started the contest'
             );
@@ -1636,9 +1628,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // If the contest has not started, user should not see it, unless it is
         // admin or has a token.
-        if (is_null($token)) {
+        if ($token === null) {
             // Crack the request to get the current user
-            if (is_null($identity)) {
+            if ($identity === null) {
                 throw new \OmegaUp\Exceptions\UnauthorizedException();
             }
             self::validateAccessContest($contest, $identity);
@@ -1715,7 +1707,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     ): array {
         // Whether the contest is private, verify that our user is invited
         if (
-            !is_null($identity) &&
+            $identity !== null &&
             $contest['admission_mode'] === 'registration'
         ) {
             $registration = \OmegaUp\DAO\ProblemsetIdentityRequest::getByPK(
@@ -1723,14 +1715,12 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $contest['problemset_id']
             );
 
-            $contest['user_registration_requested'] = !is_null($registration);
+            $contest['user_registration_requested'] = $registration !== null;
 
-            if (is_null($registration)) {
+            if ($registration === null) {
                 $contest['user_registration_answered'] = false;
             } else {
-                $contest['user_registration_answered'] = !is_null(
-                    $registration->accepted
-                );
+                $contest['user_registration_answered'] = $registration->accepted !== null;
                 $contest['user_registration_accepted'] = $registration->accepted;
                 $contest['extra_note'] = $registration->extra_note;
             }
@@ -1819,7 +1809,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $token = $r->ensureOptionalString('token');
 
         $response = self::validateDetails($contestAlias, $r->identity, $token);
-        if (is_null($response['contest']->problemset_id)) {
+        if ($response['contest']->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         [
@@ -1831,9 +1821,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         if (
             $needsInformation
-            && (is_null($r->identity->country_id)
-                || is_null($r->identity->state_id)
-                || is_null($r->identity->current_identity_school_id))
+            && ($r->identity->country_id === null
+                || $r->identity->state_id === null
+                || $r->identity->current_identity_school_id === null)
         ) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException(
                 'contestBasicInformationNeeded'
@@ -1867,7 +1857,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $r['statement_type']
                 );
 
-                if (is_null($privacyStatementId)) {
+                if ($privacyStatementId === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'privacyStatementNotFound'
                     );
@@ -1876,7 +1866,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $r->identity->identity_id,
                     $privacyStatementId
                 );
-                if (is_null($privacyStatementConsentId)) {
+                if ($privacyStatementConsentId === null) {
                     $privacyStatementConsentId = \OmegaUp\DAO\PrivacyStatementConsentLog::saveLog(
                         $r->identity->identity_id,
                         $privacyStatementId
@@ -1956,11 +1946,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
                 $result['original_contest_alias'] = null;
                 $result['original_problemset_id'] = null;
-                if (!is_null($result['rerun_id'])) {
+                if ($result['rerun_id'] !== null) {
                     $originalContest = \OmegaUp\DAO\Contests::getByPK(
                         $result['rerun_id']
                     );
-                    if (!is_null($originalContest)) {
+                    if ($originalContest !== null) {
                         $result['original_contest_alias'] = $originalContest->alias;
                         $result['original_problemset_id'] = $originalContest->problemset_id;
                     }
@@ -1969,8 +1959,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 }
 
                 if (
-                    is_null($contest->acl_id) ||
-                    is_null($contest->problemset_id)
+                    $contest->acl_id === null ||
+                    $contest->problemset_id === null
                 ) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'contestNotFound'
@@ -1979,7 +1969,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $director = \OmegaUp\DAO\UserRoles::getOwner(
                     $contest->acl_id
                 );
-                if (is_null($director)) {
+                if ($director === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'userNotExist'
                     );
@@ -2089,11 +2079,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
         unset($result['scoreboard_url']);
         unset($result['scoreboard_url_admin']);
         unset($result['rerun_id']);
-        if (!is_null($token)) {
+        if ($token !== null) {
             $result['admin'] = $contestAdmin;
             return $result;
         }
-        if (is_null($identity)) {
+        if ($identity === null) {
             throw new \OmegaUp\Exceptions\UnauthorizedException();
         }
 
@@ -2131,9 +2121,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemsetIdentity->access_time = $problemsetIdentity->access_time;
 
         // Add time left to response
-        if (is_null($contest->window_length)) {
+        if ($contest->window_length === null) {
             $result['submission_deadline'] = $contest->finish_time;
-        } elseif (!is_null($problemsetIdentity->access_time)) {
+        } elseif ($problemsetIdentity->access_time !== null) {
             $endTime = (
                 !$problemsetIdentity->end_time ?
                 $problemsetIdentity->access_time->time + $contest->window_length * 60 :
@@ -2161,7 +2151,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $adminIdentity,
         \OmegaUp\DAO\VO\Problemsets $problemset
     ): array {
-        if (is_null($contest->alias) || is_null($contest->problemset_id)) {
+        if ($contest->alias === null || $contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -2248,7 +2238,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         if (!$response['contest_admin']) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
-        if (is_null($response['contest']->problemset_id)) {
+        if ($response['contest']->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -2293,7 +2283,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         ['contest' => $contest] = self::validateBasicDetails($alias);
 
-        if (is_null($contest->contest_id) || is_null($contest->problemset_id)) {
+        if ($contest->contest_id === null || $contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -2381,7 +2371,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $contestAlias,
             $r->identity
         );
-        if (is_null($originalContest->problemset_id)) {
+        if ($originalContest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -2430,7 +2420,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         try {
             // Create the contest
             self::createContest($problemset, $contest, $r->user->user_id);
-            if (is_null($contest->problemset_id)) {
+            if ($contest->problemset_id === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
@@ -2483,7 +2473,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             fn(string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $originalContest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($originalContest)) {
+        if ($originalContest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -2504,7 +2494,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         $r->ensureOptionalInt('start_time');
         $startTime = (
-            !is_null($r['start_time']) ?
+            $r['start_time'] !== null ?
             intval($r['start_time']) :
             \OmegaUp\Time::get()
         );
@@ -2585,8 +2575,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $contest->problemset_id = $problemset->problemset_id;
             $contest->penalty_calc_policy = $contest->penalty_calc_policy ?: 'sum';
             $contest->rerun_id = $contest->rerun_id;
-            if (!is_null($originalProblemsetId)) {
-                if (is_null($contest->problemset_id)) {
+            if ($originalProblemsetId !== null) {
+                if ($contest->problemset_id === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'contestNotFound'
                     );
@@ -2604,11 +2594,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $problemset->contest_id = $contest->contest_id;
             \OmegaUp\DAO\Problemsets::update($problemset);
 
-            if (!is_null($teamsGroupAlias)) {
+            if ($teamsGroupAlias !== null) {
                 $teamsGroup = \OmegaUp\DAO\TeamGroups::getByAlias(
                     $teamsGroupAlias
                 );
-                if (is_null($teamsGroup)) {
+                if ($teamsGroup === null) {
                     throw new \OmegaUp\Exceptions\InvalidParameterException(
                         'invalidParameters',
                         'teams_group'
@@ -2690,7 +2680,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // Set private contest by default if is not sent in request
         if (
-            !is_null($r['admission_mode']) &&
+            $r['admission_mode'] !== null &&
             $r['admission_mode'] !== 'private'
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -2746,7 +2736,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'check_plagiarism' => $checkPlagiarism ? true : false,
         ]);
 
-        if (!is_null($recommendedValue)) {
+        if ($recommendedValue !== null) {
             if (\OmegaUp\Authorization::isSupportTeamMember($r->identity)) {
                 $contest->recommended = $recommendedValue;
             } else {
@@ -2811,7 +2801,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'start_time',
             required: $isRequired
         ) ?? (
-            is_null($contest)
+            $contest === null
             ? null
             : \OmegaUp\DAO\DAO::fromMySQLTimestamp(
                 $contest->start_time
@@ -2821,7 +2811,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'finish_time',
             required: $isRequired
         ) ?? (
-            is_null($contest)
+            $contest === null
             ? null
             : \OmegaUp\DAO\DAO::fromMySQLTimestamp(
                 $contest->finish_time
@@ -2830,7 +2820,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // Calculate the actual contest length
         $contestLength = 0;
-        if (!is_null($finishTime) && !is_null($startTime)) {
+        if ($finishTime !== null && $startTime !== null) {
             // Validate start & finish time where finish_time must be strictly
             // greater than start_time
             if ($startTime->time >= $finishTime->time) {
@@ -2877,8 +2867,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             fn(string $alias) => \OmegaUp\Validators::alias($alias)
         );
         if (
-            !is_null($contestAlias) &&
-            !is_null(\OmegaUp\DAO\Contests::getByAlias($contestAlias))
+            $contestAlias !== null &&
+            \OmegaUp\DAO\Contests::getByAlias($contestAlias) !== null
         ) {
             $exception = new \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException(
                 'aliasInUse'
@@ -2903,7 +2893,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // matches what is displayed in the UI.
         \OmegaUp\Validators::validateNumberInRange(
             (
-                is_null($submissionsGap) ?
+                $submissionsGap === null ?
                 null :
                 floor(intval($submissionsGap) / 60)
             ),
@@ -2930,7 +2920,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problems = $r->ensureOptionalString('problems');
 
         // Problems is optional
-        if (!is_null($problems)) {
+        if ($problems !== null) {
             /** @var list<array{problem: string, points: int}>|null */
             $requestProblems = json_decode($problems, associative: true);
             if (!is_array($requestProblems)) {
@@ -2946,7 +2936,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $problem = \OmegaUp\DAO\Problems::getByAlias(
                     $requestProblem['problem']
                 );
-                if (is_null($problem)) {
+                if ($problem === null) {
                     throw new \OmegaUp\Exceptions\InvalidParameterException(
                         'parameterNotFound',
                         'problems'
@@ -2980,7 +2970,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // languages is required only when a contest is created
         $languagesAsString = $r->ensureOptionalString('languages', $isRequired);
-        if (is_null($languagesAsString)) {
+        if ($languagesAsString === null) {
             return;
         }
 
@@ -3084,7 +3074,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // Prevent date changes if a contest already has runs
         $startTime = $r->ensureOptionalTimestamp('start_time');
         if (
-            !is_null($startTime) &&
+            $startTime !== null &&
             $startTime->time != $contest->start_time->time
         ) {
             $runCount = 0;
@@ -3116,7 +3106,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity
     ): \OmegaUp\DAO\VO\Contests {
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest)) {
+        if ($contest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -3161,7 +3151,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // Only director is allowed to create problems in contest
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'contestNotFound'
             );
@@ -3222,7 +3212,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -3239,7 +3229,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             intval($contest->problemset_id)
         );
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -3251,7 +3241,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         if (
-            is_null($originalProblemsetProblem)
+            $originalProblemsetProblem === null
             &&
             \OmegaUp\DAO\ProblemsetProblems::countProblemsetProblems(
                 $problemset
@@ -3382,7 +3372,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity
     ): array {
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest) || is_null($contest->problemset_id)) {
+        if ($contest === null || $contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'contest_alias'
@@ -3396,7 +3386,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'problem_alias'
@@ -3467,7 +3457,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -3476,8 +3466,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
             intval($problem->problem_id)
         );
         if (
-            is_null($problemsetProblem)
-            || is_null($problemsetProblem->version)
+            $problemsetProblem === null
+            || $problemsetProblem->version === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
         }
@@ -3510,13 +3500,13 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         $contest = self::validateContestAdmin($contestAlias, $identity);
 
-        if (is_null($contest->rerun_id)) {
+        if ($contest->rerun_id === null) {
             return [$identityToAddOrRemove, $contest];
         }
 
         $originalContest = \OmegaUp\DAO\Contests::getByPK($contest->rerun_id);
 
-        if (is_null($originalContest)) {
+        if ($originalContest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -3563,7 +3553,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'usersCanNotBeAddedInContestForTeams'
             );
         }
-        if (is_null($identity->identity_id)) {
+        if ($identity->identity_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -3708,7 +3698,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $teamsGroup = \OmegaUp\DAO\TeamGroups::getByAlias($teamsGroupAlias);
-        if (is_null($teamsGroup)) {
+        if ($teamsGroup === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -3726,7 +3716,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             intval($contest->problemset_id)
         );
-        if (is_null($problemset) || is_null($problemset->acl_id)) {
+        if ($problemset === null || $problemset->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         if (\OmegaUp\DAO\Problemsets::hasSubmissions($problemset)) {
@@ -3788,7 +3778,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -3801,7 +3791,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             intval($contest->problemset_id)
         );
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         if ($contest->contest_for_teams) {
@@ -3845,7 +3835,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -3855,7 +3845,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             intval($contest->problemset_id)
         );
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -3899,7 +3889,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $user = \OmegaUp\Controllers\User::resolveUser($r['usernameOrEmail']);
 
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
-        if (is_null($contest->acl_id)) {
+        if ($contest->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -3938,7 +3928,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
             $r['usernameOrEmail']
         );
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
@@ -3985,7 +3975,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -4026,7 +4016,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -4115,7 +4105,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             ),
             intval($contest->problemset_id)
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -4177,7 +4167,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     ) {
         $params = \OmegaUp\ScoreboardParams::fromContest($contest);
         $params->admin = (
-            !is_null($identity) &&
+            $identity !== null &&
             \OmegaUp\Authorization::isContestAdmin($identity, $contest) &&
             !\OmegaUp\DAO\Contests::isVirtual($contest)
         );
@@ -4262,7 +4252,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         if (empty($token)) {
             // User should be logged
-            if (is_null($identity)) {
+            if ($identity === null) {
                 throw new \OmegaUp\Exceptions\UnauthorizedException();
             }
 
@@ -4331,7 +4321,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'problemset' => $problemset
         ] = self::validateDetails($contestAlias, $identity, $scoreboardToken);
 
-        if (is_null($problemset->problemset_id)) {
+        if ($problemset->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -4454,7 +4444,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $contests = [];
         foreach ($contestAliases as $contestAlias) {
             $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-            if (is_null($contest)) {
+            if ($contest === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
@@ -4466,7 +4456,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         // Get all scoreboards
         $scoreboards = [];
         foreach ($contests as $contest) {
-            if (is_null($contest->alias)) {
+            if ($contest->alias === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
@@ -4585,7 +4575,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
 
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -4609,7 +4599,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             if (!empty($adminId) && !array_key_exists($adminId, $admins)) {
                 $admin = [];
                 $data = \OmegaUp\DAO\Identities::findByUserId($adminId);
-                if (!is_null($data)) {
+                if ($data !== null) {
                     $admin = [
                         'username' => $data->username,
                     ];
@@ -4656,7 +4646,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'note'
         );
 
-        if (is_null($r['resolution'])) {
+        if ($r['resolution'] === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -4667,7 +4657,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $targetIdentity = \OmegaUp\DAO\Identities::findByUsername(
             $r['username']
         );
-        if (is_null($targetIdentity) || is_null($targetIdentity->username)) {
+        if ($targetIdentity === null || $targetIdentity->username === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -4678,7 +4668,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $contest->problemset_id
         );
 
-        if (is_null($request)) {
+        if ($request === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'userNotInListOfRequests'
             );
@@ -4712,7 +4702,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         $response = ['status' => 'ok'];
 
-        if (is_null($targetIdentity->user_id)) {
+        if ($targetIdentity->user_id === null) {
             return $response;
         }
 
@@ -4884,7 +4874,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             fn(string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $contest = self::validateUpdate($r, $r->identity, $contestAlias);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'contestNotFound'
             );
@@ -4906,9 +4896,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         $contestForTeams = $r->ensureOptionalBool('contest_for_teams');
         if (
-            !is_null(
-                $contestForTeams
-            ) && $contest->contest_for_teams !== $contestForTeams
+            $contestForTeams !== null && $contest->contest_for_teams !== $contestForTeams
         ) {
             if ($contest->contest_for_teams) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -4927,7 +4915,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         // Handle recommended flag - only available for admins and support team
         $recommendedValue = $r->ensureOptionalBool('recommended');
-        if (!is_null($recommendedValue)) {
+        if ($recommendedValue !== null) {
             if (\OmegaUp\Authorization::isSupportTeamMember($r->identity)) {
                 $contest->recommended = $recommendedValue;
             } else {
@@ -4938,7 +4926,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         }
 
         // Update contest DAO
-        if (!is_null($r['admission_mode'])) {
+        if ($r['admission_mode'] !== null) {
             \OmegaUp\Validators::validateOptionalInEnum(
                 $r['admission_mode'],
                 'admission_mode',
@@ -5010,7 +4998,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $originalContest = \OmegaUp\DAO\Contests::getByPK(
             intval($contest->contest_id)
         );
-        if (is_null($originalContest)) {
+        if ($originalContest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'contestNotFound'
             );
@@ -5033,7 +5021,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 $problemset = \OmegaUp\DAO\Problemsets::getByPK(
                     intval($contest->problemset_id)
                 );
-                if (is_null($problemset) || is_null($problemset->acl_id)) {
+                if ($problemset === null || $problemset->acl_id === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemsetNotFound'
                     );
@@ -5046,7 +5034,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 );
 
                 if ($originalContest->contest_for_teams) {
-                    if (is_null($teamsGroupAlias)) {
+                    if ($teamsGroupAlias === null) {
                         throw new \OmegaUp\Exceptions\InvalidParameterException(
                             'teamsGroupAliasMustBeRequired'
                         );
@@ -5054,7 +5042,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     $teamsGroup = \OmegaUp\DAO\TeamGroups::getByAlias(
                         $teamsGroupAlias
                     );
-                    if (is_null($teamsGroup)) {
+                    if ($teamsGroup === null) {
                         throw new \OmegaUp\Exceptions\InvalidParameterException(
                             'invalidParameters',
                             'teams_group'
@@ -5072,7 +5060,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
                             'role_id' => \OmegaUp\Authorization::CONTESTANT_ROLE,
                         ])
                     );
-                    if (!is_null($teamsGroup->name)) {
+                    if ($teamsGroup->name !== null) {
                         $result['teamsGroupName'] = $teamsGroup->name;
                     }
                 }
@@ -5084,8 +5072,8 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     intval($contest->problemset_id)
                 );
                 if (
-                    is_null($problemset)
-                    || is_null($problemset->problemset_id)
+                    $problemset === null
+                    || $problemset->problemset_id === null
                 ) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemsetNotFound'
@@ -5174,7 +5162,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $identity->identity_id,
             $contest->problemset_id
         );
-        if (is_null($problemsetIdentity)) {
+        if ($problemsetIdentity === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetIdentityNotFound'
             );
@@ -5212,7 +5200,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             ($originalContest->finish_time != $contest->finish_time) ||
             ($originalContest->window_length !== $contest->window_length)
         ) {
-            if (!is_null($contest->window_length)) {
+            if ($contest->window_length !== null) {
                 // When window length is enabled, end time value is access time + window length
                 \OmegaUp\DAO\ProblemsetIdentities::recalculateEndTimeForProblemsetIdentities(
                     $contest
@@ -5255,7 +5243,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             fn(string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -5265,7 +5253,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         $username = $r->ensureOptionalString('username');
 
         $identity = null;
-        if (!is_null($username)) {
+        if ($username !== null) {
             $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
                 $username
             );
@@ -5278,9 +5266,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
             required: false,
             validator: fn(string $alias) => \OmegaUp\Validators::alias($alias)
         );
-        if (!is_null($problemAlias)) {
+        if ($problemAlias !== null) {
             $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-            if (is_null($problem)) {
+            if ($problem === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -5300,9 +5288,9 @@ class Contest extends \OmegaUp\Controllers\Controller {
                 'verdict',
                 \OmegaUp\Controllers\Run::VERDICTS
             ),
-            !is_null($problem) ? $problem->problem_id : null,
+            $problem !== null ? $problem->problem_id : null,
             $r->ensureOptionalEnum('language', $languages),
-            !is_null($identity) ? $identity->identity_id : null,
+            $identity !== null ? $identity->identity_id : null,
             max($r->ensureOptionalInt('offset') ?? 0, 0),
             $r->ensureOptionalInt('rowcount') ?? 100
         );
@@ -5497,7 +5485,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $problemset = \OmegaUp\DAO\Problemsets::getByPK(
                 intval($contest->problemset_id)
             );
-            if (is_null($problemset)) {
+            if ($problemset === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemsetNotFound'
                 );
@@ -5776,7 +5764,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'contest' => $contest,
             'contestWithDirector' => $contestWithDirector,
         ] = self::validateContestWithDirector($contestAlias);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -5831,7 +5819,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         foreach ($contestReport['problems'] as $entry) {
             $problemAlias = $entry['alias'];
             $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-            if (is_null($problem)) {
+            if ($problem === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -5959,7 +5947,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
-        if (is_null($contest->problemset_id)) {
+        if ($contest->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         include_once __DIR__ . '/../../libs/third_party/ZipStream.php';
@@ -5998,7 +5986,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         $token = $r->ensureOptionalString('token');
         if ($contestAlias === 'all-events') {
-            if (is_null($r->identity)) {
+            if ($r->identity === null) {
                 throw new \OmegaUp\Exceptions\UnauthorizedException();
             }
             if (\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
@@ -6040,7 +6028,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             fn(string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest)) {
+        if ($contest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
@@ -6075,7 +6063,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
         $contest = self::validateContestAdmin($contestAlias, $r->identity);
 
-        if (is_null($contest->contest_id)) {
+        if ($contest->contest_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
         if (
@@ -6121,7 +6109,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         );
 
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest) || is_null($contest->contest_id)) {
+        if ($contest === null || $contest->contest_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 

--- a/frontend/server/src/Controllers/Controller.php
+++ b/frontend/server/src/Controllers/Controller.php
@@ -26,7 +26,7 @@ class Controller {
             $r->ensureIdentity();
         } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
             // allow unauthenticated only if it has $r["username"]
-            if (is_null($r['username'])) {
+            if ($r['username'] === null) {
                 throw $e;
             }
         }
@@ -49,13 +49,13 @@ class Controller {
         // By default use current user
         $user = $r->user;
 
-        if (!is_null($r['username'])) {
+        if ($r['username'] !== null) {
             \OmegaUp\Validators::validateStringNonEmpty(
                 $r['username'],
                 'username'
             );
             $user = \OmegaUp\DAO\Users::FindByUsername($r['username']);
-            if (is_null($user)) {
+            if ($user === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
             }
         }
@@ -88,9 +88,9 @@ class Controller {
             )
         );
 
-        if (!is_null($username)) {
+        if ($username !== null) {
             $identity = \OmegaUp\DAO\Identities::findByUsername($username);
-            if (is_null($identity)) {
+            if ($identity === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
             }
         }
@@ -146,7 +146,7 @@ class Controller {
         foreach ($properties as $source => $info) {
             $propertyConfig = self::parsePropertyConfiguration($source, $info);
 
-            if (is_null($request[$propertyConfig['fieldName']])) {
+            if ($request[$propertyConfig['fieldName']] === null) {
                 continue;
             }
 
@@ -217,7 +217,7 @@ class Controller {
      * @return mixed
      */
     private static function getTransformedValue($value, ?callable $transform) {
-        if (is_null($transform)) {
+        if ($transform === null) {
             return $value;
         }
         return $transform($value);

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -122,7 +122,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course,
             $assignmentAlias
         );
-        if (is_null($assignment)) {
+        if ($assignment === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -166,11 +166,9 @@ class Course extends \OmegaUp\Controllers\Controller {
         $startTime = $r->ensureTimestamp(
             'start_time',
             lowerBound: null,
-            upperBound: is_null(
-                $course->finish_time
-            ) ? null : $course->finish_time->time
+            upperBound: $course->finish_time === null ? null : $course->finish_time->time
         );
-        if ($unlimitedDuration && !is_null($course->finish_time)) {
+        if ($unlimitedDuration && $course->finish_time !== null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'courseDoesNotHaveUnlimitedDuration',
                 'unlimited_duration'
@@ -179,10 +177,8 @@ class Course extends \OmegaUp\Controllers\Controller {
         $finishTime = $r->ensureOptionalTimestamp(
             'finish_time',
             lowerBound: null,
-            upperBound: is_null(
-                $course->finish_time
-            ) ? null : $course->finish_time->time,
-            required: !is_null($course->finish_time) || !$unlimitedDuration,
+            upperBound: $course->finish_time === null ? null : $course->finish_time->time,
+            required: $course->finish_time !== null || !$unlimitedDuration,
         );
 
         if ($startTime->time < $course->start_time->time) {
@@ -193,7 +189,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         if (
-            !is_null($finishTime)
+            $finishTime !== null
             && $finishTime->time < $course->start_time->time
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -203,7 +199,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         if (
-            !is_null($finishTime) &&
+            $finishTime !== null &&
             $startTime->time > $finishTime->time
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -238,11 +234,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                 }
 
                 if (
-                    is_null(
-                        \OmegaUp\DAO\Problems::getByAlias(
+                    \OmegaUp\DAO\Problems::getByAlias(
                             $problemData['alias']
-                        )
-                    )
+                        ) === null
                 ) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemNotFound'
@@ -278,7 +272,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
         $r->ensureInt('start_time');
         if (
-            is_null($r->identity)
+            $r->identity === null
             || (
                 !\OmegaUp\Authorization::isCourseAdmin($r->identity, $course)
                 && $course->admission_mode !== self::ADMISSION_MODE_PUBLIC
@@ -330,7 +324,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         if (
             !$unlimitedDuration &&
-            !is_null($finishTime) &&
+            $finishTime !== null &&
             $startTime->time > $finishTime->time
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -472,18 +466,18 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
         $r->ensureOptionalInt('school_id');
 
-        if (is_null($r['school_id'])) {
+        if ($r['school_id'] === null) {
             $school = null;
         } else {
             $school = \OmegaUp\DAO\Schools::getByPK(intval($r['school_id']));
-            if (is_null($school)) {
+            if ($school === null) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'schoolNotFound'
                 );
             }
         }
         $languages = $r->ensureOptionalString('languages');
-        if (!is_null($languages)) {
+        if ($languages !== null) {
             $languagesSet = explode(',', $languages);
             \OmegaUp\Validators::validateValidSubset(
                 $languagesSet,
@@ -502,7 +496,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         if (
-            is_null($r['admission_mode']) ||
+            $r['admission_mode'] === null ||
             $r['admission_mode'] !== self::ADMISSION_MODE_PUBLIC
         ) {
             return;
@@ -533,7 +527,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      */
     private static function validateCourseExists(string $courseAlias): \OmegaUp\DAO\VO\Courses {
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         return $course;
@@ -564,12 +558,12 @@ class Course extends \OmegaUp\Controllers\Controller {
     public static function resolveGroup(
         \OmegaUp\DAO\VO\Courses $course
     ): \OmegaUp\DAO\VO\Groups {
-        if (is_null($course->group_id)) {
+        if ($course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
         $group = \OmegaUp\DAO\Groups::getByPK($course->group_id);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseGroupNotFound'
             );
@@ -650,7 +644,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $token = $r->ensureOptionalString('token');
         $originalCourse = self::validateCourseExists($courseAlias);
         $decodedToken = null;
-        if (!is_null($token)) {
+        if ($token !== null) {
             try {
                 $decodedToken = \OmegaUp\SecurityTools::getDecodedCloneCourseToken(
                     $token,
@@ -721,7 +715,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $offset = $startTime->time - $originalCourse->start_time->time;
 
         $cloneCourseFinishTime = null;
-        if (!is_null($originalCourse->finish_time)) {
+        if ($originalCourse->finish_time !== null) {
             $cloneCourseFinishTime = new \OmegaUp\Timestamp(
                 $originalCourse->finish_time->time + $offset
             );
@@ -772,7 +766,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                             $offset
                         ),
                         'finish_time' => (
-                            is_null($assignmentProblems['finish_time']) ?
+                            $assignmentProblems['finish_time'] === null ?
                             null :
                             new \OmegaUp\Timestamp(
                                 $assignmentProblems['finish_time']->time +
@@ -784,7 +778,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     ]),
                     $r->identity
                 );
-                if (is_null($problemset->problemset_id)) {
+                if ($problemset->problemset_id === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemsetNotFound'
                     );
@@ -817,9 +811,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                         \OmegaUp\Request::getServerVar('REMOTE_ADDR') ?? ''
                     ),
                     'course_id' => $originalCourse->course_id,
-                    'new_course_id' => !is_null(
-                        $course
-                    ) ? $course->course_id : null,
+                    'new_course_id' => $course !== null ? $course->course_id : null,
                     'token_payload' => json_encode($decodedToken),
                     'timestamp' => \OmegaUp\Time::get(),
                     'user_id' => $r->user->user_id,
@@ -863,11 +855,11 @@ class Course extends \OmegaUp\Controllers\Controller {
         $r->ensureMainUserIdentityIsOver13();
         $courseParams = self::convertRequestToCourseParams($r);
 
-        if (is_null($courseParams->schoolId)) {
+        if ($courseParams->schoolId === null) {
             $school = null;
         } else {
             $school = \OmegaUp\DAO\Schools::getByPK($courseParams->schoolId);
-            if (is_null($school)) {
+            if ($school === null) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'schoolNotFound'
                 );
@@ -877,7 +869,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         // Only curator can set public
         $admissionMode = $r->ensureOptionalString('admission_mode');
         if (
-            !is_null($admissionMode) &&
+            $admissionMode !== null &&
             $admissionMode === self::ADMISSION_MODE_PUBLIC &&
             !\OmegaUp\Authorization::canCreatePublicCourse($r->identity)
         ) {
@@ -922,13 +914,13 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Courses $course,
         \OmegaUp\DAO\VO\Users $creator
     ): \OmegaUp\DAO\VO\Courses {
-        if (is_null($course->alias)) {
+        if ($course->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
-        if (is_null($creator->user_id)) {
+        if ($creator->user_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
-        if (!is_null(\OmegaUp\DAO\Courses::getByAlias($course->alias))) {
+        if (\OmegaUp\DAO\Courses::getByAlias($course->alias) !== null) {
                 $exception = new \OmegaUp\Exceptions\DuplicatedEntryInDatabaseException(
                     'aliasInUse'
                 );
@@ -987,7 +979,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         array $addedProblems = []
     ): \OmegaUp\DAO\VO\Problemsets {
-        if (is_null($assignment->alias)) {
+        if ($assignment->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -1014,7 +1006,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $problemset->assignment_id = $assignment->assignment_id;
             \OmegaUp\DAO\Problemsets::update($problemset);
 
-            if (is_null($problemset->problemset_id)) {
+            if ($problemset->problemset_id === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -1078,7 +1070,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     ): void {
         // Get this problem
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1100,7 +1092,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $currentVersion,
             $identity,
             $problem->languages === '' ? 0 : $assignedPoints,
-            is_null($order) ? 1 : $order,
+            $order === null ? 1 : $order,
             $problemToAdd,
             $shouldValidateVisibility,
             $isExtraProblem
@@ -1117,7 +1109,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         string $assignmentAlias,
         string $notificationType
     ): void {
-        if (is_null($course->group_id) || is_null($course->course_id)) {
+        if ($course->group_id === null || $course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1207,11 +1199,11 @@ class Course extends \OmegaUp\Controllers\Controller {
             'finish_time',
             lowerBound: null,
             upperBound: $course->finish_time?->time,
-            required: !is_null($course->finish_time) || !$unlimitedDuration,
+            required: $course->finish_time !== null || !$unlimitedDuration,
         );
         $publishTimeDelay = $r->ensureOptionalInt('publish_time_delay');
 
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1293,7 +1285,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $unlimitedDuration = $r->ensureOptionalBool(
             'unlimited_duration'
         ) ?? false;
-        if ($unlimitedDuration && !is_null($course->finish_time)) {
+        if ($unlimitedDuration && $course->finish_time !== null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'courseDoesNotHaveUnlimitedDuration',
                 'unlimited_duration'
@@ -1302,23 +1294,17 @@ class Course extends \OmegaUp\Controllers\Controller {
         $startTime = $r->ensureOptionalTimestamp(
             'start_time',
             lowerBound: null,
-            upperBound: is_null(
-                $course->finish_time
-            ) ? null : $course->finish_time->time
+            upperBound: $course->finish_time === null ? null : $course->finish_time->time
         );
         $finishTime = $r->ensureOptionalTimestamp(
             'finish_time',
             lowerBound: null,
-            upperBound: is_null(
-                $course->finish_time
-            ) ? null : $course->finish_time->time,
-            required: !is_null($course->finish_time) || !$unlimitedDuration,
+            upperBound: $course->finish_time === null ? null : $course->finish_time->time,
+            required: $course->finish_time !== null || !$unlimitedDuration,
         );
 
         if (
-            !is_null(
-                $startTime
-            ) && $startTime->time < $course->start_time->time
+            $startTime !== null && $startTime->time < $course->start_time->time
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'courseAssignmentStartDateBeforeCourseStartDate',
@@ -1327,7 +1313,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         if (
-            !is_null($finishTime)
+            $finishTime !== null
             && $finishTime->time < $course->start_time->time
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -1337,11 +1323,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         if (
-            !is_null(
-                $startTime
-            ) && !is_null(
-                $finishTime
-            ) && $startTime->time > $finishTime->time
+            $startTime !== null && $finishTime !== null && $startTime->time > $finishTime->time
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'courseInvalidStartTime',
@@ -1351,9 +1333,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         // Prevent date changes if a course already has runs from students
         if (
-            !is_null(
-                $startTime
-            ) && $startTime->time !== $assignment->start_time->time
+            $startTime !== null && $startTime->time !== $assignment->start_time->time
         ) {
             /** @var list<int> $adminsIds */
             $adminsIds = array_map(
@@ -1362,7 +1342,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     \OmegaUp\DAO\UserRoles::getCourseAdmins(
                         $course
                     ),
-                    fn($admin) => !is_null($admin['user_id']),
+                    fn($admin) => $admin['user_id'] !== null,
                 )
             );
             $runCount = \OmegaUp\DAO\Submissions::countTotalStudentsSubmissionsOfProblemset(
@@ -1382,15 +1362,15 @@ class Course extends \OmegaUp\Controllers\Controller {
             'assignment_type',
         ];
 
-        if (!is_null($startTime)) {
+        if ($startTime !== null) {
             array_push($valueProperties, 'start_time');
         }
-        if (!is_null($finishTime)) {
+        if ($finishTime !== null) {
             array_push($valueProperties, 'finish_time');
         }
         self::updateValueProperties($r, $assignment, $valueProperties);
 
-        if (is_null($course->finish_time) && $unlimitedDuration) {
+        if ($course->finish_time === null && $unlimitedDuration) {
             $assignment->finish_time = null;
         }
         \OmegaUp\DAO\DAO::transBegin();
@@ -1448,7 +1428,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $isExtraProblem = $r->ensureOptionalBool('is_extra_problem') ?? false;
 
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1463,7 +1443,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course->course_id,
             $assignmentAlias
         );
-        if (is_null($problemset) || is_null($problemset->problemset_id)) {
+        if ($problemset === null || $problemset->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -1504,7 +1484,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
         $solutionStatus = \OmegaUp\Controllers\Problem::SOLUTION_NOT_FOUND;
 
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1542,7 +1522,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
         $problems = $r->ensureString('problems');
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1557,7 +1537,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course->course_id,
             $assignmentAlias
         );
-        if (is_null($problemSet) || is_null($problemSet->problemset_id)) {
+        if ($problemSet === null || $problemSet->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -1575,8 +1555,8 @@ class Course extends \OmegaUp\Controllers\Controller {
                 );
 
                 if (
-                    is_null($currentProblem) ||
-                    is_null($currentProblem->problem_id)
+                    $currentProblem === null ||
+                    $currentProblem->problem_id === null
                 ) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemNotFound'
@@ -1620,7 +1600,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             'assignments'
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1644,7 +1624,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
                 if (
                     empty($currentAssignment) ||
-                    is_null($currentAssignment->assignment_id)
+                    $currentAssignment->assignment_id === null
                 ) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'assignmentNotFound'
@@ -1686,7 +1666,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1698,7 +1678,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         // Get this problem
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->problem_id)) {
+        if ($problem === null || $problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1738,7 +1718,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1753,7 +1733,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course->course_id,
             $assignmentAlias
         );
-        if (is_null($problemSet)) {
+        if ($problemSet === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -1761,7 +1741,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         // Get this problem
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1770,7 +1750,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $problemSet->problemset_id,
             $problem->problem_id
         );
-        if (is_null($problemsetProblem)) {
+        if ($problemsetProblem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotPartOfAssignment'
             );
@@ -1816,7 +1796,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1886,7 +1866,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $assignmentAlias,
             $r->identity
         );
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -1901,7 +1881,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course->course_id,
             $assignmentAlias
         );
-        if (is_null($problemset) || is_null($problemset->problemset_id)) {
+        if ($problemset === null || $problemset->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -1914,7 +1894,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 \OmegaUp\DAO\UserRoles::getCourseAdmins(
                     $course
                 ),
-                fn($admin) => !is_null($admin['user_id']),
+                fn($admin) => $admin['user_id'] !== null,
             )
         );
         $runCount = \OmegaUp\DAO\Submissions::countTotalStudentsSubmissionsOfProblemset(
@@ -1976,7 +1956,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      * @return FilteredCourse
      */
     public static function convertCourseToArray(\OmegaUp\DAO\VO\Courses $course): array {
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -2013,7 +1993,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         int $pageSize,
         array $courseTypes = ['admin', 'student', 'public']
     ) {
-        if (is_null($identity->identity_id)) {
+        if ($identity->identity_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         $response = [
@@ -2087,7 +2067,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         if (
@@ -2142,7 +2122,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $targetIdentity = \OmegaUp\DAO\Identities::findByUsername(
             $r['username']
         );
-        if (is_null($targetIdentity) || is_null($targetIdentity->username)) {
+        if ($targetIdentity === null || $targetIdentity->username === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -2153,7 +2133,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course->course_id
         );
 
-        if (is_null($request)) {
+        if ($request === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'userNotInListOfRequests'
             );
@@ -2178,7 +2158,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 ])
             );
 
-            if (!is_null($targetIdentity->user_id)) {
+            if ($targetIdentity->user_id !== null) {
                 if ($request->accepted) {
                     $localizationString = new \OmegaUp\TranslationString(
                         'notificationCourseRegistrationAccepted'
@@ -2212,7 +2192,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'identity_id' => $targetIdentity->identity_id,
                     'share_user_information' => $request->share_user_information,
                 ]);
-                if (!is_null($request->accept_teacher)) {
+                if ($request->accept_teacher !== null) {
                     $groupIdentity->accept_teacher = $request->accept_teacher;
                 }
                 \OmegaUp\DAO\GroupsIdentities::create($groupIdentity);
@@ -2243,7 +2223,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -2282,7 +2262,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -2318,7 +2298,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $assignmentAlias,
             $course->course_id
         );
-        if (is_null($assignment) || is_null($assignment->problemset_id)) {
+        if ($assignment === null || $assignment->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -2338,7 +2318,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Assignments $assignment,
         \OmegaUp\DAO\VO\Identities $resolvedIdentity
     ) {
-        if (is_null($assignment->problemset_id)) {
+        if ($assignment->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -2359,9 +2339,9 @@ class Course extends \OmegaUp\Controllers\Controller {
             foreach ($runsArray as $run) {
                 $run['feedback'] = null;
                 if (
-                    !is_null($run['feedback_author']) &&
-                    !is_null($run['feedback_content']) &&
-                    !is_null($run['feedback_date'])
+                    $run['feedback_author'] !== null &&
+                    $run['feedback_content'] !== null &&
+                    $run['feedback_date'] !== null
                 ) {
                     $run['feedback'] = [
                         'author' => $run['feedback_author'],
@@ -2414,7 +2394,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -2466,7 +2446,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -2479,7 +2459,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $resolvedIdentity = \OmegaUp\Controllers\Identity::resolveIdentity(
             $r['usernameOrEmail']
         );
-        if (is_null($resolvedIdentity->identity_id)) {
+        if ($resolvedIdentity->identity_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         $acceptTeacher = $r->ensureOptionalBool('accept_teacher');
@@ -2493,7 +2473,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             && ($course->admission_mode !== self::ADMISSION_MODE_PUBLIC
             || $resolvedIdentity->identity_id !== $r->identity->identity_id)
             && $course->requests_user_information == 'no'
-            && is_null($acceptTeacher)
+            && $acceptTeacher === null
         ) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
@@ -2504,7 +2484,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             'share_user_information' => $shareUserInformation,
         ]);
 
-        if (!is_null($acceptTeacher)) {
+        if ($acceptTeacher !== null) {
             $groupIdentity->accept_teacher = $acceptTeacher;
         }
 
@@ -2528,7 +2508,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     $r['privacy_git_object_id'],
                     $r['statement_type']
                 );
-                if (is_null($privacyStatementId)) {
+                if ($privacyStatementId === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'privacyStatementNotFound'
                     );
@@ -2564,7 +2544,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     $r['accept_teacher_git_object_id'],
                     'accept_teacher'
                 );
-                if (is_null($privacyStatementId)) {
+                if ($privacyStatementId === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'privacyStatementNotFound'
                     );
@@ -2585,7 +2565,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
             if (
                 $course->admission_mode === self::ADMISSION_MODE_REGISTRATION
-                && !is_null($r->user)
+                && $r->user !== null
             ) {
                 // Pre-accept user
                 self::preAcceptAccessRequest(
@@ -2597,7 +2577,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
             if (
                 $resolvedIdentity->identity_id !== $r->identity->identity_id
-                && !is_null($resolvedIdentity->user_id)
+                && $resolvedIdentity->user_id !== null
             ) {
                 \OmegaUp\Controllers\Notification::setCommonNotification(
                     [$resolvedIdentity->user_id],
@@ -2687,7 +2667,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             'usernameOrEmail'
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->group_id)) {
+        if ($course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -2798,7 +2778,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -2854,7 +2834,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -2870,7 +2850,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         if (
             $resolvedUser->user_id !== $r->identity->user_id
-            && !is_null($resolvedUser->user_id)
+            && $resolvedUser->user_id !== null
         ) {
             \OmegaUp\Controllers\Notification::setCommonNotification(
                 [$resolvedUser->user_id],
@@ -2915,17 +2895,17 @@ class Course extends \OmegaUp\Controllers\Controller {
         $resolvedIdentity = \OmegaUp\Controllers\Identity::resolveIdentity(
             $r['usernameOrEmail']
         );
-        if (is_null($resolvedIdentity->user_id)) {
+        if ($resolvedIdentity->user_id === null) {
             // Unassociated identities can't be course admins
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
         $resolvedUser = \OmegaUp\DAO\Users::getByPK($resolvedIdentity->user_id);
-        if (is_null($resolvedUser)) {
+        if ($resolvedUser === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -2988,14 +2968,14 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3039,14 +3019,14 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3099,7 +3079,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3116,7 +3096,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         if (
             $resolvedUser->user_id !== $r->identity->user_id
-            && !is_null($resolvedUser->user_id)
+            && $resolvedUser->user_id !== null
         ) {
             \OmegaUp\Controllers\Notification::setCommonNotification(
                 [$resolvedUser->user_id],
@@ -3170,14 +3150,14 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3222,14 +3202,14 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3280,18 +3260,18 @@ class Course extends \OmegaUp\Controllers\Controller {
             $username
         );
 
-        if (is_null($resolvedIdentity->user_id)) {
+        if ($resolvedIdentity->user_id === null) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 
         $resolvedUser = \OmegaUp\DAO\Users::getByPK($resolvedIdentity->user_id);
-        if (is_null($resolvedUser)) {
+        if ($resolvedUser === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
 
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3345,7 +3325,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
 
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -3363,7 +3343,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $assignmentAlias,
             intval($course->course_id)
         );
-        if (is_null($assignment) || is_null($assignment->acl_id)) {
+        if ($assignment === null || $assignment->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -3382,7 +3362,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $r->ensureString('guid')
         );
 
-        if (is_null($submission)) {
+        if ($submission === null) {
             throw new \OmegaUp\Exceptions\NotFoundException();
         }
 
@@ -3396,7 +3376,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $assignmentAlias,
             $courseAlias
         );
-        if (is_null($courseSubmissionInfo)) {
+        if ($courseSubmissionInfo === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseSubmissionNotFound'
             );
@@ -3449,7 +3429,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $courseAlias) => \OmegaUp\Validators::alias($courseAlias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         $group = self::resolveGroup($course);
@@ -3479,7 +3459,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 $course->course_id
             );
 
-            if (is_null($registration)) {
+            if ($registration === null) {
                 $registrationResponse = [
                   'userRegistrationAnswered' => false,
                   'userRegistrationRequested' => false,
@@ -3487,9 +3467,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             } else {
                 $registrationResponse = [
                   'userRegistrationAccepted' => $registration->accepted,
-                'userRegistrationAnswered' => !is_null(
-                    $registration->accepted
-                ),
+                'userRegistrationAnswered' => $registration->accepted !== null,
                   'userRegistrationRequested' => true,
                 ];
             }
@@ -3530,7 +3508,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $courseAlias) => \OmegaUp\Validators::alias($courseAlias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         $group = self::resolveGroup($course);
@@ -3540,11 +3518,11 @@ class Course extends \OmegaUp\Controllers\Controller {
             validator: fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
 
-        if (is_null($r->identity)) {
+        if ($r->identity === null) {
             return self::getIntroDetailsForCourse($course);
         }
 
-        if (is_null($assignmentAlias)) {
+        if ($assignmentAlias === null) {
             return self::getCourseDetails($r, $course, $group, false);
         }
 
@@ -3615,16 +3593,16 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
 
         if (
-            is_null($tokenAuthenticationResult['course']->acl_id)
-            || is_null($tokenAuthenticationResult['course']->alias)
+            $tokenAuthenticationResult['course']->acl_id === null
+            || $tokenAuthenticationResult['course']->alias === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
         }
         if (
-            is_null($tokenAuthenticationResult['assignment']->problemset_id)
-            || is_null($tokenAuthenticationResult['assignment']->alias)
+            $tokenAuthenticationResult['assignment']->problemset_id === null
+            || $tokenAuthenticationResult['assignment']->alias === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
@@ -3634,7 +3612,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $director = \OmegaUp\DAO\UserRoles::getOwner(
             $tokenAuthenticationResult['course']->acl_id
         );
-        if (is_null($director)) {
+        if ($director === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
@@ -3755,11 +3733,11 @@ class Course extends \OmegaUp\Controllers\Controller {
                 $token
             )
         );
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         $creator = \OmegaUp\DAO\Courses::getCreatorInformation($course);
-        if (is_null($creator)) {
+        if ($creator === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
@@ -3852,7 +3830,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity
     ) {
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->alias)) {
+        if ($course->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         if (
@@ -3975,7 +3953,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             \OmegaUp\Cache::SCHOOL_STUDENTS_PROGRESS,
             "{$courseAlias}-{$page}-{$length}",
             function () use ($course, $page, $length) {
-                if (is_null($course->course_id) || is_null($course->group_id)) {
+                if ($course->course_id === null || $course->group_id === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'courseNotFound'
                     );
@@ -4049,7 +4027,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             \OmegaUp\Cache::SCHOOL_STUDENTS_PROGRESS,
             "{$courseAlias}-{$page}-{$length}",
             function () use ($course, $page, $length) {
-                if (is_null($course->course_id) || is_null($course->group_id)) {
+                if ($course->course_id === null || $course->group_id === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'courseNotFound'
                     );
@@ -4090,7 +4068,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         $course = self::validateCourseExists($courseAlias);
 
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -4102,7 +4080,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $student
         );
 
-        if (is_null($resolvedIdentity->identity_id)) {
+        if ($resolvedIdentity->identity_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -4168,7 +4146,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         $course = self::validateCourseExists($courseAlias);
 
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -4180,7 +4158,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $student
         );
 
-        if (is_null($resolvedIdentity->identity_id)) {
+        if ($resolvedIdentity->identity_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -4206,7 +4184,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $assignmentAlias,
             $course->course_id
         );
-        if (is_null($assignment) || is_null($assignment->problemset_id)) {
+        if ($assignment === null || $assignment->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -4293,7 +4271,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         ];
         foreach ($courses['admin'] as $course) {
             if (
-                is_null($course['finish_time'])
+                $course['finish_time'] === null
                 || $course['finish_time']->time > \OmegaUp\Time::get()
             ) {
                 $filteredCourses['admin']['filteredCourses']['current']['courses'][] = $course;
@@ -4425,7 +4403,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         $course = self::validateCourseExists($courseAlias);
 
-        if (is_null($course->course_id) || is_null($course->group_id)) {
+        if ($course->course_id === null || $course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -4477,7 +4455,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         );
         $course = self::validateCourseExists($courseAlias);
 
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -4543,7 +4521,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             ];
             foreach ($courses[$courseType] as $course) {
                 if (
-                    is_null($course['finish_time'])
+                    $course['finish_time'] === null
                     || $course['finish_time']->time > \OmegaUp\Time::get()
                 ) {
                     $filteredCourses[$courseType]['filteredCourses']['current']['courses'][] = $course;
@@ -4593,7 +4571,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course->course_id
         );
 
-        if (is_null($registration)) {
+        if ($registration === null) {
             $registrationResponse = [
                 'userRegistrationAnswered' => false,
                 'userRegistrationRequested' => false,
@@ -4601,7 +4579,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         } else {
             $registrationResponse = [
                 'userRegistrationAccepted' => $registration->accepted,
-                'userRegistrationAnswered' => !is_null($registration->accepted),
+                'userRegistrationAnswered' => $registration->accepted !== null,
                 'userRegistrationRequested' => true,
             ];
         }
@@ -4630,7 +4608,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     ): array {
         $r->ensureIdentity();
 
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -4687,7 +4665,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         }
         if (
             $shouldShowIntro
-            || is_null($hasAcceptedTeacher)
+            || $hasAcceptedTeacher === null
             || (
                 !$hasSharedUserInformation
                 && $course->requests_user_information !== 'no'
@@ -4722,7 +4700,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course,
             $assignmentAlias
         );
-        if (is_null($assignment->problemset_id)) {
+        if ($assignment->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -4789,7 +4767,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $director = \OmegaUp\DAO\UserRoles::getOwner(
             intval($course->acl_id)
         );
-        if (is_null($director)) {
+        if ($director === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
@@ -4817,7 +4795,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'payload' => [
                     'isTeachingAssistant' => $isTeachingAssistant,
                     'shouldShowFirstAssociatedIdentityRunWarning' => (
-                        !is_null($currentUser) &&
+                        $currentUser !== null &&
                         !\OmegaUp\Controllers\User::isMainIdentity(
                             $currentUser,
                             $currentIdentity
@@ -4908,7 +4886,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course,
             $assignmentAlias
         );
-        if (is_null($assignment->problemset_id)) {
+        if ($assignment->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -4990,9 +4968,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'course' => [
                         'alias' => strval($course->alias),
                         'name' => strval($course->name),
-                        'languages' => !is_null(
-                            $course->languages
-                        ) ? explode(
+                        'languages' => $course->languages !== null ? explode(
                             ',',
                             $course->languages
                         ) : null,
@@ -5039,14 +5015,14 @@ class Course extends \OmegaUp\Controllers\Controller {
             required: false,
             validator: fn (string $alias) => \OmegaUp\Validators::alias($alias),
         );
-        if (is_null($problemAlias)) {
+        if ($problemAlias === null) {
             return $response;
         }
 
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             intval($assignment->problemset_id)
         );
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
@@ -5056,7 +5032,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $problemAlias,
             intval($problemset->problemset_id)
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -5073,7 +5049,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             preventProblemsetOpen: false,
             contestAlias: null,
         );
-        if (is_null($problemDetails)) {
+        if ($problemDetails === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -5194,7 +5170,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         array $registrationResponse = []
     ): array {
         if (
-            is_null($identity) &&
+            $identity === null &&
             $shouldShowIntro &&
             $course->admission_mode === self::ADMISSION_MODE_PRIVATE
         ) {
@@ -5207,7 +5183,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $needsBasicInformation = false;
         $privacyStatementMarkdown = null;
         $statements = [];
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             $markdown = \OmegaUp\PrivacyStatement::getForConsent(
                 $identity->language_id,
                 'accept_teacher'
@@ -5215,7 +5191,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $teacherStatement = \OmegaUp\DAO\PrivacyStatements::getLatestPublishedStatement(
                 'accept_teacher'
             );
-            if (is_null($teacherStatement)) {
+            if ($teacherStatement === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'courseNotFound'
                 );
@@ -5228,9 +5204,9 @@ class Course extends \OmegaUp\Controllers\Controller {
             $needsBasicInformation = (
                 $courseDetails['needs_basic_information']
                 && (
-                    is_null($identity->country_id)
-                    || is_null($identity->state_id)
-                    || is_null($identity->current_identity_school_id)
+                    $identity->country_id === null
+                    || $identity->state_id === null
+                    || $identity->current_identity_school_id === null
                 )
             );
 
@@ -5240,13 +5216,13 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'course',
                 $requestUserInformation
             );
-            if (!is_null($privacyStatementMarkdown)) {
+            if ($privacyStatementMarkdown !== null) {
                 $statementType = "course_{$requestUserInformation}_consent";
                 $statement =
                     \OmegaUp\DAO\PrivacyStatements::getLatestPublishedStatement(
                         $statementType
                     );
-                if (!is_null($statement)) {
+                if ($statement !== null) {
                     $statements['privacy'] = [
                         'markdown' => $privacyStatementMarkdown,
                         'statementType' => $statementType,
@@ -5388,18 +5364,18 @@ class Course extends \OmegaUp\Controllers\Controller {
         $isAdmin = false;
         $isCurator = false;
         $isTeachingAssistant = false;
-        if (is_null($course->group_id)) {
+        if ($course->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
         }
         $group = \OmegaUp\DAO\Groups::getByPK($course->group_id);
-        if (is_null($group) || is_null($group->group_id)) {
+        if ($group === null || $group->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseGroupNotFound'
             );
         }
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             $isAdmin = \OmegaUp\Authorization::isCourseAdmin(
                 $identity,
                 $course
@@ -5420,7 +5396,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                 $identity
             ),
             'clarifications' => (
-                is_null($identity)
+                $identity === null
                 ? []
                 : \OmegaUp\DAO\Clarifications::getProblemsetClarifications(
                     contest: null,
@@ -5440,9 +5416,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             'school_id' => $course->school_id,
             'school_name' => null,
             'start_time' => $course->start_time,
-            'languages' => !is_null(
-                $course->languages
-            ) ? explode(
+            'languages' => $course->languages !== null ? explode(
                 ',',
                 $course->languages
             ) : null,
@@ -5467,9 +5441,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                     $group->group_id
                 );
         }
-        if (!is_null($course->school_id)) {
+        if ($course->school_id !== null) {
             $school = \OmegaUp\DAO\Schools::getByPK($course->school_id);
-            if (!is_null($school)) {
+            if ($school !== null) {
                 $result['school_name'] = $school->name;
                 $result['school_id'] = $school->school_id;
             }
@@ -5520,7 +5494,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -5566,7 +5540,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $course = self::validateCourseExists($courseAlias);
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -5598,7 +5572,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         ?string $token,
         \OmegaUp\Request $r
     ): array {
-        if (is_null($token)) {
+        if ($token === null) {
             $r->ensureIdentity();
             [
                 'course' => $course,
@@ -5628,7 +5602,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $course,
             $assignmentAlias
         );
-        if (is_null($assignment->assignment_id)) {
+        if ($assignment->assignment_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -5637,7 +5611,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $assignmentProblemset = \OmegaUp\DAO\Assignments::getByIdWithScoreboardUrls(
             $assignment->assignment_id
         );
-        if (is_null($assignmentProblemset)) {
+        if ($assignmentProblemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -5671,14 +5645,14 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity
     ): array {
         $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course) || is_null($course->course_id)) {
+        if ($course === null || $course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
         $assignment = \OmegaUp\DAO\Assignments::getByAliasAndCourse(
             $assignmentAlias,
             $course->course_id
         );
-        if (is_null($assignment) || is_null($assignment->acl_id)) {
+        if ($assignment === null || $assignment->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -5738,16 +5712,16 @@ class Course extends \OmegaUp\Controllers\Controller {
             $r
         );
         if (
-            is_null($tokenAuthenticationResult['course']->acl_id)
-            || is_null($tokenAuthenticationResult['course']->alias)
+            $tokenAuthenticationResult['course']->acl_id === null
+            || $tokenAuthenticationResult['course']->alias === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
         }
         if (
-            is_null($tokenAuthenticationResult['assignment']->problemset_id)
-            || is_null($tokenAuthenticationResult['assignment']->alias)
+            $tokenAuthenticationResult['assignment']->problemset_id === null
+            || $tokenAuthenticationResult['assignment']->alias === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
@@ -5757,7 +5731,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         $director = \OmegaUp\DAO\UserRoles::getOwner(
             $tokenAuthenticationResult['course']->acl_id
         );
-        if (is_null($director)) {
+        if ($director === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
@@ -5820,8 +5794,8 @@ class Course extends \OmegaUp\Controllers\Controller {
             $problem['accepts_submissions'] = !empty($problem['languages']);
 
             if (
-                is_null($identity)
-                || is_null($identity->identity_id)
+                $identity === null
+                || $identity->identity_id === null
             ) {
                 $nominationStatus = [
                     'solved' => false,
@@ -5855,12 +5829,12 @@ class Course extends \OmegaUp\Controllers\Controller {
                     )
                 );
                 $nominationStatus['language'] = (
-                    !is_null($problemStatement) ?
+                    $problemStatement !== null ?
                     $problemStatement['language'] :
                     'es'
                 );
             }
-            $nominationStatus['canNominateProblem'] = !is_null($user);
+            $nominationStatus['canNominateProblem'] = $user !== null;
             $nominationStatus['problemAlias'] = $problem['alias'];
             $problem['quality_payload'] = $nominationStatus;
             unset($problem['problem_id']);
@@ -5919,7 +5893,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $username
         );
 
-        if (is_null($assignment->problemset_id)) {
+        if ($assignment->problemset_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -5936,9 +5910,9 @@ class Course extends \OmegaUp\Controllers\Controller {
                 'verdict',
                 \OmegaUp\Controllers\Run::VERDICTS
             ),
-            !is_null($problem) ? $problem->problem_id : null,
+            $problem !== null ? $problem->problem_id : null,
             $r->ensureOptionalEnum('language', $languages),
-            !is_null($identity) ? $identity->identity_id : null,
+            $identity !== null ? $identity->identity_id : null,
             max($r->ensureOptionalInt('offset') ?? 0, 0),
             $r->ensureOptionalInt('rowcount') ?? 100,
             $r->ensureOptionalEnum(
@@ -5969,7 +5943,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     ): array {
         $course = self::validateCourseExists($courseAlias);
 
-        if (is_null($course->course_id)) {
+        if ($course->course_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 
@@ -5977,7 +5951,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $assignmentAlias,
             $course->course_id
         );
-        if (is_null($assignment)) {
+        if ($assignment === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'assignmentNotFound'
             );
@@ -5996,9 +5970,9 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         // Check filter by problem, is optional
         $problem = null;
-        if (!is_null($problemAlias)) {
+        if ($problemAlias !== null) {
             $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-            if (is_null($problem)) {
+            if ($problem === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -6007,7 +5981,7 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         // Get user if we have something in username
         $identity = null;
-        if (!is_null($username)) {
+        if ($username !== null) {
             $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
                 $username
             );
@@ -6401,7 +6375,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             ),
             intval($assignment->problemset_id)
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -6524,7 +6498,7 @@ class Course extends \OmegaUp\Controllers\Controller {
             $r['token'],
             $r
         );
-        if (is_null($tokenAuthenticationResult['course']->group_id)) {
+        if ($tokenAuthenticationResult['course']->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
         }
 

--- a/frontend/server/src/Controllers/Group.php
+++ b/frontend/server/src/Controllers/Group.php
@@ -112,7 +112,7 @@ class Group extends \OmegaUp\Controllers\Controller {
         );
 
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'
@@ -138,7 +138,7 @@ class Group extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity
     ): ?\OmegaUp\DAO\VO\Groups {
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group)) {
+        if ($group === null) {
             return null;
         }
 
@@ -165,7 +165,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::namespacedAlias($alias)
         );
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'
@@ -215,7 +215,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::namespacedAlias($alias)
         );
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'
@@ -234,7 +234,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             $group->group_id,
             $resolvedIdentity->identity_id
         );
-        if (is_null($groupIdentities)) {
+        if ($groupIdentities === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'User'
@@ -300,7 +300,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::namespacedAlias($alias)
         );
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('groupNotFound');
         }
 
@@ -347,7 +347,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::namespacedAlias($alias)
         );
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'
@@ -378,7 +378,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::namespacedAlias($alias)
         );
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'
@@ -424,7 +424,7 @@ class Group extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::namespacedAlias($alias)
         );
         $group = self::validateGroupAndOwner($groupAlias, $r->identity);
-        if (is_null($group) || is_null($group->group_id)) {
+        if ($group === null || $group->group_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -29,7 +29,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
         $scoreboard = \OmegaUp\DAO\GroupsScoreboards::getByAlias(
             $scoreboardAlias
         );
-        if (is_null($scoreboard)) {
+        if ($scoreboard === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'Scoreboard'
@@ -55,7 +55,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
         );
 
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest)) {
+        if ($contest === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'Contest'
@@ -302,7 +302,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
             $groupAlias,
             $r->identity
         );
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'group_alias'

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -19,11 +19,11 @@ class Identity extends \OmegaUp\Controllers\Controller {
             'usernameOrEmail'
         );
         $identity = \OmegaUp\DAO\Identities::findByUsername($userOrEmail);
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             return $identity;
         }
         $identity = \OmegaUp\DAO\Identities::findByEmail($userOrEmail);
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             return $identity;
         }
         $exception = new \OmegaUp\Exceptions\NotFoundException(
@@ -43,7 +43,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         string $password
     ): bool {
-        if (is_null($identity->password)) {
+        if ($identity->password === null) {
             // The user had logged in through a third-party account.
             throw new \OmegaUp\Exceptions\LoginDisabledException(
                 'loginThroughThirdParty'
@@ -81,7 +81,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
         $group = self::validateGroupOwnership($r);
-        if (is_null($group->alias)) {
+        if ($group->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'groupNotFound'
             );
@@ -125,7 +125,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
             );
 
             $state = null;
-            if (!is_null($countryId) && !is_null($stateId)) {
+            if ($countryId !== null && $stateId !== null) {
                 $state = \OmegaUp\DAO\States::getByPK(
                     $countryId,
                     $stateId
@@ -180,7 +180,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
      */
     public static function apiBulkCreate(\OmegaUp\Request $r): array {
         $group = self::validateGroupOwnership($r);
-        if (is_null($group->alias)) {
+        if ($group->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'groupNotFound'
             );
@@ -266,7 +266,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
                         128
                     );
                     $state = null;
-                    if (!is_null($countryId) && !is_null($stateId)) {
+                    if ($countryId !== null && $stateId !== null) {
                         $state = \OmegaUp\DAO\States::getByPK(
                             $countryId,
                             $stateId
@@ -283,7 +283,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
                     $group
                 );
 
-                if (!is_null($schoolId)) {
+                if ($schoolId !== null) {
                     // Create IdentitySchool
                     $identitySchool = new \OmegaUp\DAO\VO\IdentitiesSchools([
                         'identity_id' => $newIdentity->identity_id,
@@ -333,13 +333,13 @@ class Identity extends \OmegaUp\Controllers\Controller {
             $teamGroupAlias,
             $r->identity
         );
-        if (is_null($teamGroup)) {
+        if ($teamGroup === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'groupNotFound'
             );
         }
 
-        if (is_null($teamGroup->alias)) {
+        if ($teamGroup->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'groupNotFound'
             );
@@ -434,7 +434,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
                 );
 
                 $state = null;
-                if (!is_null($countryId) && !is_null($stateId)) {
+                if ($countryId !== null && $stateId !== null) {
                     $state = \OmegaUp\DAO\States::getByPK(
                         $countryId,
                         $stateId
@@ -451,8 +451,8 @@ class Identity extends \OmegaUp\Controllers\Controller {
                 );
 
                 if (
-                    !is_null($teamIdentity['identityUsernames'])
-                    && !is_null($team->team_id)
+                    $teamIdentity['identityUsernames'] !== null
+                    && $team->team_id !== null
                 ) {
                     /** @var list<array{password: string, username: string}> $selfGeneratedIdentities */
                     $selfGeneratedIdentities = array_filter(
@@ -476,7 +476,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
                         $preexistingIdentity = \OmegaUp\DAO\Identities::findByUsername(
                             $selfGeneratedIdentity['username']
                         );
-                        if (is_null($preexistingIdentity)) {
+                        if ($preexistingIdentity === null) {
                             \OmegaUp\DAO\Identities::create($newIdentity);
                         } else {
                             $preexistingIdentity->password = $newIdentity->password;
@@ -505,7 +505,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
                     $schoolId
                 );
 
-                if (is_null($preexistingIdentitySchool)) {
+                if ($preexistingIdentitySchool === null) {
                     // Create IdentitySchool
                     $identitySchool = new \OmegaUp\DAO\VO\IdentitiesSchools([
                         'identity_id' => $newIdentity->identity_id,
@@ -537,7 +537,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         ?string &$name,
         ?string &$gender
     ): void {
-        if (!is_null($name)) {
+        if ($name !== null) {
             $name = trim($name);
             \OmegaUp\Validators::validateLengthInRange(
                 $name,
@@ -547,7 +547,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        if (!is_null($gender)) {
+        if ($gender !== null) {
             $gender = trim($gender);
         }
         if (!empty($gender)) {
@@ -621,20 +621,18 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $originalIdentity = self::resolveIdentity($originalUsername);
 
         $originalSchoolId = null;
-        if (!is_null($originalIdentity->current_identity_school_id)) {
+        if ($originalIdentity->current_identity_school_id !== null) {
             $originalIdentitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
                 $originalIdentity->current_identity_school_id
             );
-            $originalSchoolId = !is_null(
-                $originalIdentitySchool
-            ) ? $originalIdentitySchool->school_id : null;
+            $originalSchoolId = $originalIdentitySchool !== null ? $originalIdentitySchool->school_id : null;
         }
 
         // Prepare DAOs
         $state = null;
         $countryId = $r->ensureOptionalString('country_id');
         $stateId = $r->ensureOptionalString('state_id');
-        if (!is_null($countryId) && !is_null($stateId)) {
+        if ($countryId !== null && $stateId !== null) {
             $state = \OmegaUp\DAO\States::getByPK($countryId, $stateId);
         }
         self::validateIdentityTeam($username, $name, $gender, $groupAlias);
@@ -722,7 +720,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
             $groupAlias,
             $r->identity
         );
-        if (is_null($group)) {
+        if ($group === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'groupNotFound'
             );
@@ -752,12 +750,8 @@ class Identity extends \OmegaUp\Controllers\Controller {
         return new \OmegaUp\DAO\VO\Identities([
             'username' => $username,
             'name' => $name ?? $originalIdentity->name,
-            'country_id' => !is_null(
-                $state
-            ) ? $state->country_id : $originalIdentity->country_id,
-            'state_id' => !is_null(
-                $state
-            ) ? $state->state_id : $originalIdentity->state_id,
+            'country_id' => $state !== null ? $state->country_id : $originalIdentity->country_id,
+            'state_id' => $state !== null ? $state->state_id : $originalIdentity->state_id,
             'gender' => $gender ?? $originalIdentity->gender,
             'current_identity_school_id' => $originalIdentity->current_identity_school_id,
             'password' => $originalIdentity->password,
@@ -773,19 +767,19 @@ class Identity extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Groups $group
     ): void {
-        if (is_null($identity->username)) {
+        if ($identity->username === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
         }
-        if (is_null($identity->country_id) && !is_null($identity->state_id)) {
+        if ($identity->country_id === null && $identity->state_id !== null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterInvalidStateNeedsToBelongToCountry',
                 $identity->username
             );
         } elseif (
-            !is_null($identity->country_id)
-            && !is_null($identity->state_id)
+            $identity->country_id !== null
+            && $identity->state_id !== null
         ) {
             $countryStates = \OmegaUp\DAO\States::getByCountry(
                 $identity->country_id
@@ -807,7 +801,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $preexistingIdentity = \OmegaUp\DAO\Identities::findByUsername(
             $identity->username
         );
-        if (is_null($preexistingIdentity)) {
+        if ($preexistingIdentity === null) {
             \OmegaUp\DAO\Identities::create($identity);
         } else {
             $identity->identity_id = $preexistingIdentity->identity_id;
@@ -829,20 +823,20 @@ class Identity extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\TeamGroups $teamGroup
     ): \OmegaUp\DAO\VO\Teams {
-        if (is_null($identity->username)) {
+        if ($identity->username === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
         }
-        if (is_null($identity->country_id) && !is_null($identity->state_id)) {
+        if ($identity->country_id === null && $identity->state_id !== null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterInvalidStateNeedsToBelongToCountry',
                 $identity->username
             );
         }
         if (
-            !is_null($identity->country_id)
-            && !is_null($identity->state_id)
+            $identity->country_id !== null
+            && $identity->state_id !== null
         ) {
             $countryStates = \OmegaUp\DAO\States::getByCountry(
                 $identity->country_id
@@ -864,7 +858,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $preexistingIdentity = \OmegaUp\DAO\Identities::findByUsername(
             $identity->username
         );
-        if (is_null($preexistingIdentity)) {
+        if ($preexistingIdentity === null) {
             \OmegaUp\DAO\Identities::create($identity);
         } else {
             $identity->identity_id = $preexistingIdentity->identity_id;
@@ -877,7 +871,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
             'team_group_id' => $teamGroup->team_group_id,
             'identity_id' => $identity->identity_id,
         ]);
-        if (is_null($preexistingTeam)) {
+        if ($preexistingTeam === null) {
             \OmegaUp\DAO\Teams::create($team);
             return $team;
         }
@@ -920,20 +914,18 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $originalIdentity = self::resolveIdentity($originalUsername);
 
         $originalSchoolId = null;
-        if (!is_null($originalIdentity->current_identity_school_id)) {
+        if ($originalIdentity->current_identity_school_id !== null) {
             $originalIdentitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
                 $originalIdentity->current_identity_school_id
             );
-            $originalSchoolId = !is_null(
-                $originalIdentitySchool
-            ) ? $originalIdentitySchool->school_id : null;
+            $originalSchoolId = $originalIdentitySchool !== null ? $originalIdentitySchool->school_id : null;
         }
 
         // Prepare DAOs
         $state = null;
         $countryId = $r->ensureOptionalString('country_id');
         $stateId = $r->ensureOptionalString('state_id');
-        if (!is_null($countryId) && !is_null($stateId)) {
+        if ($countryId !== null && $stateId !== null) {
             $state = \OmegaUp\DAO\States::getByPK($countryId, $stateId);
         }
         self::validateIdentity($username, $name, $gender, $groupAlias);
@@ -1157,7 +1149,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         bool $omitRank,
         string $category = 'all'
     ): array {
-        if (is_null($identity->username)) {
+        if ($identity->username === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'username'
@@ -1168,7 +1160,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
             $identity->username,
             /** @return array{birth_date?: \OmegaUp\Timestamp|null, classname: null|string, country: null|string, country_id: null|string, email?: null|string, gender?: null|string, graduation_date: \OmegaUp\Timestamp|null, gravatar_92: null|string, has_competitive_objective: bool|null, has_learning_objective: bool|null, has_scholar_objective: bool|null, has_teaching_objective: bool|null, hide_problem_tags: bool, is_own_profile: bool, is_private: bool, locale: string, name: null|string, preferred_language: null|string, scholar_degree: null|string, school: null|string, school_id: int|null, state: null|string, state_id: null|string, username: null|string, verified: bool|null} */
             function () use ($identity, $user) {
-                if (!is_null($user)) {
+                if ($user !== null) {
                     return \OmegaUp\Controllers\User::getProfileImpl(
                         $user,
                         $identity
@@ -1195,7 +1187,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
         // Do not leak plain emails, birth dates, genders and user's objectives in case the request is for a profile other than
         // the logged identity's one. Admins can see emails, birth dates, genders and user's objectives
         if (
-            !is_null($loggedIdentity)
+            $loggedIdentity !== null
             && (\OmegaUp\Authorization::isSystemAdmin($loggedIdentity)
                 || $identity->identity_id === $loggedIdentity->identity_id)
         ) {
@@ -1211,7 +1203,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
 
         // Mentors can see current coder of the month email.
         if (
-            !is_null($loggedIdentity)
+            $loggedIdentity !== null
             && \OmegaUp\Authorization::canViewEmail($loggedIdentity)
             && \OmegaUp\DAO\CoderOfTheMonth::isLastCoderOfTheMonth(
                 $identity->username,
@@ -1233,15 +1225,15 @@ class Identity extends \OmegaUp\Controllers\Controller {
         $extendedProfile = \OmegaUp\DAO\Identities::getExtendedProfileDataByPk(
             $identity->identity_id
         );
-        if (is_null($extendedProfile)) {
+        if ($extendedProfile === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         $schoolId = null;
-        if (!is_null($identity->current_identity_school_id)) {
+        if ($identity->current_identity_school_id !== null) {
             $identitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
                 $identity->current_identity_school_id
             );
-            if (!is_null($identitySchool)) {
+            if ($identitySchool !== null) {
                 $schoolId = $identitySchool->school_id;
             }
         }
@@ -1288,7 +1280,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
     ): string {
         // for quick debugging
         $requestLanguage = (
-            !is_null($request) ?
+            $request !== null ?
             $request->ensureOptionalString('lang') :
             null
         );
@@ -1301,11 +1293,11 @@ class Identity extends \OmegaUp\Controllers\Controller {
         }
 
         try {
-            if (!is_null($identity) && !is_null($identity->language_id)) {
+            if ($identity !== null && $identity->language_id !== null) {
                 $result = \OmegaUp\DAO\Languages::getByPK(
                     $identity->language_id
                 );
-                if (is_null($result) || is_null($result->name)) {
+                if ($result === null || $result->name === null) {
                     self::$log->warning('Invalid language id for identity');
                 } else {
                     return \OmegaUp\Controllers\Identity::convertToSupportedLanguage(

--- a/frontend/server/src/Controllers/Notification.php
+++ b/frontend/server/src/Controllers/Notification.php
@@ -99,7 +99,7 @@ class Notification extends \OmegaUp\Controllers\Controller {
         /** @var list<Notification> */
         $notifications = [];
         foreach (
-            is_null($r->user) ?
+            $r->user === null ?
             [] :
             \OmegaUp\DAO\Notifications::getUnreadNotifications($r->user) as $notification
         ) {
@@ -144,7 +144,7 @@ class Notification extends \OmegaUp\Controllers\Controller {
         }
         foreach ($notifications as $id) {
             $notification = \OmegaUp\DAO\Notifications::getByPK($id);
-            if (is_null($notification)) {
+            if ($notification === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'notificationNotFound'
                 );

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -160,81 +160,81 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 fn (string $alias) => \OmegaUp\Validators::alias($alias)
             ),
         ];
-        if (!is_null($r['email_clarifications'])) {
+        if ($r['email_clarifications'] !== null) {
             $params['email_clarifications'] = $r->ensureOptionalBool(
                 'email_clarifications'
             ) ?? false;
         }
-        if (!is_null($r['extra_wall_time'])) {
+        if ($r['extra_wall_time'] !== null) {
             $params['extra_wall_time'] = $r->ensureOptionalInt(
                 'extra_wall_time'
             ) ?? 0;
         }
-        if (!is_null($r['input_limit'])) {
+        if ($r['input_limit'] !== null) {
             $params['input_limit'] = $r->ensureOptionalInt('input_limit') ?? 0;
         }
         $languages = $r->ensureOptionalString('languages');
-        if (!is_null($languages)) {
+        if ($languages !== null) {
             $params['languages'] = $languages;
         }
-        if (!is_null($r['memory_limit'])) {
+        if ($r['memory_limit'] !== null) {
             $params['memory_limit'] = $r->ensureOptionalInt('memory_limit');
         }
-        if (!is_null($r['output_limit'])) {
+        if ($r['output_limit'] !== null) {
             $params['output_limit'] = $r->ensureOptionalInt('output_limit');
         }
-        if (!is_null($r['overall_wall_time_limit'])) {
+        if ($r['overall_wall_time_limit'] !== null) {
             $params['overall_wall_time_limit'] = $r->ensureOptionalInt(
                 'overall_wall_time_limit'
             );
         }
         $problemLevel = $r->ensureOptionalString('problem_level');
-        if (!is_null($problemLevel)) {
+        if ($problemLevel !== null) {
             $params['problem_level'] = $problemLevel;
         }
         $selectedTags = $r->ensureOptionalString('selected_tags');
-        if (!is_null($selectedTags)) {
+        if ($selectedTags !== null) {
             $params['selected_tags'] = $selectedTags;
         }
         $source = $r->ensureOptionalString('source');
-        if (!is_null($source)) {
+        if ($source !== null) {
             $params['source'] = $source;
         }
-        if (!is_null($r['time_limit'])) {
+        if ($r['time_limit'] !== null) {
             $params['time_limit'] = $r->ensureOptionalInt('time_limit');
         }
         $title = $r->ensureOptionalString('title');
-        if (!is_null($title)) {
+        if ($title !== null) {
             $params['title'] = $title;
         }
         $updatePublished = $r->ensureOptionalString('update_published');
-        if (!is_null($updatePublished)) {
+        if ($updatePublished !== null) {
             $params['update_published'] = $updatePublished;
         }
         $validator = $r->ensureOptionalString('validator');
-        if (!is_null($validator)) {
+        if ($validator !== null) {
             $params['validator'] = $validator;
         }
-        if (!is_null($r['validator_time_limit'])) {
+        if ($r['validator_time_limit'] !== null) {
             $params['validator_time_limit'] = $r->ensureOptionalInt(
                 'validator_time_limit'
             );
         }
         $visibility = $r->ensureOptionalString('visibility');
-        if (!is_null($visibility)) {
+        if ($visibility !== null) {
             $params['visibility'] = \OmegaUp\ProblemParams::stringVisibilityToNumeric(
                 $visibility
             );
         }
         $showDiff = $r->ensureOptionalString('show_diff');
-        if (!is_null($showDiff)) {
+        if ($showDiff !== null) {
             $params['show_diff'] = $showDiff;
         }
         $groupScorePolicy = $r->ensureOptionalString('group_score_policy');
-        if (!is_null($groupScorePolicy)) {
+        if ($groupScorePolicy !== null) {
             $params['group_score_policy'] = $groupScorePolicy;
         }
-        if (!is_null($r['allow_user_add_tags'])) {
+        if ($r['allow_user_add_tags'] !== null) {
             $params['allow_user_add_tags'] = $r->ensureOptionalBool(
                 'allow_user_add_tags'
             ) ?? false;
@@ -264,7 +264,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // In case of update, params are optional
         if (!$isRequired) {
             $problem = \OmegaUp\DAO\Problems::getByAlias($params->problemAlias);
-            if (is_null($problem)) {
+            if ($problem === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -284,7 +284,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             if (
                 ($problem->visibility === \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_BANNED ||
                   $problem->visibility === \OmegaUp\ProblemParams::VISIBILITY_PRIVATE_BANNED) &&
-                    !is_null($params->visibility) &&
+                    $params->visibility !== null &&
                     $problem->visibility !== $params->visibility &&
                     !\OmegaUp\Authorization::isQualityReviewer($identity)
             ) {
@@ -296,7 +296,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             if (
                 ($problem->visibility === \OmegaUp\ProblemParams::VISIBILITY_PUBLIC_WARNING ||
                   $problem->visibility === \OmegaUp\ProblemParams::VISIBILITY_PRIVATE_WARNING) &&
-                    !is_null($params->visibility) &&
+                    $params->visibility !== null &&
                     $problem->visibility !== $params->visibility &&
                     !\OmegaUp\Authorization::isQualityReviewer($identity)
             ) {
@@ -322,7 +322,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             }
 
             if (
-                !is_null($params->visibility)
+                $params->visibility !== null
                 && $problem->visibility !== $params->visibility
             ) {
                 if ($problem->visibility === \OmegaUp\ProblemParams::VISIBILITY_PROMOTED) {
@@ -355,7 +355,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 );
             }
             /** @var list<array{tagname: string, public: bool}>|null */
-            $selectedTags = !is_null($params->selectedTagsAsJSON) ? json_decode(
+            $selectedTags = $params->selectedTagsAsJSON !== null ? json_decode(
                 $params->selectedTagsAsJSON,
                 associative: true
             ) : null;
@@ -367,7 +367,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 );
             }
             $hasPublicTags = false;
-            if (!is_null($selectedTags)) {
+            if ($selectedTags !== null) {
                 foreach ($selectedTags as $tag) {
                     if (!$hasPublicTags) {
                         $hasPublicTags = boolval($tag['public']);
@@ -407,7 +407,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             null,
             $isRequired
         );
-        if (!is_null($params->languages)) {
+        if ($params->languages !== null) {
             $languages = explode(',', $params->languages);
             \OmegaUp\Validators::validateValidSubset(
                 $languages,
@@ -544,7 +544,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\Problems::create($problem);
 
             // Add tags
-            if (!is_null($selectedTags)) {
+            if ($selectedTags !== null) {
                 foreach ($selectedTags as $tag) {
                     $tagName = \OmegaUp\Controllers\Tag::normalize(
                         $tag['tagname']
@@ -560,7 +560,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $tag = \OmegaUp\DAO\Tags::getByName($params->problemLevel);
 
             if (
-                is_null($tag) ||
+                $tag === null ||
                 !in_array(
                     $tag->name,
                     \OmegaUp\Controllers\Tag::getLevelTags()
@@ -642,12 +642,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $user = \OmegaUp\Controllers\User::resolveUser($r['usernameOrEmail']);
-        if (is_null($user->user_id)) {
+        if ($user->user_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->acl_id)) {
+        if ($problem === null || $problem->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -688,7 +688,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->acl_id)) {
+        if ($problem === null || $problem->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -697,7 +697,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group) || is_null($group->group_id)) {
+        if ($group === null || $group->group_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('groupNotFound');
         }
 
@@ -714,7 +714,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $identity = \OmegaUp\DAO\Identities::getByPK(
                 $row['identity_id']
             );
-            if (is_null($identity)) {
+            if ($identity === null) {
                 continue;
             }
             self::invalidateProblemsAclCacheForIdentity($identity);
@@ -744,7 +744,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $r->ensureIdentity();
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -757,7 +757,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $tag = \OmegaUp\DAO\Tags::getByName($r['level_tag']);
 
             if (
-                is_null($tag) ||
+                $tag === null ||
                 !in_array(
                     $tag->name,
                     \OmegaUp\Controllers\Tag::getLevelTags()
@@ -807,7 +807,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $isPublic = $r->ensureOptionalBool('public') ?? false;
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -844,7 +844,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         $tag = \OmegaUp\DAO\Tags::getByName($tagName);
-        if (is_null($tag)) {
+        if ($tag === null) {
             if (in_array($tagName, self::RESTRICTED_TAG_NAMES)) {
                 $tag = new \OmegaUp\DAO\VO\Tags([
                     'name' => $tagName,
@@ -908,12 +908,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
             $r['usernameOrEmail']
         );
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->acl_id)) {
+        if ($problem === null || $problem->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -960,7 +960,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->acl_id)) {
+        if ($problem === null || $problem->acl_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -969,7 +969,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $group) => \OmegaUp\Validators::alias($group)
         );
         $group = \OmegaUp\DAO\Groups::findByAlias($groupAlias);
-        if (is_null($group) || is_null($group->group_id)) {
+        if ($group === null || $group->group_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidParameters'
             );
@@ -987,7 +987,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $identity = \OmegaUp\DAO\Identities::getByPK(
                 $row['identity_id']
             );
-            if (is_null($identity)) {
+            if ($identity === null) {
                 continue;
             }
             self::invalidateProblemsAclCacheForIdentity($identity);
@@ -1026,12 +1026,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
         $tag = \OmegaUp\DAO\Tags::getByName($tagName);
-        if (is_null($tag)) {
+        if ($tag === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('tagNotFound');
         }
 
@@ -1076,7 +1076,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->problem_id)) {
+        if ($problem === null || $problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1114,7 +1114,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1148,7 +1148,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
         $includeVoted = ($r['include_voted'] == 'true');
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1178,7 +1178,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         if ($problem->deprecated) {
@@ -1518,7 +1518,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $params,
             isRequired: false
         );
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -1610,7 +1610,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 );
 
                 $needsUpdate = false;
-                if (!is_null($problemDeployer->publishedCommit)) {
+                if ($problemDeployer->publishedCommit !== null) {
                     $oldCommit = $problem->commit;
                     $oldVersion = $problem->current_version;
                     [
@@ -1700,7 +1700,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $response['problem'] = \OmegaUp\DAO\Problems::getByAlias(
             $params->problemAlias
         );
-        if (is_null($response['problem'])) {
+        if ($response['problem'] === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -1785,12 +1785,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'lang',
             \OmegaUp\Controllers\Problem::ISO639_1
         );
-        if (is_null($lang)) {
+        if ($lang === null) {
             $lang = \OmegaUp\Controllers\Identity::getPreferredLanguage(
                 $identity
             );
         }
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -1874,7 +1874,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -1967,7 +1967,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $problemParams,
             isRequired: false
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -2078,7 +2078,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ];
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             return $response;
         }
 
@@ -2097,8 +2097,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $response['problem'] = $problem;
 
-        if (!is_null($problemset) && isset($problemset['problemset'])) {
-            if (is_null($identity)) {
+        if ($problemset !== null && isset($problemset['problemset'])) {
+            if ($identity === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
             }
             if (
@@ -2148,7 +2148,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     );
 
                     if (
-                        !is_null($assignment)
+                        $assignment !== null
                         && $assignment->start_time->time > \OmegaUp\Time::get()
                     ) {
                         throw new \OmegaUp\Exceptions\ForbiddenAccessException(
@@ -2160,7 +2160,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $response['problemset'] = $problemset['problemset'];
         } else {
             if (
-                is_null($identity)
+                $identity === null
                 || !\OmegaUp\Authorization::canEditProblem(
                     $identity,
                     $problem
@@ -2169,7 +2169,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 // If the problem is requested outside a contest, we need to
                 // check that it is not private and the user is logged in
                 if (!\OmegaUp\DAO\Problems::isVisible($problem)) {
-                    if (is_null($identity)) {
+                    if ($identity === null) {
                         throw new \OmegaUp\Exceptions\UnauthorizedException(
                             'userNotAllowed'
                         );
@@ -2194,7 +2194,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @return ProblemStatement|null The contents of the resource, plus some metadata.
      */
     public static function getProblemResourceImpl(array $params): ?array {
-        if (is_null($params['alias'])) {
+        if ($params['alias'] === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemArtifacts = new \OmegaUp\ProblemArtifacts(
@@ -2510,7 +2510,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         string $problemAlias
     ): \OmegaUp\DAO\VO\Problems {
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -2539,7 +2539,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $response['contest'] = \OmegaUp\DAO\Contests::getByAlias(
                 $contestAlias
             );
-            if (is_null($response['contest'])) {
+            if ($response['contest'] === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
@@ -2549,7 +2549,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     $response['contest']->problemset_id
                 )
             );
-            if (is_null($response['problemset'])) {
+            if ($response['problemset'] === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'contestNotFound'
                 );
@@ -2565,12 +2565,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'problemNotFoundInContest'
                 );
             }
-        } elseif (!is_null($problemsetId)) {
+        } elseif ($problemsetId !== null) {
             // Is it a valid problemset_id?
             $response['problemset'] = \OmegaUp\DAO\Problemsets::getByPK(
                 $problemsetId
             );
-            if (is_null($response['problemset'])) {
+            if ($response['problemset'] === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemsetNotFound'
                 );
@@ -2642,7 +2642,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $r->ensureOptionalString('statement_type') ?? '',
             $r->ensureOptionalInt('problemset_id')
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -2656,7 +2656,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $preventProblemsetOpen,
             $contestAlias
         );
-        if (is_null($details)) {
+        if ($details === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -2679,7 +2679,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         string $statementType,
         ?int $problemsetId
     ): array {
-        if (is_null($identity) && !is_null($contestAlias)) {
+        if ($identity === null && $contestAlias !== null) {
             throw new \OmegaUp\Exceptions\UnauthorizedException(
                 'userNotAllowed'
             );
@@ -2709,7 +2709,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         bool $preventProblemsetOpen,
         ?string $contestAlias = null
     ): ?array {
-        if (is_null($problem->problem_id)) {
+        if ($problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         // Get the expected commit version.
@@ -2720,7 +2720,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $problemset->problemset_id,
                 $problem->problem_id
             );
-            if (is_null($problemsetProblem)) {
+            if ($problemsetProblem === null) {
                 return null;
             }
             $commit = $problemsetProblem->commit;
@@ -2733,7 +2733,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $commit,
             $statementLanguage
         );
-        if (is_null($response['statement'])) {
+        if ($response['statement'] === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'statementNotFound'
             );
@@ -2744,7 +2744,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         // Add preferred language of the user.
-        if (!is_null($loggedIdentity)) {
+        if ($loggedIdentity !== null) {
             $preferredLanguage = \OmegaUp\DAO\Users::getPreferredLanguage(
                 $loggedIdentity->user_id
             );
@@ -2793,26 +2793,26 @@ class Problem extends \OmegaUp\Controllers\Controller {
         if (
             \OmegaUp\DAO\Problems::isVisible($problem) ||
             (
-                !is_null($loggedIdentity) &&
+                $loggedIdentity !== null &&
                 \OmegaUp\Authorization::isProblemAdmin(
                     $loggedIdentity,
                     $problem
                 )
             )
         ) {
-            if (is_null($problem->acl_id)) {
+            if ($problem->acl_id === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
             }
             $acl = \OmegaUp\DAO\ACLs::getByPK($problem->acl_id);
-            if (is_null($acl) || is_null($acl->owner_id)) {
+            if ($acl === null || $acl->owner_id === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
             }
             $problemsetter = \OmegaUp\DAO\Identities::findByUserId(
                 $acl->owner_id
             );
-            if (is_null($problemsetter) || is_null($problemsetter->username)) {
+            if ($problemsetter === null || $problemsetter->username === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
             }
             $response['problemsetter'] = [
@@ -2839,8 +2839,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 strict: true
             );
             $isOwner = (
-                !is_null($loggedIdentity) &&
-                !is_null($loggedIdentity->user_id) &&
+                $loggedIdentity !== null &&
+                $loggedIdentity->user_id !== null &&
                 $loggedIdentity->user_id === $acl->owner_id
             );
             if ($isWarningOrBanned && $isOwner) {
@@ -2856,14 +2856,14 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $isPracticeMode = false;
         $container = null;
-        if (!is_null($problemset) && !is_null($loggedIdentity)) {
+        if ($problemset !== null && $loggedIdentity !== null) {
             $response['admin'] = \OmegaUp\Authorization::isAdmin(
                 $loggedIdentity,
                 $problemset
             );
 
             if (!$response['admin'] || $preventProblemsetOpen !== true) {
-                if (is_null($problemset->problemset_id)) {
+                if ($problemset->problemset_id === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemsetNotFound'
                     );
@@ -2872,7 +2872,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $container = \OmegaUp\DAO\Problemsets::getProblemsetContainer(
                     $problemset->problemset_id
                 );
-                if (is_null($container)) {
+                if ($container === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'problemsetNotFound'
                     );
@@ -2919,11 +2919,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         if (
-            !is_null(
-                $loggedIdentity
-            ) && !is_null(
-                $loggedIdentity->identity_id
-            )
+            $loggedIdentity !== null && $loggedIdentity->identity_id !== null
         ) {
             // Get all the available runs done by the current_user
             $runsArray = \OmegaUp\DAO\Runs::getForProblemDetails(
@@ -2981,7 +2977,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'nominated' => $nominationStatus['nominated'],
                 'nominatedBeforeAc' => $nominationStatus['nominatedBeforeAc'],
                 'language' => $response['statement']['language'],
-                'canNominateProblem' => !is_null($loggedIdentity->user_id),
+                'canNominateProblem' => $loggedIdentity->user_id !== null,
                 'solved' => false,
                 'tried' => false,
             ];
@@ -3030,7 +3026,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             )),
             2
         );
-        if (is_null($loggedIdentity)) {
+        if ($loggedIdentity === null) {
             $response['score'] = 0.0;
         } else {
             $response['score'] = self::bestScore(
@@ -3075,9 +3071,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $contestAlias,
             $problemAlias,
             $r->ensureOptionalString('statement_type') ?? '',
-            !is_null($r['problemset_id']) ? intval($r['problemset_id']) : null
+            $r['problemset_id'] !== null ? intval($r['problemset_id']) : null
         );
-        if (is_null($response['problem'])) {
+        if ($response['problem'] === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemset = $response['problemset'];
@@ -3094,7 +3090,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $problemset->problemset_id,
                 $problem->problem_id
             );
-            if (is_null($problemsetProblem)) {
+            if ($problemsetProblem === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -3134,7 +3130,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'allowedSolutionsLimitReached'
                 );
             }
-            if (!is_null($response['solution'])) {
+            if ($response['solution'] !== null) {
                 // We don't consume a token if there is no solution.
                 \OmegaUp\DAO\ProblemsForfeited::create(new \OmegaUp\DAO\VO\ProblemsForfeited([
                     'user_id' => $r->user->user_id,
@@ -3168,7 +3164,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problemsetId = $r->ensureOptionalInt('problemset_id');
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -3185,13 +3181,13 @@ class Problem extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         ?int $problemsetId = null
     ) {
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         if (
             !\OmegaUp\Authorization::canEditProblem($identity, $problem) &&
             (
-                is_null($problemsetId) ||
+                $problemsetId === null ||
                 !\OmegaUp\Authorization::canEditProblemset(
                     $identity,
                     $problemsetId
@@ -3247,7 +3243,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             new \OmegaUp\ProblemArtifacts($problem->alias, 'published')
         )->commit();
 
-        if (is_null($commit)) {
+        if ($commit === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         return [
@@ -3299,12 +3295,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $updatePublished = \OmegaUp\ProblemParams::UPDATE_PUBLISHED_EDITABLE_PROBLEMSETS;
-        if (!is_null($r['update_published'])) {
+        if ($r['update_published'] !== null) {
             $updatePublished = $r['update_published'];
         }
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         if (!\OmegaUp\Authorization::canEditProblem($r->identity, $problem)) {
@@ -3338,7 +3334,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $problem->alias,
                 'published'
             ))->commit();
-            if (is_null($commit)) {
+            if ($commit === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemVersionNotFound'
                 );
@@ -3453,7 +3449,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Validators::validateStringNonEmpty($r['version'], 'version');
 
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         if (!\OmegaUp\Authorization::canEditProblem($r->identity, $problem)) {
@@ -3489,7 +3485,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     ): array {
         /** @var null|array{commit: string, tree: string, parents: string[], author: array{name: string, email: string, time: string}, committer: array{name: string, email: string, time: string}, message: string} */
         $masterCommit = null;
-        if (is_null($commit)) {
+        if ($commit === null) {
             $masterCommit = (new \OmegaUp\ProblemArtifacts(
                 strval($problem->alias),
                 'published'
@@ -3512,7 +3508,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 }
             }
         }
-        if (is_null($masterCommit)) {
+        if ($masterCommit === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemVersionNotFound'
             );
@@ -3527,7 +3523,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $privateCommitHash
         );
         $privateCommit = $problemArtifacts->commit();
-        if (is_null($privateCommit)) {
+        if ($privateCommit === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemVersionNotFound'
             );
@@ -3609,7 +3605,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         // Validate request
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->problem_id)) {
+        if ($problem === null || $problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -3624,7 +3620,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             }
             $identity = null;
             $username = $r->ensureOptionalString('username');
-            if (!is_null($username)) {
+            if ($username !== null) {
                 try {
                     $identity = \OmegaUp\DAO\Identities::findByUsername(
                         $username
@@ -3640,7 +3636,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $r->ensureOptionalString('status'),
                 $r->ensureOptionalString('verdict'),
                 $r->ensureOptionalString('language'),
-                !is_null($identity) ? intval($identity->identity_id) : null,
+                $identity !== null ? intval($identity->identity_id) : null,
                 max($r->ensureOptionalInt('offset') ?? 0, 0),
                 $r->ensureOptionalInt('rowcount') ?? 100,
                 $r->ensureOptionalString('execution'),
@@ -3689,7 +3685,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $offset = $r->ensureOptionalInt('offset');
         $rowcount = $r->ensureOptionalInt('rowcount') ?? 0;
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->problem_id)) {
+        if ($problem === null || $problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -3731,7 +3727,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         return self::getStats($problem, $r->identity);
@@ -3752,7 +3748,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         return [
@@ -3817,7 +3813,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
         /** @var array{counts: array<string, int>, last_submission_id: int}|null */
         $casesStats = $problemStatsCache->get();
-        if (is_null($casesStats)) {
+        if ($casesStats === null) {
             // Initialize the array at counts = 0
             $casesStats = [
                 'counts' => [],
@@ -3844,7 +3840,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'details.json',
                 missingOk: true
             );
-            if (!is_null($detailsJson)) {
+            if ($detailsJson !== null) {
                 /** @var null|array{verdict: string, compile_meta: array{Main: RunMetadata}, score: int, contest_score: int, max_score: int, time: float, wall_time: float, memory: int, judged_by: string, groups: list<array{group: string, score: float, contest_score: int, max_score: int, cases: list<CaseResult>}>} */
                 $details = json_decode($detailsJson, associative: true);
                 if (!is_array($details)) {
@@ -3989,11 +3985,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'language' => $language,
             'tags' => $tags,
             'keyword' => $keyword,
-            'requireAllTags' => is_null(
-                $requireAllTags
-            ) ? is_null(
-                $someTags
-            ) : $requireAllTags,
+            'requireAllTags' => $requireAllTags === null ? $someTags === null : $requireAllTags,
             'programmingLanguages' => $programmingLanguages,
             'difficultyRange' => $difficultyRange,
             'minVisibility' => $minVisibility,
@@ -4079,7 +4071,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // Defaults for offset and rowcount
         $page = $r->ensureOptionalInt('page');
         $offset = null;
-        if (is_null($page)) {
+        if ($page === null) {
             $offset = $r->ensureOptionalInt('offset') ?? 0;
         }
         $rowcount = $r->ensureOptionalInt(
@@ -4162,9 +4154,9 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // - Logged in users with normal permissions: Normal
         // - Logged in users with administrative rights: Admin
         $identityType = IDENTITY_ANONYMOUS;
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             $authorIdentityId = intval($identity->identity_id);
-            if (!is_null($user)) {
+            if ($user !== null) {
                 $authorUserId = intval($user->user_id);
             }
 
@@ -4182,7 +4174,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             }
         }
 
-        if (is_null($offset)) {
+        if ($offset === null) {
             $offset = ($page - 1) * $rowcount;
         }
 
@@ -4421,23 +4413,21 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $contestAlias,
             $problemAlias,
             $r->ensureOptionalString('statement_type') ?? '',
-            !is_null($r['problemset_id']) ? intval($r['problemset_id']) : null
+            $r['problemset_id'] !== null ? intval($r['problemset_id']) : null
         );
 
         // If username is set in the request, we use that identity as target.
         // else, we query using current_user
         $identity = self::resolveTargetIdentity($r);
 
-        if (is_null($problem['problem'])) {
+        if ($problem['problem'] === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
         return [
             'score' => self::bestScore(
                 $problem['problem'],
-                !is_null(
-                    $r['problemset_id']
-                ) ? intval(
+                $r['problemset_id'] !== null ? intval(
                     $r['problemset_id']
                 ) : $r['problemset_id'],
                 $contestAlias,
@@ -4462,9 +4452,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         int $currentLoggedIdentityId,
         ?\OmegaUp\DAO\VO\Identities $identity = null
     ): float {
-        $currentIdentityId = (is_null(
-            $identity
-        ) ? $currentLoggedIdentityId : $identity->identity_id);
+        $currentIdentityId = ($identity === null ? $currentLoggedIdentityId : $identity->identity_id);
 
         $score = 0.0;
         // Add best score info
@@ -4474,7 +4462,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $contestAlias
         );
 
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             $score = floatval(\OmegaUp\DAO\Runs::getBestProblemScore(
                 intval($problem->problem_id),
                 intval($currentIdentityId)
@@ -4495,7 +4483,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
      * @return void
      */
     private static function updateLanguages(\OmegaUp\DAO\VO\Problems $problem): void {
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($problem->alias);
@@ -4573,25 +4561,25 @@ class Problem extends \OmegaUp\Controllers\Controller {
         &$problemSettings,
         \OmegaUp\ProblemParams $params
     ): void {
-        if (!is_null($params->extraWallTime)) {
+        if ($params->extraWallTime !== null) {
             $problemSettings['Limits']['ExtraWallTime'] = "{$params->extraWallTime}ms";
         }
-        if (!is_null($params->memoryLimit)) {
+        if ($params->memoryLimit !== null) {
             $problemSettings['Limits']['MemoryLimit'] = "{$params->memoryLimit}KiB";
         }
-        if (!is_null($params->outputLimit)) {
+        if ($params->outputLimit !== null) {
             $problemSettings['Limits']['OutputLimit'] = "{$params->outputLimit}";
         }
-        if (!is_null($params->memoryLimit)) {
+        if ($params->memoryLimit !== null) {
             $problemSettings['Limits']['OverallWallTimeLimit'] = "{$params->overallWallTimeLimit}ms";
         }
-        if (!is_null($params->timeLimit)) {
+        if ($params->timeLimit !== null) {
             $problemSettings['Limits']['TimeLimit'] = "{$params->timeLimit}ms";
         }
-        if (!is_null($params->validator)) {
+        if ($params->validator !== null) {
             $problemSettings['Validator']['Name'] = "{$params->validator}";
         }
-        if (!is_null($params->groupScorePolicy)) {
+        if ($params->groupScorePolicy !== null) {
             $problemSettings['Validator']['GroupScorePolicy'] = "{$params->groupScorePolicy}";
         }
         if ($problemSettings['Validator']['Name'] === 'custom') {
@@ -4608,7 +4596,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'TimeLimit' => '30s',
                 ];
             }
-            if (!is_null($params->validatorTimeLimit)) {
+            if ($params->validatorTimeLimit !== null) {
                 $problemSettings['Validator']['Limits']['TimeLimit'] = "{$params->validatorTimeLimit}ms";
             }
         } else {
@@ -4706,7 +4694,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $basePayload = self::buildUnloggedPayload($problem, $details);
         $response['templateProperties']['payload'] = $basePayload;
 
-        if (is_null($r->identity)) {
+        if ($r->identity === null) {
             return $response;
         }
 
@@ -4829,7 +4817,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $requestData['problemsetId']
         );
 
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         // Get problem details from API
@@ -4843,7 +4831,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             contestAlias: $requestData['contestAlias'],
         );
 
-        if (is_null($details)) {
+        if ($details === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -4945,7 +4933,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         );
 
         $contents = [];
-        if (!is_null($qualityNomination)) {
+        if ($qualityNomination !== null) {
             /**
              * @var array{tags?: list<string>, quality_seal?: bool, level?: string}|null $contents
              */
@@ -4953,7 +4941,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $qualityNomination['contents'],
                 associative: true
             );
-            if (is_null($contents)) {
+            if ($contents === null) {
                 $contents = [];
             }
         }
@@ -4983,7 +4971,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity,
         $problem
     ): array {
-        if (is_null($problem->problem_id)) {
+        if ($problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -5062,7 +5050,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         bool $isAdmin,
         bool $isQualityReviewer
     ): array {
-        if (is_null($problem->problem_id)) {
+        if ($problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -5081,7 +5069,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'nominated' => $nominationStatus['nominated'],
             'nominatedBeforeAc' => $nominationStatus['nominatedBeforeAc'],
             'language' => $details['statement']['language'],
-            'canNominateProblem' => !is_null($identity->user_id),
+            'canNominateProblem' => $identity->user_id !== null,
             'solved' => false,
             'tried' => false,
         ];
@@ -5104,7 +5092,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
 
         $allowedSolutionsToSee = 0;
 
-        if (!is_null($user)) {
+        if ($user !== null) {
             // Get the count of problems forfeited by the user on the current day.
             $problemsForfeitedCount = \OmegaUp\DAO\ProblemsForfeited::getProblemsForfeitedCountInDay(
                 $user
@@ -5228,7 +5216,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             'templateProperties' => [
                 'payload' => [
                     'problems' => $result['problems'],
-                    'loggedIn' => !is_null($r->identity),
+                    'loggedIn' => $r->identity !== null,
                     'selectedTags' => $result['selectedTags'],
                     'pagerItems' => $result['pagerItems'],
                     'keyword' => $result['keyword'],
@@ -5260,7 +5248,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $allTags = self::getAllTagsFromCache();
 
         foreach ($allTags as $tag) {
-            if (is_null($tag->name)) {
+            if ($tag->name === null) {
                 continue;
             }
             if (!$tag->public) {
@@ -5408,7 +5396,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::getByAlias(
             $problemParams->problemAlias
         );
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -5562,7 +5550,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'invalidJson'
                 );
             }
-            if (is_null($cdp)) {
+            if ($cdp === null) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'cdpNotFound'
                 );
@@ -5610,7 +5598,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 );
             }
 
-            if (is_null($cdp)) {
+            if ($cdp === null) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'cdpNotFound'
                 );
@@ -5652,7 +5640,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             showSolvers: false,
             preventProblemsetOpen: false,
         );
-        if (is_null($details)) {
+        if ($details === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -5757,7 +5745,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $tags[] = ['name' => $tag->name];
         }
         $request = $r->ensureOptionalString('request');
-        if (!is_null($request) && $request === 'submit') {
+        if ($request !== null && $request === 'submit') {
             $problemParams = null;
             try {
                 $problemParams = self::convertRequestToProblemParams($r);
@@ -5779,8 +5767,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     $statusError = $response['error'];
                 }
                 if (
-                    !is_null($problemParams)
-                    && !is_null($problemParams->selectedTagsAsJSON)
+                    $problemParams !== null
+                    && $problemParams->selectedTagsAsJSON !== null
                 ) {
                     /** @var list<array{tagname: string, public: bool}> */
                     $selectedTags = json_decode(
@@ -5990,8 +5978,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
         ?int $maxDifficulty
     ) {
         if (
-            is_null($minDifficulty) ||
-            is_null($maxDifficulty) ||
+            $minDifficulty === null ||
+            $maxDifficulty === null ||
             $minDifficulty > $maxDifficulty ||
             $minDifficulty < 0 ||
             $minDifficulty > 4 ||
@@ -6063,7 +6051,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::getByAlias(
             $problemAlias
         );
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -6090,7 +6078,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -6134,7 +6122,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         if (!in_array('cat', explode(',', $problem->languages))) {
             throw new \OmegaUp\Exceptions\NotFoundException();
         }
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -6237,7 +6225,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::getByAlias(
             $problemAlias
         );
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -6550,7 +6538,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     'frequentTags' => $frequentTags,
                     'level' => $collectionLevel,
                     'problems' => $result['problems'],
-                    'loggedIn' => !is_null($r->identity),
+                    'loggedIn' => $r->identity !== null,
                     'selectedTags' => $result['selectedTags'],
                     'pagerItems' => $result['pagerItems'],
                     'keyword' => $result['keyword'],
@@ -6664,7 +6652,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $allTags = self::getAllTagsFromCache();
 
         foreach ($allTags as $tag) {
-            if (is_null($tag->name)) {
+            if ($tag->name === null) {
                 continue;
             }
             if (!$tag->public) {
@@ -6785,7 +6773,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'payload' => [
                     'authorsRanking' => $authorsRanking,
                     'problems' => $result['problems'],
-                    'loggedIn' => !is_null($r->identity),
+                    'loggedIn' => $r->identity !== null,
                     'selectedTags' => $result['selectedTags'],
                     'pagerItems' => $result['pagerItems'],
                     'keyword' => $result['keyword'],
@@ -6825,7 +6813,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -6843,7 +6831,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             statementType: 'markdown',
             problemsetId: null
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -6857,7 +6845,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             preventProblemsetOpen: false,
         );
 
-        if (is_null($details)) {
+        if ($details === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -6929,7 +6917,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         try {
-            if (!is_null($zipFilePath)) {
+            if ($zipFilePath !== null) {
                 $result = \OmegaUp\ZipToCdpConverter::convert(
                     $zipFilePath,
                     $params['alias']
@@ -6957,7 +6945,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'cdpNotFound'
             );
         } finally {
-            if (!is_null($zipFilePath) && file_exists($zipFilePath)) {
+            if ($zipFilePath !== null && file_exists($zipFilePath)) {
                 unlink($zipFilePath);
             }
         }
@@ -7036,7 +7024,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         string $message,
         string $updatePublished
     ) {
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($problem->alias);
@@ -7044,7 +7032,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // Search to see if the case exists in the CDP
         $caseInfo = self::findCaseInCDP($cdp, $newCaseData['caseID']);
 
-        $isEditOperation = !is_null($caseInfo);
+        $isEditOperation = $caseInfo !== null;
 
         $result = $isEditOperation
             ? self::handleEditCase(
@@ -7105,7 +7093,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $caseID = $newCaseData['caseID'];
         // Search for original case in CDP
         $caseInfo = self::findCaseInCDP($cdp, $caseID);
-        if (is_null($caseInfo)) {
+        if ($caseInfo === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('missingCase');
         }
 
@@ -7149,10 +7137,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // Detect changes
         $nameChanged = ($newCaseName !== $oldCaseName);
         $groupChanged = ($newGroupID !== $oldGroupID);
-        $inputChanged = !is_null($uploadedInput) || ($newInput !== $oldInput);
-        $outputChanged = !is_null(
-            $uploadedOutput
-        ) || ($newOutput !== $oldOutput);
+        $inputChanged = $uploadedInput !== null || ($newInput !== $oldInput);
+        $outputChanged = $uploadedOutput !== null || ($newOutput !== $oldOutput);
         $pointsChanged = ($newPoints !== $oldPoints);
 
         if (!$nameChanged && !$groupChanged && !$inputChanged && !$outputChanged && !$pointsChanged) {
@@ -7210,20 +7196,20 @@ class Problem extends \OmegaUp\Controllers\Controller {
             $pathsToExclude[] = $oldInputPath;
             $pathsToExclude[] = $oldOutputPath;
         } else {
-            if (!is_null($uploadedInput)) {
+            if ($uploadedInput !== null) {
                 $blobUpdate[$oldInputPath] = $uploadedInput['full'];
             } elseif ($inputChanged) {
                 $blobUpdate[$oldInputPath] = $newInput;
             }
 
-            if (!is_null($uploadedOutput)) {
+            if ($uploadedOutput !== null) {
                 $blobUpdate[$oldOutputPath] = $uploadedOutput['full'];
             } elseif ($outputChanged) {
                 $blobUpdate[$oldOutputPath] = $newOutput;
             }
         }
 
-        $newLine = is_null($uploadedInput)
+        $newLine = $uploadedInput === null
             ? $newCaseData['lines']
             : [[
                 'lineID' => $newCaseData['lines'][0]['lineID'],
@@ -7246,7 +7232,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     }
                 }
 
-                if (is_null($targetGroupIndex)) {
+                if ($targetGroupIndex === null) {
                     $cdp['casesStore']['groups'][] = [
                         'groupID' => $groupData['groupID'],
                         'name' => $groupData['name'],
@@ -7261,7 +7247,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 // Search for or create a normal group
                 $newGroupInfo = self::findGroupInCDP($cdp, $newGroupID);
 
-                if (is_null($newGroupInfo)) {
+                if ($newGroupInfo === null) {
                     // Create new group
                     $cdp['casesStore']['groups'][] = [
                         'groupID' => $groupData['groupID'],
@@ -7359,7 +7345,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 }
             }
 
-            if (is_null($targetGroupIndex)) {
+            if ($targetGroupIndex === null) {
                 // Create ungrouped group with frontend data
                 $cdp['casesStore']['groups'][] = [
                     'groupID' => $groupData['groupID'],
@@ -7372,7 +7358,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 $targetGroupIndex = count($cdp['casesStore']['groups']) - 1;
             }
         } else {
-            if (is_null($groupInfo)) {
+            if ($groupInfo === null) {
                 // The group does not exist; create it with the frontend data.
                 $cdp['casesStore']['groups'][] = [
                     'groupID' => $groupData['groupID'],
@@ -7462,7 +7448,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         string $message,
         string $updatePublished
     ) {
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($problem->alias);
@@ -7470,7 +7456,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // Search to see if the group exists in the CDP
         $groupInfo = self::findGroupInCDP($cdp, $newGroupData['groupID']);
 
-        if (is_null($groupInfo)) {
+        if ($groupInfo === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('groupNotFound');
         }
 
@@ -7581,7 +7567,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         string $message,
         string $updatePublished
     ) {
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemArtifacts = new \OmegaUp\ProblemArtifacts($problem->alias);
@@ -7589,12 +7575,12 @@ class Problem extends \OmegaUp\Controllers\Controller {
         // First try searching as a case
         $caseInfo = self::findCaseInCDP($cdp, $id);
 
-        if (!is_null($caseInfo)) {
+        if ($caseInfo !== null) {
             $result = self::handleDeleteCase($caseInfo, $cdp);
         } else {
             $groupInfo = self::findGroupInCDP($cdp, $id);
 
-            if (is_null($groupInfo)) {
+            if ($groupInfo === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'elementNotFound'
                 );
@@ -7737,7 +7723,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 'noChangesDetected'
             );
         }
-        if (is_null($problem->alias)) {
+        if ($problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemDeployer = new \OmegaUp\ProblemDeployer($problem->alias);

--- a/frontend/server/src/Controllers/ProblemBookmark.php
+++ b/frontend/server/src/Controllers/ProblemBookmark.php
@@ -23,7 +23,7 @@ class ProblemBookmark extends \OmegaUp\Controllers\Controller {
         );
 
         $targetProblem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($targetProblem) || is_null($targetProblem->problem_id)) {
+        if ($targetProblem === null || $targetProblem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -38,7 +38,7 @@ class ProblemBookmark extends \OmegaUp\Controllers\Controller {
                 $currentIdentityId,
                 $targetProblem->problem_id
             );
-            if (!is_null($existingBookmark)) {
+            if ($existingBookmark !== null) {
                 self::removeBookmark(
                     $existingBookmark,
                     $r->identity->username
@@ -79,7 +79,7 @@ class ProblemBookmark extends \OmegaUp\Controllers\Controller {
 
         // Validate that the problem exists
         $targetProblem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($targetProblem) || is_null($targetProblem->problem_id)) {
+        if ($targetProblem === null || $targetProblem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 

--- a/frontend/server/src/Controllers/Problemset.php
+++ b/frontend/server/src/Controllers/Problemset.php
@@ -30,9 +30,7 @@ class Problemset extends \OmegaUp\Controllers\Controller {
                 'problemIsBanned'
             );
         }
-        $canEditProblemset = !is_null(
-            $problemsetId
-        ) && \OmegaUp\Authorization::canEditProblemset(
+        $canEditProblemset = $problemsetId !== null && \OmegaUp\Authorization::canEditProblemset(
             $identity,
             $problemsetId
         );
@@ -47,7 +45,7 @@ class Problemset extends \OmegaUp\Controllers\Controller {
             $problemsetId,
             $problem->problem_id
         );
-        if (!is_null($problemsetProblem)) {
+        if ($problemsetProblem !== null) {
             // Invited admin should update a problem in problemset
             return;
         }
@@ -102,7 +100,7 @@ class Problemset extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\ProblemsetProblems $updatedProblemsetProblem,
         ?\OmegaUp\DAO\VO\ProblemsetProblems $oldProblemsetProblem = null,
     ): void {
-        if (is_null($oldProblemsetProblem)) {
+        if ($oldProblemsetProblem === null) {
             \OmegaUp\DAO\Base\ProblemsetProblems::create(
                 $updatedProblemsetProblem
             );
@@ -273,13 +271,13 @@ class Problemset extends \OmegaUp\Controllers\Controller {
         $problemsetId = $r->ensureInt('problemset_id');
 
         $problemset = \OmegaUp\DAO\Problemsets::getWithTypeByPK($problemsetId);
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
         }
         if ($problemset['type'] == 'Contest') {
-            if (is_null($problemset['contest_alias'])) {
+            if ($problemset['contest_alias'] === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemsetNotFound'
                 );

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -430,11 +430,11 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 $original = \OmegaUp\DAO\Problems::getByAlias(
                     $contents['original']
                 );
-                if (is_null($original)) {
+                if ($original === null) {
                     $contents['original'] = self::extractAliasFromArgument(
                         $contents['original']
                     );
-                    if (is_null($contents['original'])) {
+                    if ($contents['original'] === null) {
                         throw new \OmegaUp\Exceptions\NotFoundException(
                             'problemNotFound'
                         );
@@ -442,7 +442,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                     $original = \OmegaUp\DAO\Problems::getByAlias(
                         $contents['original']
                     );
-                    if (is_null($original)) {
+                    if ($original === null) {
                         throw new \OmegaUp\Exceptions\NotFoundException(
                             'problemNotFound'
                         );
@@ -517,9 +517,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\DAO::transBegin();
 
             if (
-                $nominationType === 'quality_tag' && !is_null(
-                    $qualityNomination
-                )
+                $nominationType === 'quality_tag' && $qualityNomination !== null
             ) {
                 $nomination->qualitynomination_id = $qualityNomination['qualitynomination_id'];
                 \OmegaUp\DAO\QualityNominations::update($nomination);
@@ -531,7 +529,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
                 $qualityReviewerGroup = \OmegaUp\DAO\Groups::findByAlias(
                     \OmegaUp\Authorization::QUALITY_REVIEWER_GROUP_ALIAS
                 );
-                if (is_null($qualityReviewerGroup)) {
+                if ($qualityReviewerGroup === null) {
                     throw new \OmegaUp\Exceptions\NotFoundException(
                         'groupNotFound'
                     );
@@ -648,7 +646,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             );
         }
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -695,7 +693,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         $qualitynomination = \OmegaUp\DAO\QualityNominations::getByPK(
             $qualityNominationId
         );
-        if (is_null($qualitynomination)) {
+        if ($qualitynomination === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'qualityNominationNotFound'
             );
@@ -713,7 +711,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
             'problem_alias',
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
-        if (is_null($qualitynomination->problem_id)) {
+        if ($qualitynomination->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemNotFound'
             );
@@ -721,7 +719,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::getByPK(
             $qualitynomination->problem_id
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -849,7 +847,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
     ): void {
         $adminUser = \OmegaUp\DAO\Problems::getAdminUser($problem);
 
-        if (is_null($adminUser)) {
+        if ($adminUser === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         [
@@ -1151,7 +1149,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         $response = \OmegaUp\DAO\QualityNominations::getById(
             $qualityNominationId
         );
-        if (is_null($response)) {
+        if ($response === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'qualityNominationNotFound'
             );
@@ -1173,7 +1171,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         $problem = \OmegaUp\DAO\Problems::getByAlias(
             $response['problem']['alias']
         );
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 

--- a/frontend/server/src/Controllers/Reset.php
+++ b/frontend/server/src/Controllers/Reset.php
@@ -26,7 +26,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
         $reset_digest = hash('sha1', $token);
 
         $user = \OmegaUp\DAO\Users::findByEmail($email);
-        if (is_null($user)) {
+        if ($user === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
@@ -90,7 +90,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
 
         $lastRequest = \OmegaUp\DAO\Identities::getExtraInformation($email);
 
-        if (is_null($lastRequest)) {
+        if ($lastRequest === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
@@ -106,7 +106,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
         $reset_digest = hash('sha1', $token);
 
         $user = \OmegaUp\DAO\Users::findByEmail($email);
-        if (is_null($user)) {
+        if ($user === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
@@ -148,7 +148,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
             'email'
         );
         $user = \OmegaUp\DAO\Users::findByEmail($r['email']);
-        if (is_null($user)) {
+        if ($user === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'userNotExist'
             );
@@ -183,7 +183,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
 
         \OmegaUp\SecurityTools::testStrongPassword($password);
 
-        if (is_null($user->reset_sent_at)) {
+        if ($user->reset_sent_at === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'passwordResetResetExpired'
             );
@@ -197,13 +197,13 @@ class Reset extends \OmegaUp\Controllers\Controller {
 
         $user->reset_digest = null;
         $user->reset_sent_at = null;
-        if (is_null($user->main_identity_id)) {
+        if ($user->main_identity_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
         }
         $identity = \OmegaUp\DAO\Identities::getByPK($user->main_identity_id);
-        if (is_null($identity)) {
+        if ($identity === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
@@ -230,7 +230,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
     private static function validateCreateRequest(\OmegaUp\Request $r): void {
         \OmegaUp\Validators::validateStringNonEmpty($r['email'], 'email');
         $user = \OmegaUp\DAO\Users::findByEmail($r['email']);
-        if (is_null($user)) {
+        if ($user === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'invalidUser'
             );
@@ -244,7 +244,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
 
         // Support doesn't need wait to reset passwords
         if (
-            !is_null($r->identity) &&
+            $r->identity !== null &&
             \OmegaUp\Authorization::isSupportTeamMember(
                 $r->identity
             )
@@ -252,7 +252,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
             return;
         }
 
-        if (is_null($user->reset_sent_at)) {
+        if ($user->reset_sent_at === null) {
             return;
         }
         $seconds = \OmegaUp\Time::get() - $user->reset_sent_at->time;

--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -125,7 +125,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             intval($identity->identity_id),
             $contest
         );
-        if (is_null($contest)) {
+        if ($contest === null) {
             $isAdmin = \OmegaUp\Authorization::isSystemAdmin($identity);
         } else {
             $isAdmin = \OmegaUp\Authorization::isAdmin($identity, $contest);
@@ -167,7 +167,7 @@ class Run extends \OmegaUp\Controllers\Controller {
 
         // Check that problem exists
         $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-        if (is_null($problem) || is_null($problem->problem_id)) {
+        if ($problem === null || $problem->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -204,7 +204,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         );
 
         // Can't set both problemset_id and contest_alias at the same time.
-        if (!is_null($problemsetId) && !is_null($contestAlias)) {
+        if ($problemsetId !== null && $contestAlias !== null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'incompatibleArgs',
                 'problemset_id and contest_alias'
@@ -215,15 +215,15 @@ class Run extends \OmegaUp\Controllers\Controller {
         $problemsetContainer = null;
         /** @var null|\OmegaUp\DAO\VO\Contests */
         $contest = null;
-        if (!is_null($problemsetId)) {
+        if ($problemsetId !== null) {
             $problemsetContainer = \OmegaUp\DAO\Problemsets::getProblemsetContainer(
                 $problemsetId
             );
-        } elseif (!is_null($contestAlias)) {
+        } elseif ($contestAlias !== null) {
             // Got a contest alias, need to fetch the problemset id.
             // Validate contest
             $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-            if (is_null($contest)) {
+            if ($contest === null) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'parameterNotFound',
                     'contest_alias'
@@ -234,7 +234,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             $problemsetContainer = $contest;
 
             // Update list of valid languages.
-            if (!is_null($contest->languages)) {
+            if ($contest->languages !== null) {
                 /** @var list<string> $allowedLanguages */
                 $allowedLanguages = array_intersect(
                     $allowedLanguages,
@@ -254,7 +254,7 @@ class Run extends \OmegaUp\Controllers\Controller {
                     $problem
                 ) &&
                 !(
-                    is_null($practiceDeadline) ||
+                    $practiceDeadline === null ||
                     \OmegaUp\Time::get() > $practiceDeadline->time
                 )
             ) {
@@ -271,14 +271,14 @@ class Run extends \OmegaUp\Controllers\Controller {
                 'problemset' => null,
             ];
         }
-        if (is_null($problemsetContainer)) {
+        if ($problemsetContainer === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'problemsetNotFound'
             );
         }
 
         $problemset = \OmegaUp\DAO\Problemsets::getByPK($problemsetId);
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'problemset_id'
@@ -286,7 +286,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         }
 
         // Validate the language.
-        if (!is_null($problemset->languages)) {
+        if ($problemset->languages !== null) {
             /** @var list<string> $allowedLanguages */
             $allowedLanguages = array_intersect(
                 $allowedLanguages,
@@ -333,7 +333,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         if (!\OmegaUp\Authorization::isAdmin($r->identity, $problemset)) {
             // Before submit something, user had to open the problem/problemset.
             if (
-                is_null($problemsetIdentity) &&
+                $problemsetIdentity === null &&
                 !\OmegaUp\Authorization::canSubmitToProblemset(
                     $r->identity,
                     $problemset
@@ -435,14 +435,12 @@ class Run extends \OmegaUp\Controllers\Controller {
             $submitDelay = 0;
             $type = 'normal';
         } else {
-            $problemsetId = !is_null(
-                $problemset
-            ) ? intval(
+            $problemsetId = $problemset !== null ? intval(
                 $problemset->problemset_id
             ) : null;
             //check the kind of penalty_type for this contest
             $start = null;
-            if (!is_null($contest) && !is_null($problemsetId)) {
+            if ($contest !== null && $problemsetId !== null) {
                 switch ($contest->penalty_type) {
                     case 'contest_start':
                         // submit_delay is calculated from the start
@@ -459,7 +457,7 @@ class Run extends \OmegaUp\Controllers\Controller {
                             $r->identity->identity_id
                         );
 
-                        if (is_null($opened)) {
+                        if ($opened === null) {
                             // welp, the user is submitting a run before even
                             // opening the problem!
                             throw new \OmegaUp\Exceptions\NotAllowedToSubmitException(
@@ -484,7 +482,7 @@ class Run extends \OmegaUp\Controllers\Controller {
                 }
             }
 
-            if (!is_null($start)) {
+            if ($start !== null) {
                 // assuming submit_delay is in minutes.
                 $submitDelay = intval(
                     (\OmegaUp\Time::get() - $start->time) / 60
@@ -495,8 +493,8 @@ class Run extends \OmegaUp\Controllers\Controller {
 
             // If user is admin and is in virtual contest, then admin will be treated as contestant
             $type = (
-                !is_null($problemset) &&
-                !is_null($contest) &&
+                $problemset !== null &&
+                $contest !== null &&
                 \OmegaUp\Authorization::isAdmin(
                     $r->identity,
                     $problemset
@@ -521,11 +519,11 @@ class Run extends \OmegaUp\Controllers\Controller {
             'type' => $type,
         ]);
 
-        if (!is_null($r->identity->current_identity_school_id)) {
+        if ($r->identity->current_identity_school_id !== null) {
             $identitySchool = \OmegaUp\DAO\IdentitiesSchools::getByPK(
                 $r->identity->current_identity_school_id
             );
-            if (!is_null($identitySchool)) {
+            if ($identitySchool !== null) {
                 $submission->school_id = $identitySchool->school_id;
             }
         }
@@ -539,7 +537,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             'time' => $submission->time,
             'memory' => 0,
             'score' => 0,
-            'contest_score' => !is_null($problemsetId) ? 0 : null,
+            'contest_score' => $problemsetId !== null ? 0 : null,
             'verdict' => 'JE',
         ]);
 
@@ -589,7 +587,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             throw $e;
         }
         $userId = $r->identity->user_id;
-        if (is_null($userId) && !is_null($r->loginIdentity)) {
+        if ($userId === null && $r->loginIdentity !== null) {
             $userId = $r->loginIdentity->user_id;
         }
 
@@ -619,8 +617,8 @@ class Run extends \OmegaUp\Controllers\Controller {
                 $problemsetId
             );
             if (
-                !is_null($problemsetIdentity) &&
-                !is_null($problemsetIdentity->end_time)
+                $problemsetIdentity !== null &&
+                $problemsetIdentity->end_time !== null
             ) {
                 $response['submission_deadline'] = $problemsetIdentity->end_time;
             } elseif (isset($problemsetContainer->finish_time)) {
@@ -639,18 +637,18 @@ class Run extends \OmegaUp\Controllers\Controller {
             lastSubmissionTime: $submission->time
         );
 
-        if (is_null($submission->guid)) {
+        if ($submission->guid === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
 
         // Expire rank cache
         \OmegaUp\Controllers\User::deleteProblemsSolvedRankCacheList();
 
-        if (!is_null($problemsetId)) {
+        if ($problemsetId !== null) {
             $assignment = \OmegaUp\DAO\Assignments::getAssignmentForProblemset(
                 $problemsetId
             );
-            if (!is_null($assignment) && !is_null($assignment->course_id)) {
+            if ($assignment !== null && $assignment->course_id !== null) {
                 \OmegaUp\Cache::invalidateAllKeys(
                     \OmegaUp\Cache::SCHOOL_STUDENTS_PROGRESS
                 );
@@ -671,14 +669,14 @@ class Run extends \OmegaUp\Controllers\Controller {
     private static function validateDetailsRequest(string $runAlias): array {
         // If user is not judge, must be the run's owner.
         $submission = \OmegaUp\DAO\Submissions::getByGuid($runAlias);
-        if (is_null($submission) || is_null($submission->current_run_id)) {
+        if ($submission === null || $submission->current_run_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
 
         $run = \OmegaUp\DAO\Runs::getByPK(
             $submission->current_run_id
         );
-        if (is_null($run)) {
+        if ($run === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
 
@@ -712,13 +710,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         );
         $submission = \OmegaUp\DAO\Submissions::getByGuid($runAlias);
         if (
-            is_null(
-                $submission
-            ) || is_null(
-                $submission->current_run_id
-            ) || is_null(
-                $submission->guid
-            )
+            $submission === null || $submission->current_run_id === null || $submission->guid === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
@@ -726,23 +718,23 @@ class Run extends \OmegaUp\Controllers\Controller {
         $run = \OmegaUp\DAO\Runs::getByGUID(
             $submission->guid
         );
-        if (is_null($run)) {
+        if ($run === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
         $problem = \OmegaUp\DAO\Problems::getByPK(
             intval($submission->problem_id)
         );
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
         $problemset = null;
-        if (!is_null($submission->problemset_id)) {
+        if ($submission->problemset_id !== null) {
             $problemset = \OmegaUp\DAO\Problemsets::getByPK(
                 $submission->problemset_id
             );
         }
         $contest = null;
-        if (!is_null($problemset) && !is_null($problemset->contest_id)) {
+        if ($problemset !== null && $problemset->contest_id !== null) {
             $contest = \OmegaUp\DAO\Contests::getByPK($problemset->contest_id);
         }
 
@@ -792,9 +784,9 @@ class Run extends \OmegaUp\Controllers\Controller {
             'status_memory' => strval($filtered['status_memory']),
             'status_runtime' => strval($filtered['status_runtime']),
         ];
-        if (!is_null($filtered['contest_score'])) {
+        if ($filtered['contest_score'] !== null) {
             if (
-                is_null($contest)
+                $contest === null
                 || $contest->score_mode == 'partial'
                 || $filtered['score'] == 1
             ) {
@@ -932,7 +924,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             )
         );
         $runs = [];
-        if (!is_null($runAlias)) {
+        if ($runAlias !== null) {
             [
                 'submission' => $submission,
             ] = self::validateDetailsRequest($runAlias);
@@ -955,8 +947,8 @@ class Run extends \OmegaUp\Controllers\Controller {
             }
             \OmegaUp\DAO\Submissions::disqualify($submission);
             $runs[] = ['guid' => $runAlias, 'username' => $username];
-        } elseif (!is_null($username)) {
-            if (is_null($contestAlias)) {
+        } elseif ($username !== null) {
+            if ($contestAlias === null) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'parameterNotFound',
                     'contest_alias'
@@ -1052,14 +1044,14 @@ class Run extends \OmegaUp\Controllers\Controller {
             $submission = \OmegaUp\DAO\Submissions::getByPK(
                 intval($run->submission_id)
             );
-            if (is_null($submission) || is_null($submission->problem_id)) {
+            if ($submission === null || $submission->problem_id === null) {
                 return;
             }
 
             // Now we need to invalidate problem stats
             $problem = \OmegaUp\DAO\Problems::getByPK($submission->problem_id);
 
-            if (!is_null($problem) && !is_null($problem->alias)) {
+            if ($problem !== null && $problem->alias !== null) {
                 // Invalidar cache stats
                 \OmegaUp\Cache::deleteFromCache(
                     \OmegaUp\Cache::PROBLEM_STATS,
@@ -1119,28 +1111,28 @@ class Run extends \OmegaUp\Controllers\Controller {
             )
         );
 
-        if (is_null($submission->problem_id)) {
+        if ($submission->problem_id === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
-        if (is_null($run->commit) || is_null($run->version)) {
+        if ($run->commit === null || $run->version === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
 
         $problem = \OmegaUp\DAO\Problems::getByPK($submission->problem_id);
-        if (is_null($problem) || is_null($problem->alias)) {
+        if ($problem === null || $problem->alias === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
         $problemset = null;
-        if (!is_null($submission->problemset_id)) {
+        if ($submission->problemset_id !== null) {
             $problemset = \OmegaUp\DAO\Problemsets::getByPK(
                 $submission->problemset_id
             );
         }
 
         $contest = null;
-        if (!is_null($problemset) && !is_null($problemset->contest_id)) {
+        if ($problemset !== null && $problemset->contest_id !== null) {
             $contest = \OmegaUp\DAO\Contests::getByPK($problemset->contest_id);
         }
 
@@ -1189,7 +1181,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         }
         if (isset($details['details'])) {
             if (
-                !is_null($contest)
+                $contest !== null
                 && $contest->feedback === 'summary'
                 && isset($details['details']['groups'])
             ) {
@@ -1401,7 +1393,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             $identityId
         );
         if (
-            !is_null($contest) &&
+            $contest !== null &&
             $contest->finish_time->time > \OmegaUp\Time::get()
         ) {
             return $contest->feedback;
@@ -1447,9 +1439,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             $response['compile_error'] = $details['compile_error'];
         }
         if (
-            !is_null(
-                $contest
-            ) && $contest->score_mode == 'all_or_nothing' && $run->score < 1
+            $contest !== null && $contest->score_mode == 'all_or_nothing' && $run->score < 1
         ) {
             $details['contest_score'] = 0.0;
             $details['score'] = 0.0;
@@ -1508,20 +1498,20 @@ class Run extends \OmegaUp\Controllers\Controller {
     ) {
         $submission = \OmegaUp\DAO\Submissions::getByGuid($guid);
         if (
-            is_null($submission) ||
-            is_null($submission->current_run_id) ||
-            is_null($submission->problem_id)
+            $submission === null ||
+            $submission->current_run_id === null ||
+            $submission->problem_id === null
         ) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
 
         $run = \OmegaUp\DAO\Runs::getByPK($submission->current_run_id);
-        if (is_null($run)) {
+        if ($run === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
         }
 
         $problem = \OmegaUp\DAO\Problems::getByPK($submission->problem_id);
-        if (is_null($problem)) {
+        if ($problem === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('problemNotFound');
         }
 
@@ -1553,7 +1543,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             $filename,
             missingOk: true
         );
-        if (is_null($result)) {
+        if ($result === null) {
             $result = self::downloadResourceFromS3(
                 "{$run->run_id}/{$filename}",
                 passthru: false
@@ -1577,7 +1567,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             missingOk: true,
             fileHeaders: $headers,
         );
-        if (is_null($result)) {
+        if ($result === null) {
             $result = self::downloadResourceFromS3(
                 "{$run->run_id}/{$filename}",
                 passthru: true,
@@ -1796,9 +1786,9 @@ class Run extends \OmegaUp\Controllers\Controller {
             required: false,
             validator: fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
-        if (!is_null($problemAlias)) {
+        if ($problemAlias !== null) {
             $problem = \OmegaUp\DAO\Problems::getByAlias($problemAlias);
-            if (is_null($problem)) {
+            if ($problem === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'problemNotFound'
                 );
@@ -1815,7 +1805,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         );
         /** @var null|\OmegaUp\DAO\VO\Identities */
         $identity = null;
-        if (!is_null($username)) {
+        if ($username !== null) {
             try {
                 $identity = \OmegaUp\Controllers\Identity::resolveIdentity(
                     $username
@@ -1861,9 +1851,9 @@ class Run extends \OmegaUp\Controllers\Controller {
             null,
             $r->ensureOptionalEnum('status', self::STATUS),
             $r->ensureOptionalEnum('verdict', self::VERDICTS),
-            !is_null($problem) ? $problem->problem_id : null,
+            $problem !== null ? $problem->problem_id : null,
             $r->ensureOptionalEnum('language', $languagesKeys),
-            !is_null($identity) ? $identity->identity_id : null,
+            $identity !== null ? $identity->identity_id : null,
             max($r->ensureOptionalInt('offset') ?? 0, 0),
             $r->ensureOptionalInt('rowcount') ?? 100
         );
@@ -1871,7 +1861,7 @@ class Run extends \OmegaUp\Controllers\Controller {
         $result = [];
         foreach ($runs as $run) {
             $run['score'] = round(floatval($run['score']), 4);
-            if (!is_null($run['contest_score'])) {
+            if ($run['contest_score'] !== null) {
                 $run['contest_score'] = round(
                     floatval(
                         $run['contest_score']

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -28,10 +28,10 @@ class School extends \OmegaUp\Controllers\Controller {
         $r->ensureIdentity();
 
         $param = $r->ensureOptionalString('query');
-        if (is_null($param)) {
+        if ($param === null) {
             $param = $r->ensureOptionalString('term');
         }
-        if (is_null($param)) {
+        if ($param === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterEmpty',
                 'query'
@@ -64,7 +64,7 @@ class School extends \OmegaUp\Controllers\Controller {
         $r->ensureInt('school_id');
         $school = \OmegaUp\DAO\Schools::getByPK(intval($r['school_id']));
 
-        if (is_null($school)) {
+        if ($school === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('schoolNotFound');
         }
 
@@ -85,25 +85,25 @@ class School extends \OmegaUp\Controllers\Controller {
             ),
         ];
 
-        if (!is_null($school->country_id)) {
+        if ($school->country_id !== null) {
             $country = \OmegaUp\DAO\Countries::getByPK(
                 strval(
                     $school->country_id
                 )
             );
-            if (!is_null($country)) {
+            if ($country !== null) {
                 $payload['country'] = [
                     'id' => strval($country->country_id),
                     'name' => strval($country->name),
                 ];
             }
 
-            if (!is_null($school->state_id)) {
+            if ($school->state_id !== null) {
                 $state = \OmegaUp\DAO\States::getByPK(
                     strval($school->country_id),
                     strval($school->state_id)
                 );
-                if (!is_null($state)) {
+                if ($state !== null) {
                     $payload['state_name'] = $state->name;
                 }
             }
@@ -145,7 +145,7 @@ class School extends \OmegaUp\Controllers\Controller {
         );
 
         $state = null;
-        if (!is_null($r['country_id']) && !is_null($r['state_id'])) {
+        if ($r['country_id'] !== null && $r['state_id'] !== null) {
             $state = \OmegaUp\DAO\States::getByPK(
                 $r['country_id'],
                 $r['state_id']
@@ -171,8 +171,8 @@ class School extends \OmegaUp\Controllers\Controller {
         // Create school object
         $school = new \OmegaUp\DAO\VO\Schools([
             'name' => $name,
-            'country_id' => !is_null($state) ? $state->country_id : null,
-            'state_id' => !is_null($state) ? $state->state_id : null,
+            'country_id' => $state !== null ? $state->country_id : null,
+            'state_id' => $state !== null ? $state->state_id : null,
         ]);
 
         $existing = \OmegaUp\DAO\Schools::findByName($name);
@@ -194,7 +194,7 @@ class School extends \OmegaUp\Controllers\Controller {
         int $schoolId
     ): array {
         $school = \OmegaUp\DAO\Schools::getByPK($schoolId);
-        if (is_null($school)) {
+        if ($school === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('schoolNotFound');
         }
 
@@ -214,7 +214,7 @@ class School extends \OmegaUp\Controllers\Controller {
     ): array {
         $school = \OmegaUp\DAO\Schools::getByPK($schoolId);
 
-        if (is_null($school)) {
+        if ($school === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('schoolNotFound');
         }
 
@@ -234,7 +234,7 @@ class School extends \OmegaUp\Controllers\Controller {
     ): array {
         $school = \OmegaUp\DAO\Schools::getByPK($schoolId);
 
-        if (is_null($school)) {
+        if ($school === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('schoolNotFound');
         }
 
@@ -275,8 +275,8 @@ class School extends \OmegaUp\Controllers\Controller {
         $r->ensureOptionalInt('page');
         $r->ensureOptionalInt('length');
 
-        $page = is_null($r['page']) ? 1 : intval($r['page']);
-        $length = is_null($r['length']) ? 100 : intval($r['length']);
+        $page = $r['page'] === null ? 1 : intval($r['page']);
+        $length = $r['length'] === null ? 100 : intval($r['length']);
 
         $schoolRank = \OmegaUp\Cache::getFromCacheOrSet(
             \OmegaUp\Cache::SCHOOL_RANK,
@@ -323,9 +323,7 @@ class School extends \OmegaUp\Controllers\Controller {
             $identity = null;
         }
 
-        $isMentor = !is_null(
-            $identity
-        ) && \OmegaUp\Authorization::isMentor(
+        $isMentor = $identity !== null && \OmegaUp\Authorization::isMentor(
             $identity
         );
 
@@ -396,7 +394,7 @@ class School extends \OmegaUp\Controllers\Controller {
             }
         }
 
-        if (is_null($schoolOfTheMonthId)) {
+        if ($schoolOfTheMonthId === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'schoolOfTheMonthNotFound'
             );
@@ -405,7 +403,7 @@ class School extends \OmegaUp\Controllers\Controller {
         // Now get the school data
         $school = \OmegaUp\DAO\Schools::getByPK($schoolOfTheMonthId);
 
-        if (is_null($school)) {
+        if ($school === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'schoolOfTheMonthNotFound'
             );
@@ -415,14 +413,14 @@ class School extends \OmegaUp\Controllers\Controller {
         $stateName = null;
         $country = \OmegaUp\DAO\Countries::getByPK($school->country_id);
 
-        if (!is_null($country)) {
+        if ($country !== null) {
             $countryName = $country->name;
 
             $state = \OmegaUp\DAO\States::getByPK(
                 $country->country_id,
                 $school->state_id
             );
-            if (!is_null($state)) {
+            if ($state !== null) {
                 $stateName = $state->name;
             }
         }
@@ -472,7 +470,7 @@ class School extends \OmegaUp\Controllers\Controller {
             )
         );
 
-        if (is_null($selectedSchool)) {
+        if ($selectedSchool === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('schoolNotFound');
         }
 
@@ -506,7 +504,7 @@ class School extends \OmegaUp\Controllers\Controller {
                     $selectedSchoolOfTheMonth = \OmegaUp\DAO\SchoolOfTheMonth::getByPK(
                         $school['school_of_the_month_id']
                     );
-                    if (is_null($selectedSchoolOfTheMonth)) {
+                    if ($selectedSchoolOfTheMonth === null) {
                         throw new \OmegaUp\Exceptions\NotFoundException(
                             'schoolNotFound'
                         );

--- a/frontend/server/src/Controllers/Scoreboard.php
+++ b/frontend/server/src/Controllers/Scoreboard.php
@@ -25,7 +25,7 @@ class Scoreboard extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 
-        if (!is_null($r['course_alias'])) {
+        if ($r['course_alias'] !== null) {
             $courseAlias = $r->ensureString(
                 'course_alias',
                 fn (string $alias) => \OmegaUp\Validators::alias($alias)
@@ -36,9 +36,9 @@ class Scoreboard extends \OmegaUp\Controllers\Controller {
             );
             $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
             if (
-                is_null($course) ||
-                is_null($course->group_id) ||
-                is_null($course->course_id)
+                $course === null ||
+                $course->group_id === null ||
+                $course->course_id === null
             ) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'courseNotFound'
@@ -48,7 +48,7 @@ class Scoreboard extends \OmegaUp\Controllers\Controller {
                 $assignmentAlias,
                 intval($course->course_id)
             );
-            if (is_null($assignment)) {
+            if ($assignment === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException(
                     'assignmentNotFound'
                 );
@@ -68,7 +68,7 @@ class Scoreboard extends \OmegaUp\Controllers\Controller {
             fn (string $alias) => \OmegaUp\Validators::alias($alias)
         );
         $contest = \OmegaUp\DAO\Contests::getByAlias($contestAlias);
-        if (is_null($contest)) {
+        if ($contest === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'contestNotFound'
             );

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -79,15 +79,13 @@ class Submission extends \OmegaUp\Controllers\Controller {
             self::MAX_SUBMISSION_LIST_PAGE_SIZE
         );
         $identity = \OmegaUp\DAO\Identities::FindByUsername($username);
-        if (is_null($identity)) {
+        if ($identity === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
 
         $user = \OmegaUp\DAO\Users::FindByUsername($username);
         if (
-            !is_null(
-                $user
-            ) &&
+            $user !== null &&
             ($user->main_identity_id == $identity->identity_id) &&
             $user->is_private
         ) {
@@ -139,7 +137,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
             null,
             self::MAX_SUBMISSION_LIST_PAGE_SIZE
         );
-        if (is_null($username)) {
+        if ($username === null) {
             return [
                 'submissions' =>  \OmegaUp\DAO\Submissions::getLatestSubmissions(
                     page: $page,
@@ -148,14 +146,12 @@ class Submission extends \OmegaUp\Controllers\Controller {
             ];
         }
         $identity = \OmegaUp\DAO\Identities::FindByUsername($username);
-        if (is_null($identity)) {
+        if ($identity === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('userNotExist');
         }
         $user = \OmegaUp\DAO\Users::FindByUsername($username);
         if (
-            !is_null(
-                $user
-            ) &&
+            $user !== null &&
             ($user->main_identity_id == $identity->identity_id) &&
             $user->is_private
         ) {
@@ -219,7 +215,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
         ?int $rangeBytesStart = null,
         ?int $rangeBytesEnd = null
     ): \OmegaUp\DAO\VO\SubmissionFeedback {
-        if (is_null($submission->guid)) {
+        if ($submission->guid === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'submissionNotFound'
             );
@@ -228,10 +224,10 @@ class Submission extends \OmegaUp\Controllers\Controller {
             $submission->guid,
             $rangeBytesStart
         );
-        if (!is_null($submissionFeedback)) {
+        if ($submissionFeedback !== null) {
             // Edit the feedback for specific range bytes is not supported yet
             // so we just return the existing submission feedback
-            if (!is_null($rangeBytesStart)) {
+            if ($rangeBytesStart !== null) {
                 return $submissionFeedback;
             }
             return self::updateFeedback(
@@ -335,7 +331,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
         $guid = $r->ensureString('guid');
 
         $submission = \OmegaUp\DAO\Submissions::getByGuid($guid);
-        if (is_null($submission) || is_null($submission->guid)) {
+        if ($submission === null || $submission->guid === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'submissionNotFound'
             );
@@ -361,7 +357,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
                 fn (string $alias) => \OmegaUp\Validators::alias($alias)
             )
         );
-        if (is_null($courseSubmissionInfo)) {
+        if ($courseSubmissionInfo === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseSubmissionNotFound'
             );
@@ -370,7 +366,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
         $course = \OmegaUp\DAO\Courses::getByPK(
             $courseSubmissionInfo['course_id']
         );
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -378,7 +374,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
 
         $submissionFeedbackId = $r->ensureOptionalInt('submission_feedback_id');
         $submissionFeedback = null;
-        if (!is_null($submissionFeedbackId)) {
+        if ($submissionFeedbackId !== null) {
             $submissionFeedbackThread = self::createFeedbackThread(
                 $r->identity,
                 $submissionFeedbackId,
@@ -407,11 +403,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
         $rangeBytesEnd = $r->ensureOptionalInt('range_bytes_end');
 
         if (
-            !is_null(
-                $rangeBytesStart
-            ) && !is_null(
-                $rangeBytesEnd
-            ) && ($rangeBytesStart < 0
+            $rangeBytesStart !== null && $rangeBytesEnd !== null && ($rangeBytesStart < 0
             ||  $rangeBytesEnd < $rangeBytesStart)
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -439,7 +431,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
             $rangeBytesEnd
         );
 
-        if (!is_null($courseSubmissionInfo['author_id'])) {
+        if ($courseSubmissionInfo['author_id'] !== null) {
             self::createNotificationForFeedback(
                 $courseSubmissionInfo['author_id'],
                 $courseSubmissionInfo['problem_alias'],
@@ -522,7 +514,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
         $guid = $r->ensureString('guid');
 
         $submission = \OmegaUp\DAO\Submissions::getByGuid($guid);
-        if (is_null($submission) || is_null($submission->guid)) {
+        if ($submission === null || $submission->guid === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'submissionNotFound'
             );
@@ -539,7 +531,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
                 fn (string $alias) => \OmegaUp\Validators::alias($alias)
             )
         );
-        if (is_null($courseSubmissionInfo)) {
+        if ($courseSubmissionInfo === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseSubmissionNotFound'
             );
@@ -548,7 +540,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
         $course = \OmegaUp\DAO\Courses::getByPK(
             $courseSubmissionInfo['course_id']
         );
-        if (is_null($course)) {
+        if ($course === null) {
             throw new \OmegaUp\Exceptions\NotFoundException(
                 'courseNotFound'
             );
@@ -579,7 +571,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
             );
         }
 
-        if (!is_null($courseSubmissionInfo['author_id'])) {
+        if ($courseSubmissionInfo['author_id'] !== null) {
             self::createNotificationForFeedback(
                 $courseSubmissionInfo['author_id'],
                 $courseSubmissionInfo['problem_alias'],

--- a/frontend/server/src/Controllers/Tag.php
+++ b/frontend/server/src/Controllers/Tag.php
@@ -29,9 +29,9 @@ class Tag extends \OmegaUp\Controllers\Controller {
         $term = $r->ensureOptionalString('term');
         $query = $r->ensureOptionalString('query');
 
-        if (!is_null($term)) {
+        if ($term !== null) {
             $param = $term;
-        } elseif (!is_null($query)) {
+        } elseif ($query !== null) {
             $param = $query;
         } else {
             throw new \OmegaUp\Exceptions\InvalidParameterException(

--- a/frontend/server/src/Controllers/TeamsGroup.php
+++ b/frontend/server/src/Controllers/TeamsGroup.php
@@ -30,7 +30,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
         \OmegaUp\DAO\VO\Identities $identity
     ): ?\OmegaUp\DAO\VO\TeamGroups {
         $teamGroup = \OmegaUp\DAO\TeamGroups::getByAlias($teamGroupAlias);
-        if (is_null($teamGroup)) {
+        if ($teamGroup === null) {
             return null;
         }
 
@@ -59,7 +59,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $teamGroupAlias,
             $r->identity
         );
-        if (is_null($teamGroup)) {
+        if ($teamGroup === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('groupNotFound');
         }
 
@@ -139,7 +139,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $teamGroupAlias,
             $r->identity
         );
-        if (is_null($teamGroup) || is_null($teamGroup->team_group_id)) {
+        if ($teamGroup === null || $teamGroup->team_group_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'team_group_alias'
@@ -278,7 +278,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $teamsGroupAlias,
             $r->identity
         );
-        if (is_null($teamsGroup)) {
+        if ($teamsGroup === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'teams_group_alias'
@@ -317,7 +317,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $teamGroupAlias,
             $r->identity
         );
-        if (is_null($teamGroup)) {
+        if ($teamGroup === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'team_group_alias'
@@ -351,7 +351,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $teamGroupAlias,
             $r->identity
         );
-        if (is_null($teamGroup)) {
+        if ($teamGroup === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'team_group_alias'
@@ -367,7 +367,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             intval($teamGroup->team_group_id),
             intval($resolvedIdentity->identity_id)
         );
-        if (is_null($teams)) {
+        if ($teams === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'User'
@@ -398,7 +398,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             )
         );
         $team = \OmegaUp\DAO\TeamGroups::getByTeamUsername($teamUsername);
-        if (is_null($team)) {
+        if ($team === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'teams_group_alias'
@@ -409,7 +409,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $team['alias'],
             $r->identity
         );
-        if (is_null($teamsGroup) || is_null($teamsGroup->team_group_id)) {
+        if ($teamsGroup === null || $teamsGroup->team_group_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'teams_group_alias'
@@ -478,7 +478,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             )
         );
         $team = \OmegaUp\DAO\TeamGroups::getByTeamUsername($teamUsername);
-        if (is_null($team)) {
+        if ($team === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'teams_group_alias'
@@ -489,7 +489,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $team['alias'],
             $r->identity
         );
-        if (is_null($teamsGroup) || is_null($teamsGroup->team_group_id)) {
+        if ($teamsGroup === null || $teamsGroup->team_group_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'teams_group_alias'
@@ -499,7 +499,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
         $identity = \OmegaUp\DAO\Identities::findByUsername(
             $r->ensureString('username')
         );
-        if (is_null($identity) || is_null($identity->identity_id)) {
+        if ($identity === null || $identity->identity_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'identity_id'
@@ -538,7 +538,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             $teamGroupAlias,
             $r->identity
         );
-        if (is_null($teamGroup) || is_null($teamGroup->team_group_id)) {
+        if ($teamGroup === null || $teamGroup->team_group_id === null) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNotFound',
                 'team_group_alias'


### PR DESCRIPTION
# Description

Replace all `is_null($x)` calls with `$x === null` and `!is_null($x)` with `$x !== null` in `frontend/server/src/Controllers/`.

This is **Sub-PR A** of 3 for issue #9270. The strict comparison (`=== null`) is slightly faster and is the more common modern PHP convention.

**Changes:** 28 files, ~1023 insertions, ~1163 deletions.

Fixes #9270 (partial)

# Comments

This is a purely mechanical find-and-replace with no logic changes. Split into 3 PRs as recommended in the issue:
- **Sub-PR A (this one):** `Controllers/`
- **Sub-PR B:** `DAO/` → see companion PR
- **Sub-PR C:** Core `src/` files → see companion PR

# Checklist

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.