### PR TITLE
Fix(#9765): Display API Tokens table as vertical card layout on mobile

### DIFF
--- a/frontend/www/js/omegaup/components/user/ManageApiTokens.vue
+++ b/frontend/www/js/omegaup/components/user/ManageApiTokens.vue
@@ -30,8 +30,8 @@
       </div>
     </div>
     <div v-else>
-      <!-- Desktop / tablet: standard table -->
-      <div class="table-responsive d-none d-sm-block">
+      <!-- Desktop / tablet (md and up): standard table -->
+      <div class="table-responsive d-none d-md-block">
         <table class="table table-striped table-over">
           <thead>
             <tr>
@@ -65,8 +65,8 @@
         </table>
       </div>
 
-      <!-- Mobile: vertical card layout -->
-      <div class="d-block d-sm-none">
+      <!-- Mobile / small screens (below md): vertical card layout -->
+      <div class="d-block d-md-none">
         <div
           v-for="apiToken in apiTokens"
           :key="apiToken.name"
@@ -180,19 +180,19 @@ export default class ManageApiTokens extends Vue {
 
 // Mobile card layout
 .api-token-card {
-  border: 1px solid #dee2e6;
+  border: 1px solid var(--user-api-token-card-border-color);
   border-radius: 0.5rem;
   padding: 1rem;
   margin-bottom: 1rem;
-  background-color: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  background-color: var(--user-api-token-card-background-color);
+  box-shadow: 0 1px 3px var(--user-api-token-card-box-shadow-color);
 
   &__row {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
     padding: 0.35rem 0;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--user-api-token-card-row-border-color);
 
     &:last-of-type {
       border-bottom: none;
@@ -201,14 +201,14 @@ export default class ManageApiTokens extends Vue {
 
   &__label {
     font-weight: 600;
-    color: #495057;
+    color: var(--user-api-token-card-label-color);
     font-size: 0.85rem;
     flex: 0 0 45%;
     padding-right: 0.5rem;
   }
 
   &__value {
-    color: #212529;
+    color: var(--user-api-token-card-value-color);
     font-size: 0.85rem;
     flex: 0 0 55%;
     text-align: right;

--- a/frontend/www/js/omegaup/components/user/ManageApiTokens.vue
+++ b/frontend/www/js/omegaup/components/user/ManageApiTokens.vue
@@ -29,40 +29,95 @@
         {{ T.profileApiTokensEmpty }}
       </div>
     </div>
-    <div v-else class="table-responsive">
-      <table class="table table-striped table-over">
-        <thead>
-          <tr>
-            <th>{{ T.apiTokenName }}</th>
-            <th>{{ T.apiTokenTimestamp }}</th>
-            <th>{{ T.apiTokenLastTimeUsed }}</th>
-            <th>{{ T.apiTokenResetTime }}</th>
-            <th>{{ T.apiTokenRemaining }}</th>
-            <th>{{ T.apiTokenLimit }}</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="apiToken in apiTokens" :key="apiToken.name">
-            <td data-label="Token">{{ apiToken.name }}</td>
-            <td data-label="Timestamp">{{ formatTime(apiToken.timestamp) }}</td>
-            <td data-label="Last used">{{ formatTime(apiToken.last_used) }}</td>
-            <td data-label="Reset time">
-              {{ formatTime(apiToken.rate_limit.reset) }}
-            </td>
-            <td data-label="Remaining">{{ apiToken.rate_limit.remaining }}</td>
-            <td data-label="Limit">{{ apiToken.rate_limit.limit }}</td>
-            <td>
-              <button
-                class="btn btn-secondary btn-sm"
-                @click="$emit('revoke-api-token', apiToken.name)"
-              >
-                {{ T.apiTokenRevoke }}
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <div v-else>
+      <!-- Desktop / tablet: standard table -->
+      <div class="table-responsive d-none d-sm-block">
+        <table class="table table-striped table-over">
+          <thead>
+            <tr>
+              <th>{{ T.apiTokenName }}</th>
+              <th>{{ T.apiTokenTimestamp }}</th>
+              <th>{{ T.apiTokenLastTimeUsed }}</th>
+              <th>{{ T.apiTokenResetTime }}</th>
+              <th>{{ T.apiTokenRemaining }}</th>
+              <th>{{ T.apiTokenLimit }}</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="apiToken in apiTokens" :key="apiToken.name">
+              <td>{{ apiToken.name }}</td>
+              <td>{{ formatTime(apiToken.timestamp) }}</td>
+              <td>{{ formatTime(apiToken.last_used) }}</td>
+              <td>{{ formatTime(apiToken.rate_limit.reset) }}</td>
+              <td>{{ apiToken.rate_limit.remaining }}</td>
+              <td>{{ apiToken.rate_limit.limit }}</td>
+              <td>
+                <button
+                  class="btn btn-secondary btn-sm"
+                  @click="$emit('revoke-api-token', apiToken.name)"
+                >
+                  {{ T.apiTokenRevoke }}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Mobile: vertical card layout -->
+      <div class="d-block d-sm-none">
+        <div
+          v-for="apiToken in apiTokens"
+          :key="apiToken.name"
+          class="api-token-card"
+        >
+          <div class="api-token-card__row">
+            <span class="api-token-card__label">{{ T.apiTokenName }}</span>
+            <span class="api-token-card__value">{{ apiToken.name }}</span>
+          </div>
+          <div class="api-token-card__row">
+            <span class="api-token-card__label">{{ T.apiTokenTimestamp }}</span>
+            <span class="api-token-card__value">{{
+              formatTime(apiToken.timestamp)
+            }}</span>
+          </div>
+          <div class="api-token-card__row">
+            <span class="api-token-card__label">{{
+              T.apiTokenLastTimeUsed
+            }}</span>
+            <span class="api-token-card__value">{{
+              formatTime(apiToken.last_used)
+            }}</span>
+          </div>
+          <div class="api-token-card__row">
+            <span class="api-token-card__label">{{ T.apiTokenResetTime }}</span>
+            <span class="api-token-card__value">{{
+              formatTime(apiToken.rate_limit.reset)
+            }}</span>
+          </div>
+          <div class="api-token-card__row">
+            <span class="api-token-card__label">{{ T.apiTokenRemaining }}</span>
+            <span class="api-token-card__value">{{
+              apiToken.rate_limit.remaining
+            }}</span>
+          </div>
+          <div class="api-token-card__row">
+            <span class="api-token-card__label">{{ T.apiTokenLimit }}</span>
+            <span class="api-token-card__value">{{
+              apiToken.rate_limit.limit
+            }}</span>
+          </div>
+          <div class="api-token-card__actions">
+            <button
+              class="btn btn-secondary btn-sm btn-block"
+              @click="$emit('revoke-api-token', apiToken.name)"
+            >
+              {{ T.apiTokenRevoke }}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -120,6 +175,53 @@ export default class ManageApiTokens extends Vue {
   th,
   td {
     vertical-align: middle;
+  }
+}
+
+// Mobile card layout
+.api-token-card {
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+  &__row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid #f0f0f0;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  &__label {
+    font-weight: 600;
+    color: #495057;
+    font-size: 0.85rem;
+    flex: 0 0 45%;
+    padding-right: 0.5rem;
+  }
+
+  &__value {
+    color: #212529;
+    font-size: 0.85rem;
+    flex: 0 0 55%;
+    text-align: right;
+    word-break: break-word;
+  }
+
+  &__actions {
+    margin-top: 0.75rem;
+
+    .btn-block {
+      display: block;
+      width: 100%;
+    }
   }
 }
 </style>

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -285,6 +285,14 @@
   --user-basic-info-form-group-border-color: #e9e9e9;
   --user-basic-info-field-data-font-color: #808080;
 
+  // USER API TOKENS
+  --user-api-token-card-border-color: #dee2e6;
+  --user-api-token-card-background-color: #fff;
+  --user-api-token-card-box-shadow-color: rgba(0, 0, 0, 0.08);
+  --user-api-token-card-row-border-color: #f0f0f0;
+  --user-api-token-card-label-color: #495057;
+  --user-api-token-card-value-color: #212529;
+
   // USER COMPARE
   --user-compare-stat-item-background-color: #f8f9fa;
   --user-compare-stat-label-font-color: #6c757d;


### PR DESCRIPTION
# Description
This pull request improves the user experience for managing API tokens on different devices by introducing a responsive design to the `ManageApiTokens.vue` component. Now, API tokens are displayed in a standard table on desktop/tablet screens and in a mobile-friendly card layout on smaller devices. The main changes are as follows:

**Responsive layout for API tokens:**

* Added a conditional layout to display API tokens as a table on desktop/tablet (`.d-none .d-sm-block`) and as vertically-stacked cards on mobile (`.d-block .d-sm-none`) in `ManageApiTokens.vue`. [[1]](diffhunk://#diff-c403417927a82635ddbbd6745d14f5bfc51da64c7b1f345172bdfa163434744bL32-R34) [[2]](diffhunk://#diff-c403417927a82635ddbbd6745d14f5bfc51da64c7b1f345172bdfa163434744bR67-R121)

**Mobile card UI implementation:**

* Implemented a new `.api-token-card` style for mobile, including visual enhancements such as borders, padding, and a shadow, as well as a flexbox-based row layout for token details and actions.

**Table markup simplification:**

* Simplified the table markup by removing unnecessary `data-label` attributes, since these are no longer needed for the desktop/tablet view.

[Screencast from 2026-04-15 22-56-28.webm](https://github.com/user-attachments/assets/2d0a55b7-879d-4218-930b-eb28861f5e37)

Fixes: #9765 

# Comments

Add any comments for the reviewers (e.g., indicating the beginning of the revision, something where the reviewer needs to pay special attention, etc.). If  there are no extra comments this section can be deleted.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
