### PR TITLE
Enforce mandatory birth_date and U13 parent_email validation in signu…

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -193,9 +193,7 @@ class User extends \OmegaUp\Controllers\Controller {
             'verification_id' => \OmegaUp\SecurityTools::randomString(50),
             'is_private' => boolval($createUserParams->isPrivate),
             'birth_date' => \OmegaUp\DAO\DAO::toMySQLTimestamp(
-                intval(
-                    $createUserParams->birthDate
-                )
+                $createUserParams->birthDate
             ),
         ];
         if (
@@ -203,7 +201,6 @@ class User extends \OmegaUp\Controllers\Controller {
                 '-13 year',
                 \OmegaUp\Time::get()
             )
-            && !is_null($createUserParams->parentEmail)
         ) {
             // Fill all the columns referring to user's parent
             $userData['parental_verification_token'] = \OmegaUp\SecurityTools::randomHexString(

--- a/frontend/server/src/CreateUserParams.php
+++ b/frontend/server/src/CreateUserParams.php
@@ -58,9 +58,9 @@ class CreateUserParams {
 
     /**
      * @readonly
-     * @var int|null
+     * @var int
      */
-    public $birthDate = null;
+    public $birthDate;
 
      /**
      * @readonly
@@ -70,6 +70,8 @@ class CreateUserParams {
 
     /**
      * @param array{birth_date?: int, email?: null|string, gender?: string, is_private?: string, name?: string, parent_email?: null|string, password?: string, recaptcha?: string, scholar_degree?: string, username?: string} $params
+     *
+     * @throws \OmegaUp\Exceptions\InvalidParameterException
      */
     public function __construct($params = []) {
         \OmegaUp\Validators::validateValidUsername(
@@ -116,8 +118,30 @@ class CreateUserParams {
 
         $this->recaptcha = $params['recaptcha'] ?? null;
 
-         // TODO: Assert that the birth date is always passed, and if and only if the user is U13,
-        // the parent email is passed.
-        $this->birthDate = $params['birth_date'] ?? null;
+        if (!isset($params['birth_date'])) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                'birth_date'
+            );
+        }
+        $this->birthDate = $params['birth_date'];
+
+        // Enforce: U13 users must provide parent_email, and non-U13 users must not.
+        $isUnder13 = $this->birthDate >= strtotime(
+            '-13 year',
+            \OmegaUp\Time::get()
+        );
+        if ($isUnder13 && is_null($this->parentEmail)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterEmpty',
+                'parent_email'
+            );
+        }
+        if (!$isUnder13 && !is_null($this->parentEmail)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'parent_email'
+            );
+        }
     }
 }

--- a/frontend/tests/controllers/UserCreateTest.php
+++ b/frontend/tests/controllers/UserCreateTest.php
@@ -418,4 +418,66 @@ class UserCreateTest extends \OmegaUp\Test\ControllerTestCase {
             $response['users']
         );
     }
+
+    /**
+     * Creating a user without birth_date should fail
+     */
+    public function testNoBirthDate() {
+        \OmegaUp\Controllers\User::$permissionKey = uniqid();
+
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'username' => \OmegaUp\Test\Utils::createRandomString(),
+                'password' => \OmegaUp\Test\Utils::createRandomString(),
+                'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey,
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('parameterEmpty', $e->getMessage());
+            $this->assertSame('birth_date', $e->parameter);
+        }
+    }
+
+    /**
+     * Creating a U13 user without parent_email should fail
+     */
+    public function testU13WithoutParentEmail() {
+        \OmegaUp\Controllers\User::$permissionKey = uniqid();
+
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'username' => \OmegaUp\Test\Utils::createRandomString(),
+                'password' => \OmegaUp\Test\Utils::createRandomString(),
+                'email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey,
+                'birth_date' => strtotime('-10 year', \OmegaUp\Time::get()),
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('parameterEmpty', $e->getMessage());
+            $this->assertSame('parent_email', $e->parameter);
+        }
+    }
+
+    /**
+     * Creating a non-U13 user with parent_email should fail
+     */
+    public function testNonU13WithParentEmail() {
+        \OmegaUp\Controllers\User::$permissionKey = uniqid();
+
+        try {
+            \OmegaUp\Controllers\User::apiCreate(new \OmegaUp\Request([
+                'username' => \OmegaUp\Test\Utils::createRandomString(),
+                'password' => \OmegaUp\Test\Utils::createRandomString(),
+                'parent_email' => \OmegaUp\Test\Utils::createRandomString() . '@' . \OmegaUp\Test\Utils::createRandomString() . '.com',
+                'permission_key' => \OmegaUp\Controllers\User::$permissionKey,
+                'birth_date' => strtotime('-20 year', \OmegaUp\Time::get()),
+            ]));
+            $this->fail('Should have failed');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('parameterInvalid', $e->getMessage());
+            $this->assertSame('parent_email', $e->parameter);
+        }
+    }
 }


### PR DESCRIPTION

# Description

Enforce mandatory birth_date collection and conditional parent_email requirement during user signup to ensure COPPA-like child-safety compliance.

## Changes:

 * [CreateUserParams.php](vscode-file://vscode-app/c:/Users/akhil/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Made birth_date a required field (throws parameterEmpty if missing). Added validation that U13 users must provide parent_email, and non-U13 users must not.
 * Controllers/User.php: Removed intval(null) call that silently converted a null birth date to epoch 1970-01-01. Simplified the U13 guard since the constructor now guarantees the invariant.
 * [UserCreateTest.php](vscode-file://vscode-app/c:/Users/akhil/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added three new tests — missing birth_date, U13 without parent_email, and non-U13 with parent_email.

Fixes: #9409 

# Comments

This is a backend-only change (controllers + PHPUnit tests). No UI modifications.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
