### PR TITLE
Feature gsoc dao tests

### DIFF
--- a/frontend/server/src/DAO/GSoCEdition.php
+++ b/frontend/server/src/DAO/GSoCEdition.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * GSoCEdition Data Access Object (DAO).
+ */
+class GSoCEdition extends \OmegaUp\DAO\Base\GSoCEdition {
+    /**
+     * @return array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}
+     */
+    private static function toPublicArray(
+        \OmegaUp\DAO\VO\GSoCEdition $edition
+    ): array {
+        return [
+            'edition_id' => intval($edition->edition_id),
+            'year' => intval($edition->year),
+            'is_active' => boolval($edition->is_active),
+            'application_deadline' => is_null($edition->application_deadline)
+                ? null
+                : \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->application_deadline),
+            'created_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->created_at),
+            'updated_at' => \OmegaUp\DAO\DAO::toMySQLTimestamp($edition->updated_at),
+        ];
+    }
+
+    /**
+     * @return list<array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}>
+     */
+    public static function getEditions(): array {
+        $result = [];
+        foreach (self::getAll() as $edition) {
+            $result[] = self::toPublicArray($edition);
+        }
+        usort(
+            $result,
+            /**
+             * @param array{year: int} $a
+             * @param array{year: int} $b
+             */
+            function (array $a, array $b): int {
+                return $b['year'] <=> $a['year'];
+            }
+        );
+        return $result;
+    }
+
+    /**
+     * @return array{edition_id: int, year: int, is_active: bool, application_deadline: string|null, created_at: string, updated_at: string}|null
+     */
+    public static function getEditionByYear(int $year): ?array {
+        $sql = '
+            SELECT
+                edition_id
+            FROM
+                GSoC_Edition
+            WHERE
+                year = ?
+            LIMIT 1;
+        ';
+        /** @var array{edition_id: int|string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$year]);
+        if (empty($row)) {
+            return null;
+        }
+        $edition = self::getByPK(intval($row['edition_id']));
+        if (is_null($edition)) {
+            return null;
+        }
+        return self::toPublicArray($edition);
+    }
+}

--- a/frontend/server/src/DAO/GSoCIdea.php
+++ b/frontend/server/src/DAO/GSoCIdea.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * GSoCIdea Data Access Object (DAO).
+ */
+class GSoCIdea extends \OmegaUp\DAO\Base\GSoCIdea {
+    /**
+     * @param array{
+     *     idea_id: int|string,
+     *     edition_id: int|string|null,
+     *     title: string,
+     *     brief_description: string|null,
+     *     expected_results: string|null,
+     *     preferred_skills: string|null,
+     *     possible_mentors: string|null,
+     *     estimated_hours: int|string|null,
+     *     skill_level: string|null,
+     *     status: string|null,
+     *     blog_link: string|null,
+     *     contributor_username: string|null,
+     *     created_at: string,
+     *     updated_at: string
+     * } $row
+     * @return array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}
+     */
+    private static function toPublicArray(array $row): array {
+        return [
+            'idea_id' => intval($row['idea_id']),
+            'edition_id' => intval($row['edition_id'] ?? 0),
+            'title' => $row['title'],
+            'brief_description' => $row['brief_description'],
+            'expected_results' => $row['expected_results'],
+            'preferred_skills' => $row['preferred_skills'],
+            'possible_mentors' => $row['possible_mentors'],
+            'estimated_hours' => is_null($row['estimated_hours']) ? null : intval($row['estimated_hours']),
+            'skill_level' => $row['skill_level'],
+            'status' => is_null($row['status']) ? 'Proposed' : $row['status'],
+            'blog_link' => $row['blog_link'],
+            'contributor_username' => $row['contributor_username'],
+            'created_at' => $row['created_at'],
+            'updated_at' => $row['updated_at'],
+        ];
+    }
+
+    /**
+     * @return list<array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}>
+     */
+    public static function getIdeas(
+        ?int $editionId = null,
+        ?string $status = null
+    ): array {
+        $sql = '
+            SELECT
+                i.idea_id,
+                ie.edition_id,
+                i.title,
+                i.brief_description,
+                i.expected_results,
+                i.preferred_skills,
+                i.possible_mentors,
+                i.estimated_hours,
+                i.skill_level,
+                ie.status,
+                i.blog_link,
+                i.contributor_username,
+                i.created_at,
+                i.updated_at
+            FROM
+                GSoC_Idea i
+            INNER JOIN
+                GSoC_Idea_Edition ie ON ie.idea_id = i.idea_id
+            INNER JOIN
+                GSoC_Edition e ON e.edition_id = ie.edition_id
+            WHERE
+                1 = 1
+        ';
+
+        $params = [];
+        if (!is_null($editionId)) {
+            $sql .= ' AND ie.edition_id = ?';
+            $params[] = $editionId;
+        }
+        if (!is_null($status)) {
+            $sql .= ' AND ie.status = ?';
+            $params[] = $status;
+        }
+        $sql .= ' ORDER BY e.year DESC, i.created_at DESC;';
+
+        /** @var list<array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}> */
+        $rows = \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, $params);
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[] = self::toPublicArray($row);
+        }
+        return $result;
+    }
+
+    /**
+     * @return array{idea_id: int, edition_id: int, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|null, skill_level: string|null, status: string, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null
+     */
+    public static function getIdeaById(int $ideaId): ?array {
+        $sql = '
+            SELECT
+                i.idea_id,
+                ie.edition_id,
+                i.title,
+                i.brief_description,
+                i.expected_results,
+                i.preferred_skills,
+                i.possible_mentors,
+                i.estimated_hours,
+                i.skill_level,
+                ie.status,
+                i.blog_link,
+                i.contributor_username,
+                i.created_at,
+                i.updated_at
+            FROM
+                GSoC_Idea i
+            LEFT JOIN
+                GSoC_Idea_Edition ie ON ie.idea_id = i.idea_id
+            LEFT JOIN
+                GSoC_Edition e ON e.edition_id = ie.edition_id
+            WHERE
+                i.idea_id = ?
+            ORDER BY
+                e.year DESC
+            LIMIT 1;
+        ';
+
+        /** @var array{idea_id: int|string, edition_id: int|string|null, title: string, brief_description: string|null, expected_results: string|null, preferred_skills: string|null, possible_mentors: string|null, estimated_hours: int|string|null, skill_level: string|null, status: string|null, blog_link: string|null, contributor_username: string|null, created_at: string, updated_at: string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [$ideaId]);
+        if (empty($row)) {
+            return null;
+        }
+        return self::toPublicArray($row);
+    }
+
+    public static function createIdea(
+        int $editionId,
+        string $title,
+        ?string $briefDescription = null,
+        ?string $expectedResults = null,
+        ?string $preferredSkills = null,
+        ?string $possibleMentors = null,
+        ?int $estimatedHours = null,
+        ?string $skillLevel = null,
+        string $status = 'Proposed',
+        ?string $blogLink = null,
+        ?string $contributorUsername = null
+    ): int {
+        $idea = new \OmegaUp\DAO\VO\GSoCIdea([
+            'title' => $title,
+            'brief_description' => $briefDescription,
+            'expected_results' => $expectedResults,
+            'preferred_skills' => $preferredSkills,
+            'possible_mentors' => $possibleMentors,
+            'estimated_hours' => $estimatedHours,
+            'skill_level' => $skillLevel,
+            'blog_link' => $blogLink,
+            'contributor_username' => $contributorUsername,
+        ]);
+        self::create($idea);
+
+        $ideaEdition = new \OmegaUp\DAO\VO\GSoCIdeaEdition([
+            'idea_id' => $idea->idea_id,
+            'edition_id' => $editionId,
+            'status' => $status,
+        ]);
+        \OmegaUp\DAO\GSoCIdeaEdition::create($ideaEdition);
+
+        return intval($idea->idea_id);
+    }
+
+    public static function updateIdea(
+        int $ideaId,
+        ?int $editionId = null,
+        ?string $title = null,
+        ?string $briefDescription = null,
+        ?string $expectedResults = null,
+        ?string $preferredSkills = null,
+        ?string $possibleMentors = null,
+        ?int $estimatedHours = null,
+        ?string $skillLevel = null,
+        ?string $status = null,
+        ?string $blogLink = null,
+        ?string $contributorUsername = null
+    ): int {
+        $idea = self::getByPK($ideaId);
+        if (is_null($idea)) {
+            return 0;
+        }
+        if (!is_null($title)) {
+            $idea->title = $title;
+        }
+        if (!is_null($briefDescription)) {
+            $idea->brief_description = $briefDescription;
+        }
+        if (!is_null($expectedResults)) {
+            $idea->expected_results = $expectedResults;
+        }
+        if (!is_null($preferredSkills)) {
+            $idea->preferred_skills = $preferredSkills;
+        }
+        if (!is_null($possibleMentors)) {
+            $idea->possible_mentors = $possibleMentors;
+        }
+        if (!is_null($estimatedHours)) {
+            $idea->estimated_hours = $estimatedHours;
+        }
+        if (!is_null($skillLevel)) {
+            $idea->skill_level = $skillLevel;
+        }
+        if (!is_null($blogLink)) {
+            $idea->blog_link = $blogLink;
+        }
+        if (!is_null($contributorUsername)) {
+            $idea->contributor_username = $contributorUsername;
+        }
+        $affectedRows = self::update($idea);
+
+        if (!is_null($editionId) || !is_null($status)) {
+            $targetEditionId = $editionId;
+            if (is_null($targetEditionId)) {
+                $existingIdea = self::getIdeaById($ideaId);
+                $targetEditionId = is_null($existingIdea) ? null : intval($existingIdea['edition_id']);
+            }
+            if (!is_null($targetEditionId) && $targetEditionId > 0) {
+                $ideaEdition = \OmegaUp\DAO\GSoCIdeaEdition::getByIdeaAndEdition(
+                    $ideaId,
+                    $targetEditionId
+                );
+                if (is_null($ideaEdition)) {
+                    $ideaEdition = new \OmegaUp\DAO\VO\GSoCIdeaEdition([
+                        'idea_id' => $ideaId,
+                        'edition_id' => $targetEditionId,
+                        'status' => is_null($status) ? 'Proposed' : $status,
+                    ]);
+                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::create($ideaEdition);
+                } elseif (!is_null($status)) {
+                    $ideaEdition->status = $status;
+                    $affectedRows += \OmegaUp\DAO\GSoCIdeaEdition::update($ideaEdition);
+                }
+            }
+        }
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/GSoCIdeaEdition.php
+++ b/frontend/server/src/DAO/GSoCIdeaEdition.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * GSoCIdeaEdition Data Access Object (DAO).
+ */
+class GSoCIdeaEdition extends \OmegaUp\DAO\Base\GSoCIdeaEdition {
+    public static function getByIdeaAndEdition(
+        int $ideaId,
+        int $editionId
+    ): ?\OmegaUp\DAO\VO\GSoCIdeaEdition {
+        $sql = '
+            SELECT
+                idea_edition_id
+            FROM
+                GSoC_Idea_Edition
+            WHERE
+                idea_id = ? AND edition_id = ?
+            LIMIT 1;
+        ';
+        /** @var array{idea_edition_id: int|string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow(
+            $sql,
+            [$ideaId, $editionId]
+        );
+        if (empty($row)) {
+            return null;
+        }
+        return self::getByPK(intval($row['idea_edition_id']));
+    }
+}

--- a/frontend/tests/controllers/GSoCDaoTest.php
+++ b/frontend/tests/controllers/GSoCDaoTest.php
@@ -1,0 +1,118 @@
+<?php
+
+class GSoCDaoTest extends \OmegaUp\Test\ControllerTestCase {
+    public function testGetEditionsAndGetEditionByYear(): void {
+        \OmegaUp\DAO\GSoCEdition::create(
+            new \OmegaUp\DAO\VO\GSoCEdition([
+                'year' => 2024,
+                'is_active' => false,
+            ])
+        );
+        \OmegaUp\DAO\GSoCEdition::create(
+            new \OmegaUp\DAO\VO\GSoCEdition([
+                'year' => 2025,
+                'is_active' => true,
+            ])
+        );
+
+        $editions = \OmegaUp\DAO\GSoCEdition::getEditions();
+        $this->assertCount(2, $editions);
+        $this->assertSame(2025, $editions[0]['year']);
+        $this->assertSame(2024, $editions[1]['year']);
+
+        $edition2024 = \OmegaUp\DAO\GSoCEdition::getEditionByYear(2024);
+        $this->assertNotNull($edition2024);
+        $this->assertSame(2024, $edition2024['year']);
+
+        $this->assertNull(\OmegaUp\DAO\GSoCEdition::getEditionByYear(2030));
+    }
+
+    public function testCreateGetAndFilterIdeas(): void {
+        $edition = new \OmegaUp\DAO\VO\GSoCEdition([
+            'year' => 2026,
+            'is_active' => true,
+        ]);
+        \OmegaUp\DAO\GSoCEdition::create($edition);
+
+        $firstIdeaId = \OmegaUp\DAO\GSoCIdea::createIdea(
+            intval($edition->edition_id),
+            'First GSoC idea',
+            briefDescription: 'Idea one',
+            expectedResults: 'Result one',
+            preferredSkills: 'PHP',
+            possibleMentors: 'mentor-1',
+            estimatedHours: 175,
+            skillLevel: 'Medium',
+            status: 'Proposed',
+            blogLink: 'https://example.com/idea-1',
+            contributorUsername: 'alice'
+        );
+        $secondIdeaId = \OmegaUp\DAO\GSoCIdea::createIdea(
+            intval($edition->edition_id),
+            'Second GSoC idea',
+            status: 'Accepted'
+        );
+
+        $idea = \OmegaUp\DAO\GSoCIdea::getIdeaById($firstIdeaId);
+        $this->assertNotNull($idea);
+        $this->assertSame($firstIdeaId, $idea['idea_id']);
+        $this->assertSame('First GSoC idea', $idea['title']);
+        $this->assertSame('Proposed', $idea['status']);
+        $this->assertSame(intval($edition->edition_id), $idea['edition_id']);
+
+        $allIdeas = \OmegaUp\DAO\GSoCIdea::getIdeas();
+        $this->assertCount(2, $allIdeas);
+
+        $acceptedIdeas = \OmegaUp\DAO\GSoCIdea::getIdeas(
+            intval($edition->edition_id),
+            'Accepted'
+        );
+        $this->assertCount(1, $acceptedIdeas);
+        $this->assertSame($secondIdeaId, $acceptedIdeas[0]['idea_id']);
+    }
+
+    public function testUpdateIdeaAndGetByIdeaAndEdition(): void {
+        $edition = new \OmegaUp\DAO\VO\GSoCEdition([
+            'year' => 2027,
+            'is_active' => true,
+        ]);
+        \OmegaUp\DAO\GSoCEdition::create($edition);
+
+        $ideaId = \OmegaUp\DAO\GSoCIdea::createIdea(
+            intval($edition->edition_id),
+            'Original title',
+            status: 'Proposed'
+        );
+
+        $affectedRows = \OmegaUp\DAO\GSoCIdea::updateIdea(
+            $ideaId,
+            title: 'Updated title',
+            status: 'Accepted'
+        );
+        $this->assertGreaterThan(0, $affectedRows);
+
+        $idea = \OmegaUp\DAO\GSoCIdea::getIdeaById($ideaId);
+        $this->assertNotNull($idea);
+        $this->assertSame('Updated title', $idea['title']);
+        $this->assertSame('Accepted', $idea['status']);
+
+        $ideaEdition = \OmegaUp\DAO\GSoCIdeaEdition::getByIdeaAndEdition(
+            $ideaId,
+            intval($edition->edition_id)
+        );
+        $this->assertNotNull($ideaEdition);
+        $this->assertSame($ideaId, intval($ideaEdition->idea_id));
+        $this->assertSame(
+            intval($edition->edition_id),
+            intval($ideaEdition->edition_id)
+        );
+
+        $this->assertSame(
+            0,
+            \OmegaUp\DAO\GSoCIdea::updateIdea(987654321, title: 'missing')
+        );
+        $this->assertNull(
+            \OmegaUp\DAO\GSoCIdeaEdition::getByIdeaAndEdition(987654321, 1)
+        );
+    }
+}

--- a/frontend/tests/controllers/GSoCDaoTest.php
+++ b/frontend/tests/controllers/GSoCDaoTest.php
@@ -16,13 +16,32 @@ class GSoCDaoTest extends \OmegaUp\Test\ControllerTestCase {
         );
 
         $editions = \OmegaUp\DAO\GSoCEdition::getEditions();
-        $this->assertCount(2, $editions);
-        $this->assertSame(2025, $editions[0]['year']);
-        $this->assertSame(2024, $editions[1]['year']);
-
-        $edition2024 = \OmegaUp\DAO\GSoCEdition::getEditionByYear(2024);
+        $edition2024 = $this->findByPredicate(
+            $editions,
+            /**
+             * @param array{year: int} $edition
+             */
+            fn (array $edition): bool => $edition['year'] === 2024
+        );
+        $edition2025 = $this->findByPredicate(
+            $editions,
+            /**
+             * @param array{year: int} $edition
+             */
+            fn (array $edition): bool => $edition['year'] === 2025
+        );
         $this->assertNotNull($edition2024);
-        $this->assertSame(2024, $edition2024['year']);
+        $this->assertNotNull($edition2025);
+
+        $index2024 = array_search(2024, array_column($editions, 'year'));
+        $index2025 = array_search(2025, array_column($editions, 'year'));
+        $this->assertNotFalse($index2024);
+        $this->assertNotFalse($index2025);
+        $this->assertLessThan($index2024, $index2025);
+
+        $editionByYear = \OmegaUp\DAO\GSoCEdition::getEditionByYear(2024);
+        $this->assertNotNull($editionByYear);
+        $this->assertSame(2024, $editionByYear['year']);
 
         $this->assertNull(\OmegaUp\DAO\GSoCEdition::getEditionByYear(2030));
     }
@@ -61,7 +80,20 @@ class GSoCDaoTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame(intval($edition->edition_id), $idea['edition_id']);
 
         $allIdeas = \OmegaUp\DAO\GSoCIdea::getIdeas();
-        $this->assertCount(2, $allIdeas);
+        $this->assertArrayContainsWithPredicate(
+            $allIdeas,
+            /**
+             * @param array{idea_id: int} $ideaSummary
+             */
+            fn (array $ideaSummary): bool => $ideaSummary['idea_id'] === $firstIdeaId
+        );
+        $this->assertArrayContainsWithPredicate(
+            $allIdeas,
+            /**
+             * @param array{idea_id: int} $ideaSummary
+             */
+            fn (array $ideaSummary): bool => $ideaSummary['idea_id'] === $secondIdeaId
+        );
 
         $acceptedIdeas = \OmegaUp\DAO\GSoCIdea::getIdeas(
             intval($edition->edition_id),
@@ -69,6 +101,7 @@ class GSoCDaoTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $this->assertCount(1, $acceptedIdeas);
         $this->assertSame($secondIdeaId, $acceptedIdeas[0]['idea_id']);
+        $this->assertSame('Accepted', $acceptedIdeas[0]['status']);
     }
 
     public function testUpdateIdeaAndGetByIdeaAndEdition(): void {


### PR DESCRIPTION
# Description

add GSOC dao tests: /Users/linl/Downloads/omegaup/frontend/tests/controllers/GSoCDaoTest.php
it tests the following:
1. testGetEditionsAndGetEditionByYear
- Creates sample editions
- Verifies getEditions() includes them and sorts by year descending
- Verifies getEditionByYear() returns the right edition
- Verifies unknown year returns null
2. testCreateGetAndFilterIdeas
- Creates one edition and two ideas with different statuses
- Verifies getIdeaById() returns correct mapped fields
- Verifies getIdeas() includes both created ideas
- Verifies getIdeas($editionId, 'Accepted') filters correctly
3. testUpdateIdeaAndGetByIdeaAndEdition
- Updates an existing idea (title + status)
- Verifies changes persist via getIdeaById()
- Verifies relation lookup via getByIdeaAndEdition()
- Verifies edge cases:
updating missing idea returns 0
missing relation returns null

Fixes: #9008 

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
