### PR TITLE
Replace insecure GUID generation in Run::apiCreate with random_bytes()

### DIFF
--- a/frontend/server/src/Controllers/Run.php
+++ b/frontend/server/src/Controllers/Run.php
@@ -512,7 +512,7 @@ class Run extends \OmegaUp\Controllers\Controller {
             'identity_id' => $r->identity->identity_id,
             'problem_id' => $problem->problem_id,
             'problemset_id' => $problemsetId,
-            'guid' => md5(uniqid(strval(rand()), true)),
+            'guid' => bin2hex(random_bytes(16)),
             'language' => $r->ensureString('language'),
             'time' => \OmegaUp\Time::get(),
             'status' => 'uploading',


### PR DESCRIPTION
# Description

Replace `md5(uniqid(strval(rand()), true))` with `bin2hex(random_bytes(16))` in `Run::apiCreate`.

The previous implementation chained three non-cryptographic primitives (~2³¹ effective entropy), allowing potential submission existence enumeration. `random_bytes()` reads from the OS CSPRNG (`/dev/urandom`), providing 128 bits of cryptographic entropy. This aligns with the existing pattern used elsewhere in the codebase (e.g., `SecurityTools::randomHexString`, `Session::registerSession`, `ApiUtils::getRandomString`).

Fixes: #9375

# Comments

Single-line change. The output format remains a 32-character hex string, so no downstream changes are needed.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.
