### PR TITLE
Feat/9679 arena v2 contest single request and debouncing

### DIFF
--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -207,6 +207,127 @@ class Contest extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * Returns paginated contest lists for current, past, and future in one API call.
+     *
+     * @return array{current: array{number_of_results: int, results: list<ContestListItem>}, future: array{number_of_results: int, results: list<ContestListItem>}, past: array{number_of_results: int, results: list<ContestListItem>}}
+     *
+     * @omegaup-request-param 'private'|'public'|'registration'|null $admission_mode
+     * @omegaup-request-param 'all'|'recommended'|'signedup'|null $filter
+     * @omegaup-request-param int $page
+     * @omegaup-request-param int $page_size
+     * @omegaup-request-param int|null $participating
+     * @omegaup-request-param string $query
+     * @omegaup-request-param int|null $recommended
+     * @omegaup-request-param null|string $sort_order
+     */
+    public static function apiListAllTabs(\OmegaUp\Request $r): array {
+        try {
+            $r->ensureIdentity();
+        } catch (\OmegaUp\Exceptions\UnauthorizedException $e) {
+            // Do nothing.
+            /** @var null $r->identity */
+        }
+
+        $recommended = $r->ensureOptionalInt(
+            'recommended'
+        ) ?? \OmegaUp\DAO\Enum\RecommendedStatus::ALL;
+        $participating = $r->ensureOptionalInt(
+            'participating'
+        ) ?? \OmegaUp\DAO\Enum\ParticipatingStatus::NO;
+        $filter = $r->ensureOptionalEnum(
+            'filter',
+            \OmegaUp\DAO\Enum\ContestFilterStatus::NAME_FOR_STATUS
+        );
+        $activeFilter = \OmegaUp\DAO\Enum\ContestFilterStatus::convertToInt(
+            fieldName: 'filter',
+            field: $filter,
+            defaultValue: \OmegaUp\DAO\Enum\ContestFilterStatus::ALL
+        );
+        if ($activeFilter === \OmegaUp\DAO\Enum\ContestFilterStatus::ONLY_RECOMMENDED) {
+            $recommended = \OmegaUp\DAO\Enum\RecommendedStatus::RECOMMENDED;
+        } elseif ($activeFilter === \OmegaUp\DAO\Enum\ContestFilterStatus::SIGNED_UP) {
+            $participating = \OmegaUp\DAO\Enum\ParticipatingStatus::YES;
+        }
+        $page = $r->ensureOptionalInt('page') ?? 1;
+        $pageSize = $r->ensureOptionalInt(
+            key: 'page_size',
+            lowerBound: 1,
+            upperBound: 100
+        ) ?? \OmegaUp\Controllers\Contest::CONTEST_LIST_PAGE_SIZE;
+        $recommended = \OmegaUp\DAO\Enum\RecommendedStatus::getIntValue(
+            $recommended
+        ) ?? \OmegaUp\DAO\Enum\RecommendedStatus::ALL;
+        $participating = \OmegaUp\DAO\Enum\ParticipatingStatus::getIntValue(
+            $participating
+        );
+        $admissionMode = $r->ensureOptionalEnum(
+            'admission_mode',
+            \OmegaUp\CourseParams::VALID_ADMISSION_MODES
+        );
+        $public = (!is_null($admissionMode) && self::isPublic($admissionMode));
+
+        if (is_null($participating)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'participating'
+            );
+        }
+        $query = $r->ensureOptionalString(
+            key: 'query',
+            required: false,
+            validator: fn(string $query) => \OmegaUp\Validators::stringOfLengthInRange(
+                $query,
+                0,
+                250
+            )
+        );
+        $order = $r->ensureOptionalEnum(
+            'sort_order',
+            \OmegaUp\DAO\Enum\ContestOrderStatus::NAME_FOR_STATUS,
+            required: false
+        );
+        $orderBy = \OmegaUp\DAO\Enum\ContestOrderStatus::convertToInt(
+            fieldName: 'order',
+            field: $order,
+            defaultValue: \OmegaUp\DAO\Enum\ContestOrderStatus::NONE
+        );
+
+        /** @var array{current: array{number_of_results: int, results: list<ContestListItem>}, future: array{number_of_results: int, results: list<ContestListItem>}, past: array{number_of_results: int, results: list<ContestListItem>}} */
+        $result = [
+            'current' => ['number_of_results' => 0, 'results' => []],
+            'past' => ['number_of_results' => 0, 'results' => []],
+            'future' => ['number_of_results' => 0, 'results' => []],
+        ];
+        $tabStatuses = [
+            'current' => \OmegaUp\DAO\Enum\ContestTabStatus::CURRENT,
+            'past' => \OmegaUp\DAO\Enum\ContestTabStatus::PAST,
+            'future' => \OmegaUp\DAO\Enum\ContestTabStatus::FUTURE,
+        ];
+        foreach ($tabStatuses as $tabKey => $activeContests) {
+            [
+                'contests' => $contests,
+                'count' => $count,
+            ] = self::getContestList(
+                $r->identity,
+                $query,
+                $page,
+                $pageSize,
+                $activeContests,
+                $recommended,
+                $public,
+                $participating,
+                $orderBy
+            );
+            $result[$tabKey] = [
+                'number_of_results' => $count,
+                'results' => $contests,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
      * @return array{contests: list<ContestListItem>, count: int}
      */
     public static function getContestList(

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -52,6 +52,7 @@
   - [`/api/contest/details/`](#apicontestdetails)
   - [`/api/contest/getNumberOfContestants/`](#apicontestgetnumberofcontestants)
   - [`/api/contest/list/`](#apicontestlist)
+  - [`/api/contest/listAllTabs/`](#apicontestlistalltabs)
   - [`/api/contest/listParticipating/`](#apicontestlistparticipating)
   - [`/api/contest/myList/`](#apicontestmylist)
   - [`/api/contest/open/`](#apicontestopen)
@@ -1199,6 +1200,33 @@ Returns a list of contests
 | ------------------- | ----------------------------- |
 | `number_of_results` | `number`                      |
 | `results`           | `List[types.ContestListItem]` |
+
+## `/api/contest/listAllTabs/`
+
+### Description
+
+Returns paginated contest lists for current, past, and future in one API call.
+
+### Parameters
+
+| Name             | Type                                        | Description | Required |
+| ---------------- | ------------------------------------------- | ----------- | -------- |
+| `page`           | `int`                                       |             | ✓        |
+| `page_size`      | `int`                                       |             | ✓        |
+| `query`          | `string`                                    |             | ✓        |
+| `admission_mode` | `'private'\|'public'\|'registration'\|null` |             |          |
+| `filter`         | `'all'\|'recommended'\|'signedup'\|null`    |             |          |
+| `participating`  | `int\|null`                                 |             |          |
+| `recommended`    | `int\|null`                                 |             |          |
+| `sort_order`     | `null\|string`                              |             |          |
+
+### Returns
+
+| Name      | Type                                                               |
+| --------- | ------------------------------------------------------------------ |
+| `current` | `{ number_of_results: number; results: types.ContestListItem[]; }` |
+| `future`  | `{ number_of_results: number; results: types.ContestListItem[]; }` |
+| `past`    | `{ number_of_results: number; results: types.ContestListItem[]; }` |
 
 ## `/api/contest/listParticipating/`
 

--- a/frontend/tests/controllers/ContestListTest.php
+++ b/frontend/tests/controllers/ContestListTest.php
@@ -979,4 +979,17 @@ class ContestListTest extends \OmegaUp\Test\ControllerTestCase {
             $response[0]['participating']
         );
     }
+
+    public function testListAllTabsReturnsCurrentPastFuture() {
+        \OmegaUp\Test\Factories\Contest::createContest();
+        $response = \OmegaUp\Controllers\Contest::apiListAllTabs(
+            new \OmegaUp\Request(['page_size' => 50])
+        );
+        foreach (['current', 'past', 'future'] as $tab) {
+            $this->assertArrayHasKey($tab, $response);
+            $this->assertArrayHasKey('results', $response[$tab]);
+            $this->assertArrayHasKey('number_of_results', $response[$tab]);
+            $this->assertIsArray($response[$tab]['results']);
+        }
+    }
 }

--- a/frontend/www/docs/Controllers.md
+++ b/frontend/www/docs/Controllers.md
@@ -58,6 +58,7 @@ For more information about the API controllers, please refer to the [Controllers
   - [`/api/contest/details/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestdetails)
   - [`/api/contest/getNumberOfContestants/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestgetnumberofcontestants)
   - [`/api/contest/list/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestlist)
+  - [`/api/contest/listAllTabs/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestlistalltabs)
   - [`/api/contest/listParticipating/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestlistparticipating)
   - [`/api/contest/myList/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestmylist)
   - [`/api/contest/open/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apicontestopen)

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -520,6 +520,33 @@ export const Contest = {
     })(x.results);
     return x;
   }),
+  listAllTabs: apiCall<
+    messages.ContestListAllTabsRequest,
+    messages._ContestListAllTabsServerResponse,
+    messages.ContestListAllTabsResponse
+  >('/api/contest/listAllTabs/', (x) => {
+    const convertTabResults = (tab: messages.ContestListResponse) => {
+      tab.results = ((rows) => {
+        if (!Array.isArray(rows)) {
+          return rows;
+        }
+        return rows.map((row: any) => {
+          row.finish_time = ((t: number) => new Date(t * 1000))(row.finish_time);
+          row.last_updated = ((t: number) => new Date(t * 1000))(row.last_updated);
+          row.original_finish_time = ((t: number) => new Date(t * 1000))(
+            row.original_finish_time,
+          );
+          row.start_time = ((t: number) => new Date(t * 1000))(row.start_time);
+          return row;
+        });
+      })(tab.results);
+      return tab;
+    };
+    x.current = convertTabResults(x.current);
+    x.past = convertTabResults(x.past);
+    x.future = convertTabResults(x.future);
+    return x;
+  }),
   listParticipating: apiCall<
     messages.ContestListParticipatingRequest,
     messages._ContestListParticipatingServerResponse,

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -525,26 +525,57 @@ export const Contest = {
     messages._ContestListAllTabsServerResponse,
     messages.ContestListAllTabsResponse
   >('/api/contest/listAllTabs/', (x) => {
-    const convertTabResults = (tab: messages.ContestListResponse) => {
-      tab.results = ((rows) => {
-        if (!Array.isArray(rows)) {
-          return rows;
+    x.current = ((x) => {
+      x.results = ((x) => {
+        if (!Array.isArray(x)) {
+          return x;
         }
-        return rows.map((row: any) => {
-          row.finish_time = ((t: number) => new Date(t * 1000))(row.finish_time);
-          row.last_updated = ((t: number) => new Date(t * 1000))(row.last_updated);
-          row.original_finish_time = ((t: number) => new Date(t * 1000))(
-            row.original_finish_time,
+        return x.map((x) => {
+          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+          x.last_updated = ((x: number) => new Date(x * 1000))(x.last_updated);
+          x.original_finish_time = ((x: number) => new Date(x * 1000))(
+            x.original_finish_time,
           );
-          row.start_time = ((t: number) => new Date(t * 1000))(row.start_time);
-          return row;
+          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+          return x;
         });
-      })(tab.results);
-      return tab;
-    };
-    x.current = convertTabResults(x.current);
-    x.past = convertTabResults(x.past);
-    x.future = convertTabResults(x.future);
+      })(x.results);
+      return x;
+    })(x.current);
+    x.future = ((x) => {
+      x.results = ((x) => {
+        if (!Array.isArray(x)) {
+          return x;
+        }
+        return x.map((x) => {
+          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+          x.last_updated = ((x: number) => new Date(x * 1000))(x.last_updated);
+          x.original_finish_time = ((x: number) => new Date(x * 1000))(
+            x.original_finish_time,
+          );
+          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+          return x;
+        });
+      })(x.results);
+      return x;
+    })(x.future);
+    x.past = ((x) => {
+      x.results = ((x) => {
+        if (!Array.isArray(x)) {
+          return x;
+        }
+        return x.map((x) => {
+          x.finish_time = ((x: number) => new Date(x * 1000))(x.finish_time);
+          x.last_updated = ((x: number) => new Date(x * 1000))(x.last_updated);
+          x.original_finish_time = ((x: number) => new Date(x * 1000))(
+            x.original_finish_time,
+          );
+          x.start_time = ((x: number) => new Date(x * 1000))(x.start_time);
+          return x;
+        });
+      })(x.results);
+      return x;
+    })(x.past);
     return x;
   }),
   listParticipating: apiCall<

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5456,9 +5456,9 @@ export namespace messages {
   export type ContestListAllTabsRequest = { [key: string]: any };
   export type _ContestListAllTabsServerResponse = any;
   export type ContestListAllTabsResponse = {
-    current: ContestListResponse;
-    future: ContestListResponse;
-    past: ContestListResponse;
+    current: { number_of_results: number; results: types.ContestListItem[] };
+    future: { number_of_results: number; results: types.ContestListItem[] };
+    past: { number_of_results: number; results: types.ContestListItem[] };
   };
   export type ContestListParticipatingRequest = { [key: string]: any };
   export type _ContestListParticipatingServerResponse = any;

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5453,6 +5453,13 @@ export namespace messages {
     number_of_results: number;
     results: types.ContestListItem[];
   };
+  export type ContestListAllTabsRequest = { [key: string]: any };
+  export type _ContestListAllTabsServerResponse = any;
+  export type ContestListAllTabsResponse = {
+    current: ContestListResponse;
+    future: ContestListResponse;
+    past: ContestListResponse;
+  };
   export type ContestListParticipatingRequest = { [key: string]: any };
   export type _ContestListParticipatingServerResponse = any;
   export type ContestListParticipatingResponse = {
@@ -6460,6 +6467,9 @@ export namespace controllers {
     list: (
       params?: messages.ContestListRequest,
     ) => Promise<messages.ContestListResponse>;
+    listAllTabs: (
+      params?: messages.ContestListAllTabsRequest,
+    ) => Promise<messages.ContestListAllTabsResponse>;
     listParticipating: (
       params?: messages.ContestListParticipatingRequest,
     ) => Promise<messages.ContestListParticipatingResponse>;

--- a/frontend/www/js/omegaup/arena/contestStore.ts
+++ b/frontend/www/js/omegaup/arena/contestStore.ts
@@ -153,11 +153,13 @@ export const contestStoreConfig = {
         return Promise.resolve();
       }
       commit('setLoading', true);
-      const {
-        tab_name: _tab,
-        replaceState: _rs,
-        ...listParams
-      } = payload.requestParams;
+      const p = payload.requestParams;
+      const listParams = {
+        page: p.page,
+        query: p.query,
+        sort_order: p.sort_order,
+        filter: p.filter,
+      };
       let listPromise = api.Contest.listAllTabs(listParams);
       listPromise = listPromise
         .then((response) => {
@@ -170,8 +172,12 @@ export const contestStoreConfig = {
             response,
             page: payload.requestParams.page,
           });
+          return response;
         })
-        .catch(ui.apiError)
+        .catch((err) => {
+          ui.apiError(err);
+          throw err;
+        })
         .finally(() => {
           commit('setLoading', false);
         });

--- a/frontend/www/js/omegaup/arena/contestStore.ts
+++ b/frontend/www/js/omegaup/arena/contestStore.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex, { Commit } from 'vuex';
 import * as api from '../api';
+import * as ui from '../ui';
 import { messages, types } from '../api_types';
 import {
   ContestTab,
@@ -16,13 +17,17 @@ export interface UrlParams {
   query: string;
   sort_order: ContestOrder;
   filter: ContestFilter;
+  replaceState?: boolean;
 }
 
 export interface ContestState {
   // The map of contest lists.
   contests: Record<string, types.ContestListItem[]>;
   countContests: Record<string, number>;
-  cache: Record<string, messages.ContestListResponse>;
+  cache: Record<
+    string,
+    messages.ContestListResponse | messages.ContestListAllTabsResponse
+  >;
   loading: boolean;
 }
 
@@ -86,18 +91,103 @@ export const contestStoreConfig = {
         number_of_results: response.number_of_results,
       });
     },
+    applyAllTabsResponse(
+      state: ContestState,
+      {
+        response,
+        page,
+      }: {
+        response: messages.ContestListAllTabsResponse;
+        page: number;
+      },
+    ) {
+      const tabs: (keyof messages.ContestListAllTabsResponse)[] = [
+        'current',
+        'past',
+        'future',
+      ];
+      for (const tab of tabs) {
+        const tabResponse = response[tab];
+        const existingContests = page === 1 ? [] : state.contests[tab] || [];
+        const newContests = tabResponse.results.filter(
+          (newContest) =>
+            !existingContests.some(
+              (existing) => existing.contest_id === newContest.contest_id,
+            ),
+        );
+        Vue.set(state.contests, tab, [...existingContests, ...newContests]);
+        Vue.set(state.countContests, tab, tabResponse.number_of_results);
+      }
+    },
+    cacheAllTabsList(
+      state: ContestState,
+      payload: {
+        cacheKey: string;
+        response: messages.ContestListAllTabsResponse;
+        requestParams: UrlParams;
+      },
+    ) {
+      Vue.set(state.cache, payload.cacheKey, payload.response);
+      const tabs = [ContestTab.Current, ContestTab.Past, ContestTab.Future];
+      for (const tab of tabs) {
+        const tabCacheKey = generateCacheKey({
+          ...payload.requestParams,
+          tab_name: tab,
+        });
+        Vue.set(state.cache, tabCacheKey, payload.response[tab]);
+      }
+    },
   },
   actions: {
+    fetchContestListAllTabs(
+      { commit, state }: { commit: Commit; state: ContestState },
+      payload: { requestParams: UrlParams },
+    ) {
+      const cacheKey = generateAllTabsCacheKey(payload.requestParams);
+      const cached = state.cache[cacheKey];
+      if (cached && 'current' in cached) {
+        commit('applyAllTabsResponse', {
+          response: cached as messages.ContestListAllTabsResponse,
+          page: payload.requestParams.page,
+        });
+        return Promise.resolve();
+      }
+      commit('setLoading', true);
+      const {
+        tab_name: _tab,
+        replaceState: _rs,
+        ...listParams
+      } = payload.requestParams;
+      let listPromise = api.Contest.listAllTabs(listParams);
+      listPromise = listPromise
+        .then((response) => {
+          commit('cacheAllTabsList', {
+            cacheKey,
+            response,
+            requestParams: payload.requestParams,
+          });
+          commit('applyAllTabsResponse', {
+            response,
+            page: payload.requestParams.page,
+          });
+        })
+        .catch(ui.apiError)
+        .finally(() => {
+          commit('setLoading', false);
+        });
+      return listPromise;
+    },
     fetchContestList(
       { commit, state }: { commit: Commit; state: ContestState },
       payload: NamedContestListRequest,
     ) {
       const cacheKey = generateCacheKey(payload.requestParams);
-      if (state.cache[cacheKey]) {
+      const cachedList = state.cache[cacheKey];
+      if (cachedList && !('current' in cachedList)) {
         commit('updateList', {
           name: payload.name,
           cacheKey,
-          response: state.cache[cacheKey],
+          response: cachedList as messages.ContestListResponse,
           page: payload.requestParams.page,
         });
         return;
@@ -112,6 +202,7 @@ export const contestStoreConfig = {
             page: payload.requestParams.page,
           });
         })
+        .catch(ui.apiError)
         .finally(() => {
           commit('setLoading', false);
         });
@@ -121,6 +212,10 @@ export const contestStoreConfig = {
 
 function generateCacheKey(params: UrlParams) {
   return `${params.tab_name}-${params.filter}-${params.sort_order}-${params.query}-${params.page}`;
+}
+
+function generateAllTabsCacheKey(params: UrlParams) {
+  return `all-tabs-${params.filter}-${params.sort_order}-${params.query}-${params.page}`;
 }
 
 export default new Vuex.Store<ContestState>(contestStoreConfig);

--- a/frontend/www/js/omegaup/arena/contest_list.ts
+++ b/frontend/www/js/omegaup/arena/contest_list.ts
@@ -119,10 +119,12 @@ OmegaUp.on('ready', () => {
             params,
             urlObj,
             shouldUpdateUrl = true,
+            allTabs = false,
           }: {
             params: UrlParams;
             urlObj: URL;
             shouldUpdateUrl?: boolean;
+            allTabs?: boolean;
           }) => {
             for (const [key, value] of Object.entries(params)) {
               if (value) {
@@ -134,10 +136,16 @@ OmegaUp.on('ready', () => {
             if (shouldUpdateUrl) {
               window.history.pushState({}, '', urlObj);
             }
-            await contestStore.dispatch('fetchContestList', {
-              requestParams: params,
-              name: params.tab_name,
-            });
+            if (allTabs) {
+              await contestStore.dispatch('fetchContestListAllTabs', {
+                requestParams: params,
+              });
+            } else {
+              await contestStore.dispatch('fetchContestList', {
+                requestParams: params,
+                name: params.tab_name,
+              });
+            }
           },
         },
       });

--- a/frontend/www/js/omegaup/arena/contest_listv2.ts
+++ b/frontend/www/js/omegaup/arena/contest_listv2.ts
@@ -178,10 +178,16 @@ OmegaUp.on('ready', () => {
             } else {
               window.history.pushState({}, '', urlObj);
             }
-            await contestStore.dispatch('fetchContestList', {
-              requestParams: params,
-              name: params.tab_name,
-            });
+            if (params.page === 1) {
+              await contestStore.dispatch('fetchContestListAllTabs', {
+                requestParams: params,
+              });
+            } else {
+              await contestStore.dispatch('fetchContestList', {
+                requestParams: params,
+                name: params.tab_name,
+              });
+            }
           },
         },
       });

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -648,25 +648,23 @@ class ArenaContestList extends Vue {
       this.hasMore = true;
       this.fetchPage(params, urlObj);
     } else {
-      // Fetch all for summary view
+      // Summary view: one request loads current, past, and future (see contest_list.ts).
+      const urlObj = new URL(window.location.href);
+      const params: UrlParams = {
+        page: 1,
+        tab_name: ContestTab.Current,
+        query: this.currentQuery,
+        sort_order: this.currentOrder,
+        filter: this.currentFilter,
+      };
       [ContestTab.Current, ContestTab.Future, ContestTab.Past].forEach(
         (tab) => {
-          const urlObj = new URL(window.location.href);
-          const params: UrlParams = {
-            page: 1,
-            tab_name: tab,
-            query: this.currentQuery,
-            sort_order: this.currentOrder,
-            filter: this.currentFilter,
-          };
-          // Only update URL for the Current tab to avoid overwriting it multiple times
-          // or setting it to 'past' which might be confusing.
-          // Actually, if we are in summary view, we probably don't want to set tab_name in URL at all?
-          // But the parent logic sets it based on params.tab_name.
-          // Let's just update for Current.
-          this.fetchPage(params, urlObj, tab === ContestTab.Current);
+          Vue.set(this.contests, tab, []);
         },
       );
+      this.currentPage = 1;
+      this.hasMore = true;
+      this.fetchPage(params, urlObj, true, true);
     }
   }
   mounted() {
@@ -777,8 +775,13 @@ class ArenaContestList extends Vue {
     }
   }
 
-  fetchPage(params: UrlParams, urlObj: URL, shouldUpdateUrl: boolean = true) {
-    this.$emit('fetch-page', { params, urlObj, shouldUpdateUrl });
+  fetchPage(
+    params: UrlParams,
+    urlObj: URL,
+    shouldUpdateUrl: boolean = true,
+    allTabs: boolean = false,
+  ) {
+    this.$emit('fetch-page', { params, urlObj, shouldUpdateUrl, allTabs });
     // Turn off refreshing after a short delay to allow parent component to respond
     setTimeout(() => {
       this.refreshing = false;

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -668,7 +668,12 @@ class ArenaContestList extends Vue {
     }
   }
   mounted() {
-    this.fetchInitialContests();
+    // Only load from the server when the parent handles `fetch-page` (arena
+    // entrypoints). Unit tests mount with static `contests` and no listener;
+    // calling fetchInitialContests() would clear those props.
+    if (this.$listeners['fetch-page']) {
+      this.fetchInitialContests();
+    }
     this.updateColumnsPerRow();
     window.addEventListener('resize', this.updateColumnsPerRow);
   }

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -18,7 +18,7 @@
                 <form @submit.prevent="onSearchQuery">
                   <div class="input-group">
                     <input
-                      v-model.lazy="currentQuery"
+                      v-model="currentQuery"
                       class="form-control nav-link"
                       type="text"
                       name="query"
@@ -27,6 +27,7 @@
                       autocapitalize="off"
                       spellcheck="false"
                       :placeholder="T.wordsKeyword"
+                      @input="onSearchQueryDebounced"
                       @keyup.enter="onSearchQuery"
                     />
                     <button
@@ -415,6 +416,18 @@
 </template>
 
 <script lang="ts">
+const debounce = (fn: (...args: any[]) => void, waitTime: number) => {
+  let timer: number | null = null;
+  return (...args: any[]) => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      fn(...args);
+    }, waitTime) as any;
+  };
+};
+
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import * as time from '../../time';
@@ -514,6 +527,10 @@ class ArenaContestList extends Vue {
   // Flag to track the very first load — initial URL normalization should use
   // replaceState to avoid creating an extra history entry (see issue #9161)
   isInitialLoad: boolean = true;
+
+  onSearchQueryDebounced = debounce(() => {
+    this.onSearchQuery();
+  }, 300);
 
   titleLinkClass(tab: ContestTab) {
     if (this.currentTab === tab) {


### PR DESCRIPTION
## Description

Optimize ArenaV2 contest search by reducing multiple requests and adding debounce.

- Add `listAllTabs` API to fetch current, past, and future contests in a single request  
- Update Arena v2 to use one request instead of three on initial/search load  
- Add ~300ms debounce to search input to prevent excessive requests  

Fixes: #9679

## Notes

- Improves performance by reducing network calls  
- Video attached showing single request + debounced search behavior  

https://github.com/user-attachments/assets/1b5d3abb-7c7e-4eb3-b1f6-7360931b5138