### PR TITLE
fix(#9580): add per-problem error handling and phase resilience

### DIFF
--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -15,7 +15,8 @@ import logging
 import operator
 import os
 import sys
-from typing import (DefaultDict, Dict, Mapping, NamedTuple, Optional, Sequence,
+import time
+from typing import (Any, DefaultDict, Dict, Mapping, NamedTuple, Optional, Sequence,
                     Tuple, Set)
 
 from mysql.connector import errorcode
@@ -505,13 +506,39 @@ def aggregate_reviewers_feedback(
     Updates the quality_seal field on Problems table and updates the
     problem level tag.
     '''
+    attempted_problems = 0
+    successful_problems = 0
+    failed_problems = 0
+
     with dbconn.cursor() as cur:
         cur.execute("""SELECT DISTINCT qn.`problem_id`
                        FROM `QualityNominations` as qn
                        WHERE qn.`nomination` = 'quality_tag';""")
         for (problem_id, ) in cur.fetchall():
-            aggregate_reviewers_feedback_for_problem(dbconn, problem_id)
-        dbconn.conn.commit()
+            attempted_problems += 1
+            try:
+                aggregate_reviewers_feedback_for_problem(dbconn, problem_id)
+                dbconn.conn.commit()
+                successful_problems += 1
+            except Exception:  # pylint: disable=broad-except
+                failed_problems += 1
+                logging.exception(
+                    'Failed to aggregate reviewers feedback for problem %d. '
+                    'Continuing with remaining problems.',
+                    problem_id)
+                try:
+                    dbconn.conn.rollback()
+                except Exception:  # pylint: disable=broad-except
+                    logging.exception(
+                        'Failed to rollback transaction for problem %d',
+                        problem_id)
+
+    logging.info(
+        'Finished aggregating reviewers feedback: '
+        'attempted=%d successful=%d failed=%d',
+        attempted_problems,
+        successful_problems,
+        failed_problems)
 
 
 def get_last_friday() -> datetime.date:
@@ -614,34 +641,54 @@ def main() -> None:
 
     logging.info('Started')
     dbconn = lib.db.connect(lib.db.DatabaseConnectionArguments.from_args(args))
+    any_phase_failed = False
     try:
+        # Phase 1: Reviewers Feedback
+        start_time = time.monotonic()
         try:
+            logging.info('Phase 1/3: Aggregating reviewers feedback...')
             aggregate_reviewers_feedback(dbconn)
-        except:  # noqa: bare-except
+            logging.info('Phase 1/3 completed in %.2fs',
+                         time.monotonic() - start_time)
+        except Exception:  # pylint: disable=broad-except
+            any_phase_failed = True
             logging.exception(
-                'Failed to calculate problem quality seal and category.')
-            raise
+                'Phase 1/3 failed (Reviewers feedback aggregation).')
 
+        # Phase 2: General Feedback
+        start_time = time.monotonic()
         try:
+            logging.info('Phase 2/3: Aggregating user feedback...')
             aggregate_feedback(dbconn)
-        except:  # noqa: bare-except
+            logging.info('Phase 2/3 completed in %.2fs',
+                         time.monotonic() - start_time)
+        except Exception:  # pylint: disable=broad-except
+            any_phase_failed = True
             logging.exception(
-                'Failed to aggregate feedback and update problem tags.')
-            raise
+                'Phase 2/3 failed (User feedback aggregation).')
 
+        # Phase 3: Problem of the Week
+        start_time = time.monotonic()
         try:
+            logging.info('Phase 3/3: Updating problem of the week...')
             # Problem of the week HAS to be computed AFTER feedback has been
             # aggregated. It uses difficulty tags computed from feedback to
             # pick a problem of the given difficulty.
             update_problem_of_the_week(dbconn, "easy")
             # TODO(heduenas): Compute "hard" problem of the week when we get
             # enough feedback records.
-        except:  # noqa: bare-except
-            logging.exception('Failed to update problem of the week')
-            raise
+            logging.info('Phase 3/3 completed in %.2fs',
+                         time.monotonic() - start_time)
+        except Exception:  # pylint: disable=broad-except
+            any_phase_failed = True
+            logging.exception(
+                'Phase 3/3 failed (Problem of the week update).')
     finally:
         dbconn.conn.close()
         logging.info('Done')
+
+    if any_phase_failed:
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/stuff/cron/aggregate_feedback_test.py
+++ b/stuff/cron/aggregate_feedback_test.py
@@ -7,6 +7,19 @@ being processed.
 
 import unittest
 from typing import Any, List, Tuple, cast
+from unittest.mock import MagicMock
+import sys
+
+# Mock dependencies since they might not be installed in the test environment
+mock_mysql = MagicMock()
+sys.modules['mysql'] = mock_mysql
+sys.modules['mysql.connector'] = mock_mysql.connector
+
+# Mock lib.db and lib.logs to avoid dependency on real DB and specific loggers
+sys.modules['lib'] = MagicMock()
+sys.modules['lib.db'] = MagicMock()
+sys.modules['lib.logs'] = MagicMock()
+sys.modules['pythonjsonlogger'] = MagicMock()
 
 import aggregate_feedback
 
@@ -52,6 +65,10 @@ class _FakeDBConnection:
     def rollback(self) -> None:
         '''Records that a rollback was requested on the fake connection.'''
         self.rollback_calls += 1
+
+    def commit(self) -> None:
+        '''Fake commit method.'''
+        pass
 
 
 class AggregateFeedbackTest(unittest.TestCase):
@@ -110,6 +127,104 @@ class AggregateFeedbackTest(unittest.TestCase):
 
         self.assertEqual(called_ids, problem_ids)
         self.assertEqual(dbconn.rollback_calls, 1)
+
+
+class AggregateReviewersFeedbackTest(unittest.TestCase):
+    '''Tests for aggregate_feedback.aggregate_reviewers_feedback.'''
+
+    def test_single_problem_failure_does_not_stop_others(self) -> None:
+        '''One failing problem should not prevent others from updating.'''
+        problem_ids = [1, 2, 3]
+        failing_problem_id = 2
+        dbconn = _FakeDBConnection(problem_ids)
+
+        called_ids: List[int] = []
+
+        def fake_aggregate_reviewers_feedback_for_problem(
+                dbconn_arg: Any,
+                problem_id: int) -> None:
+            del dbconn_arg
+            called_ids.append(problem_id)
+            if problem_id == failing_problem_id:
+                raise RuntimeError('simulated failure for testing')
+
+        original_aggregate_problem_feedback = (
+            aggregate_feedback.aggregate_reviewers_feedback_for_problem)
+        aggregate_feedback.aggregate_reviewers_feedback_for_problem = cast(
+            Any, fake_aggregate_reviewers_feedback_for_problem)
+
+        try:
+            aggregate_feedback.aggregate_reviewers_feedback(cast(Any, dbconn))
+        finally:
+            aggregate_feedback.aggregate_reviewers_feedback_for_problem = (
+                original_aggregate_problem_feedback)
+
+        self.assertEqual(called_ids, problem_ids)
+        self.assertEqual(dbconn.rollback_calls, 1)
+
+
+class MainResilienceTest(unittest.TestCase):
+    '''Tests for aggregate_feedback.main phase resilience.'''
+
+    def test_main_continues_through_failures(self) -> None:
+        '''main() should attempt all phases even if one fails.'''
+        phases_called = []
+
+        def fake_aggregate_reviewers_feedback(dbconn_arg: Any) -> None:
+            del dbconn_arg
+            phases_called.append('reviewers')
+            raise RuntimeError('phase 1 failure')
+
+        def fake_aggregate_feedback(dbconn_arg: Any) -> None:
+            del dbconn_arg
+            phases_called.append('general')
+
+        def fake_update_problem_of_the_week(dbconn_arg: Any,
+                                           difficulty: str) -> None:
+            del dbconn_arg, difficulty
+            phases_called.append('potw')
+
+        # Mocking external dependencies of main()
+        # Using patch would be cleaner but follows the existing pattern
+        original_reviewers = aggregate_feedback.aggregate_reviewers_feedback
+        original_feedback = aggregate_feedback.aggregate_feedback
+        original_potw = aggregate_feedback.update_problem_of_the_week
+        original_connect = aggregate_feedback.lib.db.connect
+        original_exit = aggregate_feedback.sys.exit
+
+        aggregate_feedback.aggregate_reviewers_feedback = fake_aggregate_reviewers_feedback
+        aggregate_feedback.aggregate_feedback = fake_aggregate_feedback
+        aggregate_feedback.update_problem_of_the_week = fake_update_problem_of_the_week
+        
+        # Mocking db connect and sys.exit to avoid real world side effects
+        class MockDB:
+            def __init__(self): self.conn = self
+            def close(self): pass
+        aggregate_feedback.lib.db.connect = lambda _: MockDB()
+        
+        exit_codes = []
+        aggregate_feedback.sys.exit = lambda code: exit_codes.append(code)
+
+        try:
+            # Mocking argparse
+            import argparse
+            original_parse = argparse.ArgumentParser.parse_args
+            argparse.ArgumentParser.parse_args = lambda _: argparse.Namespace(
+                db_host='localhost', db_user='user', db_password='password',
+                db_name='name', mysql_config_file=None, logging_level='INFO')
+            
+            aggregate_feedback.main()
+            
+            argparse.ArgumentParser.parse_args = original_parse
+        finally:
+            aggregate_feedback.aggregate_reviewers_feedback = original_reviewers
+            aggregate_feedback.aggregate_feedback = original_feedback
+            aggregate_feedback.update_problem_of_the_week = original_potw
+            aggregate_feedback.lib.db.connect = original_connect
+            aggregate_feedback.sys.exit = original_exit
+
+        self.assertEqual(phases_called, ['reviewers', 'general', 'potw'])
+        self.assertEqual(exit_codes, [1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Improved the reliability of the `aggregate_feedback.py` cron script. Previously, a failure in a single problem or an early phase would cause the entire script to crash. 

I implemented per-problem error handling and cross-phase resilience. Now, the script will log errors for individual failures and continue to the next problem or phase, ensuring maximum data aggregation even during partial failures.

Fixes: #9580


# Comments

I am applying for GSoC 2026. This fix demonstrates my ability to handle backend resilience and Python scripting. I have also added time tracking to improve observability of the cron jobs.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
