### PR TITLE
fix: add real-time date validation to course form to prevent end date before start date

### DIFF
--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -86,7 +86,6 @@
                 name="start-date"
                 :disabled="readOnly"
                 :min="update ? null : new Date()"
-                @input="validateDates"
               ></omegaup-datepicker
             ></label>
           </div>
@@ -116,14 +115,14 @@
                 :disabled="readOnly"
                 name="end-date"
                 :enabled="!unlimitedDuration"
-                :is-invalid="invalidParameterName === 'finish_time' || invalidDate"
-                @input="validateDates"
+                :is-invalid="
+                  invalidParameterName === 'finish_time' || invalidDate
+                "
               ></omegaup-datepicker
             ></label>
             <div
               v-if="invalidDate"
-              class="invalid-feedback"
-              style="display: block"
+              class="invalid-feedback invalid-date-feedback"
             >
               {{ T.courseAssignmentEndDateBeforeCourseStartDate }}
             </div>
@@ -406,7 +405,6 @@ export default class CourseDetails extends Vue {
   selectedLanguages = this.course.languages;
   levelOptions = levelOptions;
   MAX_LENGTH = MAX_LENGTH;
-  invalidDate = false;
 
   // Computed properties to track if required fields are complete
   get isNameComplete(): boolean {
@@ -563,25 +561,17 @@ export default class CourseDetails extends Vue {
     this.needsBasicInformation = this.course.needs_basic_information;
     this.requestsUserInformation = this.course.requests_user_information;
     this.unlimitedDuration = this.course.finish_time === null;
-    this.invalidDate = false;
   }
 
-  validateDates(): boolean {
-    if (
-      !this.unlimitedDuration &&
-      this.startTime !== null &&
-      this.finishTime !== null &&
-      this.finishTime <= this.startTime
-    ) {
-      this.invalidDate = true;
-      return false;
-    }
-    this.invalidDate = false;
-    return true;
+  get invalidDate(): boolean {
+    if (this.unlimitedDuration) return false;
+    if (!this.startTime || !this.finishTime) return false;
+    if (this.finishTime <= this.startTime) return true;
+    return false;
   }
 
   onSubmit(): void {
-    if (!this.validateDates()) {
+    if (this.invalidDate) {
       return;
     }
     if (!this.selectedLanguages || this.selectedLanguages.length === 0) {
@@ -647,5 +637,9 @@ export default class CourseDetails extends Vue {
   color: var(--form-character-counter-color, #6c757d);
   font-size: 0.8rem;
   margin-top: 0.25rem;
+}
+
+.invalid-date-feedback {
+  display: block;
 }
 </style>

--- a/frontend/www/js/omegaup/components/course/Form.vue
+++ b/frontend/www/js/omegaup/components/course/Form.vue
@@ -86,6 +86,7 @@
                 name="start-date"
                 :disabled="readOnly"
                 :min="update ? null : new Date()"
+                @input="validateDates"
               ></omegaup-datepicker
             ></label>
           </div>
@@ -115,9 +116,17 @@
                 :disabled="readOnly"
                 name="end-date"
                 :enabled="!unlimitedDuration"
-                :is-invalid="invalidParameterName === 'finish_time'"
+                :is-invalid="invalidParameterName === 'finish_time' || invalidDate"
+                @input="validateDates"
               ></omegaup-datepicker
             ></label>
+            <div
+              v-if="invalidDate"
+              class="invalid-feedback"
+              style="display: block"
+            >
+              {{ T.courseAssignmentEndDateBeforeCourseStartDate }}
+            </div>
           </div>
         </div>
         <div class="row">
@@ -397,6 +406,7 @@ export default class CourseDetails extends Vue {
   selectedLanguages = this.course.languages;
   levelOptions = levelOptions;
   MAX_LENGTH = MAX_LENGTH;
+  invalidDate = false;
 
   // Computed properties to track if required fields are complete
   get isNameComplete(): boolean {
@@ -553,9 +563,27 @@ export default class CourseDetails extends Vue {
     this.needsBasicInformation = this.course.needs_basic_information;
     this.requestsUserInformation = this.course.requests_user_information;
     this.unlimitedDuration = this.course.finish_time === null;
+    this.invalidDate = false;
+  }
+
+  validateDates(): boolean {
+    if (
+      !this.unlimitedDuration &&
+      this.startTime !== null &&
+      this.finishTime !== null &&
+      this.finishTime <= this.startTime
+    ) {
+      this.invalidDate = true;
+      return false;
+    }
+    this.invalidDate = false;
+    return true;
   }
 
   onSubmit(): void {
+    if (!this.validateDates()) {
+      return;
+    }
     if (!this.selectedLanguages || this.selectedLanguages.length === 0) {
       this.$emit('invalid-languages');
       return;


### PR DESCRIPTION
# Description

The course creation and edit form (`course/Form.vue`) allowed submitting with an end date before the start date. No frontend 
validation existed the form would only fail with a server-side error, leaving users confused with no clear feedback.

This fix mirrors the validation pattern already used in 
`contest/Form.vue`:

- Added `validateDates()` method that sets an `invalidDate` flag
- Added `@input="validateDates"` on both start and end date pickers so the error appears in real time as the user changes 
  dates not just on submit
- Added inline error message directly under the end date field using Bootstrap's `invalid-feedback` pattern
- Added `onSubmit()` guard that calls `validateDates()` and returns early if dates are invalid
- Added `!this.unlimitedDuration` guard courses with no end date are completely unaffected
- Reset `invalidDate = false` in the reset method to clear stale error state

**Before:** End date error appears on submit 

**After:** Inline error "The end date is previous to the course start date" appears immediately under the end date field when 
an invalid date is selected.
<img width="1872" height="896" alt="image" src="https://github.com/user-attachments/assets/0a34453e-03e6-41ae-b05d-67dcf21a109b" />


Fixes: #9705 

# Comments

The fix uses `courseAssignmentEndDateBeforeCourseStartDate` translation key which already exists in all language files 
(en, es, pt, pseudo). No new translation strings required.

The `invalidDate` flag approach was chosen over calling `ui.error()` directly to match the Bootstrap inline validation 
pattern used throughout the codebase (consistent with how `invalidParameterName` works in the same component).

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
