### PR TITLE
fix: pin yq to v4.50.1 and verify SHA256 checksum in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,16 @@ jobs:
 
       - name: Install yq
         run: |
-          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          chmod +x /usr/local/bin/yq
+          YQ_VERSION="v4.50.1"
+          YQ_BINARY="yq_linux_amd64"
+          wget -qO "/tmp/${YQ_BINARY}" \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}"
+          wget -qO /tmp/yq_checksums \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
+          EXPECTED=$(grep "${YQ_BINARY}" /tmp/yq_checksums | grep -oE '[a-f0-9]{64}' | head -1)
+          ACTUAL=$(sha256sum "/tmp/${YQ_BINARY}" | grep -oE '[a-f0-9]{64}')
+          [ "${EXPECTED}" = "${ACTUAL}" ] || { echo "Checksum mismatch! Expected: ${EXPECTED}, Got: ${ACTUAL}"; exit 1; }
+          install -m 0755 "/tmp/${YQ_BINARY}" /usr/local/bin/yq
 
       - name: Install jq
         run: |


### PR DESCRIPTION
## Description

Replaces the unpinned `latest` yq download with a specific version
(v4.50.1) and adds inline SHA256 checksum verification, consistent
with how the codecov binary is verified in the same workflow.

- Pins yq to v4.50.1 (stable release)
- Verifies `sha256sum` inline against the known checksum
- No functional change to CI logic

Fixes #9288
