### PR TITLE
Fix Bootstrap class typo justify-content-arround in COTM/SOTM lists

### DIFF
--- a/frontend/www/js/omegaup/components/coderofthemonth/List.vue
+++ b/frontend/www/js/omegaup/components/coderofthemonth/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card w-100">
-    <ul class="nav nav-tabs justify-content-arround" role="tablist">
+    <ul class="nav nav-tabs justify-content-around" role="tablist">
       <li v-for="tab in availableTabs" :key="tab.id" class="nav-item">
         <a
           :href="getTabName(tab)"

--- a/frontend/www/js/omegaup/components/schoolofthemonth/List.vue
+++ b/frontend/www/js/omegaup/components/schoolofthemonth/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card ranking-width">
-    <ul class="nav nav-tabs justify-content-arround">
+    <ul class="nav nav-tabs justify-content-around">
       <li class="nav-item">
         <a
           href="#"


### PR DESCRIPTION
# Description

Correct the invalid Bootstrap utility class `justify-content-arround` to `justify-content-around` in the Coder of the month and School of the month list components so tab nav flex alignment uses the intended spacing.

Fixes: #9759 

# Comments

Small CSS class name fix in two Vue templates.
<img width="1869" height="904" alt="image" src="https://github.com/user-attachments/assets/c9c89c1f-ffcd-41b5-9ee5-6995d0b2166a" />


# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.