### PR TITLE
feature - PWA feature implemented

### DIFF
--- a/frontend/templates/template.tpl
+++ b/frontend/templates/template.tpl
@@ -42,6 +42,19 @@
     {% if recaptchaFile %}
         <script type="text/javascript" src="{{ recaptchaFile }}"></script>
     {% endif %}
+
+    <link rel="manifest" href="/manifest.json">
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js').then(registration => {
+            console.log('ServiceWorker registered:', registration.scope);
+          }).catch(err => {
+            console.error('ServiceWorker registration failed:', err);
+          });
+        });
+      }
+    </script>
   </head>
 
   <body class="d-flex flex-column h-100{% if OMEGAUP_LOCKDOWN %} lockdown{% endif %}">

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -5,7 +5,11 @@
       data-enable-hover-dropdown
     >
       <div class="container-xl pl-0 pl-xl-3">
-        <a class="navbar-brand p-3 mr-0 mr-sm-3" href="/">
+        <a
+          class="navbar-brand p-3 mr-0 mr-sm-3"
+          href="/"
+          @click="handleLogoClick"
+        >
           <img
             alt="omegaUp"
             src="/media/omegaup_curves.png"
@@ -21,6 +25,15 @@
             height="20"
           />
         </a>
+
+        <div v-if="deferredPrompt" class="d-none d-lg-flex order-lg-1 mr-2">
+          <button
+            class="btn btn-primary btn-sm align-self-center"
+            @click="promptInstall"
+          >
+            {{ T.omegaupTitleInstallApp || 'Install omegaUp' }}
+          </button>
+        </div>
 
         <div class="d-inline-flex d-flex-row order-lg-1">
           <div
@@ -424,6 +437,7 @@ export default class Navbar extends Vue {
   ui = ui;
   AvailableTabs = AvailableTabs;
   logoutModalVisible = false;
+  deferredPrompt: any = null;
   teachingUserTypes = ['teacher', 'coach', 'independent-teacher'];
   hasTeachingObjective = this.teachingUserTypes.some((teachingType) =>
     this.userTypes.includes(teachingType),
@@ -488,6 +502,41 @@ export default class Navbar extends Vue {
         tab === AvailableTabs.Login
           ? this.formattedLoginURL
           : this.formattedSignupURL;
+    }
+  }
+
+  handleLogoClick(event: MouseEvent): void {
+    if (window.location.pathname === '/') {
+      event.preventDefault();
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  mounted() {
+    window.addEventListener('beforeinstallprompt', (e) => {
+      // Prevent Chrome 67 and earlier from automatically showing the prompt
+      e.preventDefault();
+      // Stash the event so it can be triggered later.
+      this.deferredPrompt = e;
+    });
+
+    window.addEventListener('appinstalled', () => {
+      this.deferredPrompt = null;
+      console.log('PWA was installed');
+    });
+  }
+
+  promptInstall() {
+    if (this.deferredPrompt) {
+      this.deferredPrompt.prompt();
+      this.deferredPrompt.userChoice.then((choiceResult: any) => {
+        if (choiceResult.outcome === 'accepted') {
+          console.log('User accepted the install prompt');
+        } else {
+          console.log('User dismissed the install prompt');
+        }
+        this.deferredPrompt = null;
+      });
     }
   }
 }
@@ -574,7 +623,9 @@ nav.navbar {
   }
 
   a[data-logout-button] {
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
     border-radius: 4px;
   }
 

--- a/frontend/www/manifest.json
+++ b/frontend/www/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "omegaUp",
+  "short_name": "omegaUp",
+  "description": "Competitive programming platform",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0055a5",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/media/omegaup_curves.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/media/omegaup_curves.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/frontend/www/offline.html
+++ b/frontend/www/offline.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline - omegaUp</title>
+    <link rel="stylesheet" href="/css/dist/omegaup_styles.css" />
+  </head>
+  <body class="text-center p-5">
+    <h1>You're offline</h1>
+    <p>omegaUp is currently offline. Please check your internet connection.</p>
+    <a href="/" class="btn btn-primary mt-3">Go Home</a>
+  </body>
+</html>

--- a/frontend/www/sw.js
+++ b/frontend/www/sw.js
@@ -1,0 +1,36 @@
+const CACHE_NAME = 'omegaup-pwa-v1';
+const OFFLINE_URL = '/offline.html';
+
+const urlsToCache = [
+  '/',
+  '/offline.html',
+  '/css/dist/omegaup_styles.css',
+  '/media/omegaup_curves.png',
+  '/third_party/bootstrap-4.5.0/css/bootstrap.min.css',
+  '/third_party/bootstrap-4.5.0/js/bootstrap.bundle.min.js',
+];
+
+// Install event
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache)),
+  );
+  self.skipWaiting();
+});
+
+// Activate event
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Fetch event
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) return cachedResponse;
+      return fetch(event.request).catch(() => caches.match(OFFLINE_URL));
+    }),
+  );
+});


### PR DESCRIPTION
# Description

Add Progressive Web App (PWA) support to omegaUp to improve accessibility and provide a more app-like experience.

### This PR introduces:

- Web App Manifest (manifest.json) to enable installation on desktop and mobile
- Service Worker (sw.js) to cache core assets and enable offline access
- Offline fallback page (offline.html) when network connectivity is unavailable
- Service worker registration in template.tpl
- Install omegaUp button in the navbar triggered by the beforeinstallprompt event
- Automated tests verifying manifest, service worker, offline page, and install prompt behavior

These changes allow users to install omegaUp as a lightweight app, access previously visited pages offline, and benefit from improved load performance through caching.

Here is the Demo of PWA feature link:
https://www.loom.com/share/f9e6f19873fd450b942e572870f4f575

Fixes: #9312

# Comments

### Key Changes

**Added new PWA files:**

```
frontend/www/manifest.json
frontend/www/sw.js
frontend/www/offline.html
```

### Updated:

frontend/templates/template.tpl to register the service worker and link the manifest

frontend/www/js/omegaup/components/common/Navbar.vue to support the install prompt


### Manual Verification

- Service worker registers successfully in browser.
- Cached pages load correctly when offline.
- offline.html appears when navigating offline to uncached pages.
- Install prompt appears and launches the native install dialog.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
