### PR TITLE
fix: button and input-group alignment inconsistencies

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -29,16 +29,16 @@
                       :placeholder="T.wordsKeyword"
                       @keyup.enter="onSearchQuery"
                     />
-                    <button
-                      class="btn reset-btn nav-link"
-                      type="reset"
-                      @click="onReset"
-                    >
-                      &times;
-                    </button>
                     <div class="input-group-append">
+                      <button
+                        class="btn reset-btn nav-link"
+                        type="reset"
+                        @click="onReset"
+                      >
+                        &times;
+                      </button>
                       <input
-                        class="btn btn-primary btn-style btn-md btn-block active nav-link"
+                        class="btn btn-primary btn-style nav-link"
                         type="submit"
                         :value="T.wordsSearch"
                       />
@@ -768,11 +768,7 @@ export default ArenaContestList;
 
 .btn-primary {
   background-color: var(--arena-button-border-color) !important;
-  height: 2.5rem;
   width: 7.5rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
 .contest-card {

--- a/frontend/www/js/omegaup/components/login/Login.vue
+++ b/frontend/www/js/omegaup/components/login/Login.vue
@@ -296,6 +296,10 @@ export default class Login extends Vue {
   border-color: var(--btn-github-border-color--hover);
 }
 
+.github-login-btn:active {
+  color: var(--btn-github-font-color) !important;
+}
+
 .github-login-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;


### PR DESCRIPTION
# Description

Fixes two visual UI inconsistencies. Closes #9302.

### 1. Search bar — seamless join between `x` and Search ([`ContestListv2.vue`](frontend/www/js/omegaup/components/arena/ContestListv2.vue))
<img width="1445" height="377" alt="image" src="https://github.com/user-attachments/assets/f5b4f911-cfaa-4779-a212-13d0e09dfb3b" />

The `x` reset button was placed **directly inside** `.input-group` without a Bootstrap wrapper, so Bootstrap's border-radius stitching didn't apply to it, leaving a visible gap between `x` and Search. Two separate \`input-group-append\` wrappers were also creating a seam between them.

Fix: moved the reset button **inside the same** \`input-group-append\` div as the Search submit button — both elements now live in one wrapper and Bootstrap handles the borders seamlessly.

Also removed the hardcoded \`active\`, \`btn-block\`, and \`btn-md\` classes from the Search submit (they were always triggering Bootstrap's active state and block-width styling), and removed \`height\`, \`display: flex\`, \`justify-content\`, \`align-items\` from the scoped \`.btn-primary\` rule (the explicit height was making the button slightly taller than the input, causing the border to extend below).

### 2. GitHub sign-in button — text stays visible when clicked ([`Login.vue`](frontend/www/js/omegaup/components/login/Login.vue))
<img width="1006" height="331" alt="image" src="https://github.com/user-attachments/assets/96b9bffa-c863-4562-a173-d84675932eb6" />

Bootstrap's \`btn-outline-secondary:active\` sets \`color: #fff\`, making the black GitHub octicon and label invisible on click. Added a single \`.github-login-btn:active\` rule that pins the text color back to the custom dark value. The grey pressed background (Bootstrap default) is intentionally kept — only the text color is overridden.

Fixes: #9302

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.