### PR TITLE
fix: use correct route for pagination buttons

### DIFF
--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -6344,7 +6344,7 @@ class Course extends \OmegaUp\Controllers\Controller {
                         $list['totalRows'],
                         $pageSize,
                         $page,
-                        "/course/{$course->alias}/clarifications/",
+                        "/course/{$course->alias}/clarification/",
                         adjacent: 2,
                         params: [],
                     ),


### PR DESCRIPTION
# Description

Fix route `/course/{$course->alias}/clarifications/` to `/course/{$course->alias}/clarification/` 

Fixes: #9603 

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
