### PR TITLE
fix: block GET on mailingListBackfill endpoint

### DIFF
--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -208,10 +208,10 @@ class ApiCaller {
         }
 
         $mutatingPatterns = [
-            'add', 'arbitrate', 'archive', 'associate', 'bulkcreate',
-            'change', 'confirm', 'create', 'delete', 'disqualify',
-            'execute', 'expire', 'forfeit', 'generate', 'invalidate',
-            'login', 'logout', 'read', 'refresh', 'register',
+            'add', 'arbitrate', 'archive', 'associate', 'backfill',
+            'bulkcreate', 'change', 'confirm', 'create', 'delete',
+            'disqualify', 'execute', 'expire', 'forfeit', 'generate',
+            'invalidate', 'login', 'logout', 'read', 'refresh', 'register',
             'rejudge', 'remove', 'requalify', 'resolve', 'revoke',
             'select', 'set', 'toggle', 'update', 'verify',
         ];

--- a/frontend/tests/controllers/ApiCallerGetRejectionTest.php
+++ b/frontend/tests/controllers/ApiCallerGetRejectionTest.php
@@ -46,6 +46,19 @@ class ApiCallerGetRejectionTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertArrayHasKey('time', $response);
     }
 
+    public function testGetToMailingListBackfillReturns405() {
+        $_SERVER['REQUEST_URI'] = '/api/user/mailingListBackfill';
+
+        $response = json_decode(
+            \OmegaUp\Test\ApiCallerMock::httpEntryPoint(),
+            true
+        );
+
+        $this->assertSame('error', $response['status']);
+        $this->assertSame(405, $response['errorcode']);
+        $this->assertSame('methodNotAllowed', $response['errorname']);
+    }
+
     public function testAllowlistedReadOnlyListAssociatedIdentitiesAllowsGet() {
         $_SERVER['REQUEST_URI'] = '/api/user/listAssociatedIdentities';
 


### PR DESCRIPTION
# Description

`GET /api/user/mailingListBackfill/` was not returning 405 Method Not Allowed ,it was passing through to the controller and executing bulk DB writes (updating `in_mailing_list` for all verified users not yet on the mailing list). This is a mutating endpoint and must reject GET requests.

Root cause: `'backfill'` was missing from the `$mutatingPatterns` list in `ApiCaller::isMutatingMethod()`. Added it alongside the existing patterns so the substring check correctly identifies the method as mutating.

Also added a regression test in `ApiCallerGetRejectionTest` to cover this case.

Fixes: #9389

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.