### PR TITLE
Add controller support for social media fields in user profile

### DIFF
--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -1482,6 +1482,9 @@ class User extends \OmegaUp\Controllers\Controller {
                 $user->hide_problem_tags
             ) ? false : $user->hide_problem_tags,
             'is_own_profile' => false,
+            'x_url' => $user->x_url,
+            'linkedin_url' => $user->linkedin_url,
+            'github_url' => $user->github_url,
         ];
 
         $userDb = \OmegaUp\DAO\Users::getExtendedProfileDataByPk(
@@ -2733,9 +2736,42 @@ class User extends \OmegaUp\Controllers\Controller {
             'gender',
         ];
 
+        // Social media fields
+        $xUrl = $r->ensureOptionalString('x_url', required: false);
+        $linkedinUrl = $r->ensureOptionalString(
+            'linkedin_url',
+            required: false
+        );
+        $githubUrl = $r->ensureOptionalString('github_url', required: false);
+
+        foreach (
+            [
+            'x_url' => $xUrl,
+            'linkedin_url' => $linkedinUrl,
+            'github_url' => $githubUrl,
+            ] as $field => $value
+        ) {
+            if (!is_null($value) && !\OmegaUp\Validators::isValidURL($value)) {
+                throw new \OmegaUp\Exceptions\InvalidParameterException(
+                    'parameterInvalid',
+                    $field
+                );
+            }
+        }
         self::updateValueProperties($r, $r->user, $userValueProperties);
         self::updateValueProperties($r, $r->identity, $identityValueProperties);
 
+        if ($r->hasParameter('x_url')) {
+            $r->user->x_url = $xUrl;
+        }
+
+        if ($r->hasParameter('linkedin_url')) {
+            $r->user->linkedin_url = $linkedinUrl;
+        }
+
+        if ($r->hasParameter('github_url')) {
+            $r->user->github_url = $githubUrl;
+        }
         try {
             \OmegaUp\DAO\DAO::transBegin();
 


### PR DESCRIPTION


## Description

This PR implements controller-level support for the social media fields (`x_url`, `linkedin_url`, `github_url`) as part of the feature to add social media links to user profiles.

---

### Changes

* Added handling of `x_url`, `linkedin_url`, and `github_url` in `apiUpdate`
* Added validation using existing `Validators::isValidURL`
* Supported partial updates using `hasParameter` to avoid unintended overwrites
* Supported deletion of fields by allowing `null` values
* Included social media fields in `getProfileImpl` response

---

### Design Considerations

* All fields are optional to maintain backward compatibility
* Validation leverages existing utilities to follow codebase patterns
* Updates are applied only when parameters are explicitly provided
* No changes were made to existing workflows or unrelated fields

---

### Dependencies

* Depends on DAO updates for social media fields (#8860)
* Part of #8692 (Add Social Media Links to User Profile)

---

### Notes

* Existing functionality remains unaffected
* API responses now include social media fields when available

---

Fixes #8867