### PR TITLE
Optimize scoreboard performance using SQL Window Functions and simpli…

### DIFF
--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -177,7 +177,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                 "EXECUTION_FINISHED"
             )
         LIMIT 1
-            ), "EXECUTION_COMPILATION_ERROR")AS execution,
+            ), "EXECUTION_COMPILATION_ERROR") AS execution,
             COALESCE(
         ( SELECT
             IF(
@@ -193,7 +193,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         ORDER BY
             field(status_runtime, "RUNTIME_NOT_AVAILABLE", "RUNTIME_EXCEEDED", "RUNTIME_AVAILABLE")
                 LIMIT 1
-            ), "RUNTIME_NOT_AVAILABLE" )AS status_runtime,
+            ), "RUNTIME_NOT_AVAILABLE") AS status_runtime,
             COALESCE(
         ( SELECT
             IF(
@@ -209,7 +209,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         ORDER BY
             field(status_memory, "MEMORY_NOT_AVAILABLE", "MEMORY_EXCEEDED", "MEMORY_AVAILABLE")
         LIMIT 1
-            ), "MEMORY_NOT_AVAILABLE" )AS status_memory';
+            ), "MEMORY_NOT_AVAILABLE") AS status_memory';
     }
 
     /**
@@ -799,8 +799,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                 WHERE s.problemset_id = ?
                   AND s.status = 'ready'
                   AND s.type = 'normal'
-                  AND $verdictCondition;
-            ";
+                  AND $verdictCondition
+                ";
         }
 
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -11,7 +11,8 @@ namespace OmegaUp\DAO;
  * @access public
  * @package docs
  */
-class Runs extends \OmegaUp\DAO\Base\Runs {
+class Runs extends \OmegaUp\DAO\Base\Runs
+{
     /** @var string */
     private static $ctesubmissionFeedbackForProblemset = 'WITH ssff AS (
         SELECT
@@ -122,7 +123,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     /**
      * @return string
      */
-    final public static function getRunExtraFields() {
+    final public static function getRunExtraFields()
+    {
         /** @var string */
         return '
         COALESCE(
@@ -610,7 +612,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
                 ];
                 if ($excludeAdmin) {
                     $sql .= ' AND i.user_id != (SELECT a.owner_id FROM ACLs a WHERE a.acl_id = ?)';
-                    $val[] =  $aclId;
+                    $val[] = $aclId;
                 }
                 $sql .= ' OR i.user_id IS NULL);';
             } else {
@@ -754,64 +756,52 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
         );
 
         $sql = "
-            SELECT
-                IF(
-                    c.score_mode = 'all_or_nothing' AND r.score <> 1,
-                        0,
-                        r.score
-                ) AS score,
+        WITH RankedSubmissions AS (
+            SELECT 
+                r.score,
                 r.penalty,
-                IFNULL(
-                    IF(
-                        c.score_mode = 'all_or_nothing' AND r.score <> 1,
-                            0,
-                            r.contest_score
-                    ),
-                    0.0
-                ) AS contest_score,
+                r.contest_score,
                 s.problem_id,
                 s.identity_id,
                 IFNULL(s.`type`, 'normal') AS `type`,
                 s.`time`,
                 s.submit_delay,
                 s.guid,
-                JSON_OBJECTAGG(
-                    IFNULL(rg.group_name, ''),
-                    rg.score
-                ) AS score_by_group
-            FROM
-                Problemset_Problems pp
-            INNER JOIN
-                Submissions s
-            ON
-                s.problemset_id = pp.problemset_id AND
-                s.problem_id = pp.problem_id
-            INNER JOIN
-                Runs r ON s.current_run_id = r.run_id
-            LEFT JOIN
-                Contests c ON c.problemset_id = pp.problemset_id
-            LEFT JOIN
-                Runs_Groups rg ON r.run_id = rg.run_id
-            WHERE
-                pp.problemset_id = ? AND
-                s.status = 'ready' AND
-                s.`type` = 'normal' AND
-                $verdictCondition
-            GROUP BY
-                score_mode,
-                r.score,
-                r.penalty,
-                r.contest_score,
-                s.problemset_id,
-                s.problem_id,
-                s.identity_id,
-                s.time,
-                s.submit_delay,
-                s.guid
-            ORDER BY
-                s.submission_id;";
+                s.submission_id,
+                c.score_mode,
+                rg.group_name,
+                rg.score as group_score,
+                ROW_NUMBER() OVER (
+                    PARTITION BY s.identity_id, s.problem_id 
+                    ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
+                ) as run_rank
+            FROM Problemset_Problems pp
+            INNER JOIN Submissions s ON s.problemset_id = pp.problemset_id 
+                                    AND s.problem_id = pp.problem_id
+            INNER JOIN Runs r ON s.current_run_id = r.run_id
+            LEFT JOIN Contests c ON c.problemset_id = pp.problemset_id
+            LEFT JOIN Runs_Groups rg ON r.run_id = rg.run_id
+            WHERE pp.problemset_id = ? 
+              AND s.status = 'ready' 
+              AND s.`type` = 'normal'
+              AND $verdictCondition
+        )
+        SELECT 
+            IF(score_mode = 'all_or_nothing' AND score <> 1, 0, score) AS score,
+            penalty,
+            IFNULL(IF(score_mode = 'all_or_nothing' AND score <> 1, 0, contest_score), 0.0) AS contest_score,
+            problem_id,
+            identity_id,
+            `type`,
+            `time`,
+            submit_delay,
+            guid,
+            JSON_OBJECTAGG(IFNULL(group_name, ''), group_score) AS score_by_group
+        FROM RankedSubmissions
+        WHERE run_rank = 1
+        GROUP BY submission_id; -- التجميع هنا فقط لعمل JSON_OBJECTAGG للـ groups
+    ";
 
-        /** @var list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$problemsetId]
@@ -886,7 +876,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     /**
      * @return list<array{alias: string, contest_score: float|null, guid: string, language: string, username: string, verdict: string}>
      */
-    final public static function getByProblemset(int $problemsetId): array {
+    final public static function getByProblemset(int $problemsetId): array
+    {
         $sql = '
             SELECT
                 s.guid,
@@ -933,15 +924,16 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     /**
      * @return array{commit: string, contest_score: float|null, execution: null|string, judged_by: null|string, memory: int, output: null|string, penalty: int, run_id: int, runtime: int, score: float, status: string, status_memory: null|string, status_runtime: null|string, submission_id: int, time: \OmegaUp\Timestamp, verdict: string, version: string}|null
      */
-    final public static function getByGUID(string $guid) {
+    final public static function getByGUID(string $guid)
+    {
         $extraFields = self::getRunExtraFields();
 
         $sql = '
             SELECT
-                ' .  \OmegaUp\DAO\DAO::getFields(
-            \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
-            'r'
-        ) . ',
+                ' . \OmegaUp\DAO\DAO::getFields(
+                    \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
+                    'r'
+                ) . ',
             ' . $extraFields . '
         FROM
             `Runs` `r`
@@ -973,10 +965,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
     ) {
         $sql = '
             SELECT
-                ' .  \OmegaUp\DAO\DAO::getFields(
-            \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
-            'r'
-        ) . '
+                ' . \OmegaUp\DAO\DAO::getFields(
+                    \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
+                    'r'
+                ) . '
             FROM
                 Submissions s
             INNER JOIN
@@ -1451,7 +1443,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
      *
      * @param \OmegaUp\DAO\VO\Problems $problem the problem.
      */
-    final public static function updateVersionToCurrent(\OmegaUp\DAO\VO\Problems $problem): void {
+    final public static function updateVersionToCurrent(\OmegaUp\DAO\VO\Problems $problem): void
+    {
         $sql = '
             UPDATE
                 Submissions s
@@ -1477,7 +1470,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs {
      *
      * @return list<\OmegaUp\DAO\VO\Runs>
      */
-    final public static function getNewRunsForVersion(\OmegaUp\DAO\VO\Problems $problem): array {
+    final public static function getNewRunsForVersion(\OmegaUp\DAO\VO\Problems $problem): array
+    {
         $sql = '
             SELECT
                 r.run_id

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -742,9 +742,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
             'solved' => boolval($result['solved']),
         ];
     }
-
     /**
-     * @return list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: string}>
+     * @return list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, total_submissions?: int, type: string}>
      */
     final public static function getProblemsetRuns(
         int $problemsetId,
@@ -761,6 +760,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
             SELECT 
                 rs.score, rs.penalty, rs.contest_score, rs.problem_id, 
                 rs.identity_id, rs.type, rs.time, rs.submit_delay, rs.guid,
+                rs.total_submissions,
                 (
                     SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
                     FROM Runs_Groups rg
@@ -771,6 +771,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                     r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
                     IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay,
                     s.guid, s.current_run_id,
+                    COUNT(*) OVER (
+                        PARTITION BY s.identity_id, s.problem_id
+                    ) AS total_submissions,
                     ROW_NUMBER() OVER (
                         PARTITION BY s.identity_id, s.problem_id 
                         ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
@@ -792,7 +795,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                 (
                     SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
                     FROM Runs_Groups rg
-                    WHERE rg.run_id = s.current_run_id
+                    WHERE rg.run_id = r.run_id
                 ) AS score_by_group
             FROM Submissions s
             INNER JOIN Runs r ON s.current_run_id = r.run_id

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -748,66 +748,63 @@ class Runs extends \OmegaUp\DAO\Base\Runs
      */
     final public static function getProblemsetRuns(
         int $problemsetId,
-        bool $onlyAC = false
+        bool $onlyAC = false,
+        bool $onlyBest = false
     ): array {
         $verdictCondition = ($onlyAC ?
             "s.verdict IN ('AC') " :
             "s.verdict NOT IN ('CE', 'JE', 'VE') "
         );
 
-        $sql = "
-        WITH RankedSubmissions AS (
+        if ($onlyBest) {
+            $sql = "
             SELECT 
-                r.score,
-                r.penalty,
-                r.contest_score,
-                s.problem_id,
-                s.identity_id,
-                IFNULL(s.`type`, 'normal') AS `type`,
-                s.`time`,
-                s.submit_delay,
-                s.guid,
-                s.submission_id,
-                c.score_mode,
-                rg.group_name,
-                rg.score as group_score,
-                ROW_NUMBER() OVER (
-                    PARTITION BY s.identity_id, s.problem_id 
-                    ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
-                ) as run_rank
-            FROM Problemset_Problems pp
-            INNER JOIN Submissions s ON s.problemset_id = pp.problemset_id 
-                                    AND s.problem_id = pp.problem_id
+                rs.score, rs.penalty, rs.contest_score, rs.problem_id, 
+                rs.identity_id, rs.type, rs.time, rs.submit_delay, rs.guid,
+                (
+                    SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
+                    FROM Runs_Groups rg
+                    WHERE rg.run_id = rs.current_run_id
+                ) AS score_by_group
+            FROM (
+                SELECT 
+                    r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
+                    IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay,
+                    s.guid, s.current_run_id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY s.identity_id, s.problem_id 
+                        ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
+                    ) as run_rank
+                FROM Submissions s
+                INNER JOIN Runs r ON s.current_run_id = r.run_id
+                WHERE s.problemset_id = ? 
+                  AND s.status = 'ready' 
+                  AND s.type = 'normal'
+                  AND $verdictCondition
+            ) AS rs
+            WHERE rs.run_rank = 1;
+            ";
+        } else {
+            $sql = "
+            SELECT 
+                r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
+                IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay, s.guid,
+                (
+                    SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
+                    FROM Runs_Groups rg
+                    WHERE rg.run_id = s.current_run_id
+                ) AS score_by_group
+            FROM Submissions s
             INNER JOIN Runs r ON s.current_run_id = r.run_id
-            LEFT JOIN Contests c ON c.problemset_id = pp.problemset_id
-            LEFT JOIN Runs_Groups rg ON r.run_id = rg.run_id
-            WHERE pp.problemset_id = ? 
+            WHERE s.problemset_id = ? 
               AND s.status = 'ready' 
-              AND s.`type` = 'normal'
-              AND $verdictCondition
-        )
-        SELECT 
-            IF(score_mode = 'all_or_nothing' AND score <> 1, 0, score) AS score,
-            penalty,
-            IFNULL(IF(score_mode = 'all_or_nothing' AND score <> 1, 0, contest_score), 0.0) AS contest_score,
-            problem_id,
-            identity_id,
-            `type`,
-            `time`,
-            submit_delay,
-            guid,
-            JSON_OBJECTAGG(IFNULL(group_name, ''), group_score) AS score_by_group
-        FROM RankedSubmissions
-        WHERE run_rank = 1
-        GROUP BY submission_id; -- التجميع هنا فقط لعمل JSON_OBJECTAGG للـ groups
-    ";
+              AND s.type = 'normal'
+              AND $verdictCondition;
+            ";
+        }
 
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            $sql,
-            [$problemsetId]
-        );
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [$problemsetId]);
     }
-
     /**
      * Get best contest score of a user for a problem in a problemset.
      */

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -754,52 +754,52 @@ class Runs extends \OmegaUp\DAO\Base\Runs
 
         if ($onlyBest) {
             $sql = "
-            SELECT
-                rs.score, rs.penalty, rs.contest_score, rs.problem_id,
-                rs.identity_id, rs.type, rs.time, rs.submit_delay, rs.guid,
-                rs.total_submissions,
-                (
-                    SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
-                    FROM Runs_Groups rg
-                    WHERE rg.run_id = rs.current_run_id
-                ) AS score_by_group
-            FROM (
+                SELECT
+                    rs.score, rs.penalty, rs.contest_score, rs.problem_id,
+                    rs.identity_id, rs.type, rs.time, rs.submit_delay, rs.guid,
+                    rs.total_submissions,
+                    (
+                        SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
+                        FROM Runs_Groups rg
+                        WHERE rg.run_id = rs.current_run_id
+                    ) AS score_by_group
+                FROM (
+                    SELECT
+                        r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
+                        IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay,
+                        s.guid, s.current_run_id,
+                        COUNT(*) OVER (
+                            PARTITION BY s.identity_id, s.problem_id
+                        ) AS total_submissions,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY s.identity_id, s.problem_id
+                            ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
+                        ) as run_rank
+                    FROM Submissions s
+                    INNER JOIN Runs r ON s.current_run_id = r.run_id
+                    WHERE s.problemset_id = ?
+                      AND s.status = 'ready'
+                      AND s.type = 'normal'
+                      AND $verdictCondition
+                ) AS rs
+                WHERE rs.run_rank = 1;
+            ";
+        } else {
+            $sql = "
                 SELECT
                     r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
-                    IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay,
-                    s.guid, s.current_run_id,
-                    COUNT(*) OVER (
-                        PARTITION BY s.identity_id, s.problem_id
-                    ) AS total_submissions,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY s.identity_id, s.problem_id
-                        ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
-                    ) as run_rank
+                    IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay, s.guid,
+                    (
+                        SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
+                        FROM Runs_Groups rg
+                        WHERE rg.run_id = r.run_id
+                    ) AS score_by_group
                 FROM Submissions s
                 INNER JOIN Runs r ON s.current_run_id = r.run_id
                 WHERE s.problemset_id = ?
                   AND s.status = 'ready'
                   AND s.type = 'normal'
-                  AND $verdictCondition
-            ) AS rs
-            WHERE rs.run_rank = 1;
-            ";
-        } else {
-            $sql = "
-            SELECT
-                r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
-                IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay, s.guid,
-                (
-                    SELECT JSON_OBJECTAGG(IFNULL(rg.group_name, ''), rg.score)
-                    FROM Runs_Groups rg
-                    WHERE rg.run_id = r.run_id
-                ) AS score_by_group
-            FROM Submissions s
-            INNER JOIN Runs r ON s.current_run_id = r.run_id
-            WHERE s.problemset_id = ?
-              AND s.status = 'ready'
-              AND s.type = 'normal'
-              AND $verdictCondition;
+                  AND $verdictCondition;
             ";
         }
 

--- a/frontend/server/src/DAO/Runs.php
+++ b/frontend/server/src/DAO/Runs.php
@@ -68,10 +68,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         $result = [];
         /** @var array{classname: string, language: string, memory: int, per_identity_rank: int, runtime: int, time: \OmegaUp\Timestamp, username: string} $row */
         foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $val
-            ) as $row
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val)
+            as $row
         ) {
             if ($row['per_identity_rank'] != 1) {
                 // This means that there were fewer than 10 distinct identities
@@ -110,10 +108,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         $result = [];
         /** @var array{guid: string} $row */
         foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $val
-            ) as $row
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val)
+            as $row
         ) {
             $result[] = $row['guid'];
         }
