### PR TITLE
Fix(#9460): After creating a problem, HTTP/1.1 400 - Bad Request

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -6950,6 +6950,8 @@ class Problem extends \OmegaUp\Controllers\Controller {
             return $result;
         } catch (\OmegaUp\Exceptions\NotFoundException $e) {
             return null;
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            return null;
         } catch (\OmegaUp\Exceptions\ApiException $e) {
             throw $e;
         } catch (\Exception $e) {


### PR DESCRIPTION
# Description

This pull request introduces a small improvement to error handling in the `getProblemCDPImpl` method. The change ensures that the method gracefully handles cases where an `InvalidParameterException` is thrown, returning `null` instead of propagating the error.

* Improved exception handling: Added a catch block for `OmegaUp\Exceptions\InvalidParameterException` to return `null` when this exception occurs in `getProblemCDPImpl` in `Problem.php`.


[Screencast from 2026-03-07 19-31-01.webm](https://github.com/user-attachments/assets/b6f1af4a-733b-4758-8633-e62091a36073)

Fixes: #9460 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
