### PR TITLE
fix: rename beforeDestroy -> beforeUnmount and destroyed -> unmounted for Vue 3 migration

### DIFF
--- a/frontend/www/js/omegaup/arena/contest_listv2.ts
+++ b/frontend/www/js/omegaup/arena/contest_listv2.ts
@@ -139,7 +139,7 @@ OmegaUp.on('ready', () => {
       filter: initialState.filter,
     }),
     // eslint-disable-next-line vue/no-deprecated-destroyed-lifecycle
-    beforeDestroy() {
+    beforeUnmount() {
       window.removeEventListener('popstate', onPopState);
       window.removeEventListener('hashchange', onHashChange);
     },

--- a/frontend/www/js/omegaup/components/Countdown.vue
+++ b/frontend/www/js/omegaup/components/Countdown.vue
@@ -65,7 +65,7 @@ export default class Countdown extends Vue {
     this.$emit('finish');
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.timerInterval) {
       clearInterval(this.timerInterval);
       this.timerInterval = 0;

--- a/frontend/www/js/omegaup/components/arena/Contest.vue
+++ b/frontend/www/js/omegaup/components/arena/Contest.vue
@@ -378,7 +378,7 @@ export default class ArenaContest extends Vue {
     }
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.lockdown) {
       window.removeEventListener('beforeunload', this.beforeWindowUnload);
     }

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -675,7 +675,7 @@ class ArenaContestList extends Vue {
     window.addEventListener('resize', this.updateColumnsPerRow);
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener('resize', this.updateColumnsPerRow);
   }
 

--- a/frontend/www/js/omegaup/components/arena/ContestListv2.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestListv2.vue
@@ -565,7 +565,7 @@ class ArenaContestList extends Vue {
     this.fetchInitialContests();
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     // Placeholder for cleanup when infinite scroll is re-implemented
   }
   async loadMoreContests() {

--- a/frontend/www/js/omegaup/components/badge/Badge3D.vue
+++ b/frontend/www/js/omegaup/components/badge/Badge3D.vue
@@ -59,7 +59,7 @@ export default class Badge3D extends Vue {
     this.bounds = null;
   }
 
-  beforeDestroy(): void {
+  beforeUnmount(): void {
     this.onMouseLeave();
   }
 }

--- a/frontend/www/js/omegaup/components/common/Navbar.vue
+++ b/frontend/www/js/omegaup/components/common/Navbar.vue
@@ -529,7 +529,7 @@ export default class Navbar extends Vue {
     this.updateScroll();
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     document.removeEventListener('click', this.handleDocumentClick);
     window.removeEventListener('scroll', this.updateScroll);
   }

--- a/frontend/www/js/omegaup/components/common/Typeahead.vue
+++ b/frontend/www/js/omegaup/components/common/Typeahead.vue
@@ -63,7 +63,7 @@ export default class Typeahead extends Vue {
     }, this.debounceDelay);
   }
 
