### PR TITLE
fix: initialize all 10 verdict keys in groupedPeriods to prevent NaN

### DIFF
--- a/frontend/www/js/omegaup/components/user/Charts.vue
+++ b/frontend/www/js/omegaup/components/user/Charts.vue
@@ -202,7 +202,18 @@ export default class UserCharts extends Vue {
         delta: [],
         cumulative: [],
       };
-      const verdicts = ['AC', 'PA', 'WA', 'TLE', 'RTE', 'CE', 'JE', 'MLE', 'OLE', 'VE'];
+      const verdicts = [
+        'AC',
+        'PA',
+        'WA',
+        'TLE',
+        'RTE',
+        'CE',
+        'JE',
+        'MLE',
+        'OLE',
+        'VE',
+      ];
       for (const verdict of verdicts) {
         runsByVerdict[period][verdict] = 0;
       }

--- a/frontend/www/js/omegaup/components/user/Charts.vue
+++ b/frontend/www/js/omegaup/components/user/Charts.vue
@@ -202,7 +202,7 @@ export default class UserCharts extends Vue {
         delta: [],
         cumulative: [],
       };
-      const verdicts = ['AC', 'PA', 'WA', 'TLE', 'RTE'];
+      const verdicts = ['AC', 'PA', 'WA', 'TLE', 'RTE', 'CE', 'JE', 'MLE', 'OLE', 'VE'];
       for (const verdict of verdicts) {
         runsByVerdict[period][verdict] = 0;
       }
@@ -260,7 +260,18 @@ export default class UserCharts extends Vue {
       periodStats[period] = stats.reduce(
         (groups: omegaup.VerdictByDate, item: omegaup.RunInfo) => {
           const val = item[period] || '';
-          groups[val] = groups[val] || { WA: 0, PA: 0, AC: 0, TLE: 0, RTE: 0 };
+          groups[val] = groups[val] || {
+            WA: 0,
+            PA: 0,
+            AC: 0,
+            TLE: 0,
+            RTE: 0,
+            CE: 0,
+            JE: 0,
+            MLE: 0,
+            OLE: 0,
+            VE: 0,
+          };
           groups[val][item.verdict] += item.runs;
           return groups;
         },


### PR DESCRIPTION
# Description

This PR resolves a bug in `Chartsv2.vue` where time-series ("delta" or "cumulative") charts fail and produce `NaN` values for users with non-core verdicts (such as CE, JE, MLE, OLE, or VE). 

Changes included:
* Explicitly initialized all 10 verdict keys in the `groupedPeriods` bucket to prevent `undefined + N` bugs during aggregation.
* Updated `normalizedPeriodRunCounts` to correctly iterate over all 10 verdicts instead of a hardcoded array of just 5 verdicts.

Fixes: #9751

# Comments

The fix ensures consistency by manually tracking all the exactly known 10 verdict types. 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding_guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.
