### PR TITLE
refactor: standardize null checks in core files

### DIFF
--- a/frontend/server/src/ActivityReport.php
+++ b/frontend/server/src/ActivityReport.php
@@ -21,7 +21,7 @@ class ActivityReport {
         /** @var array<int, int> */
         $ipMapping = [];
         foreach ($events as &$entry) {
-            if (is_null($entry['ip'])) {
+            if ($entry['ip'] === null) {
                 continue;
             }
             if (
@@ -43,17 +43,17 @@ class ActivityReport {
     private static function processData(array $data): array {
         $event = ['name' => $data['event_type']];
         if ($data['event_type'] === 'submit') {
-            if (!is_null($data['alias'])) {
+            if ($data['alias'] !== null) {
                 $event['problem'] = $data['alias'];
             }
         } elseif ($data['event_type'] === 'clone') {
-            if (!is_null($data['alias'])) {
+            if ($data['alias'] !== null) {
                 $event['courseAlias'] = $data['alias'];
             }
-            if (!is_null($data['name'])) {
+            if ($data['name'] !== null) {
                 $event['courseName'] = $data['name'];
             }
-            if (!is_null($data['clone_result'])) {
+            if ($data['clone_result'] !== null) {
                 $event['cloneResult'] = $data['clone_result'];
             }
         }

--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -153,7 +153,7 @@ class ApiCaller {
         $jsonEncodeFlags = 0;
         // If this request is being explicitly made from the browser,
         // pretty-print the response.
-        if (!is_null($r) && $r['prettyprint'] == 'true') {
+        if ($r !== null && $r['prettyprint'] == 'true') {
             $jsonEncodeFlags = JSON_PRETTY_PRINT;
         }
         static::setHttpHeaders($response);
@@ -280,7 +280,7 @@ class ApiCaller {
         // Reject GET for mutating endpoints
         $requestMethod = \OmegaUp\Request::getServerVar('REQUEST_METHOD');
         if (
-            !is_null($requestMethod) &&
+            $requestMethod !== null &&
             strtoupper($requestMethod) === 'GET' &&
             self::isMutatingMethod($methodName)
         ) {

--- a/frontend/server/src/ApiUtils.php
+++ b/frontend/server/src/ApiUtils.php
@@ -11,7 +11,7 @@ class ApiUtils {
     }
 
     public static function getStringTime(?int $time = null): string {
-        if (is_null($time)) {
+        if ($time === null) {
             return date('Y-m-d H:i:s', \OmegaUp\Time::get());
         }
         return date('Y-m-d H:i:s', $time);

--- a/frontend/server/src/Authorization.php
+++ b/frontend/server/src/Authorization.php
@@ -117,11 +117,11 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Submissions $submission
     ): bool {
-        if (is_null($submission->problem_id)) {
+        if ($submission->problem_id === null) {
             return false;
         }
         $problem = \OmegaUp\DAO\Problems::getByPK($submission->problem_id);
-        if (is_null($problem)) {
+        if ($problem === null) {
             return false;
         }
         if ($problem->deprecated) {
@@ -130,11 +130,11 @@ class Authorization {
             );
         }
 
-        if (!is_null($submission->problemset_id)) {
+        if ($submission->problemset_id !== null) {
             $problemset = \OmegaUp\DAO\Problemsets::getByPK(
                 $submission->problemset_id
             );
-            if (!is_null($problemset)) {
+            if ($problemset !== null) {
                 if (self::isAdmin($identity, $problemset)) {
                     return true;
                 }
@@ -143,7 +143,7 @@ class Authorization {
                         $problemset
                     );
                     if (
-                        !is_null($course) && self::isTeachingAssistant(
+                        $course !== null && self::isTeachingAssistant(
                             $identity,
                             $course
                         )
@@ -161,7 +161,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Clarifications $clarification
     ): bool {
-        if (is_null($clarification->problemset_id)) {
+        if ($clarification->problemset_id === null) {
             return false;
         }
 
@@ -174,7 +174,7 @@ class Authorization {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             $clarification->problemset_id
         );
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             return false;
         }
 
@@ -183,7 +183,7 @@ class Authorization {
         }
 
         $course = \OmegaUp\DAO\Courses::getByProblemsetId($problemset);
-        return (!is_null($course) && self::isTeachingAssistant(
+        return ($course !== null && self::isTeachingAssistant(
             $identity,
             $course
         ));
@@ -194,8 +194,8 @@ class Authorization {
         \OmegaUp\DAO\VO\Clarifications $clarification
     ): bool {
         if (
-            is_null($clarification->problemset_id)
-            || is_null($clarification->problem_id)
+            $clarification->problemset_id === null
+            || $clarification->problem_id === null
         ) {
             return false;
         }
@@ -203,12 +203,12 @@ class Authorization {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK(
             $clarification->problemset_id
         );
-        if (is_null($problemset)) {
+        if ($problemset === null) {
             return false;
         }
 
         $problem = \OmegaUp\DAO\Problems::getByPK($clarification->problem_id);
-        if (is_null($problem) || is_null($problem->acl_id)) {
+        if ($problem === null || $problem->acl_id === null) {
             return false;
         }
 
@@ -218,7 +218,7 @@ class Authorization {
 
         $course = \OmegaUp\DAO\Courses::getByProblemsetId($problemset);
         return (self::isOwner($identity, $problem->acl_id)
-                || (!is_null($course) && self::isTeachingAssistant(
+                || ($course !== null && self::isTeachingAssistant(
                     $identity,
                     $course
                 )));
@@ -226,7 +226,7 @@ class Authorization {
 
     public static function isUnderThirteenUser(\OmegaUp\DAO\VO\Users $user): bool {
         // This is mostly for users who hasn't give us their birth day
-        if (is_null($user->birth_date)) {
+        if ($user->birth_date === null) {
             return false;
         }
         // User's age is U13? $user->birth_date - current date then return true, otherwise return false
@@ -244,7 +244,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Problems $problem
     ): bool {
-        if (is_null($problem->acl_id)) {
+        if ($problem->acl_id === null) {
             return false;
         }
         return self::isProblemAdmin($identity, $problem) ||
@@ -264,7 +264,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Contests $contest
     ): bool {
-        if (is_null($contest->acl_id)) {
+        if ($contest->acl_id === null) {
             return false;
         }
         return self::isContestAdmin($identity, $contest);
@@ -278,7 +278,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Problems $problem
     ): bool {
-        if (is_null($identity->identity_id)) {
+        if ($identity->identity_id === null) {
             return false;
         }
         return self::canEditProblem($identity, $problem) ||
@@ -334,10 +334,10 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         object $entity
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
-        if (is_null($entity->acl_id)) {
+        if ($entity->acl_id === null) {
             return false;
         }
         /** @var int $entity->acl_id */
@@ -353,7 +353,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Contests $contest
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
         return self::isAdmin($identity, $contest);
@@ -363,7 +363,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Problems $problem
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
         return self::isAdmin($identity, $problem);
@@ -389,7 +389,7 @@ class Authorization {
     }
 
     public static function isSystemAdmin(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_isSystemAdmin)) {
+        if (self::$_isSystemAdmin === null) {
             self::$_isSystemAdmin = self::hasRole(
                 $identity,
                 self::SYSTEM_ACL,
@@ -400,11 +400,11 @@ class Authorization {
     }
 
     public static function isQualityReviewer(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_qualityReviewerGroup)) {
+        if (self::$_qualityReviewerGroup === null) {
             self::$_qualityReviewerGroup = \OmegaUp\DAO\Groups::findByAlias(
                 self::QUALITY_REVIEWER_GROUP_ALIAS
             );
-            if (is_null(self::$_qualityReviewerGroup)) {
+            if (self::$_qualityReviewerGroup === null) {
                 return false;
             }
         }
@@ -415,11 +415,11 @@ class Authorization {
     }
 
     public static function isMentor(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_mentorGroup)) {
+        if (self::$_mentorGroup === null) {
             self::$_mentorGroup = \OmegaUp\DAO\Groups::findByAlias(
                 self::MENTOR_GROUP_ALIAS
             );
-            if (is_null(self::$_mentorGroup)) {
+            if (self::$_mentorGroup === null) {
                 return false;
             }
         }
@@ -449,13 +449,13 @@ class Authorization {
     }
 
     public static function isCertificateGenerator(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_certificateGeneratorGroup)) {
+        if (self::$_certificateGeneratorGroup === null) {
             $certificateGeneratorGroup = \OmegaUp\DAO\Groups::findByAlias(
                 self::CERTIFICATE_GENERATOR_GROUP_ALIAS
             );
             if (
-                is_null($certificateGeneratorGroup)
-                || is_null($certificateGeneratorGroup->acl_id)
+                $certificateGeneratorGroup === null
+                || $certificateGeneratorGroup->acl_id === null
             ) {
                 return false;
             }
@@ -478,7 +478,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Courses $course
     ): bool {
-        if (is_null($course->acl_id)) {
+        if ($course->acl_id === null) {
             return false;
         }
         return self::hasRole(
@@ -499,7 +499,7 @@ class Authorization {
         if (self::isSystemAdmin($identity)) {
             return true;
         }
-        if (empty($groups) || is_null($identity->user_id)) {
+        if (empty($groups) || $identity->user_id === null) {
             return false;
         }
         return \OmegaUp\DAO\GroupsIdentities::existsByGroupId(
@@ -509,15 +509,15 @@ class Authorization {
     }
 
     public static function isGroupIdentityCreator(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_groupIdentityCreator)) {
+        if (self::$_groupIdentityCreator === null) {
             self::$_groupIdentityCreator = \OmegaUp\DAO\Groups::findByAlias(
                 self::IDENTITY_CREATOR_GROUP_ALIAS
             );
-            if (is_null(self::$_groupIdentityCreator)) {
+            if (self::$_groupIdentityCreator === null) {
                 return false;
             }
         }
-        if (is_null(self::$_groupIdentityCreator->acl_id)) {
+        if (self::$_groupIdentityCreator->acl_id === null) {
             return false;
         }
         return self::isGroupMember(
@@ -531,15 +531,15 @@ class Authorization {
     }
 
     public static function isSupportTeamMember(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_supportGroup)) {
+        if (self::$_supportGroup === null) {
             self::$_supportGroup = \OmegaUp\DAO\Groups::findByAlias(
                 self::SUPPORT_GROUP_ALIAS
             );
-            if (is_null(self::$_supportGroup)) {
+            if (self::$_supportGroup === null) {
                 return false;
             }
         }
-        if (is_null(self::$_supportGroup->acl_id)) {
+        if (self::$_supportGroup->acl_id === null) {
             return false;
         }
         return self::isGroupMember(
@@ -556,7 +556,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Groups $group
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
         return self::isAdmin($identity, $group);
@@ -566,7 +566,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\TeamGroups $teamGroup
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
         return self::isAdmin($identity, $teamGroup);
@@ -577,7 +577,7 @@ class Authorization {
         int $aclId
     ): bool {
         $acl = \OmegaUp\DAO\ACLs::getByPK($aclId);
-        if (is_null($acl)) {
+        if ($acl === null) {
             return false;
         }
         return $acl->owner_id == $identity->user_id;
@@ -590,7 +590,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         \OmegaUp\DAO\VO\Courses $course
     ): bool {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             return false;
         }
         return self::isAdmin($identity, $course);
@@ -610,11 +610,11 @@ class Authorization {
     }
 
     public static function isCourseCurator(\OmegaUp\DAO\VO\Identities $identity): bool {
-        if (is_null(self::$_courseCuratorGroup)) {
+        if (self::$_courseCuratorGroup === null) {
             self::$_courseCuratorGroup = \OmegaUp\DAO\Groups::findByAlias(
                 self::COURSE_CURATOR_GROUP_ALIAS
             );
-            if (is_null(self::$_courseCuratorGroup)) {
+            if (self::$_courseCuratorGroup === null) {
                 return false;
             }
         }
@@ -638,7 +638,7 @@ class Authorization {
         \OmegaUp\DAO\VO\Identities $identity,
         ?\OmegaUp\DAO\VO\Problemsets $problemset
     ): bool {
-        if (is_null($problemset) || is_null($problemset->acl_id)) {
+        if ($problemset === null || $problemset->acl_id === null) {
             return false;
         }
         return self::isAdmin($identity, $problemset) ||
@@ -657,7 +657,7 @@ class Authorization {
         int $problemsetId
     ): bool {
         $problemset = \OmegaUp\DAO\Problemsets::getByPK($problemsetId);
-        if (is_null($problemset) || is_null($problemset->acl_id)) {
+        if ($problemset === null || $problemset->acl_id === null) {
             return false;
         }
         return self::isAdmin($identity, $problemset);

--- a/frontend/server/src/BaseParams.php
+++ b/frontend/server/src/BaseParams.php
@@ -45,10 +45,10 @@ class BaseParams {
             // Get or calculate new value.
             /** @var null|mixed */
             $value = $this->$thisFieldName;
-            if (is_null($value)) {
+            if ($value === null) {
                 continue;
             }
-            if (!is_null($transform)) {
+            if ($transform !== null) {
                 /** @var mixed */
                 $value = $transform($value);
             }

--- a/frontend/server/src/Broadcaster.php
+++ b/frontend/server/src/Broadcaster.php
@@ -32,8 +32,8 @@ class Broadcaster {
 
             $this->log->debug("Sending update $message");
             \OmegaUp\Grader::getInstance()->broadcast(
-                is_null($contest) ? null : $contest->alias,
-                is_null($contest) ? null : $contest->problemset_id,
+                $contest === null ? null : $contest->alias,
+                $contest === null ? null : $contest->problemset_id,
                 $problem->alias,
                 $message,
                 boolval($clarification->public),
@@ -62,7 +62,7 @@ class Broadcaster {
         \OmegaUp\DAO\VO\Clarifications $clarification
     ): void {
         if (
-            !is_null($clarification->answer) ||
+            $clarification->answer !== null ||
                 !$problem->email_clarifications
         ) {
             return;
@@ -77,7 +77,7 @@ class Broadcaster {
                 ),
                 'problem_alias' => strval($problem->alias),
                 'problem_name' => htmlspecialchars(strval($problem->title)),
-                'url' => is_null($contest) ?
+                'url' => $contest === null ?
                     ("https://omegaup.com/arena/problem/{$problem->alias}#clarifications") :
                     ("https://omegaup.com/arena/{$contest->alias}#clarifications"),
                 'user_name' => strval($identity->username),

--- a/frontend/server/src/Cache.php
+++ b/frontend/server/src/Cache.php
@@ -10,7 +10,7 @@ abstract class CacheAdapter {
     private static $_instance = null;
 
     public static function getInstance(): CacheAdapter {
-        if (is_null(CacheAdapter::$_instance)) {
+        if (CacheAdapter::$_instance === null) {
             /** @psalm-suppress TypeDoesNotContainType OMEGAUP_CACHE_IMPLEMENTATION is really a variable */
             if (OMEGAUP_CACHE_IMPLEMENTATION === 'redis') {
                 CacheAdapter::$_instance = new RedisCacheAdapter();
@@ -101,7 +101,7 @@ abstract class CacheAdapter {
 
         // If there was a value in the cache for the key.
         if ($returnValue !== false) {
-            if (!is_null($cacheUsed)) {
+            if ($cacheUsed !== null) {
                 $cacheUsed = true;
             }
             return $returnValue;
@@ -126,7 +126,7 @@ abstract class CacheAdapter {
             /** @var false|T */
             $returnValue = $this->fetch($key);
             if ($returnValue !== false) {
-                if (!is_null($cacheUsed)) {
+                if ($cacheUsed !== null) {
                     $cacheUsed = true;
                 }
                 return $returnValue;
@@ -137,7 +137,7 @@ abstract class CacheAdapter {
             $returnValue = call_user_func($setFunc);
             $this->store($key, $returnValue, $timeout);
 
-            if (!is_null($cacheUsed)) {
+            if ($cacheUsed !== null) {
                 $cacheUsed = false;
             }
             return $returnValue;
@@ -355,7 +355,7 @@ class RedisCacheAdapter extends CacheAdapter {
         /** @var false|T */
         $current = $this->fetch($key);
         if ($current !== false) {
-            if (!is_null($cacheUsed)) {
+            if ($cacheUsed !== null) {
                 $cacheUsed = true;
             }
             return $current;
@@ -365,7 +365,7 @@ class RedisCacheAdapter extends CacheAdapter {
         while ($lock === false) {
             $current = $this->fetch($key);
             if ($current !== false) {
-                if (!is_null($cacheUsed)) {
+                if ($cacheUsed !== null) {
                     $cacheUsed = true;
                 }
                 /** @var T */
@@ -380,7 +380,7 @@ class RedisCacheAdapter extends CacheAdapter {
             /** @var false|T */
             $current = $this->fetch($key);
             if ($current !== false) {
-                if (!is_null($cacheUsed)) {
+                if ($cacheUsed !== null) {
                     $cacheUsed = true;
                 }
                 return $current;
@@ -390,7 +390,7 @@ class RedisCacheAdapter extends CacheAdapter {
             $returnValue = call_user_func($setFunc);
             $this->store($key, $returnValue, $timeout);
 
-            if (!is_null($cacheUsed)) {
+            if ($cacheUsed !== null) {
                 $cacheUsed = false;
             }
             return $returnValue;

--- a/frontend/server/src/CdpBuilder.php
+++ b/frontend/server/src/CdpBuilder.php
@@ -45,7 +45,7 @@ class CdpBuilder {
         string $candidateLanguage,
         string $languagePreference,
     ): bool {
-        if (is_null($currentLanguage)) {
+        if ($currentLanguage === null) {
             return true;
         }
 
@@ -219,7 +219,7 @@ class CdpBuilder {
     private static function parseTestplan(?string $testplan): array {
         $points = [];
 
-        if (is_null($testplan)) {
+        if ($testplan === null) {
             return $points;
         }
         $lines = explode("\n", trim($testplan));

--- a/frontend/server/src/ContestParams.php
+++ b/frontend/server/src/ContestParams.php
@@ -210,13 +210,11 @@ class ContestParams extends BaseParams {
      * @param array{admission_mode: "private"|"public"|"registration", alias: null|string, check_plagiarism: bool, contest_for_teams: bool, description: null|string, feedback: "detailed"|"none"|"summary"|null, finish_time: \OmegaUp\Timestamp, languages: null|string, penalty: int|null, penalty_calc_policy: "max"|"sum"|null, penalty_type: "contest_start"|"none"|"problem_open"|"runtime"|null, points_decay_factor: float|null, score_mode: "all_or_nothing"|"max_per_group"|"partial"|null, scoreboard: float|null, show_scoreboard_after: bool|null, start_time: \OmegaUp\Timestamp, submissions_gap: int|null, title: null|string, window_length?: int|null} $params
      */
     public function __construct($params) {
-        $languages = !is_null(
-            $params['languages']
-        ) ? explode(
+        $languages = $params['languages'] !== null ? explode(
             ',',
             $params['languages']
         ) : null;
-        if (!is_null($languages)) {
+        if ($languages !== null) {
             \OmegaUp\Validators::validateValidSubset(
                 $languages,
                 'languages',

--- a/frontend/server/src/CourseParams.php
+++ b/frontend/server/src/CourseParams.php
@@ -131,7 +131,7 @@ class CourseParams extends BaseParams {
      * @param array{name: string, description: string, objective: null|string, alias: string, level: null|\OmegaUp\CourseParams::COURSE_LEVEL_INTRODUCTORY|\OmegaUp\CourseParams::COURSE_LEVEL_INTERMEDIATE|\OmegaUp\CourseParams::COURSE_LEVEL_ADVANCED, start_time: int, finish_time: null|int, admission_mode: null|\OmegaUp\CourseParams::COURSE_ADMISSION_MODE_PRIVATE|\OmegaUp\CourseParams::COURSE_ADMISSION_MODE_REGISTRATION|\OmegaUp\CourseParams::COURSE_ADMISSION_MODE_PUBLIC, school_id: int|null, needs_basic_information: bool, requests_user_information: \OmegaUp\CourseParams::COURSE_REQUEST_USER_INFORMATION_NO|\OmegaUp\CourseParams::COURSE_REQUEST_USER_INFORMATION_OPTIONAL|\OmegaUp\CourseParams::COURSE_REQUEST_USER_INFORMATION_REQUIRED, show_scoreboard: bool, languages: null|string, archived: bool|null, minimum_progress_for_certificate: int|null} $params
      */
     public function __construct($params) {
-        if (!is_null($params['level'])) {
+        if ($params['level'] !== null) {
             \OmegaUp\Validators::validateInEnum(
                 $params['level'],
                 'level',
@@ -142,14 +142,14 @@ class CourseParams extends BaseParams {
                 ]
             );
         }
-        if (!is_null($params['admission_mode'])) {
+        if ($params['admission_mode'] !== null) {
             \OmegaUp\Validators::validateInEnum(
                 $params['admission_mode'],
                 'admission_mode',
                 \OmegaUp\CourseParams::VALID_ADMISSION_MODES
             );
         }
-        if (!is_null($params['requests_user_information'])) {
+        if ($params['requests_user_information'] !== null) {
             \OmegaUp\Validators::validateInEnum(
                 $params['requests_user_information'],
                 'requests_user_information',
@@ -161,13 +161,11 @@ class CourseParams extends BaseParams {
             );
         }
 
-        $languages = !is_null(
-            $params['languages']
-        ) ? explode(
+        $languages = $params['languages'] !== null ? explode(
             ',',
             $params['languages']
         ) : null;
-        if (!is_null($languages)) {
+        if ($languages !== null) {
             \OmegaUp\Validators::validateValidSubset(
                 $languages,
                 'languages',
@@ -176,7 +174,7 @@ class CourseParams extends BaseParams {
         }
 
         if (
-            !is_null($params['finish_time']) &&
+            $params['finish_time'] !== null &&
             $params['start_time'] > $params['finish_time']
         ) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -201,7 +199,7 @@ class CourseParams extends BaseParams {
         $this->showScoreboard = $params['show_scoreboard'] ?? false;
         $this->minimumProgressForCertificate = $params['minimum_progress_for_certificate'] ?? null;
 
-        $this->unlimitedDuration = is_null($this->finishTime);
+        $this->unlimitedDuration = $this->finishTime === null;
         $this->public = $this->admissionMode === \OmegaUp\CourseParams::COURSE_ADMISSION_MODE_PUBLIC;
     }
 }

--- a/frontend/server/src/Email.php
+++ b/frontend/server/src/Email.php
@@ -20,7 +20,7 @@ class Email {
         string $subject,
         string $body
     ): void {
-        if (!is_null(self::$emailSender)) {
+        if (self::$emailSender !== null) {
             self::$emailSender->sendEmail($emails, $subject, $body);
             return;
         }

--- a/frontend/server/src/Exceptions/ApiException.php
+++ b/frontend/server/src/Exceptions/ApiException.php
@@ -51,7 +51,7 @@ abstract class ApiException extends \Exception {
                 'error' => $this->getErrorMessage(),
                 'errorcode' => $this->code,
                 'header' => $this->header,
-                'cause' => !is_null($previous) ? $previous->getMessage() : null,
+                'cause' => $previous !== null ? $previous->getMessage() : null,
                 'trace' => $this->getTraceAsString(),
             ],
             $this->_customMessage

--- a/frontend/server/src/Exceptions/InvalidParameterException.php
+++ b/frontend/server/src/Exceptions/InvalidParameterException.php
@@ -43,7 +43,7 @@ class InvalidParameterException extends \OmegaUp\Exceptions\ApiException {
             $localizedText,
             $this->additionalParameters
         );
-        if (is_null($this->parameter)) {
+        if ($this->parameter === null) {
             return $localizedText;
         }
         // Try to translate the parameter name

--- a/frontend/server/src/Experiments.php
+++ b/frontend/server/src/Experiments.php
@@ -73,21 +73,21 @@ class Experiments {
         array $defines = null,
         array $knownExperiments = null
     ) {
-        if (is_null($knownExperiments)) {
+        if ($knownExperiments === null) {
             $knownExperiments = self::KNOWN_EXPERIMENTS;
         }
-        if (is_null($defines)) {
+        if ($defines === null) {
             /** @var array<string, mixed> */
             $defines = get_defined_constants(true)['user'];
         }
 
         $this->loadExperimentsFromConfig($defines, $knownExperiments);
 
-        if (!is_null($identity)) {
+        if ($identity !== null) {
             $this->loadExperimentsForIdentity($identity, $knownExperiments);
         }
 
-        if (!is_null($requestExperiments)) {
+        if ($requestExperiments !== null) {
             $this->loadExperimentsFromRequest(
                 $requestExperiments,
                 $knownExperiments
@@ -123,7 +123,7 @@ class Experiments {
         \OmegaUp\DAO\VO\Identities $identity,
         array $knownExperiments
     ): void {
-        if (is_null($identity->user_id)) {
+        if ($identity->user_id === null) {
             // No experiments can be enabled for unassociated identities.
             return;
         }
@@ -134,7 +134,7 @@ class Experiments {
         ) {
             if (
                 in_array($ue->experiment, $knownExperiments) &&
-                !is_null($ue->experiment) &&
+                $ue->experiment !== null &&
                 !$this->isEnabled($ue->experiment)
             ) {
                 $this->enabledExperiments[] = $ue->experiment;
@@ -235,7 +235,7 @@ class Experiments {
      * Returns the global instance of Experiments.
      */
     public static function getInstance(): Experiments {
-        if (is_null(self::$_instance)) {
+        if (self::$_instance === null) {
             /** @psalm-suppress RedundantCondition This is not set on tests. */
             if (isset($_REQUEST)) {
                 $request = $_REQUEST;

--- a/frontend/server/src/FileHandler.php
+++ b/frontend/server/src/FileHandler.php
@@ -16,7 +16,7 @@ class FileHandler {
     }
 
     public static function getFileUploader(): \OmegaUp\FileUploader {
-        if (is_null(self::$fileUploader)) {
+        if (self::$fileUploader === null) {
             self::$fileUploader = new \OmegaUp\FileUploader();
         }
         return self::$fileUploader;
@@ -45,7 +45,7 @@ class FileHandler {
     public static function deleteFile(string $pathName): void {
         if (!@unlink($pathName)) {
             $errors = error_get_last();
-            if (is_null($errors)) {
+            if ($errors === null) {
                 throw new \RuntimeException(
                     "FATAL: Not able to delete file {$pathName}"
                 );
@@ -79,7 +79,7 @@ class FileHandler {
 
         if (!@rmdir($dir)) {
             $errors = error_get_last();
-            if (is_null($errors)) {
+            if ($errors === null) {
                 self::$log->error("Not able to delete dir {$dir}");
             } else {
                 self::$log->error(

--- a/frontend/server/src/Grader.php
+++ b/frontend/server/src/Grader.php
@@ -22,7 +22,7 @@ class Grader {
     private static $OMEGAUP_GRADER_FAKE = OMEGAUP_GRADER_FAKE;
 
     public static function getInstance(): \OmegaUp\Grader {
-        if (is_null(self::$_instance)) {
+        if (self::$_instance === null) {
             self::$_instance = new \OmegaUp\Grader();
         }
         return self::$_instance;
@@ -42,13 +42,13 @@ class Grader {
      */
     public function grade(\OmegaUp\DAO\VO\Runs $run, string $source): void {
         if (self::$OMEGAUP_GRADER_FAKE) {
-            if (is_null($run->submission_id)) {
+            if ($run->submission_id === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
             }
             $submission = \OmegaUp\DAO\Submissions::getByPK(
                 $run->submission_id
             );
-            if (is_null($submission)) {
+            if ($submission === null) {
                 throw new \OmegaUp\Exceptions\NotFoundException('runNotFound');
             }
             file_put_contents("/tmp/{$submission->guid}", $source);
@@ -336,7 +336,7 @@ class Grader {
                     CURLOPT_TCP_KEEPINTVL => 15,
                 ]
             );
-            if (!is_null($postData)) {
+            if ($postData !== null) {
                 curl_setopt(
                     $curl,
                     CURLOPT_POSTFIELDS,

--- a/frontend/server/src/Metrics.php
+++ b/frontend/server/src/Metrics.php
@@ -22,7 +22,7 @@ class Metrics {
     }
 
     public static function getInstance(): \OmegaUp\Metrics {
-        if (is_null(self::$instance)) {
+        if (self::$instance === null) {
             self::$instance = new \OmegaUp\Metrics();
             return self::$instance;
         }

--- a/frontend/server/src/MySQLConnection.php
+++ b/frontend/server/src/MySQLConnection.php
@@ -55,11 +55,11 @@ class MySQLConnection {
      * termination.
      */
     public static function getInstance(): MySQLConnection {
-        if (is_null(self::$_instance)) {
+        if (self::$_instance === null) {
             self::$_instance = new MySQLConnection();
 
             register_shutdown_function(function () {
-                if (is_null(self::$_instance)) {
+                if (self::$_instance === null) {
                     return;
                 }
                 self::$_instance->Flush();
@@ -158,7 +158,7 @@ class MySQLConnection {
 
         $chunks = [$inputChunks[0]];
         for ($i = 0; $i < count($params); ++$i) {
-            if (is_null($params[$i])) {
+            if ($params[$i] === null) {
                 $chunks[] = 'NULL';
             } elseif ($params[$i] instanceof \OmegaUp\Timestamp) {
                 $chunks[] = "FROM_UNIXTIME({$params[$i]->time})";
@@ -246,7 +246,7 @@ class MySQLConnection {
      * @return null|int|bool|float|string|\OmegaUp\Timestamp
      */
     private function MapValue($value, int $fieldType) {
-        if (is_null($value)) {
+        if ($value === null) {
             return null;
         }
         switch ($fieldType) {
@@ -278,7 +278,7 @@ class MySQLConnection {
      * @return null|array<string, mixed>
      */
     private function MapRow(?array $row, array $fieldTypes): ?array {
-        if (is_null($row)) {
+        if ($row === null) {
             return null;
         }
         /** @var mixed $value */
@@ -339,7 +339,7 @@ class MySQLConnection {
     }
 
     private static function getTypesLogger(): \Monolog\Logger {
-        if (is_null(MySQLConnection::$_typesLogger)) {
+        if (MySQLConnection::$_typesLogger === null) {
             MySQLConnection::$_typesLogger = new \Monolog\Logger('mysqltypes');
             MySQLConnection::$_typesLogger->pushHandler(
                 (new \Monolog\Handler\StreamHandler(
@@ -429,7 +429,7 @@ class MySQLConnection {
      */
     public function GetRow(string $sql, array $params = []): ?array {
         $result = $this->Query($sql, $params, MYSQLI_USE_RESULT);
-        if (is_null($result)) {
+        if ($result === null) {
             return null;
         }
         try {
@@ -451,7 +451,7 @@ class MySQLConnection {
      */
     public function GetAll(string $sql, array $params = []): array {
         $result = $this->Query($sql, $params, MYSQLI_USE_RESULT);
-        if (is_null($result)) {
+        if ($result === null) {
             return [];
         }
         try {
@@ -461,7 +461,7 @@ class MySQLConnection {
             $fieldTypes = self::MapFieldTypes($result);
             $resultArray = [];
             /** @var array<string, mixed> $row */
-            while (!is_null($row = $result->fetch_assoc())) {
+            while ($row = $result->fetch_assoc() !== null) {
                 /** @var array<string, mixed> This cannot be null. */
                 $resultArray[] = self::MapRow($row, $fieldTypes);
             }
@@ -478,7 +478,7 @@ class MySQLConnection {
      */
     public function GetOne(string $sql, array $params = []) {
         $result = $this->Query($sql, $params, MYSQLI_USE_RESULT);
-        if (is_null($result)) {
+        if ($result === null) {
             return null;
         }
         try {

--- a/frontend/server/src/ProblemDeployer.php
+++ b/frontend/server/src/ProblemDeployer.php
@@ -175,7 +175,7 @@ class ProblemDeployer {
      * interactive problem.
      */
     public function generateLibinteractiveTemplates(?string $publishedCommit): void {
-        if (is_null($publishedCommit)) {
+        if ($publishedCommit === null) {
             return;
         }
         $problemArtifacts = new \OmegaUp\ProblemArtifacts(
@@ -324,7 +324,7 @@ class ProblemDeployer {
 
         if (!is_resource($proc)) {
             $errors = error_get_last();
-            if (is_null($errors)) {
+            if ($errors === null) {
                 $this->log->error("$cmd failed");
                 throw new \RuntimeException("$cmd failed");
             } else {
@@ -405,7 +405,7 @@ class ProblemDeployer {
             if ($create) {
                 $queryParams['create'] = 'true';
             }
-            if (!is_null($problemSettings)) {
+            if ($problemSettings !== null) {
                 $queryParams['settings'] = json_encode($problemSettings);
             }
             curl_setopt_array(
@@ -460,7 +460,7 @@ class ProblemDeployer {
             if (!empty($result['output'])) {
                 /** @var null|array{error: string} */
                 $output = json_decode($result['output'], associative: true);
-                if (is_null($output)) {
+                if ($output === null) {
                     $context = $result['output'];
                 } else {
                     $tokens = explode(': ', $output['error'], 2);

--- a/frontend/server/src/Psalm/RequestParamChecker.php
+++ b/frontend/server/src/Psalm/RequestParamChecker.php
@@ -89,7 +89,7 @@ class RequestParamChecker implements
                 $type,
                 $codebase
             );
-            if (is_null($intersectedType)) {
+            if ($intersectedType === null) {
                 throw new \Exception(
                     'Unable to reconcile types ' .
                     strval($previousType) .
@@ -123,7 +123,7 @@ class RequestParamChecker implements
         $varType = $statements_source->getNodeTypeProvider()->getType(
             $expr->var
         );
-        if (is_null($varType)) {
+        if ($varType === null) {
             return null;
         }
         $foundRequest = false;
@@ -153,9 +153,9 @@ class RequestParamChecker implements
             }
             return null;
         }
-        if (!is_null($context->calling_function_id)) {
+        if ($context->calling_function_id !== null) {
             $functionId = strtolower($context->calling_function_id);
-        } elseif (!is_null($context->calling_method_id)) {
+        } elseif ($context->calling_method_id !== null) {
             $functionId = $context->calling_method_id;
         } else {
             throw new \Exception('Empty calling method/function id');
@@ -186,7 +186,7 @@ class RequestParamChecker implements
         $varType = $statements_source->getNodeTypeProvider()->getType(
             $expr->var
         );
-        if (is_null($varType)) {
+        if ($varType === null) {
             return null;
         }
         $foundRequest = false;
@@ -213,9 +213,9 @@ class RequestParamChecker implements
             return null;
         }
 
-        if (!is_null($context->calling_function_id)) {
+        if ($context->calling_function_id !== null) {
             $functionId = strtolower($context->calling_function_id);
-        } elseif (!is_null($context->calling_method_id)) {
+        } elseif ($context->calling_method_id !== null) {
             $functionId = $context->calling_method_id;
         } else {
             throw new \Exception('Empty calling method/function id');
@@ -256,7 +256,7 @@ class RequestParamChecker implements
         $returnType = $statements_source->getNodeTypeProvider()->getType(
             $expr
         );
-        if (is_null($returnType)) {
+        if ($returnType === null) {
             return null;
         }
 
@@ -328,7 +328,7 @@ class RequestParamChecker implements
             self::$parsedMethodTypeMapping[$functionId] = [];
 
             $docblock = $methodStmt->getDocComment();
-            if (is_null($docblock)) {
+            if ($docblock === null) {
                 continue;
             }
 
@@ -397,7 +397,7 @@ class RequestParamChecker implements
         );
         /** @psalm-suppress InternalMethod This code also appears in the examples, so it should be fine. */
         $methodStorage = $codebase->methods->getStorage($methodId);
-        if (is_null($methodStorage->location)) {
+        if ($methodStorage->location === null) {
             return [];
         }
         $statements = $codebase->getStatementsForFile(
@@ -427,9 +427,9 @@ class RequestParamChecker implements
     ): void {
         $callingFunctionId = $event->getContext()->calling_function_id;
         $callingMethodId = $event->getContext()->calling_method_id;
-        if (!is_null($callingFunctionId)) {
+        if ($callingFunctionId !== null) {
             $functionId = strtolower($callingFunctionId);
-        } elseif (!is_null($callingMethodId)) {
+        } elseif ($callingMethodId !== null) {
             $functionId = $callingMethodId;
         } else {
             // Not being called from within a function-like.
@@ -568,7 +568,7 @@ class RequestParamChecker implements
     public static function afterStatementAnalysis(
         \Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent $event
     ): ?bool {
-        if (is_null($event->getClasslikeStorage()->location)) {
+        if ($event->getClasslikeStorage()->location === null) {
             return null;
         }
 
@@ -581,7 +581,7 @@ class RequestParamChecker implements
         );
 
         $classlikeStorageLocation = $event->getClasslikeStorage()->location;
-        if (is_null($classlikeStorageLocation)) {
+        if ($classlikeStorageLocation === null) {
             throw new \Exception(
                 'Unable to get location for  ' .
                 strval($event->getClasslikeStorage())
@@ -606,7 +606,7 @@ class RequestParamChecker implements
                 } else {
                     $type = $param->type;
                 }
-                if (is_null($type)) {
+                if ($type === null) {
                     continue;
                 }
                 if ($type->getAttribute('resolvedName') == 'OmegaUp\\Request') {
@@ -618,13 +618,13 @@ class RequestParamChecker implements
             $docblock = $methodStmt->getDocComment();
             $parsedDocComment = \Psalm\DocComment::parsePreservingLength(
                 new \PhpParser\Comment\Doc(
-                    !is_null($docblock) ?
+                    $docblock !== null ?
                     strval($docblock->getText()) :
                     '/** */'
                 )
             );
             $docblockStart = (
-                !is_null($docblock) ?
+                $docblock !== null ?
                 $docblock->getStartFilePos() :
                 intval(
                     $methodStmt->getAttribute(
@@ -698,7 +698,7 @@ class RequestParamChecker implements
                     continue;
                 }
                 unset($missing[$requestParam->name]);
-                if (!is_null($requestParam->description)) {
+                if ($requestParam->description !== null) {
                     $expected[$requestParam->name]->description = $requestParam->description;
                 }
                 if (
@@ -913,7 +913,7 @@ class RequestParamDescription {
 
     public function __toString(): string {
         $result = $this->stringifyType() . " \${$this->name}";
-        if (!is_null($this->description)) {
+        if ($this->description !== null) {
             $result .= " {$this->description}";
         }
         return $result;

--- a/frontend/server/src/Psalm/TranslationStringChecker.php
+++ b/frontend/server/src/Psalm/TranslationStringChecker.php
@@ -301,7 +301,7 @@ class TranslationStringChecker implements
      * @return list<string>
      */
     private static function getAllTranslationStrings(): array {
-        if (is_null(self::$allTranslationStrings)) {
+        if (self::$allTranslationStrings === null) {
             $filename = __DIR__ . '/../../../templates/en.lang';
             $translationFileContents = [];
             foreach (explode("\n", file_get_contents($filename)) as $line) {
@@ -320,7 +320,7 @@ class TranslationStringChecker implements
      * going to be written to.
      */
     private static function getTranslationStringsDirname(): string {
-        if (is_null(self::$translationStringsDirname)) {
+        if (self::$translationStringsDirname === null) {
             self::$translationStringsDirname  = dirname(
                 __DIR__,
                 3

--- a/frontend/server/src/RabbitMQConnection.php
+++ b/frontend/server/src/RabbitMQConnection.php
@@ -20,10 +20,10 @@ class RabbitMQConnection {
      * termination.
      */
     public static function getInstance(): RabbitMQConnection {
-        if (is_null(self::$_instance)) {
+        if (self::$_instance === null) {
             self::$_instance = new RabbitMQConnection();
             register_shutdown_function(function () {
-                if (is_null(self::$_instance)) {
+                if (self::$_instance === null) {
                     return;
                 }
                 self::$_instance->connection->close();

--- a/frontend/server/src/Request.php
+++ b/frontend/server/src/Request.php
@@ -67,7 +67,7 @@ class Request extends \ArrayObject {
      * @return array<int, mixed>|array<string, mixed>
      */
     public function execute(): array {
-        if (is_null($this->method) || is_null($this->methodName)) {
+        if ($this->method === null || $this->methodName === null) {
             throw new \OmegaUp\Exceptions\NotFoundException('apiNotFound');
         }
         \OmegaUp\NewRelicHelper::nameTransaction("/api/{$this->methodName}");
@@ -78,7 +78,7 @@ class Request extends \ArrayObject {
         if ($response === false) {
             throw new \OmegaUp\Exceptions\NotFoundException('apiNotFound');
         }
-        if (is_null($response) || !is_array($response)) {
+        if ($response === null || !is_array($response)) {
             throw new \OmegaUp\Exceptions\InternalServerErrorException(
                 'generalError',
                 new \Exception('API did not return an array.')
@@ -103,8 +103,8 @@ class Request extends \ArrayObject {
      */
     public function isLoggedAsMainIdentity(): bool {
         return (
-            !is_null($this->user)
-            && !is_null($this->loginIdentity)
+            $this->user !== null
+            && $this->loginIdentity !== null
             && $this->user->main_identity_id === $this->loginIdentity->identity_id
         );
     }
@@ -224,7 +224,7 @@ class Request extends \ArrayObject {
             strval($mixedVal) :
             ''
         );
-        if (!is_null($validator)) {
+        if ($validator !== null) {
             try {
                 if (!$validator($val)) {
                     throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -432,19 +432,19 @@ class Request extends \ArrayObject {
      * @return void
      */
     public function ensureIdentity(): void {
-        if (!is_null($this->user) || !is_null($this->identity)) {
+        if ($this->user !== null || $this->identity !== null) {
             return;
         }
         $this->user = null;
         $this->identity = null;
         $this->loginIdentity = null;
         $session = \OmegaUp\Controllers\Session::getCurrentSession($this);
-        if (is_null($session['identity'])) {
+        if ($session['identity'] === null) {
             throw new \OmegaUp\Exceptions\UnauthorizedException();
         }
         $this->identity = $session['identity'];
         $this->loginIdentity = $session['loginIdentity'];
-        if (!is_null($session['user'])) {
+        if ($session['user'] !== null) {
             $this->user = $session['user'];
         }
     }
@@ -468,7 +468,7 @@ class Request extends \ArrayObject {
     public function ensureMainUserIdentity(): void {
         $this->ensureIdentity();
         if (
-            is_null($this->user)
+            $this->user === null
             || $this->user->main_identity_id != $this->identity->identity_id
         ) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
@@ -485,7 +485,7 @@ class Request extends \ArrayObject {
      */
     public function ensureIdentityIsOver13(): void {
         $this->ensureIdentity();
-        if (is_null($this->user)) {
+        if ($this->user === null) {
             return;
         }
         if (\OmegaUp\Authorization::isUnderThirteenUser($this->user)) {
@@ -530,7 +530,7 @@ class Request extends \ArrayObject {
         array $default = [],
         bool $required = false
     ): array {
-        if (is_null($this[$param])) {
+        if ($this[$param] === null) {
             if ($required) {
                 throw new \OmegaUp\Exceptions\InvalidParameterException(
                     'parameterEmpty',

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -48,9 +48,7 @@ class Scoreboard {
         $cache = null;
         // A few scoreboard options are not cacheable.
         if (
-            !$sortByName && is_null(
-                $filterUsersBy
-            ) && !$this->params->only_ac
+            !$sortByName && $filterUsersBy === null && !$this->params->only_ac
         ) {
             if ($this->params->admin) {
                 $cache = new \OmegaUp\Cache(
@@ -65,7 +63,7 @@ class Scoreboard {
             }
             /** @var null|Scoreboard */
             $result = $cache->get();
-            if (!is_null($result)) {
+            if ($result !== null) {
                 \OmegaUp\Scoreboard::setIsLastRunFromCacheForTesting(true);
                 return $result;
             }
@@ -147,8 +145,8 @@ class Scoreboard {
             $this->params->auth_token
         );
 
-        if (!is_null($cache)) {
-            $timeout =  is_null($this->params->finish_time) ?
+        if ($cache !== null) {
+            $timeout =  $this->params->finish_time === null ?
                 0 :
                 max(
                     0,
@@ -189,7 +187,7 @@ class Scoreboard {
             $result = $adminEventsCache->get();
         }
 
-        if (!is_null($result) && !$this->params->admin) {
+        if ($result !== null && !$this->params->admin) {
             \OmegaUp\Scoreboard::setIsLastRunFromCacheForTesting(true);
             return $result;
         }
@@ -244,7 +242,7 @@ class Scoreboard {
             $problemMapping
         );
 
-        $timeout = is_null($this->params->finish_time) ?
+        $timeout = $this->params->finish_time === null ?
             0 :
             max(
                 0,
@@ -351,7 +349,7 @@ class Scoreboard {
 
         // Cache scoreboard until the contest ends (or forever if it has already ended).
         // Contestant cache
-        $timeout =  is_null($params->finish_time) ?
+        $timeout =  $params->finish_time === null ?
             0 :
             max(
                 0,
@@ -476,7 +474,7 @@ class Scoreboard {
     ): ?\OmegaUp\Timestamp {
         if (
             $params->admin
-            || is_null($params->finish_time)
+            || $params->finish_time === null
             || (
                 (\OmegaUp\Time::get() >= $params->finish_time->time)
                 && $params->show_scoreboard_after
@@ -627,7 +625,7 @@ class Scoreboard {
                     continue;
                 }
                 if (
-                    !is_null($scoreboardTimeLimit)
+                    $scoreboardTimeLimit !== null
                     && !empty($run['time'])
                     && $run['time']->time >= $scoreboardTimeLimit->time
                 ) {
@@ -827,7 +825,7 @@ class Scoreboard {
             }
 
             if (
-                !is_null($scoreboardTimeLimit)
+                $scoreboardTimeLimit !== null
                 && !empty($run['time'])
                 && $run['time']->time >= $scoreboardTimeLimit->time
             ) {
@@ -948,7 +946,7 @@ class Scoreboard {
         int $problemId,
         int $maxScore
     ): float {
-        if (is_null($scoreByGroup)) {
+        if ($scoreByGroup === null) {
             return 0.0;
         }
         $scoreByGroupArray = json_decode($scoreByGroup, associative: true);

--- a/frontend/server/src/ScoreboardParams.php
+++ b/frontend/server/src/ScoreboardParams.php
@@ -104,7 +104,7 @@ class ScoreboardParams {
             $params,
             required: false,
         );
-        if (!is_null($params['finish_time'])) {
+        if ($params['finish_time'] !== null) {
             if ($params['finish_time'] instanceof \OmegaUp\Timestamp) {
                 $this->finish_time = $params['finish_time'];
             } else {
@@ -133,9 +133,7 @@ class ScoreboardParams {
             required: false,
             default: null,
         );
-        $this->group_id = is_null(
-            $params['group_id']
-        ) ? null : intval(
+        $this->group_id = $params['group_id'] === null ? null : intval(
             $params['group_id']
         );
 
@@ -195,9 +193,7 @@ class ScoreboardParams {
             required: false,
             default: null,
         );
-        $this->auth_token = is_null(
-            $params['auth_token']
-        ) ? null : strval(
+        $this->auth_token = $params['auth_token'] === null ? null : strval(
             $params['auth_token']
         );
 

--- a/frontend/server/src/SecurityTools.php
+++ b/frontend/server/src/SecurityTools.php
@@ -187,7 +187,7 @@ class SecurityTools {
     ): string {
         \ParagonIE_Sodium_Compat::$fastMult = true;
 
-        if (is_null(self::$_gitserverSecretKey)) {
+        if (self::$_gitserverSecretKey === null) {
             self::$_gitserverSecretKey = new \ParagonIE\Paseto\Keys\AsymmetricSecretKey(
                 base64_decode(OMEGAUP_GITSERVER_SECRET_KEY)
             );
@@ -282,7 +282,7 @@ class SecurityTools {
     private static function getCourseCloneSecretKey() {
         \ParagonIE_Sodium_Compat::$fastMult = true;
 
-        if (is_null(self::$_courseCloneSecretKey)) {
+        if (self::$_courseCloneSecretKey === null) {
             self::$_courseCloneSecretKey = \ParagonIE\Paseto\Keys\SymmetricKey::fromEncodedString(
                 OMEGAUP_COURSE_CLONE_SECRET_KEY
             );

--- a/frontend/server/src/Template/JsIncludeParser.php
+++ b/frontend/server/src/Template/JsIncludeParser.php
@@ -11,7 +11,7 @@ class JsIncludeParser extends \Twig\TokenParser\AbstractTokenParser {
         $entrypoint = $stream->expect(\Twig\Token::STRING_TYPE)->getValue();
         /** @var string[] */
         $options = [];
-        while (!is_null($option = $stream->nextIf(\Twig\Token::NAME_TYPE))) {
+        while ($option = $stream->nextIf(\Twig\Token::NAME_TYPE) !== null) {
             /** @var string */
             $value = $option->getValue();
             $options[] = $value;

--- a/frontend/server/src/Time.php
+++ b/frontend/server/src/Time.php
@@ -7,7 +7,7 @@ class Time {
     private static $time = null;
 
     public static function get(): int {
-        if (!is_null(self::$time)) {
+        if (self::$time !== null) {
             return self::$time;
         }
         return time();

--- a/frontend/server/src/Translations.php
+++ b/frontend/server/src/Translations.php
@@ -52,7 +52,7 @@ class Translations {
      * @return \OmegaUp\Translations the singleton instance.
      */
     public static function getInstance(?\OmegaUp\DAO\VO\Identities $identity = null): \OmegaUp\Translations {
-        if (is_null(self::$_instance)) {
+        if (self::$_instance === null) {
             self::$_instance = new \OmegaUp\Translations($identity);
         }
         return self::$_instance;

--- a/frontend/server/src/UITools.php
+++ b/frontend/server/src/UITools.php
@@ -23,9 +23,7 @@ class UITools {
      */
     public static function redirectToLoginIfNotLoggedIn(): void {
         if (
-            !is_null(
-                \OmegaUp\Controllers\Session::getCurrentSession()['identity']
-            )
+            \OmegaUp\Controllers\Session::getCurrentSession()['identity'] !== null
         ) {
             return;
         }
@@ -52,7 +50,7 @@ class UITools {
      * @return array{twig: \Twig\Environment, twigContext: array<string, mixed>}
      */
     public static function getTwigInstance() {
-        if (!is_null(self::$twig)) {
+        if (self::$twig !== null) {
             return [
                 'twig' => self::$twig,
                 'twigContext' => self::$twigContext,
@@ -167,48 +165,46 @@ class UITools {
         return [
             'omegaUpLockDown' => boolval(OMEGAUP_LOCKDOWN),
             'inContest' => $inContest,
-            'isLoggedIn' => !is_null($identity),
+            'isLoggedIn' => $identity !== null,
             'isReviewer' => (
-                !is_null($identity) ?
+                $identity !== null ?
                 \OmegaUp\Authorization::isQualityReviewer($identity) :
                 false
             ),
             'gravatarURL51' => (
-                is_null($email) ?
+                $email === null ?
                 '' :
                 self::getFormattedGravatarURL(md5($email), '51')
             ),
             'gravatarURL128' => (
-                is_null($email) ?
+                $email === null ?
                 '' :
                 self::getFormattedGravatarURL(md5($email), '128')
             ),
             'currentUsername' => (
-                !is_null($identity) && !is_null($identity->username) ?
+                $identity !== null && $identity->username !== null ?
                 $identity->username :
                 ''
             ),
-            'currentName' => !is_null($identity) ? $identity->name : null,
+            'currentName' => $identity !== null ? $identity->name : null,
             'currentEmail' => $email ?? '',
             'associatedIdentities' => $associatedIdentities,
             'apiTokens' => $apiTokens,
             'isUnder13User' => $isUnder13User,
             'userVerificationDeadline' => $userVerificationDeadline,
             'userClassname' => $userClassname,
-            'userCountry' => (!is_null(
-                $identity
-            ) ? $identity->country_id : null) ?? 'xx',
+            'userCountry' => ($identity !== null ? $identity->country_id : null) ?? 'xx',
             'profileProgress' => \OmegaUp\Controllers\User::getProfileProgress(
                 $user
             ),
-            'isMainUserIdentity' => !is_null($user),
+            'isMainUserIdentity' => $user !== null,
             'isAdmin' => $isAdmin,
             'mentorCanChooseCoder' => $mentorCanChooseCoder,
             'lockDownImage' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAA6UlEQVQ4jd2TMYoCMRiFv5HBwnJBsFqEiGxtISps6RGmFD2CZRr7aQSPIFjmCGsnrFYeQJjGytJKRERsfp2QmahY+iDk5c97L/wJCchBFCclYAD8SmkBTI1WB1cb5Ji/gT+g7mxtgK7RausNiOIEYAm0pHSWOZR5BbSNVndPwTmlaZnnQFnGXGot0XgDfiw+NlrtjVZ7YOzRZAJCix893NZkAi4eYejRpJcYxckQ6AENKf0DO+EVoCN8DcyMVhM3eQR8WesO+WgAVWDituC28wiFDHkXHxBgv0IfKL7oO+UF1Ei/7zMsbuQKTFoqpb8KS2AAAAAASUVORK5CYII=',
             'navbarSection' => $navbarSection,
             'userTypes' => (
-                !is_null($identity) &&
-                !is_null($user) ?
+                $identity !== null &&
+                $user !== null ?
                 \OmegaUp\Controllers\User::getUserTypes($user, $identity) :
                 []
             ),

--- a/frontend/server/src/Validators.php
+++ b/frontend/server/src/Validators.php
@@ -130,14 +130,14 @@ class Validators {
         ?int $minLength,
         ?int $maxLength
     ): void {
-        if (!is_null($minLength) && strlen($parameter) < $minLength) {
+        if ($minLength !== null && strlen($parameter) < $minLength) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterStringTooShort',
                 $parameterName,
                 ['min_length' => strval($minLength)]
             );
         }
-        if (!is_null($maxLength) && strlen($parameter) > $maxLength) {
+        if ($maxLength !== null && strlen($parameter) > $maxLength) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterStringTooLong',
                 $parameterName,
@@ -160,14 +160,14 @@ class Validators {
         ?int $minLength,
         ?int $maxLength
     ): bool {
-        if (!is_null($minLength) && strlen($parameter) < $minLength) {
+        if ($minLength !== null && strlen($parameter) < $minLength) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterStringTooShort',
                 parameter: null,
                 additionalParameters: ['min_length' => strval($minLength)],
             );
         }
-        if (!is_null($maxLength) && strlen($parameter) > $maxLength) {
+        if ($maxLength !== null && strlen($parameter) > $maxLength) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterStringTooLong',
                 parameter: null,
@@ -531,14 +531,14 @@ class Validators {
         }
         // Coerce $parameter into a numeric value.
         $parameter = $parameter + 0;
-        if (!is_null($lowerBound) && $parameter < $lowerBound) {
+        if ($lowerBound !== null && $parameter < $lowerBound) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNumberTooSmall',
                 $parameterName,
                 ['lower_bound' => strval($lowerBound)]
             );
         }
-        if (!is_null($upperBound) && $parameter > $upperBound) {
+        if ($upperBound !== null && $parameter > $upperBound) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterNumberTooLarge',
                 $parameterName,
@@ -574,7 +574,7 @@ class Validators {
                 $parameterName
             );
         }
-        if (!is_null($lowerBound) && $parameter < $lowerBound) {
+        if ($lowerBound !== null && $parameter < $lowerBound) {
             $exception = new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterDateTooSmall',
                 $parameterName
@@ -585,7 +585,7 @@ class Validators {
             );
             throw $exception;
         }
-        if (!is_null($upperBound) && $parameter > $upperBound) {
+        if ($upperBound !== null && $parameter > $upperBound) {
             $exception = new \OmegaUp\Exceptions\InvalidParameterException(
                 'parameterDateTooLarge',
                 $parameterName
@@ -735,7 +735,7 @@ class Validators {
         string $parameterName,
         bool $required = true
     ): bool {
-        if (!is_null($parameter)) {
+        if ($parameter !== null) {
             return true;
         }
         if ($required) {


### PR DESCRIPTION
# Description

Replace all `is_null($x)` calls with `$x === null` and `!is_null($x)` with `$x !== null` in the remaining core files under `frontend/server/src/` (Authorization, Scoreboard, Request, UITools, Validators, Exceptions, Psalm, etc.).

This is **Sub-PR C** of 3 for issue #9270. The strict comparison (`=== null`) is slightly faster and is the more common modern PHP convention.

**Changes:** 31 files, ~184 insertions, ~198 deletions.

Fixes #9270 (partial)

# Comments

This is a purely mechanical find-and-replace with no logic changes. Split into 3 PRs as recommended in the issue:
- **Sub-PR A:** `Controllers/` → see companion PR
- **Sub-PR B:** `DAO/` → see companion PR
- **Sub-PR C (this one):** Core `src/` files

# Checklist

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.