-  beforeDestroy(): void {
+  beforeUnmount(): void {
     // Clean up timer on component destruction
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);

--- a/frontend/www/js/omegaup/components/notification/Clarifications.vue
+++ b/frontend/www/js/omegaup/components/notification/Clarifications.vue
@@ -88,7 +88,7 @@ export default class Clarifications extends Vue {
   flashInterval: number = 0;
   unreadClarifications = this.clarifications;
 
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.flashInterval) {
       clearInterval(this.flashInterval);
       this.flashInterval = 0;

--- a/frontend/www/js/omegaup/components/problem/CollectionList.vue
+++ b/frontend/www/js/omegaup/components/problem/CollectionList.vue
@@ -214,7 +214,7 @@ export default class CollectionList extends Vue {
     window.addEventListener('resize', this.updateViewportMode);
   }
 
-  beforeDestroy(): void {
+  beforeUnmount(): void {
     window.removeEventListener('resize', this.updateViewportMode);
   }
 

--- a/frontend/www/js/omegaup/components/problem/ProblemMarkdown.vue
+++ b/frontend/www/js/omegaup/components/problem/ProblemMarkdown.vue
@@ -199,7 +199,7 @@ export default class ProblemMarkdown extends Vue {
     }
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     for (const app of this.vueInstances) {
       app.$destroy();
       if (app.$el && app.$el.parentNode) {

--- a/frontend/www/js/omegaup/components/user/UserHeatmap.vue
+++ b/frontend/www/js/omegaup/components/user/UserHeatmap.vue
@@ -274,7 +274,7 @@ export default class UserHeatmap extends Vue {
     this.maxStreak = bestStreak;
   }
 
-  beforeDestroy(): void {
+  beforeUnmount(): void {
     if (this.chart) {
       this.chart.destroy();
     }

--- a/frontend/www/js/omegaup/grader/Ephemeral.vue
+++ b/frontend/www/js/omegaup/grader/Ephemeral.vue
@@ -503,7 +503,7 @@ export default class Ephemeral extends Vue {
     this.isCopySuccess = false;
   }
 
-  beforeDestroy() {
+  beforeUnmount() {
     if (this.copySuccessTimer) clearTimeout(this.copySuccessTimer);
   }
 

--- a/frontend/www/js/omegaup/graderv2/DiffEditorV2.vue
+++ b/frontend/www/js/omegaup/graderv2/DiffEditorV2.vue
@@ -103,7 +103,7 @@ export default class DiffEditorV2 extends Vue {
     this._resizeObserver.observe(this.$refs.wrapper as HTMLElement);
   }
 
-  beforeDestroy(): void {
+  beforeUnmount(): void {
     this._resizeObserver?.disconnect();
     this._editor?.dispose();
     this._originalModel?.dispose();

--- a/frontend/www/js/omegaup/graderv2/MonacoEditorV2.vue
+++ b/frontend/www/js/omegaup/graderv2/MonacoEditorV2.vue
@@ -305,7 +305,7 @@ export default class MonacoEditor extends Vue {
     this.onResize();
   }
 
-  destroyed(): void {
+  unmounted(): void {
     if (this.copyTimeout) clearTimeout(this.copyTimeout);
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
 

--- a/frontend/www/js/omegaup/group/edit.ts
+++ b/frontend/www/js/omegaup/group/edit.ts
@@ -343,7 +343,7 @@ OmegaUp.on('ready', () => {
   window.addEventListener('hashchange', onHashChange);
   onHashChange();
 
-  groupEdit.$once('hook:beforeDestroy', () => {
+  groupEdit.$once('hook:beforeUnmount', () => {
     window.removeEventListener('hashchange', onHashChange);
   });
 });

--- a/frontend/www/js/omegaup/teamsgroup/edit.ts
+++ b/frontend/www/js/omegaup/teamsgroup/edit.ts
@@ -412,7 +412,7 @@ OmegaUp.on('ready', () => {
   window.addEventListener('hashchange', onHashChange);
   onHashChange();
 
-  teamsGroupEdit.$once('hook:beforeDestroy', () => {
+  teamsGroupEdit.$once('hook:beforeUnmount', () => {
     window.removeEventListener('hashchange', onHashChange);
   });
 });


### PR DESCRIPTION
# Description
Renames deprecated Vue 2 lifecycle hooks to their Vue 3 equivalents across the codebase as part of the ongoing Vue 2 -> Vue 3 migration effort.

Changes made:
- `beforeDestroy` -> `beforeUnmount` in 15 components and entry files
- `destroyed` -> `unmounted` in MonacoEditorV2.vue
- `hook:beforeDestroy` -> `hook:beforeUnmount` in group/edit.ts and teamsgroup/edit.ts

These hooks were renamed in Vue 3 and while Vue 2.7 supports both names, updating them now ensures forward compatibility.

Fixes: #9688

# Comments
- No UI changes were made, only lifecycle hook renames no screenshot needed.
- All changes are simple one-line renames, no logic was altered.
- Two additional files (`group/edit.ts` and `teamsgroup/edit.ts`) were included
  beyond the 13 listed in the issue, as they used the same deprecated
  `hook:beforeDestroy` pattern and needed the same fix.

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
