### PR TITLE
Fix starTime typo in arena Summary scoreboard cutoff

### DIFF
--- a/frontend/www/js/omegaup/components/arena/Summary.vue
+++ b/frontend/www/js/omegaup/components/arena/Summary.vue
@@ -35,7 +35,7 @@
         <td>
           {{
             time.formatTimestamp(
-              new Date(starTime.getTime() + (duration * scoreboard) / 100),
+              new Date(startTime.getTime() + (duration * scoreboard) / 100),
             )
           }}
         </td>


### PR DESCRIPTION
# Description

The contest summary template referenced `starTime.getTime()` while the component prop is `startTime`. If the scoreboard cutoff row were rendered (`showRanking` true, numeric `scoreboard`, finite duration), this would throw at runtime. Replace `starTime` with `startTime` so the cutoff timestamp uses the correct value.


Fixes: #9760 

# Comments

With current parents (`show-ranking="false"` on arena summary in contest/practice), this row may not appear in production; the fix is still required for correctness and any future caller that enables the row.

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.