### PR TITLE
fix: ensure exactly one Discord notification per issue regardless of label count

### DIFF
--- a/.github/workflows/discord-issue-notification.yml
+++ b/.github/workflows/discord-issue-notification.yml
@@ -2,7 +2,7 @@ name: Discord Issue Notification
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
 
 jobs:
   notify-discord:
@@ -13,15 +13,47 @@ jobs:
         id: check-label
         run: |
           ALLOWED_LABELS=("GSoC" "good first issue")
-          CURRENT_LABEL="${{ github.event.label.name }}"
 
-          for label in "${ALLOWED_LABELS[@]}"; do
-            if [ "$(echo "$CURRENT_LABEL" | tr '[:upper:]' '[:lower:]')" == "$(echo "$label" | tr '[:upper:]' '[:lower:]')" ]; then
-              echo "should_notify=true" >> $GITHUB_OUTPUT
-              echo "matched_label=$label" >> $GITHUB_OUTPUT
+          # For 'opened' events: scan all labels, notify for the first qualifying one.
+          # This ensures exactly one notification even if the issue has multiple
+          # qualifying labels applied at creation time.
+          if [ "${{ github.event.action }}" == "opened" ]; then
+            ISSUE_LABELS='${{ toJSON(github.event.issue.labels.*.name) }}'
+            for label in "${ALLOWED_LABELS[@]}"; do
+              if echo "$ISSUE_LABELS" | grep -iq "\"$label\""; then
+                echo "should_notify=true" >> $GITHUB_OUTPUT
+                echo "matched_label=$label" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            done
+            echo "should_notify=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # For 'labeled' events: only notify if the issue is older than 60 seconds.
+          # Labels applied at issue creation also fire 'labeled' events, which are
+          # already handled by the 'opened' branch above. The age check suppresses
+          # those duplicates while still catching labels added to existing issues.
+          if [ "${{ github.event.action }}" == "labeled" ]; then
+            CREATED_AT="${{ github.event.issue.created_at }}"
+            CREATED_TS=$(date -d "$CREATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s)
+            NOW_TS=$(date +%s)
+            AGE=$((NOW_TS - CREATED_TS))
+
+            if [ "$AGE" -lt 60 ]; then
+              echo "should_notify=false" >> $GITHUB_OUTPUT
               exit 0
             fi
-          done
+
+            CURRENT_LABEL="${{ github.event.label.name }}"
+            for label in "${ALLOWED_LABELS[@]}"; do
+              if [ "$(echo "$CURRENT_LABEL" | tr '[:upper:]' '[:lower:]')" == "$(echo "$label" | tr '[:upper:]' '[:lower:]')" ]; then
+                echo "should_notify=true" >> $GITHUB_OUTPUT
+                echo "matched_label=$label" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            done
+          fi
 
           echo "should_notify=false" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

Follow-up to #9624. As reported by @pabo99, the workflow sent 3 messages when an issue was opened with both qualifying labels.

**Root cause:** GitHub fires both an `opened` event and a `labeled` event for each label applied at issue creation. An issue opened with 2 qualifying labels triggered 3 workflow runs.

After #9627 (removing `opened`), this was reduced to 2 messages — but still not exactly 1, since `labeled` fires once per qualifying label.

**Fix — two-trigger strategy with a 60-second age check:**

- **`opened` event:** Scans all labels on the issue and sends **exactly one** notification for the first qualifying label found. Handles issues created with multiple qualifying labels in a single shot.
- **`labeled` event:** Only fires if the issue is **older than 60 seconds**. GitHub fires `labeled` events even for labels applied at creation — the age check suppresses those (already handled by `opened`), while still notifying when a label is added to an existing issue.

## Scenarios

| Scenario | Result |
|---|---|
| Issue opened with GSoC + good first issue | `opened` sends 1, both `labeled` events skipped (< 60s) → **1 notification** |
| Issue opened with only GSoC | `opened` sends 1, `labeled` skipped (< 60s) → **1 notification** |
| Issue opened without labels, GSoC added later | `opened` skipped (no labels), `labeled` sends 1 (> 60s) → **1 notification** |
| Label added to existing issue | `labeled` sends 1 → **1 notification** |

## Test plan

- [ ] Open an issue with both `GSoC` and `good first issue` labels — should send exactly **1** Discord message
- [ ] Open an issue with only `GSoC` — should send exactly **1** message
- [ ] Add a qualifying label to an existing issue — should send exactly **1** message
- [ ] Confirm no errors in the Actions run log

Fixes duplicate notifications reported in #9624 (comment).