### PR TITLE
feature: Split GSOC custom DAO methods into an isolated change 

### DIFF
--- a/frontend/server/src/DAO/Base/GSoCEdition.php
+++ b/frontend/server/src/DAO/Base/GSoCEdition.php
@@ -1,0 +1,317 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** GSoCEdition Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\GSoCEdition}.
+ * @access public
+ * @abstract
+ */
+abstract class GSoCEdition {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCEdition $GSoC_Edition El objeto de tipo GSoCEdition a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\GSoCEdition $GSoC_Edition
+    ): int {
+        $sql = '
+            UPDATE
+                `GSoC_Edition`
+            SET
+                `year` = ?,
+                `is_active` = ?,
+                `application_deadline` = ?,
+                `created_at` = ?,
+                `updated_at` = ?
+            WHERE
+                (
+                    `edition_id` = ?
+                );';
+        $params = [
+            (
+                is_null($GSoC_Edition->year) ?
+                null :
+                intval($GSoC_Edition->year)
+            ),
+            intval($GSoC_Edition->is_active),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Edition->application_deadline
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Edition->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Edition->updated_at
+            ),
+            intval($GSoC_Edition->edition_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\GSoCEdition} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\GSoCEdition}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\GSoCEdition Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\GSoCEdition} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $edition_id
+    ): ?\OmegaUp\DAO\VO\GSoCEdition {
+        $sql = '
+            SELECT
+                `GSoC_Edition`.`edition_id`,
+                `GSoC_Edition`.`year`,
+                `GSoC_Edition`.`is_active`,
+                `GSoC_Edition`.`application_deadline`,
+                `GSoC_Edition`.`created_at`,
+                `GSoC_Edition`.`updated_at`
+            FROM
+                `GSoC_Edition`
+            WHERE
+                (
+                    `edition_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$edition_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\GSoCEdition($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\GSoCEdition} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\GSoCEdition}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $edition_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `GSoC_Edition`
+            WHERE
+                (
+                    `edition_id` = ?
+                );';
+        $params = [$edition_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `GSoC_Edition`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `GSoC_Edition`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\GSoCEdition} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCEdition $GSoC_Edition El
+     * objeto de tipo \OmegaUp\DAO\VO\GSoCEdition a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\GSoCEdition $GSoC_Edition
+    ): void {
+        $sql = '
+            DELETE FROM
+                `GSoC_Edition`
+            WHERE
+                (
+                    `edition_id` = ?
+                );';
+        $params = [
+            $GSoC_Edition->edition_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\GSoCEdition}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\GSoCEdition> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\GSoCEdition}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'edition_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `GSoC_Edition`.`edition_id`,
+                `GSoC_Edition`.`year`,
+                `GSoC_Edition`.`is_active`,
+                `GSoC_Edition`.`application_deadline`,
+                `GSoC_Edition`.`created_at`,
+                `GSoC_Edition`.`updated_at`
+            FROM
+                `GSoC_Edition`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\GSoCEdition(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\GSoCEdition}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCEdition $GSoC_Edition El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\GSoCEdition}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\GSoCEdition $GSoC_Edition
+    ): int {
+        $sql = '
+            INSERT INTO
+                `GSoC_Edition` (
+                    `year`,
+                    `is_active`,
+                    `application_deadline`,
+                    `created_at`,
+                    `updated_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            (
+                is_null($GSoC_Edition->year) ?
+                null :
+                intval($GSoC_Edition->year)
+            ),
+            intval($GSoC_Edition->is_active),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Edition->application_deadline
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Edition->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Edition->updated_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $GSoC_Edition->edition_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/Base/GSoCIdea.php
+++ b/frontend/server/src/DAO/Base/GSoCIdea.php
@@ -1,0 +1,355 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** GSoCIdea Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\GSoCIdea}.
+ * @access public
+ * @abstract
+ */
+abstract class GSoCIdea {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCIdea $GSoC_Idea El objeto de tipo GSoCIdea a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\GSoCIdea $GSoC_Idea
+    ): int {
+        $sql = '
+            UPDATE
+                `GSoC_Idea`
+            SET
+                `title` = ?,
+                `brief_description` = ?,
+                `expected_results` = ?,
+                `preferred_skills` = ?,
+                `possible_mentors` = ?,
+                `estimated_hours` = ?,
+                `skill_level` = ?,
+                `blog_link` = ?,
+                `contributor_username` = ?,
+                `created_at` = ?,
+                `updated_at` = ?
+            WHERE
+                (
+                    `idea_id` = ?
+                );';
+        $params = [
+            $GSoC_Idea->title,
+            $GSoC_Idea->brief_description,
+            $GSoC_Idea->expected_results,
+            $GSoC_Idea->preferred_skills,
+            $GSoC_Idea->possible_mentors,
+            (
+                is_null($GSoC_Idea->estimated_hours) ?
+                null :
+                intval($GSoC_Idea->estimated_hours)
+            ),
+            $GSoC_Idea->skill_level,
+            $GSoC_Idea->blog_link,
+            $GSoC_Idea->contributor_username,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea->updated_at
+            ),
+            intval($GSoC_Idea->idea_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\GSoCIdea} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\GSoCIdea}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\GSoCIdea Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\GSoCIdea} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $idea_id
+    ): ?\OmegaUp\DAO\VO\GSoCIdea {
+        $sql = '
+            SELECT
+                `GSoC_Idea`.`idea_id`,
+                `GSoC_Idea`.`title`,
+                `GSoC_Idea`.`brief_description`,
+                `GSoC_Idea`.`expected_results`,
+                `GSoC_Idea`.`preferred_skills`,
+                `GSoC_Idea`.`possible_mentors`,
+                `GSoC_Idea`.`estimated_hours`,
+                `GSoC_Idea`.`skill_level`,
+                `GSoC_Idea`.`blog_link`,
+                `GSoC_Idea`.`contributor_username`,
+                `GSoC_Idea`.`created_at`,
+                `GSoC_Idea`.`updated_at`
+            FROM
+                `GSoC_Idea`
+            WHERE
+                (
+                    `idea_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$idea_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\GSoCIdea($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\GSoCIdea} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\GSoCIdea}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $idea_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `GSoC_Idea`
+            WHERE
+                (
+                    `idea_id` = ?
+                );';
+        $params = [$idea_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `GSoC_Idea`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `GSoC_Idea`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\GSoCIdea} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCIdea $GSoC_Idea El
+     * objeto de tipo \OmegaUp\DAO\VO\GSoCIdea a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\GSoCIdea $GSoC_Idea
+    ): void {
+        $sql = '
+            DELETE FROM
+                `GSoC_Idea`
+            WHERE
+                (
+                    `idea_id` = ?
+                );';
+        $params = [
+            $GSoC_Idea->idea_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\GSoCIdea}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\GSoCIdea> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\GSoCIdea}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'idea_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `GSoC_Idea`.`idea_id`,
+                `GSoC_Idea`.`title`,
+                `GSoC_Idea`.`brief_description`,
+                `GSoC_Idea`.`expected_results`,
+                `GSoC_Idea`.`preferred_skills`,
+                `GSoC_Idea`.`possible_mentors`,
+                `GSoC_Idea`.`estimated_hours`,
+                `GSoC_Idea`.`skill_level`,
+                `GSoC_Idea`.`blog_link`,
+                `GSoC_Idea`.`contributor_username`,
+                `GSoC_Idea`.`created_at`,
+                `GSoC_Idea`.`updated_at`
+            FROM
+                `GSoC_Idea`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\GSoCIdea(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\GSoCIdea}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCIdea $GSoC_Idea El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\GSoCIdea}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\GSoCIdea $GSoC_Idea
+    ): int {
+        $sql = '
+            INSERT INTO
+                `GSoC_Idea` (
+                    `title`,
+                    `brief_description`,
+                    `expected_results`,
+                    `preferred_skills`,
+                    `possible_mentors`,
+                    `estimated_hours`,
+                    `skill_level`,
+                    `blog_link`,
+                    `contributor_username`,
+                    `created_at`,
+                    `updated_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            $GSoC_Idea->title,
+            $GSoC_Idea->brief_description,
+            $GSoC_Idea->expected_results,
+            $GSoC_Idea->preferred_skills,
+            $GSoC_Idea->possible_mentors,
+            (
+                is_null($GSoC_Idea->estimated_hours) ?
+                null :
+                intval($GSoC_Idea->estimated_hours)
+            ),
+            $GSoC_Idea->skill_level,
+            $GSoC_Idea->blog_link,
+            $GSoC_Idea->contributor_username,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea->updated_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $GSoC_Idea->idea_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/Base/GSoCIdeaEdition.php
+++ b/frontend/server/src/DAO/Base/GSoCIdeaEdition.php
@@ -1,0 +1,328 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** GSoCIdeaEdition Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}.
+ * @access public
+ * @abstract
+ */
+abstract class GSoCIdeaEdition {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCIdeaEdition $GSoC_Idea_Edition El objeto de tipo GSoCIdeaEdition a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\GSoCIdeaEdition $GSoC_Idea_Edition
+    ): int {
+        $sql = '
+            UPDATE
+                `GSoC_Idea_Edition`
+            SET
+                `idea_id` = ?,
+                `edition_id` = ?,
+                `status` = ?,
+                `decision_notes` = ?,
+                `created_at` = ?,
+                `updated_at` = ?
+            WHERE
+                (
+                    `idea_edition_id` = ?
+                );';
+        $params = [
+            (
+                is_null($GSoC_Idea_Edition->idea_id) ?
+                null :
+                intval($GSoC_Idea_Edition->idea_id)
+            ),
+            (
+                is_null($GSoC_Idea_Edition->edition_id) ?
+                null :
+                intval($GSoC_Idea_Edition->edition_id)
+            ),
+            $GSoC_Idea_Edition->status,
+            $GSoC_Idea_Edition->decision_notes,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea_Edition->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea_Edition->updated_at
+            ),
+            intval($GSoC_Idea_Edition->idea_edition_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\GSoCIdeaEdition} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\GSoCIdeaEdition Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\GSoCIdeaEdition} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $idea_edition_id
+    ): ?\OmegaUp\DAO\VO\GSoCIdeaEdition {
+        $sql = '
+            SELECT
+                `GSoC_Idea_Edition`.`idea_edition_id`,
+                `GSoC_Idea_Edition`.`idea_id`,
+                `GSoC_Idea_Edition`.`edition_id`,
+                `GSoC_Idea_Edition`.`status`,
+                `GSoC_Idea_Edition`.`decision_notes`,
+                `GSoC_Idea_Edition`.`created_at`,
+                `GSoC_Idea_Edition`.`updated_at`
+            FROM
+                `GSoC_Idea_Edition`
+            WHERE
+                (
+                    `idea_edition_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$idea_edition_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\GSoCIdeaEdition($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\GSoCIdeaEdition} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $idea_edition_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `GSoC_Idea_Edition`
+            WHERE
+                (
+                    `idea_edition_id` = ?
+                );';
+        $params = [$idea_edition_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `GSoC_Idea_Edition`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `GSoC_Idea_Edition`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\GSoCIdeaEdition} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCIdeaEdition $GSoC_Idea_Edition El
+     * objeto de tipo \OmegaUp\DAO\VO\GSoCIdeaEdition a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\GSoCIdeaEdition $GSoC_Idea_Edition
+    ): void {
+        $sql = '
+            DELETE FROM
+                `GSoC_Idea_Edition`
+            WHERE
+                (
+                    `idea_edition_id` = ?
+                );';
+        $params = [
+            $GSoC_Idea_Edition->idea_edition_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\GSoCIdeaEdition> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'idea_edition_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `GSoC_Idea_Edition`.`idea_edition_id`,
+                `GSoC_Idea_Edition`.`idea_id`,
+                `GSoC_Idea_Edition`.`edition_id`,
+                `GSoC_Idea_Edition`.`status`,
+                `GSoC_Idea_Edition`.`decision_notes`,
+                `GSoC_Idea_Edition`.`created_at`,
+                `GSoC_Idea_Edition`.`updated_at`
+            FROM
+                `GSoC_Idea_Edition`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\GSoCIdeaEdition(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\GSoCIdeaEdition $GSoC_Idea_Edition El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\GSoCIdeaEdition}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\GSoCIdeaEdition $GSoC_Idea_Edition
+    ): int {
+        $sql = '
+            INSERT INTO
+                `GSoC_Idea_Edition` (
+                    `idea_id`,
+                    `edition_id`,
+                    `status`,
+                    `decision_notes`,
+                    `created_at`,
+                    `updated_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            (
+                is_null($GSoC_Idea_Edition->idea_id) ?
+                null :
+                intval($GSoC_Idea_Edition->idea_id)
+            ),
+            (
+                is_null($GSoC_Idea_Edition->edition_id) ?
+                null :
+                intval($GSoC_Idea_Edition->edition_id)
+            ),
+            $GSoC_Idea_Edition->status,
+            $GSoC_Idea_Edition->decision_notes,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea_Edition->created_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $GSoC_Idea_Edition->updated_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $GSoC_Idea_Edition->idea_edition_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/GSoCEdition.php
+++ b/frontend/server/src/DAO/GSoCEdition.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * GSoCEdition Data Access Object (DAO).
+ */
+class GSoCEdition extends \OmegaUp\DAO\Base\GSoCEdition {
+    /**
+     * @return array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}
+     */
+    private static function toPublicArray(
+        \OmegaUp\DAO\VO\GSoCEdition $edition
+    ): array {
+        return [
+            'edition_id' => intval($edition->edition_id),
+            'year' => intval($edition->year),
+            'is_active' => boolval($edition->is_active),
+            'application_deadline' => is_null($edition->application_deadline)
+                ? null
+                : \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->application_deadline),
+            'created_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->created_at),
+            'updated_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->updated_at),
+        ];
+    }
+
+    /**
+     * @return list<array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}>
+     */
+    public static function getEditions(): array {
+        $result = [];
+        foreach (self::getAll() as $edition) {
+            $result[] = self::toPublicArray($edition);
+        }
+        usort(
+            $result,
+            /**
+             * @param array{year: int} $a
+             * @param array{year: int} $b
+             */
+            function (array $a, array $b): int {
+                return $b['year'] <=> $a['year'];
+            }
+        );
+        return $result;
+    }
+
+    /**
+     * @return array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}|null
+     */
+    public static function getEditionByYear(int $year): ?array {
+        $sql = '
+            SELECT
+                edition_id
+            FROM
+                GSoC_Edition
+            WHERE
+                year = ?
+            LIMIT 1;
+        ';
+        /** @var array{edition_id: int|string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$year]);
+        if (empty($row)) {
+            return null;
+        }
+        $edition = self::getByPK(intval($row['edition_id']));
+        if (is_null($edition)) {
+            return null;
+        }
+        return self::toPublicArray($edition);
+    }
+}

--- a/frontend/server/src/DAO/GSoCEdition.php
+++ b/frontend/server/src/DAO/GSoCEdition.php
@@ -18,9 +18,15 @@ class GSoCEdition extends \OmegaUp\DAO\Base\GSoCEdition {
             'is_active' => boolval($edition->is_active),
             'application_deadline' => is_null($edition->application_deadline)
                 ? null
-                : \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->application_deadline),
-            'created_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->created_at),
-            'updated_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->updated_at),
+                : \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                    $edition->application_deadline
+                ),
+            'created_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $edition->created_at
+            ),
+            'updated_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $edition->updated_at
+            ),
         ];
     }
 

--- a/frontend/server/src/DAO/GSoCEdition.php
+++ b/frontend/server/src/DAO/GSoCEdition.php
@@ -7,72 +7,42 @@ namespace OmegaUp\DAO;
  */
 class GSoCEdition extends \OmegaUp\DAO\Base\GSoCEdition {
     /**
-     * @return array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}
-     */
-    private static function toPublicArray(
-        \OmegaUp\DAO\VO\GSoCEdition $edition
-    ): array {
-        return [
-            'edition_id' => intval($edition->edition_id),
-            'year' => intval($edition->year),
-            'is_active' => boolval($edition->is_active),
-            'application_deadline' => is_null($edition->application_deadline)
-                ? null
-                : \OmegaUp\DAO\DAO::toMySQLTimestamp(
-                    $edition->application_deadline
-                ),
-            'created_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp(
-                $edition->created_at
-            ),
-            'updated_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp(
-                $edition->updated_at
-            ),
-        ];
-    }
-
-    /**
-     * @return list<array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}>
+     * @return list<array{application_deadline: null|string, created_at: null|string, edition_id: int, is_active: bool, updated_at: null|string, year: int}>
      */
     public static function getEditions(): array {
-        $result = [];
-        foreach (self::getAll() as $edition) {
-            $result[] = self::toPublicArray($edition);
-        }
-        usort(
-            $result,
-            /**
-             * @param array{year: int} $a
-             * @param array{year: int} $b
-             */
-            function (array $a, array $b): int {
-                return $b['year'] <=> $a['year'];
-            }
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\GSoCEdition::FIELD_NAMES,
+            'ge'
         );
-        return $result;
+        $sql = "
+            SELECT
+                {$fields}
+            FROM
+                `GSoC_Edition` `ge`
+            ORDER BY
+                `ge`.`year` DESC
+            LIMIT 50;
+        ";
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql);
     }
 
     /**
-     * @return array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}|null
+     * @return array{application_deadline: null|string, created_at: null|string, edition_id: int, is_active: bool, updated_at: null|string, year: int}|null
      */
     public static function getEditionByYear(int $year): ?array {
-        $sql = '
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\GSoCEdition::FIELD_NAMES,
+            'ge'
+        );
+        $sql = "
             SELECT
-                edition_id
+                {$fields}
             FROM
-                GSoC_Edition
+                `GSoC_Edition` `ge`
             WHERE
-                year = ?
+                `ge`.`year` = ?
             LIMIT 1;
-        ';
-        /** @var array{edition_id: int|string}|null */
-        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$year]);
-        if (empty($row)) {
-            return null;
-        }
-        $edition = self::getByPK(intval($row['edition_id']));
-        if (is_null($edition)) {
-            return null;
-        }
-        return self::toPublicArray($edition);
+        ";
+        return \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$year]);
     }
 }

