### PR TITLE
Add composite index on User_Roles to optimize getAdmins query

### DIFF
--- a/frontend/database/00264_add_index_user_roles_role_acl.sql
+++ b/frontend/database/00264_add_index_user_roles_role_acl.sql
@@ -1,0 +1,4 @@
+-- Add composite index on User_Roles for getAdmins query optimization.
+-- The query filters by role_id = ? AND acl_id IN (?, ?) and joins on user_id.
+-- This index allows index range scan instead of full table scan + hash join.
+CREATE INDEX idx_user_roles_role_acl_user ON User_Roles (role_id, acl_id, user_id);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1352,6 +1352,7 @@ CREATE TABLE `User_Roles` (
   KEY `user_id` (`user_id`),
   KEY `role_id` (`role_id`),
   KEY `acl_id` (`acl_id`),
+  KEY `idx_user_roles_role_acl_user` (`role_id`,`acl_id`,`user_id`),
   CONSTRAINT `fk_ur_role_id` FOREIGN KEY (`role_id`) REFERENCES `Roles` (`role_id`),
   CONSTRAINT `fk_ur_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`),
   CONSTRAINT `fk_ura_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`)


### PR DESCRIPTION
## Summary
Adds composite index `idx_user_roles_role_acl_user` on `User_Roles (role_id, acl_id, user_id)` to optimize the `getAdmins` query used by `getContestAdmins`, `getCourseAdmins`, and `getProblemAdmins`.

## Problem
The query was doing a full table scan with hash join (`type: ALL`, `Using join buffer (hash join)`). The WHERE clause filters on `role_id` and `acl_id`, but existing indexes did not support this access pattern efficiently.

## Solution
- Migration `00264_add_index_user_roles_role_acl.sql` adds the composite index
- Index order `(role_id, acl_id, user_id)` matches the query: equality on role_id, IN on acl_id, and user_id for the join with Identities

## Testing
I ran the function `getCourseAdmins($course)` 10 times on a particular course. Earlier, the average time for 10 calls was 2.32 ms and after applying the migrations, the time reduced to 1.96 ms.So yes, the changes do work.


Fixes #9360