### PR TITLE
Feat/deconstruct problem tags

### DIFF
--- a/frontend/server/src/Controllers/Problem.php
+++ b/frontend/server/src/Controllers/Problem.php
@@ -552,7 +552,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
                     if (in_array($tagName, self::RESTRICTED_TAG_NAMES)) {
                         continue;
                     }
-                    self::addTag($tagName, $tag['public'], $problem);
+                    \OmegaUp\ProblemTags::addTag($tagName, $tag['public'], $problem);
                 }
             }
 
@@ -815,70 +815,11 @@ class Problem extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 
-        self::addTag($tagName, $isPublic, $problem);
+        \OmegaUp\ProblemTags::addTag($tagName, $isPublic, $problem);
 
         return [
             'name' => $tagName,
         ];
-    }
-
-    private static function addTag(
-        string $tagName,
-        bool $isPublic,
-        \OmegaUp\DAO\VO\Problems $problem,
-        bool $allowRestricted = false
-    ): void {
-        // Normalize name.
-        if (!$isPublic) {
-            $tagName = \OmegaUp\Controllers\Tag::normalize($tagName);
-        }
-
-        if (
-            !$allowRestricted &&
-            in_array($tagName, self::RESTRICTED_TAG_NAMES)
-        ) {
-            throw new \OmegaUp\Exceptions\InvalidParameterException(
-                'tagRestricted',
-                'name'
-            );
-        }
-
-        $tag = \OmegaUp\DAO\Tags::getByName($tagName);
-        if (is_null($tag)) {
-            if (in_array($tagName, self::RESTRICTED_TAG_NAMES)) {
-                $tag = new \OmegaUp\DAO\VO\Tags([
-                    'name' => $tagName,
-                    'public' => true,
-                ]);
-            } else {
-                if ($isPublic) {
-                    throw new \OmegaUp\Exceptions\InvalidParameterException(
-                        'newPublicTagsNotAllowed',
-                        'public'
-                    );
-                }
-
-                // After normalization problemTag becomes problemtag
-                if (str_starts_with($tagName, 'problemtag')) {
-                    // Starts with 'problemtag'
-                    throw new \OmegaUp\Exceptions\InvalidParameterException(
-                        'tagPrefixRestricted',
-                        'name'
-                    );
-                }
-                $tag = new \OmegaUp\DAO\VO\Tags([
-                    'name' => $tagName,
-                    'public' => false,
-                ]);
-            }
-            \OmegaUp\DAO\Tags::create($tag);
-        }
-
-        \OmegaUp\DAO\ProblemsTags::replace(new \OmegaUp\DAO\VO\ProblemsTags([
-            'problem_id' => $problem->problem_id,
-            'tag_id' => $tag->tag_id,
-            'source' => 'owner',
-        ]));
     }
 
     /**
@@ -1039,17 +980,7 @@ class Problem extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 
-        if (in_array($tag->name, self::RESTRICTED_TAG_NAMES)) {
-            throw new \OmegaUp\Exceptions\InvalidParameterException(
-                'tagRestricted',
-                'name'
-            );
-        }
-
-        \OmegaUp\DAO\ProblemsTags::delete(new \OmegaUp\DAO\VO\ProblemsTags([
-            'problem_id' => $problem->problem_id,
-            'tag_id' => $tag->tag_id,
-        ]));
+        \OmegaUp\ProblemTags::removeTag($tagName, $problem);
 
         return [
             'status' => 'ok',

--- a/frontend/server/src/ProblemTags.php
+++ b/frontend/server/src/ProblemTags.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace OmegaUp;
+
+class ProblemTags {
+    public static function addTag(
+        string $tagName,
+        bool $isPublic,
+        \OmegaUp\DAO\VO\Problems $problem,
+        bool $allowRestricted = false
+    ): void {
+        // Normalize name.
+        if (!$isPublic) {
+            $tagName = \OmegaUp\Controllers\Tag::normalize($tagName);
+        }
+
+        if (
+            !$allowRestricted &&
+            in_array($tagName, \OmegaUp\Controllers\Problem::RESTRICTED_TAG_NAMES)
+        ) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'tagRestricted',
+                'name'
+            );
+        }
+
+        $tag = \OmegaUp\DAO\Tags::getByName($tagName);
+        if (is_null($tag)) {
+            if (in_array($tagName, \OmegaUp\Controllers\Problem::RESTRICTED_TAG_NAMES)) {
+                $tag = new \OmegaUp\DAO\VO\Tags([
+                    'name' => $tagName,
+                    'public' => true,
+                ]);
+            } else {
+                if ($isPublic) {
+                    throw new \OmegaUp\Exceptions\InvalidParameterException(
+                        'newPublicTagsNotAllowed',
+                        'public'
+                    );
+                }
+
+                // After normalization problemTag becomes problemtag
+                if (str_starts_with($tagName, 'problemtag')) {
+                    // Starts with 'problemtag'
+                    throw new \OmegaUp\Exceptions\InvalidParameterException(
+                        'tagPrefixRestricted',
+                        'name'
+                    );
+                }
+                $tag = new \OmegaUp\DAO\VO\Tags([
+                    'name' => $tagName,
+                    'public' => false,
+                ]);
+            }
+            \OmegaUp\DAO\Tags::create($tag);
+        }
+
+        \OmegaUp\DAO\ProblemsTags::replace(new \OmegaUp\DAO\VO\ProblemsTags([
+            'problem_id' => $problem->problem_id,
+            'tag_id' => $tag->tag_id,
+            'source' => 'owner',
+        ]));
+    }
+
+    public static function removeTag(
+        string $tagName,
+        \OmegaUp\DAO\VO\Problems $problem
+    ): void {
+        $tag = \OmegaUp\DAO\Tags::getByName($tagName);
+        if (is_null($tag)) {
+            throw new \OmegaUp\Exceptions\NotFoundException('tagNotFound');
+        }
+
+        if (in_array($tag->name, \OmegaUp\Controllers\Problem::RESTRICTED_TAG_NAMES)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'tagRestricted',
+                'name'
+            );
+        }
+
+        \OmegaUp\DAO\ProblemsTags::delete(new \OmegaUp\DAO\VO\ProblemsTags([
+            'problem_id' => $problem->problem_id,
+            'tag_id' => $tag->tag_id,
+        ]));
+    }
+}


### PR DESCRIPTION
# Description

This Pull Request acts as a Proof of Concept (PoC) for deconstructing the monolithic [Problem.php](cci:7://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:0:0-0:0) Controller to improve backend maintainability and enforce Domain-Driven Design principles. 

Specifically, this PR extracts the **Problem Tag Management** logic (creating, validating, replacing, and deleting tags) out of [frontend/server/src/Controllers/Problem.php](cci:7://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:0:0-0:0) and moves it into a newly created, isolated service class: `\OmegaUp\ProblemTags`.

The existing [apiAddTag](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:782:4-822:5) and [apiRemoveTag](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:944:4-987:5) HTTP endpoints have been refactored to act strictly as wrappers. They retain their original validation, parameter parsing, and authorization checks, but now securely delegate the actual business and data-access logic to the new [ProblemTags](cci:2://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/ProblemTags.php:4:0-85:1) Domain Service.

By decoupling this logic, we reduce the footprint of [Problem.php](cci:7://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:0:0-0:0) making the endpoints easier to test, debug, and maintain.

**Changes:**
- Creates [frontend/server/src/ProblemTags.php](cci:7://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/ProblemTags.php:0:0-0:0) with [addTag()](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/ProblemTags.php:5:4-62:5) and [removeTag()](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/ProblemTags.php:64:4-84:5) implementations.
- Refactors [apiAddTag](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:782:4-822:5) and [apiRemoveTag](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:944:4-987:5) in [Problem.php](cci:7://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/Controllers/Problem.php:0:0-0:0) to use the new service.
- Deletes the massive private [addTag](cci:1://file:///c:/Users/Sumit/OneDrive/Desktop/GSOC-2026/gsoc-omegaup/gsoc-omegaup/frontend/server/src/ProblemTags.php:5:4-62:5) function from the Controller, stripping nearly 60 lines of internal logic.

# Comments

* **Mentors/Reviewers:** This PR is deliberately kept small and scoped strictly to Tag Management to demonstrate the architectural viability of extracting logic from the mega-controllers without breaking the existing API contract. No downstream impact on the Vue frontend should occur.
* Static analysis (Psalm) and parameter types have been carefully preserved to match the exact signatures from the controller.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
