### PR TITLE
streamlined the text into one liner

### DIFF
--- a/frontend/www/js/omegaup/components/user/ProblemSolvingProgress.vue
+++ b/frontend/www/js/omegaup/components/user/ProblemSolvingProgress.vue
@@ -398,6 +398,7 @@ export default class ProblemSolvingProgress extends Vue {
 .difficulty-label {
   font-size: 0.85rem;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .difficulty-count {


### PR DESCRIPTION
# Description

<img width="1277" height="725" alt="Screenshot 2026-03-14 at 10 51 57 AM" src="https://github.com/user-attachments/assets/752c7636-481b-4d99-a314-a71e6af538d2" />

Fixes: #9529 

# Comments

This fixes the overflow of the text onto another line

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