--- a/frontend/server/src/DAO/GSoCIdea.php
+++ b/frontend/server/src/DAO/GSoCIdea.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * GSoCIdea Data Access Object (DAO).
+ */
+class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
+    /**
+     * @param array{
+     *     idea_id: int|string,
+     *     edition_id: int|string|null,
+     *     title: string,
+     *     brief_description: string|null,
+     *     expected_results: string|null,
+     *     preferred_skills: string|null,
+     *     possible_mentors: string|null,
+     *     estimated_hours: int|string|null,
+     *     skill_level: string|null,
+     *     status: string|null,
+     *     blog_link: string|null,
+     *     contributor_username: string|null,
+     *     created_at: string,
+     *     updated_at: string
+     * } $row
+     * @return array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}
+     */
+    private static function toPublicArray(array $row): array {
+        return [
+            'idea_id' => intval($row['idea_id']),
+            'edition_id' => intval($row['edition_id'] ?? 0),
+            'title' => $row['title'],
+            'brief_description' => $row['brief_description'],
+            'expected_results' => $row['expected_results'],
+            'preferred_skills' => $row['preferred_skills'],
+            'possible_mentors' => $row['possible_mentors'],
+            'estimated_hours' => is_null($row['estimated_hours']) ? null : intval($row['estimated_hours']),
+            'skill_level' => $row['skill_level'],
+            'status' => is_null($row['status']) ? 'Proposed' : $row['status'],
+            'blog_link' => $row['blog_link'],
+            'contributor_username' => $row['contributor_username'],
+            'created_at' => $row['created_at'],
+            'updated_at' => $row['updated_at'],
+        ];
+    }
+
+    /**
+     * @return list<array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}>
+     */
+    public static function getIdeas(
+        ?int $editionId = null,
+        ?string $status = null
+    ): array {
+        $sql = '
+            SELECT
+                i.idea_id,
+                ie.edition_id,
+                i.title,
+                i.brief_description,
+                i.expected_results,
+                i.preferred_skills,
+                i.possible_mentors,
+                i.estimated_hours,
+                i.skill_level,
+                ie.status,
+                i.blog_link,
+                i.contributor_username,
+                i.created_at,
+                i.updated_at
+            FROM
+                GSoC_Idea i
+            INNER JOIN
+                GSoC_Idea_Edition ie ON ie.idea_id = i.idea_id
+            INNER JOIN
+                GSoC_Edition e ON e.edition_id = ie.edition_id
+            WHERE
+                1 = 1
+        ';
+
+        $params = [];
+        if (!is_null($editionId)) {
+            $sql .= ' AND ie.edition_id = ?';
+            $params[] = $editionId;
+        }
+        if (!is_null($status)) {
+            $sql .= ' AND ie.status = ?';
+            $params[] = $status;
+        }
+        $sql .= ' ORDER BY e.year DESC, i.created_at DESC;';
+
+        /** @var list<array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}> */
+        $rows = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[] = self::toPublicArray($row);
+        }
+        return $result;
+    }
+
+    /**
+     * @return array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null
+     */
+    public static function getIdeaById(int $ideaId): ?array {
+        $sql = '
+            SELECT
+                i.idea_id,
+                ie.edition_id,
+                i.title,
+                i.brief_description,
+                i.expected_results,
+                i.preferred_skills,
+                i.possible_mentors,
+                i.estimated_hours,
+                i.skill_level,
+                ie.status,
+                i.blog_link,
+                i.contributor_username,
+                i.created_at,
+                i.updated_at
+            FROM
+                GSoC_Idea i
+            LEFT JOIN
+                GSoC_Idea_Edition ie ON ie.idea_id = i.idea_id
+            LEFT JOIN
+                GSoC_Edition e ON e.edition_id = ie.edition_id
+            WHERE
+                i.idea_id = ?
+            ORDER BY
+                e.year DESC
+            LIMIT 1;
+        ';
+
+        /** @var array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$ideaId]);
+        if (empty($row)) {
+            return null;
+        }
+        return self::toPublicArray($row);
+    }
+
+    public static function createIdea(
+        int $editionId,
+        string $title,
+        ?string $briefDescription = null,
+        ?string $expectedResults = null,
+        ?string $preferredSkills = null,
+        ?string $possibleMentors = null,
+        ?int $estimatedHours = null,
+        ?string $skillLevel = null,
+        string $status = 'Proposed',
+        ?string $blogLink = null,
+        ?string $contributorUsername = null
+    ): int {
+        $idea = new \OmegaUp\DAO\VO\GSoCIdea([
+            'title' => $title,
+            'brief_description' => $briefDescription,
+            'expected_results' => $expectedResults,
+            'preferred_skills' => $preferredSkills,
+            'possible_mentors' => $possibleMentors,
+            'estimated_hours' => $estimatedHours,
+            'skill_level' => $skillLevel,
+            'blog_link' => $blogLink,
+            'contributor_username' => $contributorUsername,
+        ]);
+        self::create($idea);
+
+        $ideaEdition = new \OmegaUp\DAO\VO\GSoCIdeaEdition([
+            'idea_id' => $idea->idea_id,
+            'edition_id' => $editionId,
+            'status' => $status,
+        ]);
+        \OmegaUp\DAO\GSoCIdeaEdition::create($ideaEdition);
+
+        return intval($idea->idea_id);
+    }
+
+    public static function updateIdea(
+        int $ideaId,
+        ?int $editionId = null,
+        ?string $title = null,
+        ?string $briefDescription = null,
+        ?string $expectedResults = null,
+        ?string $preferredSkills = null,
+        ?string $possibleMentors = null,
+        ?int $estimatedHours = null,
+        ?string $skillLevel = null,
+        ?string $status = null,
+        ?string $blogLink = null,
+        ?string $contributorUsername = null
+    ): int {
+        $idea = self::getByPK($ideaId);
+        if (is_null($idea)) {
+            return 0;
+        }
+        if (!is_null($title)) {
+            $idea->title = $title;
+        }
+        if (!is_null($briefDescription)) {
+            $idea->brief_description = $briefDescription;
+        }
+        if (!is_null($expectedResults)) {
+            $idea->expected_results = $expectedResults;
+        }
+        if (!is_null($preferredSkills)) {
+            $idea->preferred_skills = $preferredSkills;
+        }
+        if (!is_null($possibleMentors)) {
+            $idea->possible_mentors = $possibleMentors;
+        }
+        if (!is_null($estimatedHours)) {
+            $idea->estimated_hours = $estimatedHours;
+        }
+        if (!is_null($skillLevel)) {
+            $idea->skill_level = $skillLevel;
+        }
+        if (!is_null($blogLink)) {
+            $idea->blog_link = $blogLink;
+        }
+        if (!is_null($contributorUsername)) {
+            $idea->contributor_username = $contributorUsername;
+        }
+        $affectedRows = self::update($idea);
+
+        if (!is_null($editionId) || !is_null($status)) {
+            $targetEditionId = $editionId;
+            if (is_null($targetEditionId)) {
+                $existingIdea = self::getIdeaById($ideaId);
+                $targetEditionId = is_null($existingIdea) ? null : intval($existingIdea['edition_id']);
+            }
+            if (!is_null($targetEditionId) && $targetEditionId > 0) {
+                $ideaEdition = \OmegaUp\DAO\GSoCIdeaEdition::getByIdeaAndEdition(
+                    $ideaId,
+                    $targetEditionId
+                );
+                if (is_null($ideaEdition)) {
+                    $ideaEdition = new \OmegaUp\DAO\VO\GSoCIdeaEdition([
+                        'idea_id' => $ideaId,
+                        'edition_id' => $targetEditionId,
+                        'status' => is_null($status) ? 'Proposed' : $status,
+                    ]);
+                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::create($ideaEdition);
+                } elseif (!is_null($status)) {
+                    $ideaEdition->status = $status;
+                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::update($ideaEdition);
+                }
+            }
+        }
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/GSoCIdea.php
+++ b/frontend/server/src/DAO/GSoCIdea.php
@@ -7,49 +7,7 @@ namespace OmegaUp\DAO;
  */
 class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
     /**
-     * @param array{
-     *     idea_id: int|string,
-     *     edition_id: int|string|null,
-     *     title: string,
-     *     brief_description: string|null,
-     *     expected_results: string|null,
-     *     preferred_skills: string|null,
-     *     possible_mentors: string|null,
-     *     estimated_hours: int|string|null,
-     *     skill_level: string|null,
-     *     status: string|null,
-     *     blog_link: string|null,
-     *     contributor_username: string|null,
-     *     created_at: string,
-     *     updated_at: string
-     * } $row
-     * @return array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}
-     */
-    private static function toPublicArray(array $row): array {
-        return [
-            'idea_id' => intval($row['idea_id']),
-            'edition_id' => intval($row['edition_id'] ?? 0),
-            'title' => $row['title'],
-            'brief_description' => $row['brief_description'],
-            'expected_results' => $row['expected_results'],
-            'preferred_skills' => $row['preferred_skills'],
-            'possible_mentors' => $row['possible_mentors'],
-            'estimated_hours' => is_null(
-                $row['estimated_hours']
-            ) ? null : intval(
-                $row['estimated_hours']
-            ),
-            'skill_level' => $row['skill_level'],
-            'status' => is_null($row['status']) ? 'Proposed' : $row['status'],
-            'blog_link' => $row['blog_link'],
-            'contributor_username' => $row['contributor_username'],
-            'created_at' => $row['created_at'],
-            'updated_at' => $row['updated_at'],
-        ];
-    }
-
-    /**
-     * @return list<array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}>
+     * @return list<array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}>
      */
     public static function getIdeas(
         ?int $editionId = null,
@@ -92,18 +50,11 @@ class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
         }
         $sql .= ' ORDER BY e.year DESC, i.created_at DESC;';
 
-        /** @var list<array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}> */
-        $rows = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
-
-        $result = [];
-        foreach ($rows as $row) {
-            $result[] = self::toPublicArray($row);
-        }
-        return $result;
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
     }
 
     /**
-     * @return array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null
+     * @return array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null
      */
     public static function getIdeaById(int $ideaId): ?array {
         $sql = '
@@ -135,12 +86,7 @@ class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
             LIMIT 1;
         ';
 
-        /** @var array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null */
-        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$ideaId]);
-        if (empty($row)) {
-            return null;
-        }
-        return self::toPublicArray($row);
+        return \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$ideaId]);
     }
 
     public static function createIdea(

--- a/frontend/server/src/DAO/GSoCIdea.php
+++ b/frontend/server/src/DAO/GSoCIdea.php
@@ -34,7 +34,11 @@ class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
             'expected_results' => $row['expected_results'],
             'preferred_skills' => $row['preferred_skills'],
             'possible_mentors' => $row['possible_mentors'],
-            'estimated_hours' => is_null($row['estimated_hours']) ? null : intval($row['estimated_hours']),
+            'estimated_hours' => is_null(
+                $row['estimated_hours']
+            ) ? null : intval(
+                $row['estimated_hours']
+            ),
             'skill_level' => $row['skill_level'],
             'status' => is_null($row['status']) ? 'Proposed' : $row['status'],
             'blog_link' => $row['blog_link'],
@@ -226,7 +230,11 @@ class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
             $targetEditionId = $editionId;
             if (is_null($targetEditionId)) {
                 $existingIdea = self::getIdeaById($ideaId);
-                $targetEditionId = is_null($existingIdea) ? null : intval($existingIdea['edition_id']);
+                $targetEditionId = is_null(
+                    $existingIdea
+                ) ? null : intval(
+                    $existingIdea['edition_id']
+                );
             }
             if (!is_null($targetEditionId) && $targetEditionId > 0) {
                 $ideaEdition = \OmegaUp\DAO\GSoCIdeaEdition::getByIdeaAndEdition(
@@ -239,10 +247,14 @@ class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
                         'edition_id' => $targetEditionId,
                         'status' => is_null($status) ? 'Proposed' : $status,
                     ]);
-                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::create($ideaEdition);
+                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::create(
+                        $ideaEdition
+                    );
                 } elseif (!is_null($status)) {
                     $ideaEdition->status = $status;
-                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::update($ideaEdition);
+                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::update(
+                        $ideaEdition
+                    );
                 }
             }
         }

