### PR TITLE
Fix: Add bottom margin to course progress text to prevent card overlap

### DIFF
--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -213,7 +213,7 @@
           </div>
         </div>
         <div
-          class="w-50 mx-auto d-flex justify-content-between text-center progress-text"
+          class="w-50 mx-auto d-flex justify-content-between text-center progress-text mb-4"
         >
           <p class="my-0 text-uppercase">
             {{ T.courseDetailsProgress }}


### PR DESCRIPTION

This PR resolves a UI layout problem where the Course Progress text and score were partially obscured and overlapped on top of assignment cards beneath them.

Changes Made
I added the Bootstrap spacing utility class mb-4 on the .progress-text container in frontend/www/js/omegaup/components/course/Details.vue which gives the required margin at the bottom to push the assignment cards down thus preventing any visual overlap.

Fixes #9550

