### PR TITLE
fix: validate page parameter with lowerBound across all endpoints

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -133,7 +133,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             'tab_name',
             \OmegaUp\DAO\Enum\ContestTabStatus::NAME_FOR_STATUS
         );
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt(
             key: 'page_size',
             lowerBound: 1,
@@ -343,7 +343,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
         $showArchived = $r->ensureOptionalBool('show_archived') ?? false;
 
@@ -389,7 +389,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     ): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
         $query = $r->ensureOptionalString('query');
         $showArchived = $r->ensureOptionalBool('show_archived') ?? false;
@@ -1248,7 +1248,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             field: $tabName,
             defaultValue: \OmegaUp\DAO\Enum\ContestTabStatus::CURRENT
         );
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt(
             'page_size'
         ) ?? \OmegaUp\Controllers\Contest::CONTEST_LIST_PAGE_SIZE;
@@ -2236,7 +2236,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $r->identity = null;
         }
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $contestAlias = $r->ensureString(
             'contest_alias',
@@ -2284,7 +2284,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
 
         $alias = $r->ensureString(
@@ -5677,7 +5677,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
             $r->identity = null;
         }
 
-        $page = $r->ensureOptionalInt('page') ?? 1; // The default page is 1 always
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1; // The default page is 1 always
         $pageSize = $r->ensureOptionalInt(
             'page_size'
         ) ?? \OmegaUp\Controllers\Contest::CONTEST_LIST_PAGE_SIZE;

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -3958,7 +3958,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     ): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
 
         $courseAlias = $r->ensureString(
@@ -4032,7 +4032,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     ): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
 
         $courseAlias = $r->ensureString(
@@ -4258,7 +4258,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r
     ): array {
         $r->ensureIdentity();
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 1000;
 
         $courses = self::getCoursesList(
@@ -4468,7 +4468,7 @@ class Course extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Request $r
     ): array {
         $r->ensureMainUserIdentity();
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
 
         $courseAlias = $r->ensureString(
@@ -5513,7 +5513,7 @@ class Course extends \OmegaUp\Controllers\Controller {
      */
     public static function apiActivityReport(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $courseAlias = $r->ensureString(
             'course_alias',
@@ -6299,7 +6299,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     public static function getClarificationsForTypeScript(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 100;
 
         $course = self::validateCourseExists(

--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -3931,7 +3931,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                 \OmegaUp\Controllers\Problem::VALID_SORTING_COLUMNS
             )
         ) ?? '';
-        $page = $r->ensureOptionalInt('page') ?? 0;
+        $page = $r->ensureOptionalInt('page', lowerBound: 0) ?? 0;
         $language = $r->ensureOptionalEnum(
             'language',
             array_merge(
@@ -4077,7 +4077,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         }
 
         // Defaults for offset and rowcount
-        $page = $r->ensureOptionalInt('page');
+        $page = $r->ensureOptionalInt('page', lowerBound: 1);
         $offset = null;
         if (is_null($page)) {
             $offset = $r->ensureOptionalInt('offset') ?? 0;
@@ -4228,7 +4228,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
     public static function apiAdminList(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt(
             'page_size'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
@@ -4325,7 +4325,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
         $pageSize = $r->ensureOptionalInt(
             'rowcount'
         ) ?? \OmegaUp\Controllers\Problem::PAGE_SIZE;
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
 
         $query = substr(
             $r->ensureOptionalString('query') ?? '',

--- a/frontend/server/src/Controllers/QualityNomination.php
+++ b/frontend/server/src/Controllers/QualityNomination.php
@@ -937,7 +937,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         ?int $nominator,
         ?int $assignee
     ): array {
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? self::PAGE_SIZE;
 
         $types = $r->getStringList('types', ['promotion', 'demotion']);
@@ -1264,7 +1264,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
 
         $r->ensureMainUserIdentity();
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? self::PAGE_SIZE;
         self::validateMemberOfReviewerGroup($r->identity);
 
@@ -1296,7 +1296,7 @@ class QualityNomination extends \OmegaUp\Controllers\Controller {
         \OmegaUp\Controllers\Controller::ensureNotInLockdown();
 
         $r->ensureMainUserIdentity();
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? self::PAGE_SIZE;
 
         return [

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -272,7 +272,7 @@ class School extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int $page
      */
     public static function getRankForTypeScript(\OmegaUp\Request $r): array {
-        $r->ensureOptionalInt('page');
+        $r->ensureOptionalInt('page', lowerBound: 1);
         $r->ensureOptionalInt('length');
 
         $page = is_null($r['page']) ? 1 : intval($r['page']);

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -25,7 +25,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $pageSize
      */
     public static function getLatestSubmissionsForTypeScript(\OmegaUp\Request $r): array {
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt(
             'pageSize'
         ) ?? self::SUBMISSION_LIST_PAGE_SIZE_DEFAULT ;
@@ -67,7 +67,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      */
     public static function getLatestUserSubmissionsForTypeScript(\OmegaUp\Request $r): array {
         $username = $r->ensureString('username');
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt(
             'pageSize'
         ) ?? self::SUBMISSION_LIST_PAGE_SIZE_DEFAULT;
@@ -128,7 +128,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      */
     public static function apiList(\OmegaUp\Request $r): array {
         $username = $r->ensureOptionalString('username');
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt(
             'pageSize'
         ) ?? self::SUBMISSION_LIST_PAGE_SIZE_DEFAULT;

--- a/frontend/server/src/Controllers/TeamsGroup.php
+++ b/frontend/server/src/Controllers/TeamsGroup.php
@@ -528,7 +528,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
     public static function apiTeamsMembers(\OmegaUp\Request $r): array {
         $r->ensureIdentity();
 
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $pageSize = $r->ensureOptionalInt('page_size') ?? 100;
         $teamGroupAlias = $r->ensureString(
             'team_group_alias',

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2968,7 +2968,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $page
      */
     public static function getAuthorRankForTypeScript(\OmegaUp\Request $r) {
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
 
         $authorsRanking = self::getAuthorsRank(
@@ -4103,7 +4103,7 @@ class User extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param int|null $page
      */
     public static function getRankForTypeScript(\OmegaUp\Request $r) {
-        $page = $r->ensureOptionalInt('page') ?? 1;
+        $page = $r->ensureOptionalInt('page', lowerBound: 1) ?? 1;
         $length = $r->ensureOptionalInt('length') ?? 100;
         $filter = $r->ensureOptionalEnum(
             'filter',


### PR DESCRIPTION
# Description

API endpoints accepting a `page` parameter (`/api/contest/list/`, `/api/problem/list/`, `/api/course/list*`, etc.) did not enforce a lower bound, so `page=-5` or `page=0` silently returned results as though `page=1` was requested.

## BEFORE:
<img width="1376" height="958" alt="Screenshot 2026-03-06 144859" src="https://github.com/user-attachments/assets/7508e813-74f2-49f4-9a29-80e42ffb3a97" />

## AFTER:
<img width="1872" height="698" alt="Screenshot 2026-03-06 145055" src="https://github.com/user-attachments/assets/4f0316c0-7386-41ed-9514-0c5ba6ff0c9b" />

Meanwhile, `page_size` on the same endpoints already validated with `lowerBound: 1`, making the inconsistency clear.

**Fix:** Added `lowerBound: 1` (or `lowerBound: 0` where page 0 has valid "unset" semantics) to every `ensureOptionalInt('page')` call across all 8 affected controllers:

- `Contest.php` (7 call sites)
- `Course.php` (6 call sites)
- `Problem.php` (4 call sites)
- `QualityNomination.php` (3 call sites)
- `Submission.php` (3 call sites)
- `User.php` (2 call sites)
- `TeamsGroup.php` (1 call site)
- `School.php` (1 call site)

Now `page=-1` returns HTTP 400 with `parameterNumberTooSmall`, consistent with how `page_size` already behaves.

Fixes: #9387

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.