### PR TITLE
Fix :Docker dev environment: db-migrate.py fails because /.my.cnf is missing for non-ubuntu users

### DIFF
--- a/stuff/docker/Dockerfile.dev-php
+++ b/stuff/docker/Dockerfile.dev-php
@@ -65,6 +65,9 @@ COPY ./etc/sudoers.d/* /etc/sudoers.d/
 RUN chmod 440 /etc/sudoers.d/ubuntu
 COPY ./usr/bin/* /usr/bin/
 RUN chmod +x /usr/bin/yarn-dev.sh /usr/bin/developer-environment.sh
+# Copy MySQL config to both locations: /home/ubuntu/.my.cnf is needed for Linux
+# (where ~ resolves to /home/ubuntu), and /.my.cnf is needed for macOS users
+# (where ~ may resolve to / inside the container depending on the user context).
 COPY ./my.cnf /home/ubuntu/.my.cnf
 COPY ./my.cnf /.my.cnf
 


### PR DESCRIPTION
# Description

Copy `.my.cnf` to `/` in addition to `/home/ubuntu/` in the Docker dev image so that `developer-environment.sh` can find the MySQL config when the container runs as a non-ubuntu user (e.g., macOS UID 501 where `$HOME=/`).

Previously, `db-migrate.py` failed on first boot because it looked for `${HOME}/.my.cnf` which resolved to `/.my.cnf`, but the file was only copied to `/home/ubuntu/.my.cnf`. This caused database migrations to never run, resulting in missing tables and HTTP 400/500 errors.

Fixes: #9489

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.