### PR TITLE
Batch INSERTs in insert_school_of_the_month_candidates using executemany()

### DIFF
--- a/stuff/cron/database/school_of_the_month.py
+++ b/stuff/cron/database/school_of_the_month.py
@@ -283,24 +283,30 @@ def insert_school_of_the_month_candidates(
 ) -> None:
     '''Insert school of the month candidates'''
     logging.info("Inserting school of the month candidates")
-    for index, row in enumerate(candidates):
-        cur.execute(
-            '''
-            INSERT INTO
-                `School_Of_The_Month` (
-                    `school_id`,
-                    `time`,
-                    `ranking`,
-                    `score`
-                )
-            VALUES(
-                %s,
-                %s,
-                %s,
-                %s
-            );
-            ''', (row.school_id, first_day_of_next_month,
-                  index + 1, row.score))
+    if not candidates:
+        return
+
+    rows = [
+        (row.school_id, first_day_of_next_month, index + 1, row.score)
+        for index, row in enumerate(candidates)
+    ]
+
+    cur.executemany(
+        '''
+        INSERT INTO
+            `School_Of_The_Month` (
+                `school_id`,
+                `time`,
+                `ranking`,
+                `score`
+            )
+        VALUES(
+            %s,
+            %s,
+            %s,
+            %s
+        );
+        ''', rows)
 
 
 def get_last_12_schools_of_the_month(


### PR DESCRIPTION
# Description

This PR batches the inserts in `insert_school_of_the_month_candidates` in `stuff/cron/database/school_of_the_month.py`.

Previously, the function inserted candidates using a loop that executed one `INSERT` query per candidate:

```python
for index, row in enumerate(candidates):
    cur.execute(...)
```
This resulted in multiple database round-trips during the cron execution.

This change collects the parameters first and uses `executemany()` to perform the inserts in a single batch while keeping the SQL query and ranking logic (`index + 1`) unchanged.

The behavior remains identical, but the number of database round-trips is reduced.

Fixes: #9492

# Comments
This is a minimal change that preserves the existing logic and SQL semantics. Only the insert execution pattern was updated from multiple `execute()` calls to a single `executemany()` call.

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.