### PR TITLE
fix(arena): hide empty download bullets for non-admin users in RunDetailsPopup

### DIFF
--- a/frontend/www/js/omegaup/components/arena/RunDetailsPopup.vue
+++ b/frontend/www/js/omegaup/components/arena/RunDetailsPopup.vue
@@ -148,22 +148,22 @@
                 >{{ T.wordsDownloadCode }}</a
               >
             </li>
-            <li>
-              <a
-                v-if="data.admin"
-                class="output"
-                :href="`/api/run/download/run_alias/${data.guid}/`"
-                >{{ T.wordsDownloadOutput }}</a
-              >
-            </li>
-            <li>
-              <a
-                v-if="data.admin"
-                class="details"
-                :href="`/api/run/download/run_alias/${data.guid}/complete/true/`"
-                >{{ T.wordsDownloadDetails }}</a
-              >
-            </li>
+            <template v-if="data.admin">
+              <li>
+                <a
+                  class="output"
+                  :href="`/api/run/download/run_alias/${data.guid}/`"
+                  >{{ T.wordsDownloadOutput }}</a
+                >
+              </li>
+              <li>
+                <a
+                  class="details"
+                  :href="`/api/run/download/run_alias/${data.guid}/complete/true/`"
+                  >{{ T.wordsDownloadDetails }}</a
+                >
+              </li>
+            </template>
           </ul>
         </div>
         <div v-if="data.judged_by" class="judged_by">


### PR DESCRIPTION
# Description
Move `v-if="data.admin"` from the `<a>` tag to the `<li>` tag for the two admin-only download links in `RunDetailsPopup.vue`. Previously, the `<li>` elements were always rendered even when empty, causing students to see two empty bullets in the Download section of the Run Details modal.

Fixes: #9523

# Comments
The fix is a 2-line change in the template. No logic changes, no new components. Before/after screenshots included below.

**Before (student view):**
- Download code
- *(empty bullet)*
- *(empty bullet)*

<img width="1282" height="632" alt="image" src="https://github.com/user-attachments/assets/be6bc1e7-5799-48b8-bb28-aea96ad80d1c" />


**After (student view):**
- Download code

<img width="1919" height="879" alt="image" src="https://github.com/user-attachments/assets/b4cfa6ef-0e62-462c-8476-17ded651ac5b" />


**Admin view:**
Admin view is unchanged (all 3 links still visible).

<img width="1918" height="870" alt="image" src="https://github.com/user-attachments/assets/429715c5-6d5e-4d2d-888f-3479cf11cdfa" />


# Checklist:
- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.