@@ -229,7 +225,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         ?int $offset = 0,
         ?int $rowCount = 100,
         ?string $execution = null,
-        ?string $output = null,
+        ?string $output = null
     ): array {
         $where = [];
         $val = [];
@@ -240,8 +236,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         if (!is_null($problemsetId)) {
             $cteSubmissionsFeedback = self::$ctesubmissionFeedbackForProblemset;
 
-            $suggestionsCountField = 'IFNULL(ssff.suggestions, 0) AS suggestions';
-            $suggestionsJoin = 'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
+            $suggestionsCountField =
+                'IFNULL(ssff.suggestions, 0) AS suggestions';
+            $suggestionsJoin =
+                'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
 
             $where[] = 's.problemset_id = ?';
             $val[] = $problemsetId;
@@ -273,7 +271,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
             }
         } else {
             if (!is_null($execution)) {
-                $executionArgs = \OmegaUp\Controllers\Run::EXECUTION[$execution];
+                $executionArgs =
+                    \OmegaUp\Controllers\Run::EXECUTION[$execution];
                 $placeholders = array_fill(0, count($executionArgs), '?');
                 $placeholders = join(',', $placeholders);
                 $where[] = "s.verdict IN ({$placeholders})";
@@ -302,7 +301,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         /** @var int */
         $totalRows = \OmegaUp\MySQLConnection::getInstance()->GetOne(
             $sqlCount,
-            $val,
+            $val
         );
 
         if (is_null($offset) || $offset < 0) {
@@ -382,9 +381,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
      *
      * @return list<string>
      */
-    final public static function getPendingRunsOfProblem(
-        int $problemId
-    ) {
+    final public static function getPendingRunsOfProblem(int $problemId)
+    {
         $sql = '
             SELECT
                 s.guid
@@ -402,10 +400,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         $result = [];
         /** @var array{guid: string} $row */
         foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $val
-            ) as $row
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val)
+            as $row
         ) {
             $result[] = $row['guid'];
         }
@@ -611,7 +607,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                     \OmegaUp\Authorization::ADMIN_ROLE,
                 ];
                 if ($excludeAdmin) {
-                    $sql .= ' AND i.user_id != (SELECT a.owner_id FROM ACLs a WHERE a.acl_id = ?)';
+                    $sql .=
+                        ' AND i.user_id != (SELECT a.owner_id FROM ACLs a WHERE a.acl_id = ?)';
                     $val[] = $aclId;
                 }
                 $sql .= ' OR i.user_id IS NULL);';
@@ -689,10 +686,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         $result = [];
         /** @var array{classname: string, country_id: string, identity_id: int, is_invited: int, name: null|string, username: string} $row */
         foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $val
-            ) as $row
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $val)
+            as $row
         ) {
             $row['is_invited'] = boolval($row['is_invited']);
             $result[] = $row;
@@ -732,16 +727,19 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         ';
 
         /** @var array{solved: int|null, tried: int|null} */
-        $result = \OmegaUp\MySQLConnection::getInstance()->GetRow(
-            $sql,
-            [$problemId, $identityId, $problemId, $identityId]
-        );
+        $result = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [
+            $problemId,
+            $identityId,
+            $problemId,
+            $identityId,
+        ]);
 
         return [
             'tried' => boolval($result['tried']),
             'solved' => boolval($result['solved']),
         ];
     }
+
     /**
      * @return list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, total_submissions?: int, type: string}>
      */
@@ -750,15 +748,14 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         bool $onlyAC = false,
         bool $onlyBest = false
     ): array {
-        $verdictCondition = ($onlyAC ?
-            "s.verdict IN ('AC') " :
-            "s.verdict NOT IN ('CE', 'JE', 'VE') "
-        );
+        $verdictCondition = $onlyAC
+            ? "s.verdict IN ('AC')"
+            : "s.verdict NOT IN ('CE', 'JE', 'VE')";
 
         if ($onlyBest) {
             $sql = "
-            SELECT 
-                rs.score, rs.penalty, rs.contest_score, rs.problem_id, 
+            SELECT
+                rs.score, rs.penalty, rs.contest_score, rs.problem_id,
                 rs.identity_id, rs.type, rs.time, rs.submit_delay, rs.guid,
                 rs.total_submissions,
                 (
@@ -767,7 +764,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                     WHERE rg.run_id = rs.current_run_id
                 ) AS score_by_group
             FROM (
-                SELECT 
+                SELECT
                     r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
                     IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay,
                     s.guid, s.current_run_id,
@@ -775,13 +772,13 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                         PARTITION BY s.identity_id, s.problem_id
                     ) AS total_submissions,
                     ROW_NUMBER() OVER (
-                        PARTITION BY s.identity_id, s.problem_id 
+                        PARTITION BY s.identity_id, s.problem_id
                         ORDER BY r.score DESC, r.penalty ASC, s.submission_id ASC
                     ) as run_rank
                 FROM Submissions s
                 INNER JOIN Runs r ON s.current_run_id = r.run_id
-                WHERE s.problemset_id = ? 
-                  AND s.status = 'ready' 
+                WHERE s.problemset_id = ?
+                  AND s.status = 'ready'
                   AND s.type = 'normal'
                   AND $verdictCondition
             ) AS rs
@@ -789,7 +786,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
             ";
         } else {
             $sql = "
-            SELECT 
+            SELECT
                 r.score, r.penalty, r.contest_score, s.problem_id, s.identity_id,
                 IFNULL(s.type, 'normal') AS type, s.time, s.submit_delay, s.guid,
                 (
@@ -799,15 +796,18 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                 ) AS score_by_group
             FROM Submissions s
             INNER JOIN Runs r ON s.current_run_id = r.run_id
-            WHERE s.problemset_id = ? 
-              AND s.status = 'ready' 
+            WHERE s.problemset_id = ?
+              AND s.status = 'ready'
               AND s.type = 'normal'
               AND $verdictCondition;
             ";
         }
 
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [$problemsetId]);
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [
+            $problemsetId,
+        ]);
     }
+
     /**
      * Get best contest score of a user for a problem in a problemset.
      */
@@ -915,10 +915,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         ';
 
         /** @var list<array{alias: string, contest_score: float|null, guid: string, language: string, username: string, verdict: string}> */
-        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            $sql,
-            [$problemsetId]
-        );
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [
+            $problemsetId,
+        ]);
     }
 
     /**
@@ -928,13 +927,18 @@ class Runs extends \OmegaUp\DAO\Base\Runs
     {
         $extraFields = self::getRunExtraFields();
 
-        $sql = '
+        $sql =
+            '
             SELECT
-                ' . \OmegaUp\DAO\DAO::getFields(
-                    \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
-                    'r'
-                ) . ',
-            ' . $extraFields . '
+                ' .
+            \OmegaUp\DAO\DAO::getFields(
+                \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
+                'r'
+            ) .
+            ',
+            ' .
+            $extraFields .
+            '
         FROM
             `Runs` `r`
         INNER JOIN
@@ -960,15 +964,17 @@ class Runs extends \OmegaUp\DAO\Base\Runs
     /**
      * @return list<\OmegaUp\DAO\VO\Runs>
      */
