### PR TITLE
Replace ended contest banner with global notification

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -33,9 +33,11 @@
         </a>
       </template>
       <template #clock>
+      <!--
         <div v-if="isContestFinished" class="alert alert-warning" role="alert">
           <a :href="urlPractice">{{ T.arenaContestEndedUsePractice }}</a>
         </div>
+        -->
         <omegaup-countdown
           v-show="!isContestStarted"
           :countdown-format="omegaup.CountdownFormat.ContestHasNotStarted"
@@ -309,8 +311,19 @@ export default class ArenaContest extends Vue {
   @Prop({ default: null }) blockedMessage!: string | null;
 
   T = T;
-  ui = ui;
-  omegaup = omegaup;
+ui = ui;
+omegaup = omegaup;
+
+mounted(): void {
+  if (this.isContestFinished) {
+    ui.notifications.add({
+      message: this.T.arenaContestEndedUsePractice,
+      type: 'info',
+    });
+  }
+}
+    }
+  
   AdmissionMode = AdmissionMode;
   PopupDisplayed = PopupDisplayed;
   ContestClarificationType = ContestClarificationType;


### PR DESCRIPTION

![Uploading WhatsApp Image 2026-03-02 at 2.28.51 PM22.jpeg…]()
## Description
'Fixes #9370 
This change replaces the yellow banner shown when a contest ends with a global notification.

When the contest is finished (isContestFinished), a notification appears informing users that the contest has ended and that they can continue submitting solutions in Practice Mode.

## Changes
- Removed the banner displayed after contest ends.
- Added a global notification using ui.notifications.

## Testing
Open a finished contest and verify that the notification appears instead of the banner.