### PR TITLE
Fix stray apostrophe in group scoreboard “Coder” column when display name differs from username

### DIFF
--- a/frontend/www/js/omegaup/components/group/ScoreboardDetails.vue
+++ b/frontend/www/js/omegaup/components/group/ScoreboardDetails.vue
@@ -24,7 +24,7 @@
             <td class="legend"></td>
             <td class="user">
               {{ rank.username }}
-              {{ rank.name == rank.username ? '' : `(${rank.name})'` }}
+              {{ rank.name == rank.username ? '' : `(${rank.name})` }}
             </td>
             <td
               v-for="contest in contests"


### PR DESCRIPTION
# Description

Remove a typo in the group scoreboard details template: the display name suffix used a template literal ending with `)'` instead of `)`, which rendered an extra apostrophe after the parenthesized name (e.g. `user (Display Name)'`).

If this PR is merged, the commit message can be:

Fix stray quote in group scoreboard details display name

Fixes: #9758 

# Comments

UI-only string fix in `ScoreboardDetails.vue`. 
<img width="1874" height="909" alt="image" src="https://github.com/user-attachments/assets/515e475c-4539-4669-a1b4-c3127fea7972" />


# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
