### PR TITLE
Hide empty sections in arenav2 summary view

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestList.test.ts
+++ b/frontend/www/js/omegaup/components/arena/ContestList.test.ts
@@ -230,6 +230,43 @@ describe('ContestList.vue', () => {
     expect(pastContestTab.text()).toContain('Past Contest 1');
   });
 
+  it('Should hide empty summary sections in ArenaV2 view', async () => {
+    const contestsWithOnlyPast: types.ContestList = {
+      current: [],
+      future: [],
+      past: contests.past,
+    };
+    const wrapper = mount(arena_ContestList, {
+      propsData: {
+        contests: contestsWithOnlyPast,
+        tab: ContestTab.Current,
+      },
+    });
+
+    const sections = wrapper.findAll('.section-container');
+    expect(sections.length).toBe(1);
+    expect(wrapper.text()).toContain('Past Contest 1');
+    expect(wrapper.text()).not.toContain('Current Contest 1');
+    expect(wrapper.text()).not.toContain('Future Contest 1');
+  });
+
+  it('Should show empty message when all summary sections are empty', async () => {
+    const emptyContests: types.ContestList = {
+      current: [],
+      future: [],
+      past: [],
+    };
+    const wrapper = mount(arena_ContestList, {
+      propsData: {
+        contests: emptyContests,
+        tab: ContestTab.Current,
+      },
+    });
+
+    expect(wrapper.findAll('.section-container').length).toBe(0);
+    expect(wrapper.text()).toContain(T.contestListEmpty);
+  });
+
   it('Should not render Virtual/Practice in Current contests', () => {
     const wrapper = mount(arena_ContestList, {
       propsData: {

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -159,15 +159,14 @@
 
     <!-- Summary View (Horizontal Scrolling) -->
     <div v-if="!viewAllCategory">
+      <div v-if="visibleContestTabs.length === 0" class="empty-category">
+        {{ T.contestListEmpty }}
+      </div>
       <div
-        v-for="(tab, index) in [
-          ContestTab.Current,
-          ContestTab.Future,
-          ContestTab.Past,
-        ]"
+        v-for="(tab, index) in visibleContestTabs"
         :key="tab"
         class="mb-5 section-container"
-        :class="{ 'section-separator': index < 2 }"
+        :class="{ 'section-separator': index < visibleContestTabs.length - 1 }"
       >
         <div
           class="d-flex justify-content-between align-items-center mb-3 px-3"
@@ -197,13 +196,7 @@
             class="horizontal-scroll-container px-3 pb-3"
             @scroll="onScroll(tab)"
           >
-            <div
-              v-if="getContestsForTab(tab).length === 0"
-              class="text-muted font-italic ml-3"
-            >
-              {{ T.contestListEmpty }}
-            </div>
-            <div v-else class="d-flex">
+            <div class="d-flex">
               <div
                 v-for="contestItem in getContestsForTab(tab).slice(0, 10)"
                 :key="contestItem.contest_id"
@@ -617,6 +610,12 @@ class ArenaContestList extends Vue {
       default:
         return [];
     }
+  }
+
+  get visibleContestTabs(): ContestTab[] {
+    return [ContestTab.Current, ContestTab.Future, ContestTab.Past].filter(
+      (tab) => this.getContestsForTab(tab).length > 0,
+    );
   }
 
   onSearchQuery() {


### PR DESCRIPTION
Hides empty contest sections (Current, Future, Past) in `/arenav2/` to reduce visual clutter and improve user experience. Sections are only rendered when they contain contests.

Fixes: #9626

<img width="1920" height="1080" alt="Screenshot from 2026-03-25 22-17-23" src="https://github.com/user-attachments/assets/f30aee0f-c91e-4f49-9b1e-ac02d11b19c8" />
