### PR TITLE
fix: browser back button now updates tab on coderofthemonth pages (#9…

### DIFF
--- a/frontend/www/js/omegaup/coderofthemonth/index.ts
+++ b/frontend/www/js/omegaup/coderofthemonth/index.ts
@@ -9,9 +9,9 @@ import coderofthemonth_List from '../components/coderofthemonth/List.vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CoderOfTheMonthPayload();
   const locationHash = window.location.hash.substring(1).split('/')[0];
-  const selectedTab = getSelectedValidTab(locationHash);
-  if (selectedTab !== locationHash) {
-    history.replaceState(null, '', `#${selectedTab}`);
+  const initialTab = getSelectedValidTab(locationHash);
+  if (initialTab !== locationHash) {
+    history.replaceState(null, '', `#${initialTab}`);
   }
   const coderOfTheMonthList = new Vue({
     el: '#main-container',
@@ -20,22 +20,32 @@ OmegaUp.on('ready', () => {
     },
     data: () => ({
       coderIsSelected:
-        payload.isMentor && payload.options && payload.options.coderIsSelected,
+        payload.isMentor &&
+        payload.options &&
+        payload.options.coderIsSelected,
+      selectedTab: getSelectedValidTab(
+        window.location.hash.substring(1).split('/')[0]
+      ),
     }),
     render: function (createElement) {
       return createElement('omegaup-coder-of-the-month-list', {
         props: {
           codersOfCurrentMonth: payload.codersOfCurrentMonth,
           codersOfPreviousMonth: payload.codersOfPreviousMonth,
-          candidatesToCoderOfTheMonth: payload.candidatesToCoderOfTheMonth,
+          candidatesToCoderOfTheMonth:
+            payload.candidatesToCoderOfTheMonth,
           isMentor: payload.isMentor,
-          selectedTab,
-          canChooseCoder: payload.isMentor && payload.options?.canChooseCoder,
+          selectedTab: this.selectedTab,
+          canChooseCoder:
+            payload.isMentor && payload.options?.canChooseCoder,
           coderIsSelected: this.coderIsSelected,
           category: payload.category,
         },
         on: {
-          'select-coder': (coderUsername: string, category: string) => {
+          'select-coder': (
+            coderUsername: string,
+            category: string,
+          ) => {
             api.User.selectCoderOfTheMonth({
               username: coderUsername,
               category: category,
@@ -54,6 +64,16 @@ OmegaUp.on('ready', () => {
       });
     },
   });
+
+  // Handle browser back/forward button navigation
+  // Same pattern used in frontend/www/js/omegaup/user/profile.ts
+  const onHashChange = () => {
+    const hash = window.location.hash.substring(1).split('/')[0];
+    const validTab = getSelectedValidTab(hash);
+    coderOfTheMonthList.selectedTab = validTab;
+  };
+
+  window.addEventListener('hashchange', onHashChange);
 
   function getSelectedValidTab(tab: string): string {
     const validTabs = [

--- a/frontend/www/js/omegaup/coderofthemonth/index.ts
+++ b/frontend/www/js/omegaup/coderofthemonth/index.ts
@@ -9,9 +9,9 @@ import coderofthemonth_List from '../components/coderofthemonth/List.vue';
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.CoderOfTheMonthPayload();
   const locationHash = window.location.hash.substring(1).split('/')[0];
-  const selectedTab = getSelectedValidTab(locationHash);
-  if (selectedTab !== locationHash) {
-    history.replaceState(null, '', `#${selectedTab}`);
+  const initialTab = getSelectedValidTab(locationHash);
+  if (initialTab !== locationHash) {
+    history.replaceState(null, '', `#${initialTab}`);
   }
   const coderOfTheMonthList = new Vue({
     el: '#main-container',
@@ -20,22 +20,32 @@ OmegaUp.on('ready', () => {
     },
     data: () => ({
       coderIsSelected:
-        payload.isMentor && payload.options && payload.options.coderIsSelected,
+        payload.isMentor &&
+        payload.options &&
+        payload.options.coderIsSelected,
+      selectedTab: getSelectedValidTab(
+        window.location.hash.substring(1).split('/')[0]
+      ),
     }),
     render: function (createElement) {
       return createElement('omegaup-coder-of-the-month-list', {
         props: {
           codersOfCurrentMonth: payload.codersOfCurrentMonth,
           codersOfPreviousMonth: payload.codersOfPreviousMonth,
-          candidatesToCoderOfTheMonth: payload.candidatesToCoderOfTheMonth,
+          candidatesToCoderOfTheMonth:
+            payload.candidatesToCoderOfTheMonth,
           isMentor: payload.isMentor,
-          selectedTab,
-          canChooseCoder: payload.isMentor && payload.options?.canChooseCoder,
+          selectedTab: this.selectedTab,
+          canChooseCoder:
+            payload.isMentor && payload.options?.canChooseCoder,
           coderIsSelected: this.coderIsSelected,
           category: payload.category,
         },
         on: {
-          'select-coder': (coderUsername: string, category: string) => {
+          'select-coder': (
+            coderUsername: string,
+            category: string,
+          ) => {
             api.User.selectCoderOfTheMonth({
               username: coderUsername,
               category: category,
@@ -53,6 +63,21 @@ OmegaUp.on('ready', () => {
         },
       });
     },
+  });
+
+  // Handle browser back/forward button navigation
+  // Same pattern used in frontend/www/js/omegaup/user/profile.ts
+  const onHashChange = () => {
+    const hash = window.location.hash.substring(1).split('/')[0];
+    const validTab = getSelectedValidTab(hash);
+    coderOfTheMonthList.selectedTab = validTab;
+  };
+
+  window.addEventListener('hashchange', onHashChange);
+
+  // Clean up event listener on Vue instance destruction to prevent memory leaks
+  coderOfTheMonthList.$on('hook:destroyed', () => {
+    window.removeEventListener('hashchange', onHashChange);
   });
 
   function getSelectedValidTab(tab: string): string {

--- a/frontend/www/js/omegaup/components/coderofthemonth/List.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/List.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import T from '../../lang';
 import user_Username from '../user/Username.vue';
 import coderofthemonth_CodersList from './CodersList.vue';
@@ -76,6 +76,11 @@ export default class CoderOfTheMonthList extends Vue {
 
   T = T;
   currentSelectedTab = this.selectedTab;
+
+  @Watch('selectedTab')
+  onSelectedTabChanged(newTab: string): void {
+    this.currentSelectedTab = newTab;
+  }
 
   get availableTabs(): { id: string; component: string; title: string }[] {
     const availableTabs = [


### PR DESCRIPTION
# Description

Fix browser back/forward button not updating the displayed tab content on 
`/coderofthemonth/` and `/coderofthemonth/?category=female` pages.

Fixes: https://github.com/omegaup/omegaup/issues/9677

## Problem

When users press the browser Back button after viewing different tabs, the URL 
hash updates correctly but the displayed tab content remains stuck on the 
previously viewed tab.

Example:
- Click "Candidates" tab → URL: #candidatesToCoderOfTheMonth, Content: Candidates
- Click "Top 100" tab → URL: #codersOfPreviousMonth, Content: Top 100
- Press Back → URL: #candidatesToCoderOfTheMonth, Content: **still shows Top 100**

## Root Cause

No `hashchange` event listener existed in `index.ts`. When the browser Back button 
is pressed, `window.location.hash` updates automatically but the Vue component's 
`currentSelectedTab` is never notified of the change.

## Solution

Applied the proven reactive synchronization pattern from `user/profile.ts` 
(PR #9396, which fixed identical issue #9392):

1. **index.ts** - Moved `selectedTab` into reactive `data()` so Vue can propagate 
   changes to child component
2. **index.ts** - Added `hashchange` event listener that updates `selectedTab` 
   when browser Back/Forward is pressed
3. **List.vue** - Added `@Watch('selectedTab')` decorator to sync `currentSelectedTab` 
   when the prop changes from parent

## Demonstration

### Before Fix
Browser back button changes URL but content stays on previous tab (not working):


https://github.com/user-attachments/assets/0d34fa82-2aca-4087-abce-966daa9c957b

### After Fix
Browser back button updates both URL and tab content correctly:



https://github.com/user-attachments/assets/86c4c9d1-b485-452e-9744-112f5a1d0f82



## Changes

- `frontend/www/js/omegaup/coderofthemonth/index.ts` (34 insertions, 9 deletions)
- `frontend/www/js/omegaup/components/coderofthemonth/List.vue` (5 insertions)

Both `/coderofthemonth/` and `/coderofthemonth/?category=female` are fixed with 
this single change since both use the same component.

## Verification

- ESLint: No errors
- Build: yarn build passed (47s + 5s)
- Tests: 729/729 tests passed
- Back button now correctly updates both URL and tab content

Fixes: #9677

# Comments

Reference: Identical fix pattern used in `user/profile.ts` line 562 
(`window.addEventListener('hashchange', ...)`) which resolved issue #9392 
via PR #9396.

# Checklist:

- [x] The code follows the coding guidelines of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] The change is small and focused — single PR sufficient.
- [x] No breaking changes to existing functionality.
- [x] Backward compatible with all existing code.