### PR TITLE
added color scheme for the verdicts

### DIFF
--- a/frontend/www/js/omegaup/components/user/Chartsv2.vue
+++ b/frontend/www/js/omegaup/components/user/Chartsv2.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="card-body text-center">
     <label class="pr-4"
       ><input v-model="type" type="radio" value="delta" />
@@ -93,6 +93,14 @@ const VERDICT_LABELS: Record<string, string> = {
   MLE: T.verdictMLE,
   OLE: T.verdictOLE,
   VE: T.verdictVE,
+};
+
+const GROUPED_VERDICT_COLORS: Record<string, string> = {
+  AC: '#1b5e20',
+  PA: '#1e88e5',
+  WA: '#c62828',
+  TLE: '#f9a825',
+  RTE: '#fbc02d',
 };
 
 const emptyGroupedPeriods = {
@@ -350,6 +358,7 @@ export default class UserCharts extends Vue {
           ({
             data: x.data,
             name: x.name,
+            color: GROUPED_VERDICT_COLORS[x.name],
             type: 'column',
           } as Highcharts.SeriesColumnOptions),
       ),
@@ -405,3 +414,5 @@ export default class UserCharts extends Vue {
   }
 }
 </script>
+
+


### PR DESCRIPTION
# Description
Added color scheme for the 5 verdict categories AC, RTE, WA, PA, MLE

Fixes: #9426 

# Comments
I have chosen colors according to my understanding, let me know if something needs to be changed. 
I have not been able to test this feature on the local because the local doesn't reflect data on the graph as this is a dummy user with no real problem solving stats, I am not aware of how developers test the features on omegaup. If you can help me with some docs/resources to follow, I will be happy to test this as well.