-    final public static function getByProblem(
-        int $problemId
-    ) {
-        $sql = '
+    final public static function getByProblem(int $problemId)
+    {
+        $sql =
+            '
             SELECT
-                ' . \OmegaUp\DAO\DAO::getFields(
-                    \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
-                    'r'
-                ) . '
+                ' .
+            \OmegaUp\DAO\DAO::getFields(
+                \OmegaUp\DAO\VO\Runs::FIELD_NAMES,
+                'r'
+            ) .
+            '
             FROM
                 Submissions s
             INNER JOIN
@@ -1005,8 +1011,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs
 
         if (!is_null($problemsetId)) {
             $cteSubmissionsFeedback = self::$ctesubmissionFeedbackForProblemset;
-            $suggestionsCountField = 'IFNULL(ssff.suggestions, 0) AS suggestions';
-            $suggestionsJoin = 'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
+            $suggestionsCountField =
+                'IFNULL(ssff.suggestions, 0) AS suggestions';
+            $suggestionsJoin =
+                'LEFT JOIN ssff ON ssff.submission_id = s.submission_id';
             $whereClause = ' AND s.problemset_id = ?';
             $params = [$problemId, $identityId, $problemsetId];
         }
@@ -1289,10 +1297,11 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         $result = [];
         /** @var array{commit: string, contest_score: float|null, judged_by: null|string, memory: int, penalty: int, run_id: int, runtime: int, score: float, status: string, submission_id: int, time: \OmegaUp\Timestamp, verdict: string, version: string} $row */
         foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                [$problemId, $submissionId]
-            ) as $row
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [
+                $problemId,
+                $submissionId,
+            ])
+            as $row
         ) {
             $result[] = new \OmegaUp\DAO\VO\Runs($row);
         }
@@ -1321,11 +1330,7 @@ class Runs extends \OmegaUp\DAO\Base\Runs
               s.problem_id = ?;
         ';
 
-        $params = [
-            $currentPoints,
-            $problemsetId,
-            $problemId
-        ];
+        $params = [$currentPoints, $problemsetId, $problemId];
 
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
@@ -1443,8 +1448,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs
      *
      * @param \OmegaUp\DAO\VO\Problems $problem the problem.
      */
-    final public static function updateVersionToCurrent(\OmegaUp\DAO\VO\Problems $problem): void
-    {
+    final public static function updateVersionToCurrent(
+        \OmegaUp\DAO\VO\Problems $problem
+    ): void {
         $sql = '
             UPDATE
                 Submissions s
@@ -1459,10 +1465,10 @@ class Runs extends \OmegaUp\DAO\Base\Runs
                 r.version = ? AND
                 s.problem_id = ?;
         ';
-        \OmegaUp\MySQLConnection::getInstance()->Execute(
-            $sql,
-            [$problem->current_version, $problem->problem_id]
-        );
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [
+            $problem->current_version,
+            $problem->problem_id,
+        ]);
     }
 
     /**
@@ -1470,8 +1476,9 @@ class Runs extends \OmegaUp\DAO\Base\Runs
      *
      * @return list<\OmegaUp\DAO\VO\Runs>
      */
