### PR TITLE
Bootstrap 5 migration: replace form-group with mb-3 in login component

### DIFF
--- a/frontend/www/js/omegaup/components/login/Login.vue
+++ b/frontend/www/js/omegaup/components/login/Login.vue
@@ -50,7 +50,7 @@
         <div class="col-md-4 col-md-offset-2 introjs-native">
           <h4>{{ T.loginNative }}</h4>
           <form class="form-horizontal">
-            <div class="form-group">
+            <div class="mb-3">
               <label for="user">{{ T.loginEmailUsername }}</label>
               <input
                 v-model="usernameOrEmail"
@@ -63,7 +63,7 @@
               />
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <label for="pass"
                 >{{ T.loginPassword }} (<a
                   href="/login/password/recover/"
@@ -80,7 +80,7 @@
               />
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <button
                 data-login-submit
                 class="btn btn-primary form-control"


### PR DESCRIPTION
Fixes: #9599

# Description

Replaced deprecated Bootstrap 4 class `form-group` with Bootstrap 5 spacing utility `mb-3` in the login component.

This change updates the UI to be compatible with Bootstrap 5 while maintaining the existing layout and spacing.

No functional changes were introduced.

# Comments

This is a small, isolated change as part of the Bootstrap 4 to 5 migration effort. Only the login component was updated to keep the PR minimal and easy to review.

# Checklist:

- [x] The code follows the coding guidelines of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.