### PR TITLE
fix: reset page on filter change and guard division by zero in GridPaginator

### DIFF
--- a/frontend/www/js/omegaup/components/common/GridPaginator.vue
+++ b/frontend/www/js/omegaup/components/common/GridPaginator.vue
@@ -132,6 +132,9 @@ export default class GridPaginator extends Vue {
   }
 
   private get totalPagesCount(): number {
+    if (this.rowsPerPage === 0) {
+      return 1;
+    }
     const totalRows = Math.ceil(this.filteredItems.length / this.columns);
     return Math.ceil(totalRows / this.rowsPerPage);
   }
@@ -149,6 +152,9 @@ export default class GridPaginator extends Vue {
   }
 
   private get paginatedItems(): LinkableResource[][] {
+    if (this.rowsPerPage === 0) {
+      return this.itemsRows;
+    }
     const start = this.currentPageNumber * this.rowsPerPage;
     const end = start + this.rowsPerPage;
     return this.itemsRows.slice(start, end);
@@ -160,6 +166,7 @@ export default class GridPaginator extends Vue {
 
   @Watch('filter')
   onFilterChange(newFilter: string) {
+    this.currentPageNumber = 0;
     this.filteredItems = this.items.filter((item: LinkableResource) =>
       item.toString().toLowerCase().includes(newFilter.toLowerCase()),
     );


### PR DESCRIPTION
# Description

Two related bugs in `GridPaginator.vue` that caused blank pages when navigating paginated results with active filters:

**Bug 1 - Stale page index when filter changes:**
When a filter is applied that reduces the total number of pages, `currentPageNumber` was not reset. If the user was 
on page 3 and the filter left only 1 page of results, the grid sliced an empty range and rendered nothing.

Fixed by resetting `currentPageNumber = 0` at the start of the `onFilterChange` watcher.

**Bug 2 - Division by zero when itemsPerPage < columns:**
If `itemsPerPage < columns`, then:
`rowsPerPage = Math.floor(itemsPerPage / columns) = 0`
`totalPagesCount = Math.ceil(totalRows / 0) = Infinity`
`paginatedItems = items.slice(start, start) = []`

This produced an always-empty grid even with data present.

Fixed by adding early return guards in `totalPagesCount` and `paginatedItems` when `rowsPerPage === 0`.

**Reproduced on production at:**
`https://omegaup.com/problem/` → Problem Finder → select multiple tags → navigate to page 2+

**Before:** Blank page, pagination numbers invisible also navigation stucks
**After:** Results display correctly on all pages

Fixes: #9704 

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
