### PR TITLE
fix: include group-inherited roles in user system roles lookup

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1755,9 +1755,14 @@ class User extends \OmegaUp\Controllers\Controller {
         $response = array_merge(
             $response,
             [
-                'roles' => \OmegaUp\DAO\UserRoles::getSystemRoles(
-                    $user->user_id
-                ),
+                'roles' => array_values(array_unique(array_merge(
+                    \OmegaUp\DAO\UserRoles::getSystemRoles($user->user_id),
+                    !is_null($user->main_identity_id)
+                        ? \OmegaUp\DAO\GroupRoles::getSystemRoles(
+                            $user->main_identity_id
+                        )
+                        : []
+                ))),
             ]
         );
         return $response;
@@ -4629,8 +4634,14 @@ class User extends \OmegaUp\Controllers\Controller {
             $userExperimentsList[] = $userExperiment->experiment;
         }
 
-        // TODO: Also support GroupRoles.
-        $systemRoles = \OmegaUp\DAO\UserRoles::getSystemRoles($user->user_id);
+        $systemRoles = array_values(array_unique(array_merge(
+            \OmegaUp\DAO\UserRoles::getSystemRoles($user->user_id),
+            !is_null($user->main_identity_id)
+                ? \OmegaUp\DAO\GroupRoles::getSystemRoles(
+                    $user->main_identity_id
+                )
+                : []
+        )));
 
         $roles = \OmegaUp\DAO\Roles::getAll();
         $rolesList = [];

--- a/frontend/tests/controllers/UserPrivilegesTest.php
+++ b/frontend/tests/controllers/UserPrivilegesTest.php
@@ -98,6 +98,61 @@ class UserPrivilegesTest extends \OmegaUp\Test\ControllerTestCase {
         }
     }
 
+    public function testGroupRolesAppearsInSystemRoles() {
+        // Create the target user whose roles we'll inspect
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+
+        // Create an admin to perform privileged operations
+        ['identity' => $admin] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $adminLogin = self::login($admin);
+
+        // Create a group and add the target user to it
+        $groupData = \OmegaUp\Test\Factories\Groups::createGroup(
+            $admin,
+            null,
+            null,
+            null,
+            $adminLogin
+        );
+        \OmegaUp\Test\Factories\Groups::addUserToGroup(
+            $groupData,
+            $identity,
+            $adminLogin
+        );
+
+        // Assign the Reviewer system role to the group
+        \OmegaUp\DAO\GroupRoles::create(new \OmegaUp\DAO\VO\GroupRoles([
+            'group_id' => $groupData['group']->group_id,
+            'role_id'  => \OmegaUp\Authorization::REVIEWER_ROLE,
+            'acl_id'   => \OmegaUp\Authorization::SYSTEM_ACL,
+        ]));
+
+        // getUserDetailsForTypeScript must include the group-inherited role
+        [
+            'systemRoles' => $systemRoles,
+        ] = \OmegaUp\Controllers\User::getUserDetailsForTypeScript(
+            new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'username'   => $identity->username,
+            ])
+        )['templateProperties']['payload'];
+
+        $this->assertContains('Reviewer', $systemRoles);
+
+        // apiExtraInformation must also surface the group-inherited role
+        ['identity' => $supportIdentity] = \OmegaUp\Test\Factories\User::createSupportUser();
+        $supportLogin = self::login($supportIdentity);
+
+        $extraInfo = \OmegaUp\Controllers\User::apiExtraInformation(
+            new \OmegaUp\Request([
+                'auth_token'      => $supportLogin->auth_token,
+                'usernameOrEmail' => $identity->username,
+            ])
+        );
+
+        $this->assertContains('Reviewer', $extraInfo['roles']);
+    }
+
     public function testPreviouslyAddedRoles() {
         $username = 'testuserrole';
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser(


### PR DESCRIPTION
# Description

`User::apiExtraInformation` and `User::getUserDetailsForTypeScript` both called `UserRoles::getSystemRoles()` to fetch a user's system roles, but never consulted `GroupRoles::getSystemRoles()`. This meant that any system role assigned to a user through group membership (via `Group_Roles` with `acl_id = SYSTEM_ACL`) was silently omitted from the returned role list.

`Authorization::hasRole()` already queries both `UserRoles` and `GroupRoles` when performing permission checks, so users with group-inherited roles had the permissions but couldn't see them reflected in the admin UI or support tooling.

**Fix:** In both call sites, merge the direct `UserRoles::getSystemRoles($user->user_id)` results with `GroupRoles::getSystemRoles($user->main_identity_id)` using `array_unique` to deduplicate. The TODO comment in `getUserDetailsForTypeScript` is also removed.

**Test:** `testGroupRolesAppearsInSystemRoles` in `UserPrivilegesTest` creates a user, adds them to a group, assigns a `Reviewer` system role to that group, then asserts that both `getUserDetailsForTypeScript` and `apiExtraInformation` surface the inherited role.

Fixes: #9388

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.