--- a/frontend/server/src/DAO/GSoCIdeaEdition.php
+++ b/frontend/server/src/DAO/GSoCIdeaEdition.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * GSoCIdeaEdition Data Access Object (DAO).
+ */
+class GSoCIdeaEdition extends \OmegaUp\DAO\Base\GSoCIdeaEdition {
+    public static function getByIdeaAndEdition(
+        int $ideaId,
+        int $editionId
+    ): ?\OmegaUp\DAO\VO\GSoCIdeaEdition {
+        $sql = '
+            SELECT
+                idea_edition_id
+            FROM
+                GSoC_Idea_Edition
+            WHERE
+                idea_id = ? AND edition_id = ?
+            LIMIT 1;
+        ';
+        /** @var array{idea_edition_id: int|string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow(
+            $sql,
+            [$ideaId, $editionId]
+        );
+        if (empty($row)) {
+            return null;
+        }
+        return self::getByPK(intval($row['idea_edition_id']));
+    }
+}

--- a/frontend/server/src/DAO/VO/GSoCEdition.php
+++ b/frontend/server/src/DAO/VO/GSoCEdition.php
@@ -1,0 +1,138 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `GSoC_Edition`.
+ *
+ * @access public
+ */
+class GSoCEdition extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'edition_id' => true,
+        'year' => true,
+        'is_active' => true,
+        'application_deadline' => true,
+        'created_at' => true,
+        'updated_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['edition_id'])) {
+            $this->edition_id = intval(
+                $data['edition_id']
+            );
+        }
+        if (isset($data['year'])) {
+            $this->year = intval(
+                $data['year']
+            );
+        }
+        if (isset($data['is_active'])) {
+            $this->is_active = boolval(
+                $data['is_active']
+            );
+        }
+        if (isset($data['application_deadline'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['application_deadline']
+             * @var \OmegaUp\Timestamp $this->application_deadline
+             */
+            $this->application_deadline = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['application_deadline']
+                )
+            );
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['updated_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['updated_at']
+             * @var \OmegaUp\Timestamp $this->updated_at
+             */
+            $this->updated_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['updated_at']
+                )
+            );
+        } else {
+            $this->updated_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $edition_id = 0;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var int|null
+     */
+    public $year = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var bool
+     */
+    public $is_active = false;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $application_deadline = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $updated_at;  // CURRENT_TIMESTAMP
+}

