### PR TITLE
[Bug] fixed the Tab navigation wraps to two lines on Female Coder of the Month page

### DIFF
--- a/frontend/www/js/omegaup/components/coderofthemonth/List.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/List.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="card ranking-width">
-    <ul class="nav nav-tabs justify-content-arround" role="tablist">
+    <ul class="nav nav-tabs justify-content-around" role="tablist">
       <li v-for="tab in availableTabs" :key="tab.id" class="nav-item">
         <a
-          :href="getTabName(tab)"
-          class="nav-link"
-          data-toggle="tab"
-          role="tab"
-          :aria-controls="tab.id"
-          :class="{ active: currentSelectedTab === tab.id }"
-          :aria-selected="currentSelectedTab === tab.id"
-          @click="getSelectedTab(tab)"
-        >
-          {{ tab.title }}
-        </a>
+  :href="getTabName(tab)"
+  class="nav-link"
+  role="tab"
+  :aria-controls="tab.id"
+  :class="{ active: currentSelectedTab === tab.id }"
+  :aria-selected="currentSelectedTab === tab.id"
+  @click.prevent="getSelectedTab(tab)"
+>
+  {{ tab.title }}
+</a>
       </li>
     </ul>
+
     <component
       :is="currentTabComponent"
       class="tab"
@@ -75,10 +75,12 @@ export default class CoderOfTheMonthList extends Vue {
   @Prop() selectedTab!: string;
 
   T = T;
+
+  // initial tab
   currentSelectedTab = this.selectedTab;
 
   get availableTabs(): { id: string; component: string; title: string }[] {
-    const availableTabs = [
+    return [
       {
         id: 'codersOfTheMonth',
         component: 'omegaup-coders-list',
@@ -104,51 +106,72 @@ export default class CoderOfTheMonthList extends Vue {
             : T.codersOfTheMonthFemaleListCandidate,
       },
     ];
-
-    return availableTabs;
   }
 
   get visibleCoders(): types.CoderOfTheMonthList[] {
     switch (this.currentSelectedTab) {
+      case 'codersOfPreviousMonth':
+        return this.codersOfPreviousMonth;
+
+      case 'candidatesToCoderOfTheMonth':
+        return this.candidatesToCoderOfTheMonth;
+
       case 'codersOfTheMonth':
       default:
         return this.codersOfCurrentMonth;
-      case 'codersOfPreviousMonth':
-        return this.codersOfPreviousMonth;
-      case 'candidatesToCoderOfTheMonth':
-        return this.candidatesToCoderOfTheMonth;
     }
   }
 
   get currentTabComponent(): string {
     return (
       this.availableTabs.find((tab) => tab.id === this.currentSelectedTab)
-        ?.component ?? 'codersOfTheMonth'
+        ?.component ?? 'omegaup-coders-list'
     );
   }
 
   getSelectedTab(tab: { id: string; component: string; title: string }): void {
     this.currentSelectedTab = tab.id;
-    window.location.hash = tab.id;
+    window.history.pushState(null, '', `#${tab.id}`);
   }
 
   getTabName(tab: { id: string; component: string; title: string }): string {
     return `#${tab.id}`;
   }
+
+  mounted(): void {
+    const hash = window.location.hash.replace('#', '');
+    if (hash) {
+      this.currentSelectedTab = hash;
+    }
+
+    window.addEventListener('popstate', () => {
+      const newHash = window.location.hash.replace('#', '');
+      if (newHash) {
+        this.currentSelectedTab = newHash;
+      }
+    });
+  }
 }
 </script>
 
 <style scoped>
+
 .nav-link.active,
 .nav-link:hover {
   border: none;
   border-left: 0.0625rem solid #dee2e6;
   border-right: 0.0625rem solid #dee2e6;
-  border-top-left-radius: 0rem;
-  border-top-right-radius: 0rem;
 }
+
 .nav .nav-tabs {
   border-bottom: 0rem;
+}
+
+.nav-tabs {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
 }
 
 .nav-link {
@@ -156,8 +179,11 @@ export default class CoderOfTheMonthList extends Vue {
   letter-spacing: 0.022rem;
   padding: 0.65rem 1rem;
 }
+
 .ranking-width {
-  max-width: 55rem;
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
 }
+
 </style>


### PR DESCRIPTION
# Description

Fix the tab navigation layout on the **Female Coder of the Month** page where the tab titles were wrapping into two lines.

The tabs now stay on a single line and allow horizontal scrolling on smaller screens to maintain proper layout and readability.


Fixes: #9454 

# Comments
This change updates the tab navigation styling to prevent text wrapping and ensures consistent layout across screen sizes.

Normal desktop :<br>
<img width="1917" height="925" alt="image" src="https://github.com/user-attachments/assets/b90766b3-b928-496c-8ce0-f4a094a00abe" />

Responsive:<br>
<img width="876" height="840" alt="image" src="https://github.com/user-attachments/assets/f0f7ef71-a766-4930-aafc-0e1a8f4944e5" />

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
