### PR TITLE
Run button 405 error

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_contestant.ts
+++ b/frontend/www/js/omegaup/arena/contest_contestant.ts
@@ -268,7 +268,7 @@ OmegaUp.on('ready', async () => {
           }: {
             target: Vue & { currentNextExecutionTimestamp: Date };
           }) => {
-            api.Run.execute()
+            api.Run.execute({})
               .then(time.remoteTimeAdapter)
               .then((response) => {
                 target.currentNextExecutionTimestamp =

--- a/frontend/www/js/omegaup/arena/contest_practice.ts
+++ b/frontend/www/js/omegaup/arena/contest_practice.ts
@@ -144,7 +144,7 @@ OmegaUp.on('ready', async () => {
           }: {
             target: Vue & { currentNextExecutionTimestamp: Date };
           }) => {
-            api.Run.execute()
+            api.Run.execute({})
               .then(time.remoteTimeAdapter)
               .then((response) => {
                 target.currentNextExecutionTimestamp =

--- a/frontend/www/js/omegaup/arena/contest_virtual.ts
+++ b/frontend/www/js/omegaup/arena/contest_virtual.ts
@@ -255,7 +255,7 @@ OmegaUp.on('ready', async () => {
           }: {
             target: Vue & { currentNextExecutionTimestamp: Date };
           }) => {
-            api.Run.execute()
+            api.Run.execute({})
               .then(time.remoteTimeAdapter)
               .then((response) => {
                 target.currentNextExecutionTimestamp =

--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -236,7 +236,7 @@ OmegaUp.on('ready', async () => {
           }: {
             target: Vue & { currentNextExecutionTimestamp: Date };
           }) => {
-            api.Run.execute()
+            api.Run.execute({})
               .then(time.remoteTimeAdapter)
               .then((response) => {
                 target.currentNextExecutionTimestamp =

--- a/frontend/www/js/omegaup/grader/ide.ts
+++ b/frontend/www/js/omegaup/grader/ide.ts
@@ -33,7 +33,7 @@ OmegaUp.on('ready', () => {
         },
         on: {
           'execute-run': () => {
-            api.Run.executeForIDE()
+            api.Run.executeForIDE({})
               .then(time.remoteTimeAdapter)
               .then((response) => {
                 ideComponent.nextExecutionTimestamp =

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -495,7 +495,7 @@ OmegaUp.on('ready', async () => {
             });
           break;
         case 'executeRun':
-          api.Run.execute()
+          api.Run.execute({})
             .then(time.remoteTimeAdapter)
             .then((response) => {
               problemDetailsView.nextExecutionTimestamp =


### PR DESCRIPTION

# Description

Fixes an issue where clicking the **Run** button triggered a `GET` request to execution endpoints, resulting in a `405 Method Not Allowed` response.

## Root Cause

The `apiCall(...)` helper defaults to `GET` when called without parameters.
The Run execution endpoints require a mutating HTTP method (e.g., `POST`).

## Fix

Updated Run execution calls to explicitly send an empty params object so the request is sent as `POST`:

* `api.Run.execute({})`
* `api.Run.executeForIDE({})`

This ensures the correct HTTP method is used while preserving existing execution handling logic.

## Affected Flows

* Problem details run
* Contest (contestant / practice / virtual)
* Course arena run
* Grader IDE run

Fixes: #9323

---

# Comments

Validated locally by:

* Opening each affected page
* Clicking **Run**
* Confirming the request method is `POST` in DevTools
* Verifying no `405 Method Not Allowed` is returned
* Ensuring `nextExecutionTimestamp` updates correctly
* Confirming execution results render as expected

---

# Checklist:

* [x] The code follows the coding guidelines of omegaUp.
* [x] The tests were executed and all of them passed.
* [ ] If you are creating a feature, the new tests were added.
* [x] If the change is large (> 200 lines), this PR was split appropriately (not applicable, small fix).
