### PR TITLE
fix: per-tab filter and sort state

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestListv2.test.ts
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.test.ts
@@ -469,4 +469,33 @@ describe('ContestListv2.vue', () => {
     await wrapper.vm.$nextTick();
     expect(vm.currentOrder).toBe(ContestOrder.Title);
   });
+
+  it('Should apply URL filter only to the initial active tab, not all tabs', () => {
+    // Simulate URL: ?tab_name=past&filter=recommended
+    const wrapper = mount(arena_ContestList, {
+      propsData: {
+        contests,
+        tab: ContestTab.Past,
+        filter: ContestFilter.OnlyRecommended,
+        sortOrder: ContestOrder.Title,
+      },
+    });
+
+    const vm = wrapper.vm as InstanceType<typeof arena_ContestList>;
+
+    // Active tab (Past) should have the URL filter/order applied
+    expect(vm.currentFilter).toBe(ContestFilter.OnlyRecommended);
+    expect(vm.currentOrder).toBe(ContestOrder.Title);
+
+    // Inactive tabs should start with defaults, not inherit URL params
+    ((wrapper.vm as unknown) as { currentTab: ContestTab }).currentTab =
+      ContestTab.Current;
+    expect(vm.currentFilter).toBe(ContestFilter.All);
+    expect(vm.currentOrder).toBe(ContestOrder.None);
+
+    ((wrapper.vm as unknown) as { currentTab: ContestTab }).currentTab =
+      ContestTab.Future;
+    expect(vm.currentFilter).toBe(ContestFilter.All);
+    expect(vm.currentOrder).toBe(ContestOrder.None);
+  });
 });

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.test.ts
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.test.ts
@@ -409,4 +409,64 @@ describe('ContestListv2.vue', () => {
     const tabChangeParams = allEvents[allEvents.length - 1][0].params;
     expect(tabChangeParams.replaceState).toBe(false);
   });
