### PR TITLE
fix: scope navbar css styles to avoid conflicting .progress class sty…

### DIFF
--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -549,7 +549,7 @@ export default class Navbar extends Vue {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '../../../../sass/main.scss';
 
 .mentor-can-choose-coder {


### PR DESCRIPTION
# Description

the styling of the `frontend/www/js/omegaup/components/course/Details.vue` component has a div with `progress` class. This same `progress` class is defined in the NavBar component with some css styles and the The css for the navbar was not scoped which resulted in conflicting styles being applied in wrong places.   

Before scoping the NavBar component styles:
<img width="1009" height="136" alt="image" src="https://github.com/user-attachments/assets/a8055976-10f0-4649-ad2a-a3093f62142c" />

After adding scoped:
<img width="568" height="131" alt="image" src="https://github.com/user-attachments/assets/5769cfd0-f2b6-4034-8e7e-10449775208c" />



Fixes: #9601 

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
