### PR TITLE
Optimizando limpieza de Auth_Tokens para reducir lock contention

### DIFF
--- a/frontend/database/00266_auth_tokens_create_time_index.sql
+++ b/frontend/database/00266_auth_tokens_create_time_index.sql
@@ -1,0 +1,8 @@
+-- Add composite index on (identity_id, create_time) to optimize token cleanup
+-- This helps with:
+-- 1. Fast deletion of old tokens by identity
+-- 2. Fast ordering by create_time when keeping only recent tokens
+-- 3. Cron job that deletes tokens older than N days
+
+ALTER TABLE `Auth_Tokens`
+  ADD KEY `idx_identity_create_time` (`identity_id`, `create_time`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -105,6 +105,7 @@ CREATE TABLE `Auth_Tokens` (
   PRIMARY KEY (`token`),
   KEY `identity_id` (`identity_id`),
   KEY `fk_ati_acting_identity_id` (`acting_identity_id`),
+  KEY `idx_identity_create_time` (`identity_id`,`create_time`),
   CONSTRAINT `fk_ati_acting_identity_id` FOREIGN KEY (`acting_identity_id`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_ati_identity_id` FOREIGN KEY (`identity_id`) REFERENCES `Identities` (`identity_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Tokens de autorización para los logins.';

--- a/frontend/server/src/Controllers/Session.php
+++ b/frontend/server/src/Controllers/Session.php
@@ -459,13 +459,14 @@ class Session extends \OmegaUp\Controllers\Controller {
 
         self::invalidateLocalCache();
 
-        //erase expired tokens
+        //erase expired tokens (only old ones to reduce lock contention)
+        // During massive login events, this cleanup is lightweight and won't block
         try {
             \OmegaUp\DAO\AuthTokens::expireAuthTokens(
                 intval($identity->identity_id)
             );
         } catch (\Exception $e) {
-            // Best effort
+            // Best effort - don't fail login if cleanup fails
             self::$log->error(
                 'Failed to delete expired tokens',
                 ['exception' => $e],
@@ -481,7 +482,9 @@ class Session extends \OmegaUp\Controllers\Controller {
         );
         $token = "{$entropy}-{$identity->identity_id}-{$hash}";
 
-        \OmegaUp\DAO\AuthTokens::replace(new \OmegaUp\DAO\VO\AuthTokens([
+        // Use create() instead of replace() since tokens are always unique
+        // This avoids the implicit DELETE in REPLACE, reducing lock contention
+        \OmegaUp\DAO\AuthTokens::create(new \OmegaUp\DAO\VO\AuthTokens([
             'user_id' => $identity->user_id,
             'identity_id' => $identity->identity_id,
             'token' => $token,

--- a/frontend/server/src/DAO/AuthTokens.php
+++ b/frontend/server/src/DAO/AuthTokens.php
@@ -114,10 +114,14 @@ class AuthTokens extends \OmegaUp\DAO\Base\AuthTokens {
     }
 
     public static function expireAuthTokens(int $identityId): int {
+        // Delete only old tokens (> 7 days) to reduce lock contention during
+        // massive logins
         $sql = 'DELETE FROM
                     `Auth_Tokens`
                 WHERE
-                    identity_id = ?;';
+                    identity_id = ?
+                    AND create_time < DATE_SUB(NOW(), INTERVAL 7 DAY)
+                LIMIT 100;';
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, [$identityId]);
 
         return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();


### PR DESCRIPTION
# Description

Se optimizan los lugares donde se eliminan y/o remplazan los `AuthTokens` de un usuario.
 
- Ahora sólo se borran tokens mayores a 7 días para reducir duración de locks, se usa el nuevo índice
- Se agrega `LIMIT 100` para prevenir bloqueos largos
- Se agregar el índice compuesto (`identity_id`, `create_time`) para range scans rápidos
- Se deja de usar  `REPLACE` debido a que este realiza dos acciones (`DELETE` y `CREATE`) cuando no tiene sentido porque los token que se generan deben ser únicos


# Comments

Este PR se puede revisar una vez que se apruebe el #9629 debido a los consecutivos de los scripts

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
