### PR TITLE
fix: use parameterized queries in coder_of_the_month.py

### DIFF
--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -201,8 +201,6 @@ def get_cotm_eligible_users(
 ) -> List[UserRank]:
     '''Returns the list of eligible users for coder of the month'''
 
-    last_12_coders_str = ', '.join(f"'{coder}'" for coder in last_12_coders)
-
     if category == 'female':
         gender_clause = " AND i.gender = 'female'"
     else:
@@ -210,8 +208,11 @@ def get_cotm_eligible_users(
 
     if not last_12_coders:
         last_12_coders_clause = ''
+        last_12_coders_params: tuple = ()
     else:
-        last_12_coders_clause = f'AND i.username NOT IN ({last_12_coders_str})'
+        placeholders = ', '.join(['%s'] * len(last_12_coders))
+        last_12_coders_clause = f'AND i.username NOT IN ({placeholders})'
+        last_12_coders_params = tuple(last_12_coders)
     logging.info(
         'Getting the list of eligible users in the category [%s] for coder of '
         'the month', category
@@ -277,6 +278,7 @@ def get_cotm_eligible_users(
     cur_readonly.execute(sql, (
         first_day_of_current_month,
         first_day_of_next_month,
+        *last_12_coders_params,
     ))
 
     usernames: List[UserRank] = []
@@ -328,8 +330,8 @@ def get_eligible_problems(
 
 def get_user_problems(
     cur_readonly: mysql.connector.cursor.MySQLCursorDict,
-    identity_ids_str: str,
-    problem_ids_str: str,
+    identity_ids: List[int],
+    problem_ids: List[int],
     eligible_users: List[UserRank],
     first_day_of_current_month: datetime.date,
 ) -> Dict[int, UserProblems]:
@@ -344,8 +346,10 @@ def get_user_problems(
     first_day_of_next_month = get_first_day_of_next_month(
         first_day_of_current_month)
 
-    problems_admins = get_problems_admins(cur_readonly, problem_ids_str)
+    problems_admins = get_problems_admins(cur_readonly, problem_ids)
 
+    id_placeholders = ', '.join(['%s'] * len(identity_ids))
+    prob_placeholders = ', '.join(['%s'] * len(problem_ids))
     cur_readonly.execute(f'''
             WITH
                 ProblemsForfeitedByUser AS (
@@ -374,14 +378,14 @@ def get_user_problems(
                 pfbu.user_id = i.user_id
                 AND pfbu.problem_id = s.problem_id
             WHERE
-                s.identity_id IN ({identity_ids_str})
-                AND s.problem_id IN ({problem_ids_str})
+                s.identity_id IN ({id_placeholders})
+                AND s.problem_id IN ({prob_placeholders})
                 AND s.verdict = 'AC'
                 AND s.type = 'normal'
                 AND pfbu.forfeited_date IS NULL
             GROUP BY
                 s.identity_id, s.problem_id;
-    ''')
+    ''', (*identity_ids, *problem_ids))
 
     # Populate user_problems dictionary with the problems solved by each user
     for row in cur_readonly.fetchall():
@@ -401,10 +405,11 @@ def get_user_problems(
 
 def get_problems_admins(
     cur_readonly: mysql.connector.cursor.MySQLCursorDict,
-    problem_ids_str: str,
+    problem_ids: List[int],
 ) -> Dict[int, List[int]]:
     '''Get the list of problems admins'''
 
+    placeholders = ', '.join(['%s'] * len(problem_ids))
     cur_readonly.execute(f'''
         SELECT
             p.problem_id,
@@ -416,7 +421,7 @@ def get_problems_admins(
         INNER JOIN
             Identities AS ai ON a.owner_id = ai.user_id
         WHERE
-            p.problem_id IN ({problem_ids_str})
+            p.problem_id IN ({placeholders})
         UNION DISTINCT
         SELECT
             p.problem_id,
@@ -429,7 +434,7 @@ def get_problems_admins(
         INNER JOIN
             Identities uri ON ur.user_id = uri.user_id
         WHERE
-            p.problem_id IN ({problem_ids_str})
+            p.problem_id IN ({placeholders})
         UNION DISTINCT
         SELECT
             p.problem_id,
@@ -442,10 +447,10 @@ def get_problems_admins(
         INNER JOIN
             Groups_Identities gi ON gi.group_id = gr.group_id
         WHERE
-            p.problem_id IN ({problem_ids_str})
+            p.problem_id IN ({placeholders})
         ORDER BY
             problem_id;
-    ''')
+    ''', (*problem_ids, *problem_ids, *problem_ids))
 
     problems_admins: Dict[int, List[int]] = {}
 

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -499,15 +499,9 @@ def compute_points_for_user(
         logging.info('No eligible problems found.')
         return []
 
-    # Convert the list of identity IDs to a comma-separated string
-    identity_ids_str = ', '.join(map(str, identity_ids))
-
-    # Convert the list of problem IDs to a comma-separated string
-    problem_ids_str = ', '.join(map(str, problem_ids))
-
     user_problems = get_user_problems(cur_readonly,
-                                      identity_ids_str,
-                                      problem_ids_str,
+                                      identity_ids,
+                                      problem_ids,
                                       eligible_users,
                                       first_day_of_current_month,
                                       )


### PR DESCRIPTION
Replace f-string SQL interpolation in get_cotm_eligible_users, get_user_problems, and get_problems_admins with dynamic %s placeholders, consistent with the rest of the file.
Fixes #9291

# Description

Please include a description of the changes you have made. The text you put in this section will be used as the **commit message** when this PR is merged.

If you modify the **User Interface**, please include a screenshot or a video.

Fixes: #(issue)

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
