### PR TITLE
Fix broken Google Docs link in GSoC 2026 documentation

### DIFF
--- a/frontend/www/docs/Google-Summer-of-Code-2026.md
+++ b/frontend/www/docs/Google-Summer-of-Code-2026.md
@@ -20,7 +20,7 @@ This project aims to improve the platform’s performance by optimizing SQL quer
 * One Integration test that analyzes the EXPLAIN of all queries to determine if it's efficient or not.
 * One integration test that analyzes the performance of all queries by running them on a synthetic dataset with dimensions comparable to those of production. 
 
-The goal is to ensure quick response times for frequent operations and ensure scalability under high-load scenarios. More details about the requirements can be found in [this doc](https://docs.google.com/document/d/1X_fAm97L6_v9P8_R0S_Lp7X6e7x7j7z-X5z5-x5z5z5).
+The goal is to ensure quick response times for frequent operations and ensure scalability under high-load scenarios. More details about the requirements are described in the sections below.
 
 **Current status**:
 


### PR DESCRIPTION
This PR fixes issue #9326 a broken Google Docs link in the GSoC 2026 documentation.

The previous link returned a "file does not exist" error. The broken external link has been removed to avoid confusion for contributors.

Fixes: #9326