### PR TITLE
Fixes #8944

### DIFF
--- a/frontend/www/help.php
+++ b/frontend/www/help.php
@@ -1,0 +1,3 @@
+<?php
+header("Location: /docs/");
+exit;


### PR DESCRIPTION
Fixes #8944

## Issue
The /help route currently returns a generic 404 page, which is not helpful for users looking for support or documentation.

## Fix
Added a help.php handler that redirects users to the documentation page (/docs/).

## Result
Users visiting /help are now redirected to a relevant resource instead of seeing a 404 error.

## Checklist:
- [x] The code follows the coding guidelines of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.