+
+  it('Should maintain independent filter state per tab', async () => {
+    const wrapper = mount(arena_ContestList, {
+      propsData: {
+        contests,
+        tab: ContestTab.Current,
+      },
+    });
+
+    const vm = wrapper.vm as InstanceType<typeof arena_ContestList>;
+
+    // Change filter on current tab to recommended
+    const dropdownFilterBy = wrapper.findComponent({ ref: 'dropdownFilterBy' });
+    await dropdownFilterBy
+      .find('[data-filter-by-recommended]')
+      .trigger('click');
+    expect(vm.currentFilter).toBe(ContestFilter.OnlyRecommended);
+
+    // Switch to past tab
+    ((wrapper.vm as unknown) as { currentTab: ContestTab }).currentTab =
+      ContestTab.Past;
+    await wrapper.vm.$nextTick();
+
+    // Past tab should still have the default "All" filter
+    expect(vm.currentFilter).toBe(ContestFilter.All);
+
+    // Switch back to current tab — filter should still be OnlyRecommended
+    ((wrapper.vm as unknown) as { currentTab: ContestTab }).currentTab =
+      ContestTab.Current;
+    await wrapper.vm.$nextTick();
+    expect(vm.currentFilter).toBe(ContestFilter.OnlyRecommended);
+  });
+
+  it('Should maintain independent sort order per tab', async () => {
+    const wrapper = mount(arena_ContestList, {
+      propsData: {
+        contests,
+        tab: ContestTab.Current,
+      },
+    });
+
+    const vm = wrapper.vm as InstanceType<typeof arena_ContestList>;
+
+    // Change order on current tab to Title
+    const dropdownOrderBy = wrapper.findComponent({ ref: 'dropdownOrderBy' });
+    await dropdownOrderBy.find('[data-order-by-title]').trigger('click');
+    expect(vm.currentOrder).toBe(ContestOrder.Title);
+
+    // Switch to future tab — order should be the default None
+    ((wrapper.vm as unknown) as { currentTab: ContestTab }).currentTab =
+      ContestTab.Future;
+    await wrapper.vm.$nextTick();
+    expect(vm.currentOrder).toBe(ContestOrder.None);
+
+    // Switch back to current tab — order should still be Title
+    ((wrapper.vm as unknown) as { currentTab: ContestTab }).currentTab =
+      ContestTab.Current;
+    await wrapper.vm.$nextTick();
+    expect(vm.currentOrder).toBe(ContestOrder.Title);
+  });
 });

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -491,9 +491,18 @@ class ArenaContestList extends Vue {
   ContestFilter = ContestFilter;
   currentTab: ContestTab = this.tab;
   currentQuery: string = this.query;
-  currentOrder: ContestOrder = this.sortOrder;
-  currentFilter: ContestFilter = this.filter;
   currentPage: number = this.page;
+  // Per-tab independent filter and sort-order state (fixes #9258)
+  tabFilters: Record<ContestTab, ContestFilter> = {
+    [ContestTab.Current]: this.filter,
+    [ContestTab.Future]: ContestFilter.All,
+    [ContestTab.Past]: ContestFilter.All,
+  };
+  tabOrders: Record<ContestTab, ContestOrder> = {
+    [ContestTab.Current]: this.sortOrder,
+    [ContestTab.Future]: ContestOrder.None,
+    [ContestTab.Past]: ContestOrder.None,
+  };
   refreshing: boolean = false;
   isScrollLoading: boolean = false;
   hasMore: boolean = true;
@@ -609,40 +618,57 @@ class ArenaContestList extends Vue {
     return `${getExternalUrl('TimeAndDateBaseURL')}?iso=${time.toISOString()}`;
   }
 
+  get currentFilter(): ContestFilter {
+    return this.tabFilters[this.currentTab];
+  }
+
+  get currentOrder(): ContestOrder {
+    return this.tabOrders[this.currentTab];
+  }
+
   orderByTitle() {
-    this.currentOrder = ContestOrder.Title;
+    Vue.set(this.tabOrders, this.currentTab, ContestOrder.Title);
+    this.fetchInitialContests();
   }
 
   orderByEnds() {
-    this.currentOrder = ContestOrder.Ends;
+    Vue.set(this.tabOrders, this.currentTab, ContestOrder.Ends);
+    this.fetchInitialContests();
   }
 
   orderByDuration() {
-    this.currentOrder = ContestOrder.Duration;
+    Vue.set(this.tabOrders, this.currentTab, ContestOrder.Duration);
+    this.fetchInitialContests();
   }
 
   orderByOrganizer() {
-    this.currentOrder = ContestOrder.Organizer;
+    Vue.set(this.tabOrders, this.currentTab, ContestOrder.Organizer);
+    this.fetchInitialContests();
   }
 
   orderByContestants() {
-    this.currentOrder = ContestOrder.Contestants;
+    Vue.set(this.tabOrders, this.currentTab, ContestOrder.Contestants);
+    this.fetchInitialContests();
   }
 
   orderBySignedUp() {
-    this.currentOrder = ContestOrder.SignedUp;
+    Vue.set(this.tabOrders, this.currentTab, ContestOrder.SignedUp);
+    this.fetchInitialContests();
   }
 
   filterBySignedUp() {
-    this.currentFilter = ContestFilter.SignedUp;
+    Vue.set(this.tabFilters, this.currentTab, ContestFilter.SignedUp);
+    this.fetchInitialContests();
   }
 
   filterByRecommended() {
-    this.currentFilter = ContestFilter.OnlyRecommended;
+    Vue.set(this.tabFilters, this.currentTab, ContestFilter.OnlyRecommended);
+    this.fetchInitialContests();
   }
 
   filterByAll() {
-    this.currentFilter = ContestFilter.All;
+    Vue.set(this.tabFilters, this.currentTab, ContestFilter.All);
+    this.fetchInitialContests();
   }
 
   get showMoreContestButtonText(): string {
@@ -681,13 +707,13 @@ class ArenaContestList extends Vue {
   @Watch('sortOrder')
   onSortOrderPropChanged(newValue: ContestOrder) {
     this.isFromBrowserNavigation = true;
-    this.currentOrder = newValue;
+    Vue.set(this.tabOrders, this.currentTab, newValue);
   }
 
   @Watch('filter')
   onFilterPropChanged(newValue: ContestFilter) {
     this.isFromBrowserNavigation = true;
-    this.currentFilter = newValue;
+    Vue.set(this.tabFilters, this.currentTab, newValue);
   }
 
   @Watch('page')
@@ -696,27 +722,9 @@ class ArenaContestList extends Vue {
     this.currentPage = newValue;
   }
 
-  // Watchers for internal state - fetch data when user interacts with UI
+  // Watcher for tab change - fetch data when user switches tabs
   @Watch('currentTab', { immediate: true, deep: true })
   onCurrentTabChanged(newValue: ContestTab, oldValue: undefined | ContestTab) {
-    if (typeof oldValue === 'undefined') return;
-    this.fetchInitialContests();
-  }
-
-  @Watch('currentOrder', { immediate: true, deep: true })
-  onCurrentOrderChanged(
-    newValue: ContestOrder,
-    oldValue: undefined | ContestOrder,
-  ) {
-    if (typeof oldValue === 'undefined') return;
-    this.fetchInitialContests();
-  }
-
-  @Watch('currentFilter', { immediate: true, deep: true })
-  onCurrentFilterChanged(
-    newValue: ContestFilter,
-    oldValue: undefined | ContestFilter,
-  ) {
     if (typeof oldValue === 'undefined') return;
     this.fetchInitialContests();
   }

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -492,9 +492,7 @@ class ArenaContestList extends Vue {
   currentTab: ContestTab = this.tab;
   currentQuery: string = this.query;
   currentPage: number = this.page;
-  // Per-tab independent filter and sort-order state (fixes #9258).
-  // Apply the URL's filter/order only to the active tab on load;
-  // other tabs start with defaults so they are not pre-filtered.
+  // Per-tab independent filter and sort-order state
   tabFilters: Record<ContestTab, ContestFilter> = {
     [ContestTab.Current]:
       this.tab === ContestTab.Current ? this.filter : ContestFilter.All,

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -492,16 +492,24 @@ class ArenaContestList extends Vue {
   currentTab: ContestTab = this.tab;
   currentQuery: string = this.query;
   currentPage: number = this.page;
-  // Per-tab independent filter and sort-order state (fixes #9258)
+  // Per-tab independent filter and sort-order state (fixes #9258).
+  // Apply the URL's filter/order only to the active tab on load;
+  // other tabs start with defaults so they are not pre-filtered.
   tabFilters: Record<ContestTab, ContestFilter> = {
-    [ContestTab.Current]: this.filter,
-    [ContestTab.Future]: ContestFilter.All,
-    [ContestTab.Past]: ContestFilter.All,
+    [ContestTab.Current]:
+      this.tab === ContestTab.Current ? this.filter : ContestFilter.All,
+    [ContestTab.Future]:
+      this.tab === ContestTab.Future ? this.filter : ContestFilter.All,
+    [ContestTab.Past]:
+      this.tab === ContestTab.Past ? this.filter : ContestFilter.All,
   };
   tabOrders: Record<ContestTab, ContestOrder> = {
-    [ContestTab.Current]: this.sortOrder,
-    [ContestTab.Future]: ContestOrder.None,
-    [ContestTab.Past]: ContestOrder.None,
+    [ContestTab.Current]:
+      this.tab === ContestTab.Current ? this.sortOrder : ContestOrder.None,
+    [ContestTab.Future]:
+      this.tab === ContestTab.Future ? this.sortOrder : ContestOrder.None,
+    [ContestTab.Past]:
+      this.tab === ContestTab.Past ? this.sortOrder : ContestOrder.None,
   };
   refreshing: boolean = false;
   isScrollLoading: boolean = false;


### PR DESCRIPTION
# Description

Fixes #9258. Related: #9259.

https://github.com/user-attachments/assets/6c59ab0e-5662-4421-9de0-b397a0e8bbac

Each of the three contest tabs (Current / Future / Past) previously shared a single `currentFilter` and `currentOrder` state. Selecting *Only recommended* on the Past tab would immediately bleed into Current and Future — the same filter was used when fetching data for the newly-active tab, and the dropdown checkmark stayed set regardless of which tab was visible.

**Root cause:**

```ts
// single shared variables — tab switch inherited the previous tab's values
currentFilter: ContestFilter = this.filter;
currentOrder:  ContestOrder  = this.sortOrder;

@Watch('currentTab')
onCurrentTabChanged() {
  this.fetchInitialContests();
  // ↑ used the stale shared currentFilter/currentOrder from the previous tab
}
```

**Fix — per-tab maps + computed getters:**

```ts
// each tab keeps its own filter and order; only the active tab is seeded from the URL
tabFilters: Record<ContestTab, ContestFilter> = {
  [ContestTab.Current]: this.tab === ContestTab.Current ? this.filter : ContestFilter.All,
  [ContestTab.Future]:  this.tab === ContestTab.Future  ? this.filter : ContestFilter.All,
  [ContestTab.Past]:    this.tab === ContestTab.Past    ? this.filter : ContestFilter.All,
};
tabOrders: Record<ContestTab, ContestOrder> = { /* same pattern */ };

get currentFilter() { return this.tabFilters[this.currentTab]; }
get currentOrder()  { return this.tabOrders[this.currentTab];  }
```

Filter/order methods (`filterByAll`, `orderByTitle`, …) now write to the **current tab's slot** via `Vue.set` and call `fetchInitialContests()` directly. The redundant `@Watch('currentFilter')` and `@Watch('currentOrder')` watchers (which caused the cross-tab bleed) are removed.

The dropdown checkmarks in the template (`v-if="currentFilter === …"`) already read the computed `currentFilter`, so the UI indicator now correctly reflects each tab's independent state — which also lays the groundwork for the visual-indicator improvements tracked in #9259.

**Result:**
- Selecting *Only recommended* on Past → Past shows recommended contests only; switching to Current shows all; switching to Future shows all.
- Each tab remembers its own selection when you switch back.
- Loading `?tab_name=past&filter=recommended` seeds only the Past tab, not Current/Future.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.