### PR TITLE
Optimize QualityNominations list and votes queries

### DIFF
--- a/frontend/database/00264_optimize_quality_nominations_queries.sql
+++ b/frontend/database/00264_optimize_quality_nominations_queries.sql
@@ -1,0 +1,11 @@
+-- Optimize QualityNominations list query: support filter by nomination + ORDER BY qualitynomination_id
+-- Eliminates "Using temporary; Using filesort"
+CREATE INDEX idx_nomination_qualitynomination ON QualityNominations(nomination, qualitynomination_id);
+
+-- Optimize getVotesForNomination: support correlated subquery for last vote per qualitynomination_id, user_id
+-- Eliminates full scan on QualityNomination_Comments for MAX(qualitynomination_comment_id) lookup
+CREATE INDEX idx_qnc_nomination_user_comment ON QualityNomination_Comments(
+    qualitynomination_id,
+    user_id,
+    qualitynomination_comment_id
+);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -930,6 +930,7 @@ CREATE TABLE `QualityNomination_Comments` (
   PRIMARY KEY (`qualitynomination_comment_id`),
   KEY `user_id` (`user_id`),
   KEY `qualitynomination_id` (`qualitynomination_id`),
+  KEY `idx_qnc_nomination_user_comment` (`qualitynomination_id`,`user_id`,`qualitynomination_comment_id`),
   CONSTRAINT `fk_qnc_qualitynomination_id` FOREIGN KEY (`qualitynomination_id`) REFERENCES `QualityNominations` (`qualitynomination_id`),
   CONSTRAINT `fk_qnc_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comentarios para una nominación';
@@ -977,6 +978,7 @@ CREATE TABLE `QualityNominations` (
   KEY `problem_id` (`problem_id`),
   KEY `idx_nomination` (`nomination`),
   KEY `idx_nomination_problem` (`nomination`,`problem_id`),
+  KEY `idx_nomination_qualitynomination` (`nomination`,`qualitynomination_id`),
   CONSTRAINT `fk_qn_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`),
   CONSTRAINT `fk_qn_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='La cola de nominación a promoción / democión de problemas';

--- a/frontend/server/src/DAO/QualityNominations.php
+++ b/frontend/server/src/DAO/QualityNominations.php
@@ -169,6 +169,8 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
      * @return list<array{time: \OmegaUp\Timestamp|null, vote: int, user: array{username: string, name: string|null}}>
      */
     private static function getVotesForNomination(int $qualitynomination_id) {
+        // Use derived table instead of correlated subquery to avoid per-row execution.
+        // Index idx_qnc_nomination_user_comment supports the latest-vote lookup.
         $sql = '
         SELECT
             i.username,
@@ -177,27 +179,21 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
             qnc.`time`
         FROM
             QualityNomination_Reviewers qnr
-        LEFT JOIN
-            QualityNomination_Comments qnc
-        ON
-            qnc.qualitynomination_id = qnr.qualitynomination_id AND
-            qnc.user_id = qnr.user_id AND
-            qnc.qualitynomination_comment_id = (
-                -- Gets the last vote per qualitynomination_id, user_id.
-                SELECT
-                    MAX(qualitynomination_comment_id)
-                FROM
-                    QualityNomination_Comments
-                WHERE
-                    qualitynomination_id = qnr.qualitynomination_id AND
-                    user_id = qnr.user_id
-                GROUP BY
-                    user_id
-            )
         INNER JOIN
-            Identities i
-        ON
-            i.user_id = qnr.user_id
+            Identities i ON i.user_id = qnr.user_id
+        LEFT JOIN (
+            SELECT qnc1.qualitynomination_id, qnc1.user_id, qnc1.vote, qnc1.`time`
+            FROM QualityNomination_Comments qnc1
+            INNER JOIN (
+                SELECT qualitynomination_id, user_id, MAX(qualitynomination_comment_id) as max_id
+                FROM QualityNomination_Comments
+                WHERE qualitynomination_id = ?
+                GROUP BY qualitynomination_id, user_id
+            ) latest
+            ON qnc1.qualitynomination_id = latest.qualitynomination_id
+              AND qnc1.user_id = latest.user_id
+              AND qnc1.qualitynomination_comment_id = latest.max_id
+        ) qnc ON qnc.qualitynomination_id = qnr.qualitynomination_id AND qnc.user_id = qnr.user_id
         WHERE
             qnr.qualitynomination_id = ?
         ORDER BY
@@ -209,7 +205,7 @@ class QualityNominations extends \OmegaUp\DAO\Base\QualityNominations {
         foreach (
             \OmegaUp\MySQLConnection::getInstance()->GetAll(
                 $sql,
-                [$qualitynomination_id]
+                [$qualitynomination_id, $qualitynomination_id]
             ) as $vote
         ) {
             $vote['user'] = [


### PR DESCRIPTION
## Changes
- **Migration 00264**: Add indexes for QualityNominations and QualityNomination_Comments
- **getVotesForNomination**: Replace correlated subquery with derived table to avoid per-row execution
- **schema.sql**: Add new index definitions

## Performance
- getNominations: Eliminates "Using temporary; Using filesort" via idx_nomination_qualitynomination
- getVotesForNomination: Eliminates correlated subquery, uses idx_qnc_nomination_user_comment

```
docker compose exec frontend php -r "
require_once 'frontend/server/bootstrap.php';
\$start = microtime(true);
for (\$i = 0; \$i < 10; \$i++) {
  \OmegaUp\DAO\QualityNominations::getNominations(null, null, 1, 10, ['demotion', 'promotion'], 'all', null, null);
}
\$elapsed = (microtime(true) - \$start) * 1000;
echo 'QualityNominations::getNominations: ' . round(\$elapsed / 10, 2) . ' ms avg (10 runs)' . PHP_EOL;
"
```

For reference, I ran the above benchmark the track the time it took for the function to ecxecute. Before migration, time it took for 10 runs on average was 42.09ms and after migrations, it was 6.28ms. So, yes, the changes do work.

Fixes #9382