### PR TITLE
feat: Display contest dates in human-readable and relative format in ArenaV2 cards

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -225,7 +225,7 @@
                       <font-awesome-icon icon="calendar-alt" />
                       <a
                         :href="getTimeLink(contestItem.finish_time)"
-                        :title="exactContestDate(contestItem.finish_time)"
+                        :title="exactContestDateTime(contestItem.finish_time)"
                       >
                         {{ currentContestDate(contestItem) }}
                       </a>
@@ -234,7 +234,7 @@
                       <font-awesome-icon icon="calendar-alt" />
                       <a
                         :href="getTimeLink(contestItem.start_time)"
-                        :title="exactContestDate(contestItem.start_time)"
+                        :title="exactContestDateTime(contestItem.start_time)"
                       >
                         {{ futureContestDate(contestItem) }}
                       </a>
@@ -243,7 +243,7 @@
                       <font-awesome-icon icon="calendar-alt" />
                       <a
                         :href="getTimeLink(contestItem.finish_time)"
-                        :title="exactContestDate(contestItem.finish_time)"
+                        :title="exactContestDateTime(contestItem.finish_time)"
                       >
                         {{ pastContestDate(contestItem) }}
                       </a>
@@ -363,7 +363,7 @@
                   <font-awesome-icon icon="calendar-alt" />
                   <a
                     :href="getTimeLink(contestItem.finish_time)"
-                    :title="exactContestDate(contestItem.finish_time)"
+                    :title="exactContestDateTime(contestItem.finish_time)"
                   >
                     {{ currentContestDate(contestItem) }}
                   </a>
@@ -372,7 +372,7 @@
                   <font-awesome-icon icon="calendar-alt" />
                   <a
                     :href="getTimeLink(contestItem.start_time)"
-                    :title="exactContestDate(contestItem.start_time)"
+                    :title="exactContestDateTime(contestItem.start_time)"
                   >
                     {{ futureContestDate(contestItem) }}
                   </a>
@@ -381,7 +381,7 @@
                   <font-awesome-icon icon="calendar-alt" />
                   <a
                     :href="getTimeLink(contestItem.finish_time)"
-                    :title="exactContestDate(contestItem.finish_time)"
+                    :title="exactContestDateTime(contestItem.finish_time)"
                   >
                     {{ pastContestDate(contestItem) }}
                   </a>
@@ -792,8 +792,8 @@ class ArenaContestList extends Vue {
     return time.getDisplayForPastContest(contest.finish_time);
   }
 