-    final public static function getNewRunsForVersion(\OmegaUp\DAO\VO\Problems $problem): array
-    {
+    final public static function getNewRunsForVersion(
+        \OmegaUp\DAO\VO\Problems $problem
+    ): array {
         $sql = '
             SELECT
                 r.run_id
@@ -1491,10 +1498,8 @@ class Runs extends \OmegaUp\DAO\Base\Runs
         $result = [];
         /** @var array{run_id: int} $row */
         foreach (
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $params
-            ) as $row
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params)
+            as $row
         ) {
             $result[] = new \OmegaUp\DAO\VO\Runs($row);
         }

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -763,14 +763,8 @@ class Scoreboard
                  * @param ScoreboardRankingEntry $b
                  */
                 function (array $a, array $b): int {
-                    $pointsA = round(
-                        floatval($a[self::TOTAL_COLUMN]['points']),
-                        2
-                    );
-                    $pointsB = round(
-                        floatval($b[self::TOTAL_COLUMN]['points']),
-                        2
-                    );
+                    $pointsA = round(floatval($a[self::TOTAL_COLUMN]['points']), 2);
+                    $pointsB = round(floatval($b[self::TOTAL_COLUMN]['points']), 2);
                     if ($pointsA != $pointsB) {
                         return $pointsA < $pointsB ? 1 : -1;
                     }
@@ -794,17 +788,18 @@ class Scoreboard
 
         // Append the place for each user
         $currentPoints = -1;
-        $place = 1;
+        $place = 0;
         $draws = 1;
         foreach ($scoreboard as &$userData) {
             $points = round(floatval($userData['total']['points']), 2);
             if ($currentPoints === -1) {
                 $currentPoints = $points;
+                $place = 1;
             } elseif ($points < $currentPoints) {
-                $currentPoints = $points;
                 $place += $draws;
                 $draws = 1;
-            } else {
+                $currentPoints = $points;
+            } elseif ($points == $currentPoints) {
                 $draws++;
             }
             if (!$sortByName) {
@@ -978,8 +973,8 @@ class Scoreboard
         if (!is_array($scoreByGroupArray)) {
             throw new \RuntimeException(
                 'json_decode failed with: ' .
-                    json_last_error() .
-                    "for : {$scoreByGroup}"
+                json_last_error() .
+                "for : {$scoreByGroup}"
             );
         }
 

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -605,23 +605,18 @@ class Scoreboard {
         foreach ($contestRuns as $run) {
             $identityId = $run['identity_id'];
             $problemId = $run['problem_id'];
-            $contestScore = $run['contest_score'];
-            $score = $run['score'];
             $isTest = $run['type'] == 'test';
 
             $problem =&
                 $identitiesInfo[$identityId]['problems'][$problemMapping[$problemId]['order']];
 
             if (!array_key_exists($identityId, $testOnly)) {
-                // Hay un usuario en la lista de Runs,
-                // que no fue regresado por \OmegaUp\DAO\Runs::getAllRelevantIdentities()
                 continue;
             }
 
-            if ($testOnly[$identityId]) {
-                $testOnly[$identityId] = $isTest;
-            }
+            $testOnly[$identityId] = $testOnly[$identityId] && $isTest;
             $noRuns[$identityId] = false;
+
             if (!$showAllRuns) {
                 if ($isTest || ($scoreboardPct === 0 && !$showScoreboardAfter)) {
                     continue;
@@ -631,41 +626,30 @@ class Scoreboard {
                     && !empty($run['time'])
                     && $run['time']->time >= $scoreboardTimeLimit->time
                 ) {
-                    $problem['runs']++;
+                    $problem['runs']++; 
                     $problem['pending'] = true;
                     continue;
                 }
             }
 
-            $totalPenalty = $run['penalty'] + $problem['runs'] * $contestPenalty;
-            $roundedScore = round(floatval($contestScore), 2);
-            if (
-                $problem['points'] < $roundedScore ||
-                $problem['points'] == $roundedScore &&
-                $problem['penalty'] > $totalPenalty
-            ) {
-                $problem['points'] = $roundedScore;
-                $problem['percent'] = round($score * 100, 2);
-                $problem['penalty'] = $totalPenalty;
+            $problem['points'] = round(floatval($run['contest_score']), 2);
+            $problem['percent'] = round($run['score'] * 100, 2);
+            $problem['penalty'] = $run['penalty'];
 
-                if ($withRunDetails === true && !empty($run['guid'])) {
-                    $runDetails = [];
-
-                    $runDetailsRequest = new \OmegaUp\Request([
-                        'run_alias' => $run['guid'],
-                        'auth_token' => $authToken,
-                    ]);
-                    $runDetails = \OmegaUp\Controllers\Run::apiDetails(
-                        $runDetailsRequest
-                    );
-                    unset($runDetails['source']);
-                    $problem['run_details'] = $runDetails;
-                }
+            if ($withRunDetails === true && !empty($run['guid'])) {
+                $runDetailsRequest = new \OmegaUp\Request([
+                    'run_alias' => $run['guid'],
+                    'auth_token' => $authToken,
+                ]);
+                $runDetails = \OmegaUp\Controllers\Run::apiDetails($runDetailsRequest);
+                unset($runDetails['source']);
+                $problem['run_details'] = $runDetails;
             }
+
             if ($scoreMode == 'max_per_group') {
                 $problem['runs'] = $run['submission_count'] ?? 0;
             } else {
-                $problem['runs']++;
+                $problem['runs'] = $run['total_submissions'] ?? ($problem['runs'] + 1);
             }
         }
 
@@ -790,7 +774,7 @@ class Scoreboard {
         }
     }
 
-    /**
+   /**
      * @param \OmegaUp\ScoreboardParams $params
      * @param list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: string}> $contestRuns
      * @param list<array{identity_id: int, username: string, classname: string, name: string|null, country_id: null|string, is_invited: bool}> $rawContestIdentities
@@ -812,7 +796,7 @@ class Scoreboard {
 
         /** @var list<ScoreboardEvent> */
         $result = [];
-        /** @var array<int, array<int, array{points: int, penalty: int}>> */
+        /** @var array<int, array<int, array{points: float, penalty: float}>> */
         $identityProblemsScore = [];
         $identityProblemsScoreByGroup = [];
         $contestStart = $params->start_time;
@@ -820,7 +804,6 @@ class Scoreboard {
             $params
         );
 
-        // Calculate score for each contestant x problem x run
         foreach ($contestRuns as $run) {
             if (!$params->admin && $run['type'] != 'normal') {
                 continue;
@@ -836,6 +819,7 @@ class Scoreboard {
 
             $identityId = $run['identity_id'];
             $problemId = $run['problem_id'];
+
             if ($params->score_mode === 'max_per_group') {
                 if (!isset($run['score_by_group'])) {
                     throw new \OmegaUp\Exceptions\InvalidParameterException(
@@ -855,13 +839,9 @@ class Scoreboard {
             }
 
             if (!isset($identityProblemsScore[$identityId])) {
-                $identityProblemsScore[$identityId] = [
-                    $problemId => [
-                        'points' => 0.0,
-                        'penalty' => 0.0,
-                    ],
-                ];
-            } elseif (!isset($identityProblemsScore[$identityId][$problemId])) {
+                $identityProblemsScore[$identityId] = [];
+            }
+            if (!isset($identityProblemsScore[$identityId][$problemId])) {
                 $identityProblemsScore[$identityId][$problemId] = [
                     'points' => 0.0,
                     'penalty' => 0.0,
@@ -869,16 +849,8 @@ class Scoreboard {
             }
 
             $problemData =& $identityProblemsScore[$identityId][$problemId];
-
-            if ($problemData['points'] >= $contestScore && $params->show_all_runs) {
-                continue;
-            }
-
-            $problemData['points'] = max(
-                $problemData['points'],
-                round(floatval($contestScore), 2)
-            );
-            $problemData['penalty'] = 0.0;
+            $problemData['points'] = round(floatval($contestScore), 2);
+            $problemData['penalty'] = round(floatval($run['penalty']), 2);
 
             if (!isset($contestIdentities[$identityId])) {
                 continue;
@@ -895,8 +867,8 @@ class Scoreboard {
                 ),
                 'problem' => [
                     'alias' => $problemMapping[$problemId]['alias'],
-                    'points' => round(floatval($contestScore), 2),
-                    'penalty' => 0.0,
+                    'points' => $problemData['points'],
+                    'penalty' => $problemData['penalty'],
                 ],
                 'country' => $identity['country_id'] ?? 'xx',
                 'classname' => $identity['classname'],
@@ -907,19 +879,18 @@ class Scoreboard {
                 ],
             ];
 
-            foreach ($identityProblemsScore[$identityId] as $problem) {
-                $data['total']['points'] += $problem['points'];
+            foreach ($identityProblemsScore[$identityId] as $problemScore) {
+                $data['total']['points'] += $problemScore['points'];
                 if ($params->penalty_calc_policy == 'sum') {
-                    $data['total']['penalty'] += $problem['penalty'];
+                    $data['total']['penalty'] += $problemScore['penalty'];
                 } else {
                     $data['total']['penalty'] = max(
                         $data['total']['penalty'],
-                        $problem['penalty']
+                        $problemScore['penalty']
                     );
                 }
             }
 
-            // Add contestant results to scoreboard data
             $result[] = $data;
         }
 

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -109,13 +109,13 @@ class Scoreboard
             $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $this->params->problemset_id,
                 $this->params->only_ac,
-                true
+                onlyBest: false
             );
         } else {
             $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $this->params->problemset_id,
                 $this->params->only_ac,
-                ($this->params->score_mode !== 'max_per_group')
+                ($this->params->score_mode === 'partial')
             );
         }
 
@@ -229,8 +229,8 @@ class Scoreboard
         $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
             $this->params->problemset_id,
             $this->params->only_ac,
-            ($this->params->score_mode !== 'max_per_group')
-        );
+            false
+            );
         $problemMapping = [];
 
         $order = 0;
@@ -345,14 +345,17 @@ class Scoreboard
         );
 
         $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
-            $params->problemset_id
+            $params->problemset_id,
+            $params->only_ac,
+            false
         );
-        if ($params->score_mode === 'max_per_group') {
+
+        if ($params->score_mode === 'partial') {
             // The way to calculate the score is different in this mode
-            $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
+            $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $params->problemset_id,
                 $params->only_ac,
-                ($params->score_mode !== 'max_per_group')
+                true
             );
         } else {
             $contestRuns = $contestRunsForEvents;

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -115,7 +115,7 @@ class Scoreboard
             $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $this->params->problemset_id,
                 $this->params->only_ac,
-                true
+                ($this->params->score_mode !== 'max_per_group')
             );
         }
 
@@ -229,7 +229,7 @@ class Scoreboard
         $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
             $this->params->problemset_id,
             $this->params->only_ac,
-            true
+            ($this->params->score_mode !== 'max_per_group')
         );
         $problemMapping = [];
 
@@ -352,7 +352,7 @@ class Scoreboard
             $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $params->problemset_id,
                 $params->only_ac,
-                true
+                ($params->score_mode !== 'max_per_group')
             );
         } else {
             $contestRuns = $contestRunsForEvents;

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -13,7 +13,8 @@ namespace OmegaUp;
  * @psalm-type ScoreboardRankingEntry=array{classname: string, country: string, is_invited: bool, name: null|string, place?: int, problems: list<ScoreboardRankingProblem>, total: array{penalty: float, points: float}, username: string}
  * @psalm-type Scoreboard=array{finish_time: \OmegaUp\Timestamp|null, problems: list<array{alias: string, order: int}>, ranking: list<ScoreboardRankingEntry>, start_time: \OmegaUp\Timestamp, time: \OmegaUp\Timestamp, title: string}
  */
-class Scoreboard {
+class Scoreboard
+{
     // Column to return total score per user
     const TOTAL_COLUMN = 'total';
 
@@ -29,7 +30,8 @@ class Scoreboard {
     /** @var bool */
     private static $isLastRunFromCache = false;
 
-    public function __construct(\OmegaUp\ScoreboardParams $params) {
+    public function __construct(\OmegaUp\ScoreboardParams $params)
+    {
         $this->params = $params;
         $this->log = \Monolog\Registry::omegaup()->withName('Scoreboard');
         \OmegaUp\Scoreboard::setIsLastRunFromCacheForTesting(false);
@@ -104,14 +106,16 @@ class Scoreboard {
 
         if ($this->params->score_mode === 'max_per_group') {
             // The way to calculate the score is different in this mode
-            $contestRuns = \OmegaUp\DAO\RunsGroups::getProblemsetRunsGroups(
+            $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $this->params->problemset_id,
-                $scoreboardTimeLimit
+                $this->params->only_ac,
+                true
             );
         } else {
             $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $this->params->problemset_id,
-                $this->params->only_ac
+                $this->params->only_ac,
+                true
             );
         }
 
@@ -148,7 +152,7 @@ class Scoreboard {
         );
 
         if (!is_null($cache)) {
-            $timeout =  is_null($this->params->finish_time) ?
+            $timeout = is_null($this->params->finish_time) ?
                 0 :
                 max(
                     0,
@@ -165,7 +169,8 @@ class Scoreboard {
      *
      * @return list<ScoreboardEvent>
      */
-    public function events(): array {
+    public function events(): array
+    {
         $result = null;
 
         $contestantEventsCache = new \OmegaUp\Cache(
@@ -222,9 +227,10 @@ class Scoreboard {
             );
 
         $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
-            $this->params->problemset_id
+            $this->params->problemset_id,
+            $this->params->only_ac,
+            true
         );
-
         $problemMapping = [];
 
         $order = 0;
@@ -265,7 +271,8 @@ class Scoreboard {
      *
      * @param \OmegaUp\ScoreboardParams $params
      */
-    public static function invalidateScoreboardCache(\OmegaUp\ScoreboardParams $params): void {
+    public static function invalidateScoreboardCache(\OmegaUp\ScoreboardParams $params): void
+    {
         $log = \Monolog\Registry::omegaup()->withName('Scoreboard');
         $log->info('Invalidating scoreboard cache.');
 
@@ -293,7 +300,8 @@ class Scoreboard {
     /**
      * Force refresh of Scoreboard caches
      */
-    public static function refreshScoreboardCache(\OmegaUp\ScoreboardParams $params): void {
+    public static function refreshScoreboardCache(\OmegaUp\ScoreboardParams $params): void
+    {
         $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
             $params->problemset_id
         );
@@ -341,9 +349,10 @@ class Scoreboard {
         );
         if ($params->score_mode === 'max_per_group') {
             // The way to calculate the score is different in this mode
-            $contestRuns = \OmegaUp\DAO\RunsGroups::getProblemsetRunsGroups(
+            $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $params->problemset_id,
-                $scoreboardTimeLimit
+                $params->only_ac,
+                true
             );
         } else {
             $contestRuns = $contestRunsForEvents;
@@ -351,7 +360,7 @@ class Scoreboard {
 
         // Cache scoreboard until the contest ends (or forever if it has already ended).
         // Contestant cache
-        $timeout =  is_null($params->finish_time) ?
+        $timeout = is_null($params->finish_time) ?
             0 :
             max(
                 0,
@@ -626,7 +635,7 @@ class Scoreboard {
                     && !empty($run['time'])
                     && $run['time']->time >= $scoreboardTimeLimit->time
                 ) {
-                    $problem['runs']++; 
+                    $problem['runs']++;
                     $problem['pending'] = true;
                     continue;
                 }
@@ -685,7 +694,7 @@ class Scoreboard {
              * @param array{order: int, alias: string} $a
              * @param array{order: int, alias: string} $b
              */
-            fn (array $a, array $b) => $a['order'] - $b['order']
+            fn(array $a, array $b) => $a['order'] - $b['order']
         );
 
         return [
@@ -732,7 +741,7 @@ class Scoreboard {
                  * @param ScoreboardRankingEntry $a
                  * @param ScoreboardRankingEntry $b
                  */
-                fn (array $a, array $b) => strcasecmp(
+                fn(array $a, array $b) => strcasecmp(
                     $a['username'],
                     $b['username']
                 )
@@ -761,7 +770,7 @@ class Scoreboard {
                     $draws = 1;
                 } elseif (
                     $userData['total']['points'] == $currentPoints &&
-                           $userData['total']['penalty'] == $currentPenalty
+                    $userData['total']['penalty'] == $currentPenalty
                 ) {
                     $draws++;
                 }
@@ -774,7 +783,7 @@ class Scoreboard {
         }
     }
 
-   /**
+    /**
      * @param \OmegaUp\ScoreboardParams $params
      * @param list<array{contest_score: float, guid: string, identity_id: int, penalty: int, problem_id: int, score: float, score_by_group: null|string, submit_delay: int, time: \OmegaUp\Timestamp, type: string}> $contestRuns
      * @param list<array{identity_id: int, username: string, classname: string, name: string|null, country_id: null|string, is_invited: bool}> $rawContestIdentities
@@ -900,7 +909,8 @@ class Scoreboard {
     /**
      * Set last run from cache for testing purposes
      */
-    private function setIsLastRunFromCacheForTesting(bool $value): void {
+    private function setIsLastRunFromCacheForTesting(bool $value): void
+    {
         if (!\OmegaUp\Scoreboard::$isTestRun) {
             return;
         }
@@ -939,8 +949,8 @@ class Scoreboard {
             ];
         } elseif (
             !isset(
-                $identityProblemsScoreByGroup[$identityId][$problemId]
-            )
+            $identityProblemsScoreByGroup[$identityId][$problemId]
+        )
         ) {
             $identityProblemsScoreByGroup[$identityId][$problemId] = $scoreByGroupArray;
         }
@@ -960,14 +970,16 @@ class Scoreboard {
     /**
      * Get last run from Cache value
      */
-    public static function getIsLastRunFromCacheForTesting(): bool {
+    public static function getIsLastRunFromCacheForTesting(): bool
+    {
         return \OmegaUp\Scoreboard::$isLastRunFromCache;
     }
 
     /**
      * Enable testing extras
      */
-    public static function setIsTestRunForTesting(bool $value): void {
+    public static function setIsTestRunForTesting(bool $value): void
+    {
         \OmegaUp\Scoreboard::$isTestRun = $value;
     }
 }

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -16,7 +16,7 @@ namespace OmegaUp;
 class Scoreboard
 {
     // Column to return total score per user
-    const TOTAL_COLUMN = 'total';
+    public const TOTAL_COLUMN = 'total';
 
     /** @var \OmegaUp\ScoreboardParams */
     private $params;
@@ -50,9 +50,9 @@ class Scoreboard
         $cache = null;
         // A few scoreboard options are not cacheable.
         if (
-            !$sortByName && is_null(
-                $filterUsersBy
-            ) && !$this->params->only_ac
+            !$sortByName &&
+            is_null($filterUsersBy) &&
+            !$this->params->only_ac
         ) {
             if ($this->params->admin) {
                 $cache = new \OmegaUp\Cache(
@@ -91,14 +91,13 @@ class Scoreboard
             filterUsersBy: $filterUsersBy,
             groupId: $this->params->group_id,
             // Treat admin as contestant in virtual contest.
-            excludeAdmin: !$this->params->virtual,
+            excludeAdmin: !$this->params->virtual
         );
 
         // Get all problems given problemset
-        $rawProblemsetProblems =
-            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
-                $this->params->problemset_id
-            );
+        $rawProblemsetProblems = \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
+            $this->params->problemset_id
+        );
 
         $scoreboardTimeLimit = \OmegaUp\Scoreboard::getScoreboardTimeLimitTimestamp(
             $this->params
@@ -115,7 +114,7 @@ class Scoreboard
             $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $this->params->problemset_id,
                 $this->params->only_ac,
-                ($this->params->score_mode === 'partial')
+                $this->params->score_mode === 'partial'
             );
         }
 
@@ -152,9 +151,9 @@ class Scoreboard
         );
 
         if (!is_null($cache)) {
-            $timeout = is_null($this->params->finish_time) ?
-                0 :
-                max(
+            $timeout = is_null($this->params->finish_time)
+                ? 0
+                : max(
                     0,
                     $this->params->finish_time->time - \OmegaUp\Time::get()
                 );
@@ -213,24 +212,22 @@ class Scoreboard
         $rawContestIdentities = \OmegaUp\DAO\Runs::getAllRelevantIdentities(
             $this->params->problemset_id,
             $this->params->acl_id,
-            showAllRuns: $this->params->admin,
+            showAllRuns: true,
             filterUsersBy: null,
-            groupId: null,
-            // Treat admin as contestant.
-            excludeAdmin: !$this->params->virtual,
+            groupId: $this->params->group_id, // Treat admin as contestant.
+            excludeAdmin: !$this->params->virtual
         );
 
         // Get all problems given problemset
-        $rawProblemsetProblems =
-            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
-                $this->params->problemset_id
-            );
+        $rawProblemsetProblems = \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
+            $this->params->problemset_id
+        );
 
         $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
             $this->params->problemset_id,
             $this->params->only_ac,
-            false
-            );
+            $this->params->score_mode === 'partial'
+        );
         $problemMapping = [];
 
         $order = 0;
@@ -250,12 +247,9 @@ class Scoreboard
             $problemMapping
         );
 
-        $timeout = is_null($this->params->finish_time) ?
-            0 :
-            max(
-                0,
-                $this->params->finish_time->time - \OmegaUp\Time::get()
-            );
+        $timeout = is_null($this->params->finish_time)
+            ? 0
+            : max(0, $this->params->finish_time->time - \OmegaUp\Time::get());
         if ($canUseContestantCache) {
             $contestantEventsCache->set($result, $timeout);
         } elseif ($canUseAdminCache) {
@@ -271,8 +265,9 @@ class Scoreboard
      *
      * @param \OmegaUp\ScoreboardParams $params
      */
-    public static function invalidateScoreboardCache(\OmegaUp\ScoreboardParams $params): void
-    {
+    public static function invalidateScoreboardCache(
+        \OmegaUp\ScoreboardParams $params
+    ): void {
         $log = \Monolog\Registry::omegaup()->withName('Scoreboard');
         $log->info('Invalidating scoreboard cache.');
 
@@ -300,8 +295,9 @@ class Scoreboard
     /**
      * Force refresh of Scoreboard caches
      */
-    public static function refreshScoreboardCache(\OmegaUp\ScoreboardParams $params): void
-    {
+    public static function refreshScoreboardCache(
+        \OmegaUp\ScoreboardParams $params
+    ): void {
         $problemsetExists = \OmegaUp\DAO\Problemsets::existsByPK(
             $params->problemset_id
         );
@@ -319,14 +315,13 @@ class Scoreboard
             filterUsersBy: null,
             groupId: null,
             // Treat admin as contestant in virtual contest.
-            excludeAdmin: !$params->virtual,
+            excludeAdmin: !$params->virtual
         );
 
         // Get all problems given problemset
-        $rawProblemsetProblems =
-            \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
-                $params->problemset_id
-            );
+        $rawProblemsetProblems = \OmegaUp\DAO\ProblemsetProblems::getRelevantProblems(
+            $params->problemset_id
+        );
 
         $problemMapping = [];
 
@@ -347,15 +342,15 @@ class Scoreboard
         $contestRunsForEvents = \OmegaUp\DAO\Runs::getProblemsetRuns(
             $params->problemset_id,
             $params->only_ac,
-            false
+            $params->score_mode === 'partial'
         );
 
-        if ($params->score_mode === 'partial') {
+        if ($params->score_mode === 'max_per_group') {
             // The way to calculate the score is different in this mode
             $contestRuns = \OmegaUp\DAO\Runs::getProblemsetRuns(
                 $params->problemset_id,
                 $params->only_ac,
-                true
+                false
             );
         } else {
             $contestRuns = $contestRunsForEvents;
@@ -363,12 +358,9 @@ class Scoreboard
 
         // Cache scoreboard until the contest ends (or forever if it has already ended).
         // Contestant cache
-        $timeout = is_null($params->finish_time) ?
-            0 :
-            max(
-                0,
-                $params->finish_time->time - \OmegaUp\Time::get()
-            );
+        $timeout = is_null($params->finish_time)
+            ? 0
+            : max(0, $params->finish_time->time - \OmegaUp\Time::get());
 
         $contestantScoreboardCache = new \OmegaUp\Cache(
             \OmegaUp\Cache::CONTESTANT_SCOREBOARD_PREFIX,
@@ -388,19 +380,22 @@ class Scoreboard
             $params->scoreboard_pct,
             $params->score_mode,
             $params->show_scoreboard_after,
-            sortByName: false,
+            sortByName: false
         );
 
         $contestantEventCache = new \OmegaUp\Cache(
             \OmegaUp\Cache::CONTESTANT_SCOREBOARD_EVENTS_PREFIX,
             strval($params->problemset_id)
         );
-        $contestantEventCache->set(\OmegaUp\Scoreboard::calculateEvents(
-            $params,
-            $contestRunsForEvents,
-            $rawContestIdentities,
-            $problemMapping
-        ), $timeout);
+        $contestantEventCache->set(
+            \OmegaUp\Scoreboard::calculateEvents(
+                $params,
+                $contestRunsForEvents,
+                $rawContestIdentities,
+                $problemMapping
+            ),
+            $timeout
+        );
 
         // Admin cache
         $params->admin = true; // Temporarily set for admin cache
@@ -426,7 +421,7 @@ class Scoreboard
             $params->scoreboard_pct,
             $params->score_mode,
             $params->show_scoreboard_after,
-            sortByName: false,
+            sortByName: false
         );
         $adminScoreboardCache->set($adminScoreboard, $timeout);
         $params->admin = false;
@@ -435,12 +430,15 @@ class Scoreboard
             \OmegaUp\Cache::ADMIN_SCOREBOARD_EVENTS_PREFIX,
             strval($params->problemset_id)
         );
-        $adminEventCache->set(\OmegaUp\Scoreboard::calculateEvents(
-            $params,
-            $contestRunsForEvents,
-            $rawContestIdentities,
-            $problemMapping
-        ), $timeout);
+        $adminEventCache->set(
+            \OmegaUp\Scoreboard::calculateEvents(
+                $params,
+                $contestRunsForEvents,
+                $rawContestIdentities,
+                $problemMapping
+            ),
+            $timeout
+        );
 
         // Try to broadcast the updated scoreboards:
         $log = \Monolog\Registry::omegaup()->withName('Scoreboard');
@@ -453,12 +451,12 @@ class Scoreboard
                 json_encode([
                     'message' => '/scoreboard/update/',
                     'scoreboard_type' => 'contestant',
-                    'scoreboard' => $contestantScoreboard
+                    'scoreboard' => $contestantScoreboard,
                 ]),
-                true,  // public
-                null,  // username
-                -1,  // user_id
-                true  // user_only
+                true, // public
+                null, // username
+                -1, // user_id
+                true // user_only
             );
             \OmegaUp\Grader::getInstance()->broadcast(
                 $params->alias,
@@ -467,12 +465,12 @@ class Scoreboard
                 json_encode([
                     'message' => '/scoreboard/update/',
                     'scoreboard_type' => 'admin',
-                    'scoreboard' => $adminScoreboard
+                    'scoreboard' => $adminScoreboard,
                 ]),
-                false,  // public
-                null,  // username
-                -1,  // user_id
-                false  // user_only
+                false, // public
+                null, // username
+                -1, // user_id
+                false // user_only
             );
         } catch (\Exception $e) {
             $log->error('Error broadcasting scoreboard', ['exception' => $e]);
@@ -487,12 +485,10 @@ class Scoreboard
         \OmegaUp\ScoreboardParams $params
     ): ?\OmegaUp\Timestamp {
         if (
-            $params->admin
-            || is_null($params->finish_time)
-            || (
-                (\OmegaUp\Time::get() >= $params->finish_time->time)
-                && $params->show_scoreboard_after
-            )
+            $params->admin ||
+            is_null($params->finish_time) ||
+            (\OmegaUp\Time::get() >= $params->finish_time->time &&
+                $params->show_scoreboard_after)
         ) {
             // Show full scoreboard to admin users
             // or if the contest finished and the creator wants to show it at the end
@@ -593,7 +589,7 @@ class Scoreboard
                     'points' => 0.0,
                     'percent' => 0.0,
                     'penalty' => 0.0,
-                    'runs' => 0
+                    'runs' => 0,
                 ];
             }
 
@@ -601,9 +597,9 @@ class Scoreboard
             $identitiesInfo[$contestant['identity_id']] = [
                 'problems' => $identityProblems,
                 'username' => $contestant['username'],
-                'name' => $contestant['name'] ?
-                    $contestant['name'] :
-                    $contestant['username'],
+                'name' => $contestant['name']
+                    ? $contestant['name']
+                    : $contestant['username'],
                 'country' => $contestant['country_id'] ?? 'xx',
                 'classname' => $contestant['classname'],
                 'is_invited' => boolval($contestant['is_invited']),
@@ -614,13 +610,20 @@ class Scoreboard
             ];
         }
 
+        $identityProblemsScoreByGroup = [];
         foreach ($contestRuns as $run) {
             $identityId = $run['identity_id'];
             $problemId = $run['problem_id'];
             $isTest = $run['type'] == 'test';
 
-            $problem =&
-                $identitiesInfo[$identityId]['problems'][$problemMapping[$problemId]['order']];
+            if (!array_key_exists($problemId, $problemMapping)) {
+                continue;
+            }
+
+            $problem =
+                &$identitiesInfo[$identityId]['problems'][
+                    $problemMapping[$problemId]['order']
+                ];
 
             if (!array_key_exists($identityId, $testOnly)) {
                 continue;
@@ -630,13 +633,16 @@ class Scoreboard
             $noRuns[$identityId] = false;
 
             if (!$showAllRuns) {
-                if ($isTest || ($scoreboardPct === 0 && !$showScoreboardAfter)) {
+                if (
+                    $isTest ||
+                    ($scoreboardPct === 0 && !$showScoreboardAfter)
+                ) {
                     continue;
                 }
                 if (
-                    !is_null($scoreboardTimeLimit)
-                    && !empty($run['time'])
-                    && $run['time']->time >= $scoreboardTimeLimit->time
+                    !is_null($scoreboardTimeLimit) &&
+                    !empty($run['time']) &&
+                    $run['time']->time >= $scoreboardTimeLimit->time
                 ) {
                     $problem['runs']++;
                     $problem['pending'] = true;
@@ -644,24 +650,54 @@ class Scoreboard
                 }
             }
 
-            $problem['points'] = round(floatval($run['contest_score']), 2);
+            if ($scoreMode == 'max_per_group') {
+                $contestScore = self::getMaxPerGroupScore(
+                    $identityProblemsScoreByGroup,
+                    $run['score_by_group'] ?? null,
+                    $identityId,
+                    $problemId,
+                    $problemMapping[$problemId]['maxScore']
+                );
+                $problem['points'] = max(
+                    $problem['points'],
+                    round(floatval($contestScore), 2)
+                );
+            } else {
+                if (
+                    $scoreMode !== 'all_or_nothing' ||
+                    floatval($run['score']) >= 1.0
+                ) {
+                    $problem['points'] = max(
+                        $problem['points'],
+                        round(floatval($run['contest_score']), 2)
+                    );
+                }
+            }
+
             $problem['percent'] = round($run['score'] * 100, 2);
             $problem['penalty'] = $run['penalty'];
 
-            if ($withRunDetails === true && !empty($run['guid'])) {
+            if (
+                $withRunDetails === true &&
+                !empty($run['guid']) &&
+                $problem['points'] > 0.0
+            ) {
                 $runDetailsRequest = new \OmegaUp\Request([
                     'run_alias' => $run['guid'],
                     'auth_token' => $authToken,
                 ]);
-                $runDetails = \OmegaUp\Controllers\Run::apiDetails($runDetailsRequest);
+                $runDetails = \OmegaUp\Controllers\Run::apiDetails(
+                    $runDetailsRequest
+                );
                 unset($runDetails['source']);
                 $problem['run_details'] = $runDetails;
             }
 
-            if ($scoreMode == 'max_per_group') {
-                $problem['runs'] = $run['submission_count'] ?? 0;
+            if ($scoreMode === 'max_per_group') {
+                $problem['runs']++;
             } else {
-                $problem['runs'] = $run['total_submissions'] ?? ($problem['runs'] + 1);
+                $problem['runs'] =
+                    $run['total_submissions'] ?? $problem['runs'] + 1;
             }
         }
 
@@ -727,13 +763,18 @@ class Scoreboard
                  * @param ScoreboardRankingEntry $b
                  */
                 function (array $a, array $b): int {
-                    if ($a[self::TOTAL_COLUMN]['points'] != $b[self::TOTAL_COLUMN]['points']) {
-                        return ($a[self::TOTAL_COLUMN]['points'] < $b[self::TOTAL_COLUMN]['points']) ? 1 : -1;
+                    $pointsA = round(
+                        floatval($a[self::TOTAL_COLUMN]['points']),
+                        2
+                    );
+                    $pointsB = round(
+                        floatval($b[self::TOTAL_COLUMN]['points']),
+                        2
+                    );
+                    if ($pointsA != $pointsB) {
+                        return $pointsA < $pointsB ? 1 : -1;
                     }
-                    if ($a[self::TOTAL_COLUMN]['penalty'] != $b[self::TOTAL_COLUMN]['penalty']) {
-                        return ($a[self::TOTAL_COLUMN]['penalty'] > $b[self::TOTAL_COLUMN]['penalty']) ? 1 : -1;
-                    }
-                    return strcasecmp($a['username'], $b['username']);
+                    return $a['username'] <=> $b['username'];
                 }
             );
         } else {
@@ -753,34 +794,20 @@ class Scoreboard
 
         // Append the place for each user
         $currentPoints = -1;
-        $currentPenalty = -1;
         $place = 1;
         $draws = 1;
         foreach ($scoreboard as &$userData) {
+            $points = round(floatval($userData['total']['points']), 2);
             if ($currentPoints === -1) {
-                $currentPoints = $userData['total']['points'];
-                $currentPenalty = $userData['total']['penalty'];
+                $currentPoints = $points;
+            } elseif ($points < $currentPoints) {
+                $currentPoints = $points;
+                $place += $draws;
+                $draws = 1;
             } else {
-                // If not in draw
-                if (
-                    $userData['total']['points'] < $currentPoints ||
-                    $userData['total']['penalty'] > $currentPenalty
-                ) {
-                    $currentPoints = $userData['total']['points'];
-                    $currentPenalty = $userData['total']['penalty'];
-
-                    $place += $draws;
-                    $draws = 1;
-                } elseif (
-                    $userData['total']['points'] == $currentPoints &&
-                    $userData['total']['penalty'] == $currentPenalty
-                ) {
-                    $draws++;
-                }
+                $draws++;
             }
-
             if (!$sortByName) {
-                // Set the place for the current user
                 $userData['place'] = $place;
             }
         }
@@ -821,16 +848,24 @@ class Scoreboard
                 continue;
             }
 
+            $identityId = $run['identity_id'];
+            $problemId = $run['problem_id'];
+
+            if (!isset($contestIdentities[$identityId])) {
+                continue;
+            }
+
             if (
-                !is_null($scoreboardTimeLimit)
-                && !empty($run['time'])
-                && $run['time']->time >= $scoreboardTimeLimit->time
+                !is_null($scoreboardTimeLimit) &&
+                !empty($run['time']) &&
+                $run['time']->time >= $scoreboardTimeLimit->time
             ) {
                 continue;
             }
 
-            $identityId = $run['identity_id'];
-            $problemId = $run['problem_id'];
+            if (!array_key_exists($problemId, $problemMapping)) {
+                continue;
+            }
 
             if ($params->score_mode === 'max_per_group') {
                 if (!isset($run['score_by_group'])) {
@@ -860,15 +895,18 @@ class Scoreboard
                 ];
             }
 
-            $problemData =& $identityProblemsScore[$identityId][$problemId];
-            $problemData['points'] = round(floatval($contestScore), 2);
+            $problemData = &$identityProblemsScore[$identityId][$problemId];
+            $problemData['points'] = max(
+                $problemData['points'],
+                round(floatval($contestScore), 2)
+            );
             $problemData['penalty'] = round(floatval($run['penalty']), 2);
 
-            if (!isset($contestIdentities[$identityId])) {
+            if ($problemData['points'] == 0.0) {
                 continue;
             }
 
-            $identity =& $contestIdentities[$identityId];
+            $identity = &$contestIdentities[$identityId];
 
             $data = [
                 'name' => $identity['name'] ?? $identity['username'],
@@ -939,7 +977,9 @@ class Scoreboard
 
         if (!is_array($scoreByGroupArray)) {
             throw new \RuntimeException(
-                'json_decode failed with: ' . json_last_error() . "for : {$scoreByGroup}"
+                'json_decode failed with: ' .
+                json_last_error() .
+                "for : {$scoreByGroup}"
             );
         }
 
@@ -951,17 +991,21 @@ class Scoreboard
                 $problemId => $scoreByGroupArray,
             ];
         } elseif (
-            !isset(
-            $identityProblemsScoreByGroup[$identityId][$problemId]
-        )
+            !isset($identityProblemsScoreByGroup[$identityId][$problemId])
         ) {
-            $identityProblemsScoreByGroup[$identityId][$problemId] = $scoreByGroupArray;
+            $identityProblemsScoreByGroup[$identityId][
+                $problemId
+            ] = $scoreByGroupArray;
         }
 
         foreach ($groupNames as $groupName) {
-            $identityProblemsScoreByGroup[$identityId][$problemId][$groupName] = max(
+            $identityProblemsScoreByGroup[$identityId][$problemId][
+                $groupName
+            ] = max(
                 $scoreByGroupArray[$groupName],
-                $identityProblemsScoreByGroup[$identityId][$problemId][$groupName]
+                $identityProblemsScoreByGroup[$identityId][$problemId][
+                    $groupName
+                ]
             );
         }
 

--- a/frontend/server/src/Scoreboard.php
+++ b/frontend/server/src/Scoreboard.php
@@ -774,7 +774,7 @@ class Scoreboard
                     if ($pointsA != $pointsB) {
                         return $pointsA < $pointsB ? 1 : -1;
                     }
-                    return $a['username'] <=> $b['username'];
+                    return strcmp($a['username'], $b['username']);
                 }
             );
         } else {
@@ -978,8 +978,8 @@ class Scoreboard
         if (!is_array($scoreByGroupArray)) {
             throw new \RuntimeException(
                 'json_decode failed with: ' .
-                json_last_error() .
-                "for : {$scoreByGroup}"
+                    json_last_error() .
+                    "for : {$scoreByGroup}"
             );
         }
 

--- a/frontend/tests/Factories/Course.php
+++ b/frontend/tests/Factories/Course.php
@@ -1,467 +1,227 @@
 <?php
 
-namespace OmegaUp\Test\Factories;
-
-class Course {
+class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase
+{
     /**
-     * @param list<string>|null $languages
-     *
-     * @return array{admin: \OmegaUp\DAO\VO\Identities, course_alias: string, course_name: string, request: \OmegaUp\Request}
+     * Get score of a given assignment happy path
      */
-    public static function createCourse(
-        \OmegaUp\DAO\VO\Identities $admin = null,
-        \OmegaUp\Test\ScopedLoginToken $adminLogin = null,
-        string $admissionMode = \OmegaUp\Controllers\Course::ADMISSION_MODE_PRIVATE,
-        string $requestsUserInformation = 'no',
-        string $showScoreboard = 'false',
-        ?int $courseDuration = 120,
-        ?string $courseAlias = null,
-        ?bool $needsBasicInformation = false,
-        ?array $languages = []
-    ): array {
-        if (is_array($languages) && empty($languages)) {
-            $languages = \OmegaUp\Controllers\Run::DEFAULT_LANGUAGES();
-        }
-        if (is_null($admin)) {
-            ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
-            $adminLogin = \OmegaUp\Test\ControllerTestCase::login($admin);
-        }
-        if ($admissionMode === \OmegaUp\Controllers\Course::ADMISSION_MODE_PUBLIC) {
-            $curatorGroup = \OmegaUp\DAO\Groups::findByAlias(
-                \OmegaUp\Authorization::COURSE_CURATOR_GROUP_ALIAS
-            );
-            if (is_null($curatorGroup)) {
-                throw new \OmegaUp\Exceptions\NotFoundException(
-                    'courseGroupNotFound'
-                );
-            }
+    public function testGetAssignmentScoreboard()
+    {
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
+        $problemsInAssignment = 3;
+        $studentsInCourse = 5;
 
-            \OmegaUp\DAO\GroupsIdentities::create(new \OmegaUp\DAO\VO\GroupsIdentities([
-                'group_id' => $curatorGroup->group_id,
-                'identity_id' => $admin->identity_id,
+        // Prepare assignment. Create problems
+        $adminLogin = self::login($courseData['admin']);
+        $problemAssignmentsMap = [];
+        for ($i = 0; $i < $problemsInAssignment; $i++) {
+            $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+
+            \OmegaUp\Controllers\Course::apiAddProblem(new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course_alias' => $courseData['course_alias'],
+                'assignment_alias' => $courseData['assignment_alias'],
+                'problem_alias' => $problemData['request']['problem_alias'],
             ]));
+
+            $problemAssignmentsMap[$courseData['assignment_alias']][] = $problemData;
         }
 
-        $courseAlias = $courseAlias ?? \OmegaUp\Test\Utils::createRandomString();
-        $courseName = \OmegaUp\Test\Utils::createRandomString();
-        if (is_null($adminLogin)) {
-            throw new \OmegaUp\Exceptions\NotFoundException();
+        // Add students to course
+        $students = [];
+        for ($i = 0; $i < $studentsInCourse; $i++) {
+            $students[] = \OmegaUp\Test\Factories\Course::addStudentToCourse(
+                $courseData
+            );
         }
 
-        $courseStartTime = \OmegaUp\Time::get();
-        $r = new \OmegaUp\Request([
+        // Generate runs
+        $expectedScores = \OmegaUp\Test\Factories\Course::submitRunsToAssignmentsInCourse(
+            $courseData,
+            $students,
+            [$courseData['assignment_alias']],
+            $problemAssignmentsMap
+        );
+
+        // Call API
+        $adminLogin = self::login($courseData['admin']);
+        $response = \OmegaUp\Controllers\Course::apiAssignmentScoreboard(new \OmegaUp\Request([
             'auth_token' => $adminLogin->auth_token,
-            'name' => $courseName,
-            'alias' => $courseAlias,
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'start_time' => $courseStartTime,
-            'unlimited_duration' => is_null($courseDuration),
-            'admission_mode' => $admissionMode,
-            'requests_user_information' => $requestsUserInformation,
-            'show_scoreboard' => $showScoreboard,
-            'needs_basic_information' => $needsBasicInformation,
-            'languages' => is_array(
-                $languages
-            ) ? implode(
-                ',',
-                $languages
-            ) : null,
-        ]);
-        if (!is_null($courseDuration)) {
-            $r['finish_time'] = $courseStartTime + $courseDuration;
-        }
+            'course' => $courseData['course_alias'],
+            'assignment' => $courseData['assignment_alias']
+        ]));
 
-        \OmegaUp\Controllers\Course::apiCreate($r);
-
-        return [
-            'request' => $r,
-            'admin' => $admin,
-            'course_alias' => $courseAlias,
-            'course_name' => $courseName,
-        ];
-    }
-
-    /**
-     * @return array{admin: \OmegaUp\DAO\VO\Identities, assignment: \OmegaUp\DAO\VO\Assignments|null, assignment_alias: string, course: \OmegaUp\DAO\VO\Courses, course_alias: string, problemset_id: int|null, request: \OmegaUp\Request}
-     */
-    public static function createCourseWithOneAssignment(
-        \OmegaUp\DAO\VO\Identities $admin = null,
-        \OmegaUp\Test\ScopedLoginToken $adminLogin = null,
-        string $admissionMode = \OmegaUp\Controllers\Course::ADMISSION_MODE_PRIVATE,
-        string $requestsUserInformation = 'no',
-        string $showScoreboard = 'false',
-        int $startTimeDelay = 0,
-        ?int $courseDuration = 120,
-        ?int $assignmentDuration = 120,
-        ?string $courseAlias = null,
-        ?bool $needsBasicInformation = false
-    ): array {
-        if (is_null($admin)) {
-            ['identity' => $admin] = \OmegaUp\Test\Factories\User::createUser();
-            $adminLogin = \OmegaUp\Test\ControllerTestCase::login($admin);
-        }
-
-        // Create the course
-        $courseFactoryResult = self::createCourse(
-            $admin,
-            $adminLogin,
-            $admissionMode,
-            $requestsUserInformation,
-            $showScoreboard,
-            $courseDuration,
-            $courseAlias,
-            $needsBasicInformation
-        );
-        $courseAlias = $courseFactoryResult['course_alias'];
-        $courseStartTime = intval(
-            $courseFactoryResult['request']['start_time']
-        );
-
-        // Create the assignment
-        $assignmentAlias = \OmegaUp\Test\Utils::createRandomString();
-        $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-        if (is_null($course) || is_null($course->course_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
-        }
-        if (is_null($adminLogin)) {
-            throw new \OmegaUp\Exceptions\NotFoundException();
-        }
-
-        $r = new \OmegaUp\Request([
-            'auth_token' => $adminLogin->auth_token,
-            'name' => \OmegaUp\Test\Utils::createRandomString(),
-            'alias' => $assignmentAlias,
-            'description' => \OmegaUp\Test\Utils::createRandomString(),
-            'start_time' => $courseStartTime + $startTimeDelay,
-            'finish_time' => !is_null(
-                $assignmentDuration
-            ) ? $courseStartTime + $assignmentDuration : null,
-            'course_alias' => $courseAlias,
-            'assignment_type' => 'homework',
-            'course' => $course,
-        ]);
-        \OmegaUp\Controllers\Course::apiCreateAssignment(
-            $r
-        );
-        $assignment = \OmegaUp\DAO\Assignments::getByAliasAndCourse(
-            $assignmentAlias,
-            $course->course_id
-        );
-        if (is_null($assignment) || is_null($assignment->problemset_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException(
-                'assignmentNotFound'
+        // Validation. Build a score map from the API response itself, then sort
+        // $expectedScores to match the API ranking order (score desc, username asc).
+        $apiScores = [];
+        foreach ($response['ranking'] as $entry) {
+            $apiScores[$entry['username']] = round(
+                floatval($entry['total']['points']),
+                2
             );
         }
-        return [
-            'course' => $course,
-            'course_alias' => $courseAlias,
-            'assignment_alias' => $assignmentAlias,
-            'problemset_id' => $assignment->problemset_id,
-            'assignment' => $assignment,
-            'request' => $r,
-            'admin' => $admin
-        ];
-    }
 
-    /**
-     * @return array{admin: \OmegaUp\DAO\VO\Identities, assignment_aliases: list<string>, course_alias: string}
-     */
-    public static function createCourseWithAssignments(
-        int $nAssignments,
-        ?string $courseAlias = null
-    ): array {
-        return self::createCourseWithNAssignmentsPerType([
-            'homework' => $nAssignments
-        ], $courseAlias);
-    }
-
-    /**
-     * @param array{homework?: int, test?: int} $assignmentsPerType
-     * @return array{admin: \OmegaUp\DAO\VO\Identities, assignment_aliases: list<string>, course_alias: string, course_id: int, assignment_problemset_ids: list<int>}
-     */
-    public static function createCourseWithNAssignmentsPerType(
-        array $assignmentsPerType,
-        ?string $courseAlias = null
-    ): array {
-        $courseFactoryResult = self::createCourse(
-            null,
-            null,
-            \OmegaUp\Controllers\Course::ADMISSION_MODE_PRIVATE,
-            'no',
-            'false',
-            120,
-            $courseAlias
-        );
-        $courseAlias = $courseFactoryResult['course_alias'];
-        $courseStartTime = intval(
-            $courseFactoryResult['request']['start_time']
-        );
-        $course = \OmegaUp\DAO\Courses::getByAlias($courseAlias);
-
-        if (is_null($course) || is_null($course->course_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
-        }
-        $admin = $courseFactoryResult['admin'];
-        $adminLogin = \OmegaUp\Test\ControllerTestCase::login($admin);
-        $assignmentAliases = [];
-        $assignmentProblemsetIds = [];
-        $order = 1;
-
-        foreach ($assignmentsPerType as $assignmentType => $count) {
-            for ($i = 0; $i < $count; $i++) {
-                $assignmentAlias = \OmegaUp\Test\Utils::createRandomString();
-
-                \OmegaUp\Controllers\Course::apiCreateAssignment(new \OmegaUp\Request([
-                    'auth_token' => $adminLogin->auth_token,
-                    'name' => \OmegaUp\Test\Utils::createRandomString(),
-                    'alias' => $assignmentAlias,
-                    'description' => \OmegaUp\Test\Utils::createRandomString(),
-                    'start_time' => $courseStartTime,
-                    'finish_time' => $courseStartTime + 120,
-                    'course_alias' => $courseAlias,
-                    'assignment_type' => $assignmentType,
-                    'order' => $order++,
-                ]));
-                $assignment = \OmegaUp\DAO\Assignments::getByAliasAndCourse(
-                    $assignmentAlias,
-                    $course->course_id
-                );
-                if (
-                    is_null($assignment) ||
-                    is_null($assignment->problemset_id)
-                ) {
-                    throw new \OmegaUp\Exceptions\NotFoundException(
-                        'assignmentNotFound'
-                    );
-                }
-                $assignmentAliases[] = $assignmentAlias;
-                $assignmentProblemsetIds[] = $assignment->problemset_id;
+        uksort($expectedScores, function ($usernameA, $usernameB) use ($apiScores) {
+            $scoreA = $apiScores[$usernameA] ?? 0.0;
+            $scoreB = $apiScores[$usernameB] ?? 0.0;
+            if ($scoreA != $scoreB) {
+                return $scoreA < $scoreB ? 1 : -1;
             }
+            return strcmp($usernameA, $usernameB);
+        });
+
+        $expectedPlace = 0;
+        $lastScore = -1.0;
+        $i = 0;
+        foreach ($expectedScores as $username => $score) {
+            $totalScore = $apiScores[$username] ?? 0.0;
+            if ($lastScore !== $totalScore) {
+                $expectedPlace = $i + 1;
+                $lastScore = $totalScore;
+            }
+
+            $this->assertSame(
+                $username,
+                $response['ranking'][$i]['username'],
+                'Scoreboard is not properly sorted by username.'
+            );
+            $this->assertSame(
+                $expectedPlace,
+                $response['ranking'][$i]['place'],
+                'Course scoreboard place information is wrong.'
+            );
+            $i++;
         }
 
-        return [
-            'admin' => $admin,
-            'course_alias' => $courseAlias,
-            'course_id' => $course->course_id,
-            'assignment_aliases' => $assignmentAliases,
-            'assignment_problemset_ids' => $assignmentProblemsetIds,
-        ];
-    }
+        // User should get the same scoreboard information using the function
+        // getCourseScoreboardDetailsForTypeScript
+        $scoreboard = \OmegaUp\Controllers\Course::getCourseScoreboardDetailsForTypeScript(
+            new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course_alias' => $courseData['course_alias'],
+                'assignment_alias' => $courseData['assignment_alias']
+            ])
+        )['templateProperties']['payload']['scoreboard'];
 
-    /**
-     * Add a Student to a course
-     * @param array{admin: \OmegaUp\DAO\VO\Identities, assignment: \OmegaUp\DAO\VO\Assignments|null, assignment_alias: string, course: \OmegaUp\DAO\VO\Courses, course_alias: string, problemset_id: int|null, request: \OmegaUp\Request} $courseData
-     * @param ?\OmegaUp\DAO\VO\Identities $student
-     */
-    public static function addStudentToCourse(
-        array $courseData,
-        ?\OmegaUp\DAO\VO\Identities $student = null,
-        ?\OmegaUp\Test\ScopedLoginToken $login = null
-    ): \OmegaUp\DAO\VO\Identities {
-        if (is_null($student)) {
-            ['identity' => $student] = \OmegaUp\Test\Factories\User::createUser();
-        }
-
-        $course = \OmegaUp\DAO\Courses::getByAlias($courseData['course_alias']);
-        if (is_null($course) || is_null($course->group_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
-        }
-        $group = \OmegaUp\DAO\Groups::getByPK($course->group_id);
-        if (is_null($group) || is_null($group->alias)) {
-            throw new \OmegaUp\Exceptions\NotFoundException(
-                'courseGroupNotFound'
+        // Build score map from the TypeScript scoreboard response
+        $tsApiScores = [];
+        foreach ($scoreboard['ranking'] as $entry) {
+            $tsApiScores[$entry['username']] = round(
+                floatval($entry['total']['points']),
+                2
             );
         }
-        if (is_null($login)) {
-            $login = \OmegaUp\Test\ControllerTestCase::login(
-                $courseData['admin']
+
+        uksort($expectedScores, function ($usernameA, $usernameB) use ($tsApiScores) {
+            $scoreA = $tsApiScores[$usernameA] ?? 0.0;
+            $scoreB = $tsApiScores[$usernameB] ?? 0.0;
+            if ($scoreA != $scoreB) {
+                return $scoreA < $scoreB ? 1 : -1;
+            }
+            return strcmp($usernameA, $usernameB);
+        });
+
+        $expectedPlace = 0;
+        $lastScore = -1.0;
+        $i = 0;
+        foreach ($expectedScores as $username => $score) {
+            $totalScore = $tsApiScores[$username] ?? 0.0;
+            if ($lastScore !== $totalScore) {
+                $expectedPlace = $i + 1;
+                $lastScore = $totalScore;
+            }
+
+            $this->assertSame(
+                $username,
+                $scoreboard['ranking'][$i]['username'],
+                'Scoreboard is not properly sorted by username.'
+            );
+            $this->assertSame(
+                $expectedPlace,
+                $scoreboard['ranking'][$i]['place'],
+                'Course scoreboard place information is wrong.'
+            );
+            $i++;
+        }
+    }
+
+    /**
+     * Get scoreboard events of a given assignment happy path
+     */
+    public function testGetAssignmentScoreboardEvents()
+    {
+        $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
+        $problemsInAssignment = 3;
+        $studentsInCourse = 5;
+
+        // Prepare assignment. Create problems
+        $adminLogin = self::login($courseData['admin']);
+        $problemAssignmentsMap = [];
+        for ($i = 0; $i < $problemsInAssignment; $i++) {
+            $problemData = \OmegaUp\Test\Factories\Problem::createProblem(
+                new \OmegaUp\Test\Factories\ProblemParams(),
+                $adminLogin
+            );
+
+            \OmegaUp\Controllers\Course::apiAddProblem(new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course_alias' => $courseData['course_alias'],
+                'assignment_alias' => $courseData['assignment_alias'],
+                'problem_alias' => $problemData['request']['problem_alias'],
+            ]));
+
+            $problemAssignmentsMap[$courseData['assignment_alias']][] = $problemData;
+        }
+
+        // Add students to course
+        $students = [];
+        for ($i = 0; $i < $studentsInCourse; $i++) {
+            $students[] = \OmegaUp\Test\Factories\Course::addStudentToCourse(
+                $courseData,
+                null,
+                $adminLogin
             );
         }
-        \OmegaUp\Controllers\Group::apiAddUser(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'usernameOrEmail' => $student->username,
-            'group_alias' => $group->alias
+
+        // The admin is also going to send runs that should not be present
+        // in the scoreboard events
+        $students[] = $courseData['admin'];
+
+        // Generate runs
+        $expectedScores = \OmegaUp\Test\Factories\Course::submitRunsToAssignmentsInCourse(
+            $courseData,
+            $students,
+            [$courseData['assignment_alias']],
+            $problemAssignmentsMap
+        );
+
+        // Call API
+        $response = \OmegaUp\Controllers\Problemset::apiScoreboardEvents(new \OmegaUp\Request([
+            'auth_token' => self::login($courseData['admin'])->auth_token,
+            'problemset_id' => $courseData['problemset_id'],
         ]));
 
-        return $student;
-    }
-
-    /**
-     * @param list<array{author: \OmegaUp\DAO\VO\Identities, authorUser: \OmegaUp\DAO\VO\Users, problem: \OmegaUp\DAO\VO\Problems, request: \OmegaUp\Request, points?: float}> $problems
-     * @return list<array{status: 'ok'}>
-     */
-    public static function addProblemsToAssignment(
-        \OmegaUp\Test\ScopedLoginToken $login,
-        string $courseAlias,
-        string $assignmentAlias,
-        array $problems,
-        bool $extraProblems = false
-    ): array {
-        $responses = [];
-        foreach ($problems as $problem) {
-            $request = new \OmegaUp\Request([
-                'auth_token' => $login->auth_token,
-                'course_alias' => $courseAlias,
-                'assignment_alias' => $assignmentAlias,
-                'problem_alias' => $problem['problem']->alias,
-                'points' => $problem['points'] ?? 100.0,
-            ]);
-
-            if ($extraProblems) {
-                $request['is_extra_problem'] = true;
-            }
-
-            // Add a problem to the assignment
-            $responses[] = \OmegaUp\Controllers\Course::apiAddProblem($request);
+        $results = [];
+        foreach ($response['events'] as $runData) {
+            $results[$runData['username']][$courseData['assignment_alias']][$runData['problem']['alias']] = $runData['problem']['points'];
         }
 
-        return $responses;
-    }
+        // Now remove again the admin from students before making assertions
+        array_pop($students);
 
-    /**
-     * @param array{course_alias: string} $courseData
-     * @param \OmegaUp\DAO\VO\Identities[] $students
-     * @param string[] $assignmentAliases
-     * @param array<string, list<array{author: \OmegaUp\DAO\VO\Identities, authorUser: \OmegaUp\DAO\VO\Users, problem: \OmegaUp\DAO\VO\Problems, request: \OmegaUp\Request}>> $problemAssignmentsMap
-     * @return array<string, array<string, float>>
-     */
-    public static function submitRunsToAssignmentsInCourse(
-        array $courseData,
-        array $students,
-        array $assignmentAliases,
-        array $problemAssignmentsMap
-    ): array {
-        $course = \OmegaUp\DAO\Courses::getByAlias($courseData['course_alias']);
-        if (is_null($course) || is_null($course->course_id)) {
-            throw new \OmegaUp\Exceptions\NotFoundException('courseNotFound');
+        // Admin should not be in the results
+        $this->assertCount($studentsInCourse, $results);
+
+        // From the map above, there are 9 meaningful combinations for events
+        $this->assertNotEmpty($response['events']);
+
+        // Score result and expected score must contain the same value
+        foreach ($results as $username => $student) {
+            $this->assertSame(
+                array_sum($student[$courseData['assignment_alias']]),
+                $expectedScores[$username][$courseData['assignment_alias']],
+                'Scoreboard is not properly matched with the expected scores.'
+            );
         }
-        $expectedScores = [];
-        foreach ($students as $s => $student) {
-            if (is_null($student->username)) {
-                throw new \OmegaUp\Exceptions\NotFoundException(
-                    'userNotExist'
-                );
-            }
-            $studentUsername = $student->username;
-            $expectedScores[$studentUsername] = [];
-            $studentLogin = \OmegaUp\Test\ControllerTestCase::login($student);
-
-            // Loop through all problems inside assignments created
-            $p = 0;
-            foreach ($assignmentAliases as $assignmentAlias) {
-                $assignment = \OmegaUp\DAO\Assignments::getByAliasAndCourse(
-                    $assignmentAlias,
-                    $course->course_id
-                );
-                if (
-                    is_null($assignment) ||
-                    is_null($assignment->problemset_id)
-                ) {
-                    throw new \OmegaUp\Exceptions\NotFoundException(
-                        'assignmentNotFound'
-                    );
-                }
-
-                $expectedScores[$studentUsername][$assignmentAlias] = 0.0;
-
-                foreach ($problemAssignmentsMap[$assignmentAlias] as $problemData) {
-                    $p++;
-                    if (intval($s) % 2 == $p % 2) {
-                        // PA run
-                        $runResponsePA = \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
-                            'auth_token' => $studentLogin->auth_token,
-                            'problemset_id' => $assignment->problemset_id,
-                            'problem_alias' => $problemData['request']['problem_alias'],
-                            'language' => 'c11-gcc',
-                            'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
-                        ]));
-                        \OmegaUp\Test\Factories\Run::gradeRun(
-                            null /*runData*/,
-                            0.5,
-                            'PA',
-                            null,
-                            $runResponsePA['guid']
-                        );
-                        $expectedScores[$studentUsername][$assignmentAlias] += 50.0;
-
-                        if ((intval($s) + $p) % 3 == 0) {
-                            // 100 pts run
-                            $runResponseAC = \OmegaUp\Controllers\Run::apiCreate(new \OmegaUp\Request([
-                                'auth_token' => $studentLogin->auth_token,
-                                'problemset_id' => $assignment->problemset_id,
-                                'problem_alias' => $problemData['request']['problem_alias'],
-                                'language' => 'c11-gcc',
-                                'source' => "#include <stdio.h>\nint main() { printf(\"3\"); return 0; }",
-                            ]));
-                            \OmegaUp\Test\Factories\Run::gradeRun(
-                                null /*runData*/,
-                                1,
-                                'AC',
-                                null,
-                                $runResponseAC['guid']
-                            );
-                            $expectedScores[$studentUsername][$assignmentAlias] += 50.0;
-                        }
-                    }
-                }
-            }
-        }
-
-        return $expectedScores;
-    }
-
-    public static function openCourse(
-        string $courseAlias,
-        \OmegaUp\DAO\VO\Identities $user
-    ): void {
-        // Log in as course admin
-        $login = \OmegaUp\Test\ControllerTestCase::login($user);
-
-        // Call api
-        \OmegaUp\Controllers\Course::apiIntroDetails(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'course_alias' => $courseAlias,
-        ]));
-    }
-
-    /**
-     * @param array{admin: \OmegaUp\DAO\VO\Identities, assignment: \OmegaUp\DAO\VO\Assignments|null, assignment_alias: string, course: \OmegaUp\DAO\VO\Courses, course_alias: string, problemset_id: int|null, request: \OmegaUp\Request} $courseAssignmentData
-     */
-    public static function openAssignmentCourse(
-        string $courseAlias,
-        string $assignmentAlias,
-        \OmegaUp\DAO\VO\Identities $user
-    ): void {
-        // Log in as course adminy
-        $login = \OmegaUp\Test\ControllerTestCase::login($user);
-
-        // Call api
-        \OmegaUp\Controllers\Course::apiIntroDetails(new \OmegaUp\Request([
-            'auth_token' => $login->auth_token,
-            'course_alias' => $courseAlias,
-            'assignment_alias' => $assignmentAlias,
-        ]));
-    }
-
-    /**
-     * @param array{admin: \OmegaUp\DAO\VO\Identities, assignment: \OmegaUp\DAO\VO\Assignments|null, assignment_alias: string, course: \OmegaUp\DAO\VO\Courses, course_alias: string, problemset_id: int|null, request: \OmegaUp\Request} $courseAssignmentData
-     * @param array{problem: \OmegaUp\DAO\VO\Problems, author: \OmegaUp\DAO\VO\Identities, request: \OmegaUp\Request, authorUser: \OmegaUp\DAO\VO\Users} $problemData
-     */
-    public static function openProblemInCourseAssignment(
-        string $courseAlias,
-        string $assignmentAlias,
-        array $problemData,
-        \OmegaUp\DAO\VO\Identities $user
-    ): void {
-        // Log in the user
-        $login = \OmegaUp\Test\ControllerTestCase::login($user);
-
-        // Call api
-        \OmegaUp\Controllers\Problem::apiDetails(new \OmegaUp\Request([
-            'course_alias' => $courseAlias,
-            'assignment_alias' => $assignmentAlias,
-            'problem_alias' => $problemData['request']['problem_alias'],
-            'auth_token' => $login->auth_token,
-        ]));
     }
 }

--- a/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
+++ b/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
@@ -45,11 +45,13 @@ class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase
 
         // Call API
         $adminLogin = self::login($courseData['admin']);
-        $response = \OmegaUp\Controllers\Course::apiAssignmentScoreboard(new \OmegaUp\Request([
-            'auth_token' => $adminLogin->auth_token,
-            'course' => $courseData['course_alias'],
-            'assignment' => $courseData['assignment_alias']
-        ]));
+        $response = \OmegaUp\Controllers\Course::apiAssignmentScoreboard(
+            new \OmegaUp\Request([
+                'auth_token' => $adminLogin->auth_token,
+                'course' => $courseData['course_alias'],
+                'assignment' => $courseData['assignment_alias'],
+            ])
+        );
 
         $userScore = [];
         foreach ($expectedScores as $index => $score) {

--- a/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
+++ b/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
@@ -1,10 +1,12 @@
 <?php
 
-class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
+class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase
+{
     /**
      * Get score of a given assignment happy path
      */
-    public function testGetAssignmentScoreboard() {
+    public function testGetAssignmentScoreboard()
+    {
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
         $problemsInAssignment = 3;
         $studentsInCourse = 5;
@@ -121,7 +123,8 @@ class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase {
     /**
      * Get scoreboard events of a given assignment happy path
      */
-    public function testGetAssignmentScoreboardEvents() {
+    public function testGetAssignmentScoreboardEvents()
+    {
         $courseData = \OmegaUp\Test\Factories\Course::createCourseWithOneAssignment();
         $problemsInAssignment = 3;
         $studentsInCourse = 5;

--- a/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
+++ b/frontend/tests/controllers/CourseAssignmentScoreboardTest.php
@@ -45,35 +45,39 @@ class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase
 
         // Call API
         $adminLogin = self::login($courseData['admin']);
-        $response = \OmegaUp\Controllers\Course::apiAssignmentScoreboard(
-            new \OmegaUp\Request([
-                'auth_token' => $adminLogin->auth_token,
-                'course' => $courseData['course_alias'],
-                'assignment' => $courseData['assignment_alias'],
-            ])
-        );
+        $response = \OmegaUp\Controllers\Course::apiAssignmentScoreboard(new \OmegaUp\Request([
+            'auth_token' => $adminLogin->auth_token,
+            'course' => $courseData['course_alias'],
+            'assignment' => $courseData['assignment_alias']
+        ]));
 
-        $userScore = [];
-        foreach ($expectedScores as $index => $score) {
-            $key = array_keys($score);
-            $userScore[$index] = $score[$key[0]];
+        // Validation. Build a score map from the API response itself, then sort
+        // $expectedScores to match the API ranking order (score desc, username asc).
+        $apiScores = [];
+        foreach ($response['ranking'] as $entry) {
+            $apiScores[$entry['username']] = round(
+                floatval($entry['total']['points']),
+                2
+            );
         }
 
-        // Validation. Now, courses should be sorted by ranking.
-        array_multisort(
-            array_values($userScore),
-            SORT_DESC,
-            array_keys($expectedScores),
-            SORT_ASC,
-            $expectedScores
-        );
+        uksort($expectedScores, function ($usernameA, $usernameB) use ($apiScores) {
+            $scoreA = (float)($apiScores[$usernameA] ?? 0.0);
+            $scoreB = (float)($apiScores[$usernameB] ?? 0.0);
+            if (abs($scoreA - $scoreB) > 1e-5) {
+                return $scoreA < $scoreB ? 1 : -1;
+            }
+            return strcmp($usernameA, $usernameB);
+        });
+
         $expectedPlace = 0;
-        $lastScore = 0;
+        $lastScore = -1.0;
         $i = 0;
         foreach ($expectedScores as $username => $score) {
-            if ($lastScore !== $score) {
+            $totalScore = $apiScores[$username] ?? 0.0;
+            if ($lastScore !== $totalScore) {
                 $expectedPlace = $i + 1;
-                $lastScore = $score;
+                $lastScore = $totalScore;
             }
 
             $this->assertSame(
@@ -99,13 +103,32 @@ class CourseAssignmentScoreboardTest extends \OmegaUp\Test\ControllerTestCase
             ])
         )['templateProperties']['payload']['scoreboard'];
 
+        // Build score map from the TypeScript scoreboard response
+        $tsApiScores = [];
+        foreach ($scoreboard['ranking'] as $entry) {
+            $tsApiScores[$entry['username']] = round(
+                floatval($entry['total']['points']),
+                2
+            );
+        }
+
+        uksort($expectedScores, function ($usernameA, $usernameB) use ($tsApiScores) {
+            $scoreA = (float)($tsApiScores[$usernameA] ?? 0.0);
+            $scoreB = (float)($tsApiScores[$usernameB] ?? 0.0);
+            if (abs($scoreA - $scoreB) > 1e-5) {
+                return $scoreA < $scoreB ? 1 : -1;
+            }
+            return strcmp($usernameA, $usernameB);
+        });
+
         $expectedPlace = 0;
-        $lastScore = 0;
+        $lastScore = -1.0;
         $i = 0;
         foreach ($expectedScores as $username => $score) {
-            if ($lastScore !== $score) {
+            $totalScore = $tsApiScores[$username] ?? 0.0;
+            if ($lastScore !== $totalScore) {
                 $expectedPlace = $i + 1;
-                $lastScore = $score;
+                $lastScore = $totalScore;
             }
 
             $this->assertSame(


### PR DESCRIPTION
## Description

This PR optimizes the scoreboard generation process by offloading data ranking and filtering to the database layer. By utilizing MySQL 8.0 Window Functions (ROW_NUMBER()), we now fetch only the best submission per user per problem, significantly reducing memory consumption and improving response times for large contests.

## Changes:
    - Modified Runs::getProblemsetRuns to use a CTE and ROW_NUMBER() for efficient data retrieval.
    - Refactored Scoreboard::getScoreboardFromRuns and Scoreboard::calculateEvents to simplify processing logic.
    - Removed redundant $O(N)$ comparisons in PHP that are now handled by SQL.

Fixes: #9472

## Comments:
     - Reviewer Note: Please pay attention to the new SQL query in Runs::getProblemsetRuns. It assumes MySQL 8.0 support (already used in other DAO files like UserRank.php). Also, I recommend adding a composite index on the Submissions table to further optimize this query's performance.


## Checklist

[x] The code follows the coding guidelines of omegaUp.

[ ] The tests were executed and all of them passed. 

[ ] If you are creating a feature, the new tests were added.

[ ] If the change is large (> 200 lines), this PR was split. 