--- a/frontend/server/src/DAO/VO/GSoCIdea.php
+++ b/frontend/server/src/DAO/VO/GSoCIdea.php
@@ -1,0 +1,210 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `GSoC_Idea`.
+ *
+ * @access public
+ */
+class GSoCIdea extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'idea_id' => true,
+        'title' => true,
+        'brief_description' => true,
+        'expected_results' => true,
+        'preferred_skills' => true,
+        'possible_mentors' => true,
+        'estimated_hours' => true,
+        'skill_level' => true,
+        'blog_link' => true,
+        'contributor_username' => true,
+        'created_at' => true,
+        'updated_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['idea_id'])) {
+            $this->idea_id = intval(
+                $data['idea_id']
+            );
+        }
+        if (isset($data['title'])) {
+            $this->title = is_scalar(
+                $data['title']
+            ) ? strval($data['title']) : '';
+        }
+        if (isset($data['brief_description'])) {
+            $this->brief_description = is_scalar(
+                $data['brief_description']
+            ) ? strval($data['brief_description']) : '';
+        }
+        if (isset($data['expected_results'])) {
+            $this->expected_results = is_scalar(
+                $data['expected_results']
+            ) ? strval($data['expected_results']) : '';
+        }
+        if (isset($data['preferred_skills'])) {
+            $this->preferred_skills = is_scalar(
+                $data['preferred_skills']
+            ) ? strval($data['preferred_skills']) : '';
+        }
+        if (isset($data['possible_mentors'])) {
+            $this->possible_mentors = is_scalar(
+                $data['possible_mentors']
+            ) ? strval($data['possible_mentors']) : '';
+        }
+        if (isset($data['estimated_hours'])) {
+            $this->estimated_hours = intval(
+                $data['estimated_hours']
+            );
+        }
+        if (isset($data['skill_level'])) {
+            $this->skill_level = is_scalar(
+                $data['skill_level']
+            ) ? strval($data['skill_level']) : '';
+        }
+        if (isset($data['blog_link'])) {
+            $this->blog_link = is_scalar(
+                $data['blog_link']
+            ) ? strval($data['blog_link']) : '';
+        }
+        if (isset($data['contributor_username'])) {
+            $this->contributor_username = is_scalar(
+                $data['contributor_username']
+            ) ? strval($data['contributor_username']) : '';
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['updated_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['updated_at']
+             * @var \OmegaUp\Timestamp $this->updated_at
+             */
+            $this->updated_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['updated_at']
+                )
+            );
+        } else {
+            $this->updated_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $idea_id = 0;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $title = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $brief_description = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $expected_results = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $preferred_skills = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $possible_mentors = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var int|null
+     */
+    public $estimated_hours = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $skill_level = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $blog_link = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string|null
+     */
+    public $contributor_username = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $updated_at;  // CURRENT_TIMESTAMP
+}