-  exactContestDate(date: Date): string {
-    return time.formatDateForContest(date);
+  exactContestDateTime(date: Date): string {
+    return `${time.formatDateForContest(date)}, ${date.toLocaleTimeString()}`;
   }
 
   getTimeLink(time: Date): string {

--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -223,32 +223,29 @@
                   <template #text-contest-date>
                     <b-card-text v-if="tab === ContestTab.Current">
                       <font-awesome-icon icon="calendar-alt" />
-                      <a :href="getTimeLink(contestItem.finish_time)">
-                        {{
-                          ui.formatString(T.contestEndTime, {
-                            endDate: finishContestDate(contestItem),
-                          })
-                        }}
+                      <a
+                        :href="getTimeLink(contestItem.finish_time)"
+                        :title="exactContestDate(contestItem.finish_time)"
+                      >
+                        {{ currentContestDate(contestItem) }}
                       </a>
                     </b-card-text>
                     <b-card-text v-else-if="tab === ContestTab.Future">
                       <font-awesome-icon icon="calendar-alt" />
-                      <a :href="getTimeLink(contestItem.start_time)">
-                        {{
-                          ui.formatString(T.contestStartTime, {
-                            startDate: startContestDate(contestItem),
-                          })
-                        }}
+                      <a
+                        :href="getTimeLink(contestItem.start_time)"
+                        :title="exactContestDate(contestItem.start_time)"
+                      >
+                        {{ futureContestDate(contestItem) }}
                       </a>
                     </b-card-text>
                     <b-card-text v-else-if="tab === ContestTab.Past">
                       <font-awesome-icon icon="calendar-alt" />
-                      <a :href="getTimeLink(contestItem.start_time)">
-                        {{
-                          ui.formatString(T.contestStartedTime, {
-                            startedDate: startContestDate(contestItem),
-                          })
-                        }}
+                      <a
+                        :href="getTimeLink(contestItem.finish_time)"
+                        :title="exactContestDate(contestItem.finish_time)"
+                      >
+                        {{ pastContestDate(contestItem) }}
                       </a>
                     </b-card-text>
                   </template>
@@ -364,32 +361,29 @@
               <template #text-contest-date>
                 <b-card-text v-if="viewAllCategory === ContestTab.Current">
                   <font-awesome-icon icon="calendar-alt" />
-                  <a :href="getTimeLink(contestItem.finish_time)">
-                    {{
-                      ui.formatString(T.contestEndTime, {
-                        endDate: finishContestDate(contestItem),
-                      })
-                    }}
+                  <a
+                    :href="getTimeLink(contestItem.finish_time)"
+                    :title="exactContestDate(contestItem.finish_time)"
+                  >
+                    {{ currentContestDate(contestItem) }}
                   </a>
                 </b-card-text>
                 <b-card-text v-else-if="viewAllCategory === ContestTab.Future">
                   <font-awesome-icon icon="calendar-alt" />
-                  <a :href="getTimeLink(contestItem.start_time)">
-                    {{
-                      ui.formatString(T.contestStartTime, {
-                        startDate: startContestDate(contestItem),
-                      })
-                    }}
+                  <a
+                    :href="getTimeLink(contestItem.start_time)"
+                    :title="exactContestDate(contestItem.start_time)"
+                  >
+                    {{ futureContestDate(contestItem) }}
                   </a>
                 </b-card-text>
                 <b-card-text v-else-if="viewAllCategory === ContestTab.Past">
                   <font-awesome-icon icon="calendar-alt" />
-                  <a :href="getTimeLink(contestItem.start_time)">
-                    {{
-                      ui.formatString(T.contestStartedTime, {
-                        startedDate: startContestDate(contestItem),
-                      })
-                    }}
+                  <a
+                    :href="getTimeLink(contestItem.finish_time)"
+                    :title="exactContestDate(contestItem.finish_time)"
+                  >
+                    {{ pastContestDate(contestItem) }}
                   </a>
                 </b-card-text>
               </template>
@@ -478,6 +472,7 @@ const debounce = (fn: (...args: any[]) => void, waitTime: number) => {
 
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { types } from '../../api_types';
+import * as time from '../../time';
 import * as ui from '../../ui';
 import T from '../../lang';
 import { getExternalUrl } from '../../urlHelper';
@@ -785,12 +780,20 @@ class ArenaContestList extends Vue {
     }, 1000);
   }
 
-  finishContestDate(contest: types.ContestListItem): string {
-    return contest.finish_time.toLocaleDateString();
+  currentContestDate(contest: types.ContestListItem): string {
+    return time.getDisplayForCurrentContest(contest.finish_time);
   }
 
-  startContestDate(contest: types.ContestListItem): string {
-    return contest.start_time.toLocaleDateString();
+  futureContestDate(contest: types.ContestListItem): string {
+    return time.getDisplayForFutureContest(contest.start_time);
+  }
+
+  pastContestDate(contest: types.ContestListItem): string {
+    return time.getDisplayForPastContest(contest.finish_time);
+  }
+
+  exactContestDate(date: Date): string {
+    return time.formatDateForContest(date);
   }
 
   getTimeLink(time: Date): string {


### PR DESCRIPTION
# Description

This PR updates the ArenaV2 horizontal grid layout to format contest dates using human-readable, relative time (e.g. "Ends in 3 days", "Started 2 hours ago"). 

Previously, these dates were displayed using raw locale representations. This change brings consistent date formatting UI parity across both the `/arena/` and `/arenav2/` interfaces, including proper translation localization using existing configuration.

# Changes

- `frontend/www/js/omegaup/components/arena/ContestList.vue`: Replaced localized date string methods (`finishContestDate`, `startContestDate`) with human-readable string wrappers from `time.ts` (`getDisplayForCurrentContest`, `getDisplayForFutureContest`, `getDisplayForPastContest`). Added exact explicit dates as hover `title` tooltips.

Fixes #9646

# Comments

The logic relies entirely on pre-existing localized functions within `time.ts` that were previously implemented for the legacy list-view component.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.

<img width="1919" height="954" alt="Screenshot 2026-04-05 020905" src="https://github.com/user-attachments/assets/0e882248-42ec-4a03-b5ca-00dcb4144356" />