### PR TITLE
Fix course progress text alignment in course details page

### DIFF
--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -199,7 +199,7 @@
       </div>
     </div>
     <template v-else>
-      <div class="mt-4 mb-1">
+      <div class="mt-4 mb-3 course-progress-container">
         <div class="progress w-50 mx-auto">
           <div
             class="progress-bar text-dark"
@@ -213,7 +213,7 @@
           </div>
         </div>
         <div
-          class="w-50 mx-auto d-flex justify-content-between text-center progress-text"
+          class="w-50 mx-auto d-flex justify-content-between align-items-center progress-text"
         >
           <p class="my-0 text-uppercase">
             {{ T.courseDetailsProgress }}
@@ -426,8 +426,20 @@ export default class CourseDetails extends Vue {
 <style lang="scss" scoped>
 @import '../../../../sass/main.scss';
 
+.course-progress-container{
+  .prgress{
+     min-height: 1.5rem;
+}
+
 .progress-text {
   font-size: 0.85rem;
+  margin-top: 0.5rem;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.progress-text p{
+   margin-bottom: 0;
 }
 
 .progress-bar {

--- a/frontend/www/js/omegaup/components/course/Details.vue
+++ b/frontend/www/js/omegaup/components/course/Details.vue
@@ -427,7 +427,7 @@ export default class CourseDetails extends Vue {
 @import '../../../../sass/main.scss';
 
 .course-progress-container{
-  .prgress{
+  .progress{
      min-height: 1.5rem;
 }
 


### PR DESCRIPTION
## Description

This PR fixes the layout of the course progress section in the student course details view.

The progress label and completed points text could appear misaligned and overlap surrounding content on the course page. This update keeps the progress section in the normal page flow and improves spacing/alignment so it renders more consistently.

## Changes made

- Added a wrapper class for the course progress section
- Added spacing below the progress bar
- Added flex wrapping for the progress text
- Improved alignment of the progress label and completed points text

## Issue

Fixes #8869

## Comments

This is a small UI-only fix focused on improving layout stability for the course progress section.