--- a/frontend/server/src/DAO/VO/GSoCIdeaEdition.php
+++ b/frontend/server/src/DAO/VO/GSoCIdeaEdition.php
@@ -1,0 +1,145 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `GSoC_Idea_Edition`.
+ *
+ * @access public
+ */
+class GSoCIdeaEdition extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'idea_edition_id' => true,
+        'idea_id' => true,
+        'edition_id' => true,
+        'status' => true,
+        'decision_notes' => true,
+        'created_at' => true,
+        'updated_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['idea_edition_id'])) {
+            $this->idea_edition_id = intval(
+                $data['idea_edition_id']
+            );
+        }
+        if (isset($data['idea_id'])) {
+            $this->idea_id = intval(
+                $data['idea_id']
+            );
+        }
+        if (isset($data['edition_id'])) {
+            $this->edition_id = intval(
+                $data['edition_id']
+            );
+        }
+        if (isset($data['status'])) {
+            $this->status = is_scalar(
+                $data['status']
+            ) ? strval($data['status']) : '';
+        }
+        if (isset($data['decision_notes'])) {
+            $this->decision_notes = is_scalar(
+                $data['decision_notes']
+            ) ? strval($data['decision_notes']) : '';
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['updated_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['updated_at']
+             * @var \OmegaUp\Timestamp $this->updated_at
+             */
+            $this->updated_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['updated_at']
+                )
+            );
+        } else {
+            $this->updated_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $idea_edition_id = 0;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var int|null
+     */
+    public $idea_id = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var int|null
+     */
+    public $edition_id = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string
+     */
+    public $status = 'Proposed';
+
+    /**
+     * Notas explicando la decisión tomada para este proyecto en esta edición
+     *
+     * @var string|null
+     */
+    public $decision_notes = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $updated_at;  // CURRENT_TIMESTAMP
+}


### PR DESCRIPTION
feature: Split GSOC custom DAO methods into an isolated change 

# Description

Split custom DAO methods into an isolated change 
frontend/server/src/DAO/GSoCIdeaEdition.php
 frontend/server/src/DAO/GSoCIdea.php
frontend/server/src/DAO/GSoCEdition.php

Fixes: #9008


# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
