### PR TITLE
Optimize Coder of the Month query with index and query restructuring

### DIFF
--- a/frontend/database/00264_optimize_coder_of_the_month_query.sql
+++ b/frontend/database/00264_optimize_coder_of_the_month_query.sql
@@ -1,0 +1,7 @@
+-- Add covering index for NOT EXISTS subquery and time-range filters in getCodersOfTheMonth.
+-- The index (category, time, selected_by) enables:
+-- 1. Efficient lookup in the "months with selected coder" subquery (selected_by IS NOT NULL)
+-- 2. Better time-range filtering for the main query (category=? AND time IN range)
+-- 3. Index-only scan when checking existence, avoiding table access
+ALTER TABLE `Coder_Of_The_Month`
+ADD INDEX `idx_category_time_selected` (`category`, `time`, `selected_by`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -198,6 +198,7 @@ CREATE TABLE `Coder_Of_The_Month` (
   KEY `school_id` (`school_id`),
   KEY `rank_time_category` (`category`,`ranking`,`time`),
   KEY `time_category` (`category`,`time`),
+  KEY `idx_category_time_selected` (`category`,`time`,`selected_by`),
   CONSTRAINT `fk_coms_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`),
   CONSTRAINT `fk_cotmi_identity_id` FOREIGN KEY (`selected_by`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_cotmu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)

--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -66,6 +66,8 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
 
         // This query should be always synchronized with the one in the cron
         // update_ranks.py, specifically in the function get_last_12_coders_of_the_month.
+        // Uses LEFT JOIN to pre-computed "selected months" instead of correlated NOT EXISTS
+        // for better performance (index idx_category_time_selected).
         $sql = "
           SELECT
               cm.time,
@@ -80,24 +82,21 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
           INNER JOIN
               Identities i ON i.identity_id = u.main_identity_id
           LEFT JOIN
-              Emails e ON e.user_id = u.user_id
+              Emails e ON e.email_id = u.main_email_id
           LEFT JOIN
               User_Rank ur ON ur.user_id = cm.user_id
+          LEFT JOIN (
+              SELECT time, category
+              FROM Coder_Of_The_Month
+              WHERE selected_by IS NOT NULL
+                  AND category = ?
+                  AND time <= ?
+              GROUP BY time, category
+          ) selected_months
+              ON selected_months.time = cm.time AND selected_months.category = cm.category
           WHERE
               (cm.selected_by IS NOT NULL
-              OR (
-                  cm.`ranking` = 1 AND
-                  NOT EXISTS (
-                      SELECT
-                          *
-                      FROM
-                          Coder_Of_The_Month
-                      WHERE
-                          time = cm.time AND
-                          selected_by IS NOT NULL AND
-                          category = ?
-                  )
-              ))
+              OR (cm.`ranking` = 1 AND selected_months.time IS NULL))
               AND cm.category = ?
               AND cm.time <= ?
           ORDER BY
@@ -107,7 +106,7 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
       /** @var list<array{classname: string, country_id: string, email: null|string, time: string, username: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
-            [$category, $category, $date]
+            [$category, $date, $category, $date]
         );
     }
 

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -76,6 +76,8 @@ def get_last_12_coders_of_the_month(
 
     # Note: This query should be always syncronized with the one in the
     # function getCodersOfTheMonth located in the /DAO/CoderOfTheMonth.php file
+    # Uses LEFT JOIN to pre-computed "selected months" instead of correlated
+    # NOT EXISTS for better performance (index idx_category_time_selected).
     sql = '''
           SELECT
               cm.time,
@@ -90,24 +92,23 @@ def get_last_12_coders_of_the_month(
           INNER JOIN
               Identities i ON i.identity_id = u.main_identity_id
           LEFT JOIN
-              Emails e ON e.user_id = u.user_id
+              Emails e ON e.email_id = u.main_email_id
           LEFT JOIN
               User_Rank ur ON ur.user_id = cm.user_id
+          LEFT JOIN (
+              SELECT time, category
+              FROM Coder_Of_The_Month
+              WHERE selected_by IS NOT NULL
+                  AND category = %s
+                  AND time <= %s
+                  AND time > DATE_SUB(%s, INTERVAL 12 MONTH)
+              GROUP BY time, category
+          ) selected_months
+              ON selected_months.time = cm.time
+              AND selected_months.category = cm.category
           WHERE
               (cm.selected_by IS NOT NULL
-              OR (
-                  cm.`ranking` = 1 AND
-                  NOT EXISTS (
-                      SELECT
-                          *
-                      FROM
-                          Coder_Of_The_Month
-                      WHERE
-                          time = cm.time AND
-                          selected_by IS NOT NULL AND
-                          category = %s
-                  )
-              ))
+              OR (cm.`ranking` = 1 AND selected_months.time IS NULL))
               AND cm.category = %s
               AND cm.time <= %s
               AND cm.time > DATE_SUB(%s, INTERVAL 12 MONTH)
@@ -116,9 +117,17 @@ def get_last_12_coders_of_the_month(
           LIMIT
               0, 12;
     '''
-    cur_readonly.execute(sql, (category, category,
-                               first_day_of_current_month,
-                               first_day_of_current_month))
+    cur_readonly.execute(
+        sql,
+        (
+            category,
+            first_day_of_current_month,
+            first_day_of_current_month,
+            category,
+            first_day_of_current_month,
+            first_day_of_current_month,
+        ),
+    )
 
     coders = []
     for row in cur_readonly.fetchall():


### PR DESCRIPTION
## Changes
- Add index `idx_category_time_selected` on Coder_Of_The_Month for NOT EXISTS / time filters
- Replace correlated NOT EXISTS with LEFT JOIN to precomputed derived table
- Update Emails join to use `main_email_id` for correctness and performance
- Keep PHP and cron queries in sync

After applying the migration:
<img width="1048" height="1528" alt="CleanShot 2026-03-03 at 02 33 44@2x" src="https://github.com/user-attachments/assets/afef30c9-398f-4bce-b724-643e42402fd3" />

Before applying the migration:
<img width="1052" height="1196" alt="CleanShot 2026-03-03 at 02 25 08@2x" src="https://github.com/user-attachments/assets/a29b6dde-47d6-48ee-ab99-9d2e8a72b167" />

The time reduced from 4ms to 1ms for the query, as shown using `EXPLAIN ANALYZE`.

For reference, this was the command used:
```
EXPLAIN ANALYZE
SELECT
  cm.time,
  i.username,
  IFNULL(i.country_id, 'xx') AS country_id,
  e.email,
  IFNULL(ur.classname, 'user-rank-unranked') AS classname
FROM Coder_Of_The_Month cm
INNER JOIN Users u ON u.user_id = cm.user_id
INNER JOIN Identities i ON i.identity_id = u.main_identity_id
LEFT JOIN Emails e ON e.email_id = u.main_email_id
LEFT JOIN User_Rank ur ON ur.user_id = cm.user_id
LEFT JOIN (
  SELECT time, category
  FROM Coder_Of_The_Month
  WHERE selected_by IS NOT NULL
    AND category = 'all'
    AND time <= CURDATE()
    AND time > DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
  GROUP BY time, category
) selected_months ON selected_months.time = cm.time AND selected_months.category = cm.category
WHERE (cm.selected_by IS NOT NULL OR (cm.ranking = 1 AND selected_months.time IS NULL))
  AND cm.category = 'all'
  AND cm.time <= CURDATE()
  AND cm.time > DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
ORDER BY cm.time DESC
LIMIT 0, 12;
```

Fixes #9390