### PR TITLE
fix: send regular Discord messages instead of threads, fix label case sensitivity

### DIFF
--- a/.github/workflows/discord-issue-notification.yml
+++ b/.github/workflows/discord-issue-notification.yml
@@ -32,7 +32,7 @@ jobs:
             for label in "${ALLOWED_LABELS[@]}"; do
               if [ "$(echo "$CURRENT_LABEL" | tr '[:upper:]' '[:lower:]')" == "$(echo "$label" | tr '[:upper:]' '[:lower:]')" ]; then
                 echo "should_notify=true" >> $GITHUB_OUTPUT
-                echo "matched_label=$CURRENT_LABEL" >> $GITHUB_OUTPUT
+                echo "matched_label=$label" >> $GITHUB_OUTPUT
                 exit 0
               fi
             done


### PR DESCRIPTION
## Description

Follow-up to #8574. The merged workflow had two issues discovered post-merge:

1. **Thread creation fails on regular channels** — Discord only allows thread creation in Forum-type channels. The `dev-training` channel is a regular channel and changing its type is not possible. This PR removes thread creation so notifications are sent as standard rich embed messages, which work in any channel.

2. **Case sensitivity bug** — The label filter only matched `"good first issue"` (lowercase) but not `"Good first issue"` (capitalized), causing some issues to be silently skipped. The comparison is now case-insensitive.

## Key changes

- Removed `thread_name` from the Discord webhook payload
- Removed `?wait=true` query parameter from the webhook URL (only needed for thread creation)
- Made `"good first issue"` label matching case-insensitive in the bash label check step
- Renamed workflow from `Discord Issue Thread Notification` to `Discord Issue Notification`

## Test plan

- [ ] Verify a new issue labeled `"good first issue"` triggers a Discord message (not a thread)
- [ ] Verify a new issue labeled `"Good first issue"` (capital G) also triggers a notification
- [ ] Verify a new issue labeled `"GSoC"` triggers a Discord message
- [ ] Confirm no errors in the Actions run log

Fixes the runtime error reported in #8574 (comment).