### PR TITLE
Fix false 405 errors for execute endpoints

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -198,6 +198,8 @@ class ApiCaller {
         $lower = strtolower($methodName);
 
         $readOnlyAllowlist = [
+            'execute',
+            'executeforide',
             'listassociatedidentities',
             'statusverified',
         ];

--- a/frontend/www/js/omegaup/user/profile.ts
+++ b/frontend/www/js/omegaup/user/profile.ts
@@ -482,7 +482,7 @@ OmegaUp.on('ready', () => {
               .catch(ui.apiError);
           },
           'request-delete-account': () => {
-            api.User.deleteRequest()
+            api.User.deleteRequest({})
               .then(({ token }) => {
                 api.User.deleteConfirm({ token })
                   .then(() => {


### PR DESCRIPTION
## Summary

Fixes a regression introduced by PR #9005 where users see:

 “This API endpoint does not allow GET requests. Use POST, PUT, or PATCH.”

while running/submitting code, even though the run itself succeeds.

Fixes: #9372 

<img width="3024" height="1804" alt="image" src="https://github.com/user-attachments/assets/f89f13cc-aa51-4307-bc85-36998cb4fb1b" />

i have tested it locally now not coming anything like it 

