### PR TITLE
UX: Redirect to #ranking in scoreboard links for finished contests #9597

### DIFF
--- a/frontend/www/js/omegaup/components/contest/Links.vue
+++ b/frontend/www/js/omegaup/components/contest/Links.vue
@@ -19,12 +19,16 @@
         }}</a>
         <a
           class="list-group-item"
-          :href="`/arena/${contest.alias}/scoreboard/${contest.scoreboard_url}`"
+          :href="`/arena/${contest.alias}/scoreboard/${contest.scoreboard_url}${
+            isContestFinished ? '#ranking' : ''
+          }`"
           >{{ T.contestScoreboardLink }}</a
         >
         <a
           class="list-group-item"
-          :href="`/arena/${contest.alias}/scoreboard/${contest.scoreboard_url_admin}`"
+          :href="`/arena/${contest.alias}/scoreboard/${
+            contest.scoreboard_url_admin
+          }${isContestFinished ? '#ranking' : ''}`"
           >{{ T.contestScoreboardAdminLink }}</a
         >
         <a
@@ -49,6 +53,10 @@ export default class Links extends Vue {
 
   T = T;
   contest = this.data;
+
+  get isContestFinished(): boolean {
+    return this.contest.finish_time < new Date();
+  }
 
   @Emit('download-csv-scoreboard')
   onDownloadCsv(contestAlias: string): string {


### PR DESCRIPTION

# Description

Redirect users directly to the scoreboard ranking for finished contests by appending `#ranking` to the URL in `Links.vue`.

Currently, visiting a finished contest's scoreboard without having participated forces the user through an unnecessary "Start Contest" (Iniciar concurso) screen. This change improves UX by landing the user directly on the standings.

Changes:

- Added isContestFinished computed property.
- Conditionally appended #ranking to scoreboard links in Links.vue.

Fixes: #9597


# Checklist:

- [ x ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ x ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
