### PR TITLE
Fix/accent insensitive typeahead

### DIFF
--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.test.ts
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.test.ts
@@ -1,4 +1,4 @@
-import VoerroTagsInput from '@voerro/vue-tagsinput';
+import VoerroTagsInput from './VoerroTagsInput.vue';
 import { mount } from '@vue/test-utils';
 import Vue from 'vue';
 import common_MultiTypeahead from './MultiTypeahead.vue';

--- a/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
+++ b/frontend/www/js/omegaup/components/common/MultiTypeahead.vue
@@ -20,7 +20,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import VoerroTagsInput from '@voerro/vue-tagsinput';
+import VoerroTagsInput from './VoerroTagsInput.vue';
 import '@voerro/vue-tagsinput/dist/style.css';
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/common/Typeahead.test.ts
+++ b/frontend/www/js/omegaup/components/common/Typeahead.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import common_Typeahead from './Typeahead.vue';
-import VoerroTagsInput from '@voerro/vue-tagsinput';
+import VoerroTagsInput from './VoerroTagsInput.vue';
 import Vue from 'vue';
 
 describe('Typeahead.vue', () => {

--- a/frontend/www/js/omegaup/components/common/Typeahead.vue
+++ b/frontend/www/js/omegaup/components/common/Typeahead.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import VoerroTagsInput from '@voerro/vue-tagsinput';
+import VoerroTagsInput from './VoerroTagsInput.vue';
 import '@voerro/vue-tagsinput/dist/style.css';
 import T from '../../lang';
 import { types } from '../../api_types';

--- a/frontend/www/js/omegaup/components/common/VoerroTagsInput.vue
+++ b/frontend/www/js/omegaup/components/common/VoerroTagsInput.vue
@@ -1,922 +1,969 @@
-<!--
-  Vendored from @voerro/vue-tagsinput@2.7.1 (src/VoerroTagsInput.vue).
-  OmegaUp-only changes: accent-insensitive typeahead matching (normalizeForSearch in doSearch
-  and tagFromInput). Upstream PR voerro/vue-tagsinput#177 was never merged.
--->
 <template>
-    <div class="tags-input-root" style="position: relative;">
-        <div :class="{
-            [wrapperClass + ' tags-input']: true,
-            'active': isActive,
-            'disabled': disabled,
-        }">
-            <span v-for="(tag, index) in tags"
-                :key="index"
-                class="tags-input-badge tags-input-badge-pill tags-input-badge-selected-default"
-                :class="{ 'disabled': disabled }"
-            >
-                <slot name="selected-tag"
-                    :tag="tag"
-                    :index="index"
-                    :removeTag="removeTag"
-                >
-                    <span v-html="tag[textField]"></span>
+  <!-- eslint-disable vue/no-v-html -->
+  <div class="tags-input-root" style="position: relative">
+    <div
+      :class="{
+        [wrapperClass + ' tags-input']: true,
+        active: isActive,
+        disabled: disabled,
+      }"
+    >
+      <span
+        v-for="(tag, index) in tags"
+        :key="index"
+        class="tags-input-badge tags-input-badge-pill tags-input-badge-selected-default"
+        :class="{ disabled: disabled }"
+      >
+        <slot
+          name="selected-tag"
+          :tag="tag"
+          :index="index"
+          :removeTag="removeTag"
+        >
+          <span v-html="tag[textField]"></span>
 
-                    <a v-show="!disabled"
-                        href="#"
-                        class="tags-input-remove"
-                        @click.prevent="removeTag(index)"></a>
-                </slot>
-            </span>
+          <a
+            v-show="!disabled"
+            href="#"
+            class="tags-input-remove"
+            @click.prevent="removeTag(index)"
+          ></a>
+        </slot>
+      </span>
 
-            <input type="text"
-                ref="taginput"
-                :id="inputId"
-                :name="inputId"
-                :placeholder="placeholder"
-                :value="input"
-                @input="e => input = e.target.value"
-                v-show="!hideInputField"
-                @compositionstart="composing=true"
-                @compositionend="composing=false"
-                @keydown.enter.prevent="tagFromInput(false)"
-                @keydown.8="removeLastTag"
-                @keydown.down="nextSearchResult"
-                @keydown.up="prevSearchResult"
-                @keydown="onKeyDown"
-                @keyup="onKeyUp"
-                @keyup.esc="clearSearchResults"
-                @focus="onFocus"
-                @click="onClick"
-                @blur="onBlur"
-                @value="tags">
+      <input
+        v-show="!hideInputField"
+        :id="inputId"
+        ref="taginput"
+        type="text"
+        :name="inputId"
+        :placeholder="placeholder"
+        :value="input"
+        @input="(e) => (input = e.target.value)"
+        @compositionstart="composing = true"
+        @compositionend="composing = false"
+        @keydown.enter.prevent="tagFromInput(false)"
+        @keydown.8="removeLastTag"
+        @keydown.down="nextSearchResult"
+        @keydown.up="prevSearchResult"
+        @keydown="onKeyDown"
+        @keyup="onKeyUp"
+        @keyup.esc="clearSearchResults"
+        @focus="onFocus"
+        @click="onClick"
+        @blur="onBlur"
+        @value="tags"
+      />
 
-            <div style="display: none;" v-if="elementId">
-                <input v-for="(tag, index) in tags"
-                    :key="index"
-                    type="hidden"
-                    :name="`${elementId}[]`"
-                    :value="hiddenInputValue(tag)">
-            </div>
-        </div>
-
-        <!-- Typeahead/Autocomplete -->
-        <div v-show="searchResults.length">
-            <p v-if="typeaheadStyle === 'badges'"
-                :class="`typeahead-${typeaheadStyle}`"
-            >
-                <span v-if="!typeaheadHideDiscard"
-                    class="tags-input-badge typeahead-hide-btn tags-input-typeahead-item-default"
-                    @click.prevent="clearSearchResults(true)"
-                    v-text="discardSearchText"></span>
-
-                <span v-for="(tag, index) in searchResults"
-                    :key="index"
-                    v-html="tag[textField]"
-                    @mouseover="searchSelection = index"
-                    @mousedown.prevent="tagFromSearchOnClick(tag)"
-                    class="tags-input-badge"
-                    v-bind:class="{
-                        'tags-input-typeahead-item-default': index != searchSelection,
-                        'tags-input-typeahead-item-highlighted-default': index == searchSelection
-                    }"></span>
-            </p>
-
-            <ul v-else-if="typeaheadStyle === 'dropdown'"
-                :class="`typeahead-${typeaheadStyle}`"
-            >
-                <li v-if="!typeaheadHideDiscard"
-                    class="tags-input-typeahead-item-default typeahead-hide-btn"
-                    @click.prevent="clearSearchResults(true)"
-                    v-text="discardSearchText"></li>
-
-                <li v-for="(tag, index) in searchResults"
-                    :key="index"
-                    v-html="getDisplayField(tag)"
-                    @mouseover="searchSelection = index"
-                    @mousedown.prevent="tagFromSearchOnClick(tag)"
-                    v-bind:class="{
-                        'tags-input-typeahead-item-default': index != searchSelection,
-                        'tags-input-typeahead-item-highlighted-default': index == searchSelection
-                    }"></li>
-            </ul>
-        </div>
+      <div v-if="elementId" style="display: none">
+        <input
+          v-for="(tag, index) in tags"
+          :key="index"
+          type="hidden"
+          :name="`${elementId}[]`"
+          :value="hiddenInputValue(tag)"
+        />
+      </div>
     </div>
+
+    <!-- Typeahead/Autocomplete -->
+    <div v-show="searchResults.length">
+      <p
+        v-if="typeaheadStyle === 'badges'"
+        :class="`typeahead-${typeaheadStyle}`"
+      >
+        <span
+          v-if="!typeaheadHideDiscard"
+          class="tags-input-badge typeahead-hide-btn tags-input-typeahead-item-default"
+          @click.prevent="clearSearchResults(true)"
+          v-text="discardSearchText"
+        ></span>
+
+        <span
+          v-for="(tag, index) in searchResults"
+          :key="index"
+          class="tags-input-badge"
+          :class="{
+            'tags-input-typeahead-item-default': index != searchSelection,
+            'tags-input-typeahead-item-highlighted-default':
+              index == searchSelection,
+          }"
+          @mouseover="searchSelection = index"
+          @mousedown.prevent="tagFromSearchOnClick(tag)"
+          v-html="tag[textField]"
+        ></span>
+      </p>
+
+      <ul
+        v-else-if="typeaheadStyle === 'dropdown'"
+        :class="`typeahead-${typeaheadStyle}`"
+      >
+        <li
+          v-if="!typeaheadHideDiscard"
+          class="tags-input-typeahead-item-default typeahead-hide-btn"
+          @click.prevent="clearSearchResults(true)"
+          v-text="discardSearchText"
+        ></li>
+
+        <li
+          v-for="(tag, index) in searchResults"
+          :key="index"
+          :class="{
+            'tags-input-typeahead-item-default': index != searchSelection,
+            'tags-input-typeahead-item-highlighted-default':
+              index == searchSelection,
+          }"
+          @mouseover="searchSelection = index"
+          @mousedown.prevent="tagFromSearchOnClick(tag)"
+          v-html="getDisplayField(tag)"
+        ></li>
+      </ul>
+    </div>
+  </div>
+  <!-- eslint-enable vue/no-v-html -->
 </template>
 
 <script>
 export default {
-    props: {
-        elementId: String,
-
-        inputId: String,
-
-        existingTags: {
-            type: Array,
-            default: () => {
-                return [];
-            }
-        },
-
-        value: {
-            type: Array,
-            default: () => {
-                return [];
-            }
-        },
-
-        idField: {
-            type: String,
-            default: 'key',
-        },
-
-        textField: {
-            type: String,
-            default: 'value',
-        },
-
-        displayField: {
-          type: String,
-          default: null,
-        },
-
-        valueFields: {
-            type: String,
-            default: null,
-        },
-
-        disabled: {
-            type: Boolean,
-            default: false
-        },
-
-        typeahead: {
-            type: Boolean,
-            default: false
-        },
-
-        typeaheadStyle: {
-            type: String,
-            default: 'badges'
-        },
-
-        typeaheadActivationThreshold: {
-            type: Number,
-            default: 1
-        },
-
-        typeaheadMaxResults: {
-            type: Number,
-            default: 0
-        },
-
-        typeaheadAlwaysShow: {
-            type: Boolean,
-            default: false
-        },
-
-        typeaheadShowOnFocus: {
-            type: Boolean,
-            default: true
-        },
-
-        typeaheadHideDiscard: {
-            type: Boolean,
-            default: false
-        },
-
-        typeaheadUrl: {
-            type: String,
-            default: ''
-        },
-
-        typeaheadCallback: {
-            type: Function,
-            default: null
-        },
-
-        placeholder: {
-            type: String,
-            default: 'Add a tag'
-        },
-
-        discardSearchText: {
-            type: String,
-            default: 'Discard Search Results'
-        },
-
-        limit: {
-            type: Number,
-            default: 0
-        },
-
-        hideInputOnLimit: {
-            type: Boolean,
-            default: false
-        },
-
-        onlyExistingTags: {
-            type: Boolean,
-            default: false
-        },
-
-        deleteOnBackspace: {
-            type: Boolean,
-            default: true
-        },
-
-        allowDuplicates: {
-            type: Boolean,
-            default: false
-        },
-
-        validate: {
-            type: Function,
-            default: () => true
-        },
-
-        addTagsOnComma: {
-            type: Boolean,
-            default: false
-        },
-
-        addTagsOnSpace: {
-            type: Boolean,
-            default: false
-        },
-
-        addTagsOnBlur: {
-            type: Boolean,
-            default: false
-        },
-
-        wrapperClass: {
-            type: String,
-            default: 'tags-input-wrapper-default'
-        },
-
-        sortSearchResults: {
-            type: Boolean,
-            default: true
-        },
-
-        caseSensitiveTags: {
-            type: Boolean,
-            default: false
-        },
-
-        beforeAddingTag: {
-            type: Function,
-            default: () => true
-        },
-
-        beforeRemovingTag: {
-            type: Function,
-            default: () => true
-        },
+  props: {
+    elementId: {
+      type: String,
+      default: '',
     },
 
-    data() {
-        return {
-            badgeId: 0,
-            tags: [],
-
-            input: '',
-            oldInput: '',
-            hiddenInput: '',
-
-            searchResults: [],
-            searchSelection: 0,
-
-            selectedTag: -1,
-
-            isActive: false,
-            composing: false,
-        };
+    inputId: {
+      type: String,
+      default: '',
     },
 
-    created () {
-        this.typeaheadTags = this.cloneArray(this.existingTags);
+    existingTags: {
+      type: Array,
+      default: () => {
+        return [];
+      },
+    },
 
-        this.tagsFromValue();
+    value: {
+      type: Array,
+      default: () => {
+        return [];
+      },
+    },
+
+    idField: {
+      type: String,
+      default: 'key',
+    },
+
+    textField: {
+      type: String,
+      default: 'value',
+    },
+
+    displayField: {
+      type: String,
+      default: null,
+    },
+
+    valueFields: {
+      type: String,
+      default: null,
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+
+    typeahead: {
+      type: Boolean,
+      default: false,
+    },
+
+    typeaheadStyle: {
+      type: String,
+      default: 'badges',
+    },
+
+    typeaheadActivationThreshold: {
+      type: Number,
+      default: 1,
+    },
+
+    typeaheadMaxResults: {
+      type: Number,
+      default: 0,
+    },
+
+    typeaheadAlwaysShow: {
+      type: Boolean,
+      default: false,
+    },
+
+    typeaheadShowOnFocus: {
+      type: Boolean,
+      default: true,
+    },
+
+    typeaheadHideDiscard: {
+      type: Boolean,
+      default: false,
+    },
+
+    typeaheadUrl: {
+      type: String,
+      default: '',
+    },
+
+    typeaheadCallback: {
+      type: Function,
+      default: null,
+    },
+
+    placeholder: {
+      type: String,
+      default: 'Add a tag',
+    },
+
+    discardSearchText: {
+      type: String,
+      default: 'Discard Search Results',
+    },
+
+    limit: {
+      type: Number,
+      default: 0,
+    },
+
+    hideInputOnLimit: {
+      type: Boolean,
+      default: false,
+    },
+
+    onlyExistingTags: {
+      type: Boolean,
+      default: false,
+    },
+
+    deleteOnBackspace: {
+      type: Boolean,
+      default: true,
+    },
+
+    allowDuplicates: {
+      type: Boolean,
+      default: false,
+    },
+
+    validate: {
+      type: Function,
+      default: () => true,
+    },
+
+    addTagsOnComma: {
+      type: Boolean,
+      default: false,
+    },
+
+    addTagsOnSpace: {
+      type: Boolean,
+      default: false,
+    },
+
+    addTagsOnBlur: {
+      type: Boolean,
+      default: false,
+    },
+
+    wrapperClass: {
+      type: String,
+      default: 'tags-input-wrapper-default',
+    },
+
+    sortSearchResults: {
+      type: Boolean,
+      default: true,
+    },
+
+    caseSensitiveTags: {
+      type: Boolean,
+      default: false,
+    },
+
+    beforeAddingTag: {
+      type: Function,
+      default: () => true,
+    },
+
+    beforeRemovingTag: {
+      type: Function,
+      default: () => true,
+    },
+  },
+
+  data() {
+    return {
+      badgeId: 0,
+      tags: [],
+
+      input: '',
+      oldInput: '',
+      hiddenInput: '',
+
+      searchResults: [],
+      searchSelection: 0,
+
+      selectedTag: -1,
+
+      isActive: false,
+      composing: false,
+    };
+  },
+
+  computed: {
+    hideInputField() {
+      return (
+        (this.hideInputOnLimit &&
+          this.limit > 0 &&
+          this.tags.length >= this.limit) ||
+        this.disabled
+      );
+    },
+  },
+
+  watch: {
+    input(newVal, oldVal) {
+      this.searchTag(false);
+
+      if (newVal.length && newVal != oldVal) {
+        if (this.addTagsOnSpace) {
+          if (newVal.endsWith(' ')) {
+            // The space shouldn't actually be inserted
+            this.input = newVal.trim();
+
+            // Add the inputed tag
+            this.tagFromInput(true);
+          }
+        }
+
+        if (this.addTagsOnComma) {
+          newVal = newVal.trim();
+
+          if (newVal.endsWith(',')) {
+            // The comma shouldn't actually be inserted
+            this.input = newVal.substring(0, newVal.length - 1);
+
+            // Add the inputed tag
+            this.tagFromInput(true);
+          }
+        }
+
+        this.$emit('change', newVal);
+      }
+    },
+
+    existingTags(newVal) {
+      this.typeaheadTags.splice(0);
+
+      this.typeaheadTags = this.cloneArray(newVal);
+
+      this.searchTag();
+    },
+
+    tags() {
+      // Updating the hidden input
+      this.hiddenInput = JSON.stringify(this.tags);
+
+      // Update the bound v-model value
+      this.$emit('input', this.tags);
+    },
+
+    value() {
+      this.tagsFromValue();
+    },
+
+    typeaheadAlwaysShow(newValue) {
+      if (newValue) {
+        this.searchTag(false);
+      } else {
+        this.clearSearchResults();
+      }
+    },
+  },
+
+  created() {
+    this.typeaheadTags = this.cloneArray(this.existingTags);
+
+    this.tagsFromValue();
+
+    if (this.typeaheadAlwaysShow) {
+      this.searchTag(false);
+    }
+  },
+
+  mounted() {
+    // Emit an event
+    this.$emit('initialized');
+
+    document.addEventListener('click', (e) => {
+      if (e.target !== this.$refs['taginput']) {
+        this.clearSearchResults();
+      }
+    });
+  },
+
+  methods: {
+    /**
+     * Remove reserved regex characters from a string so that they don't
+     * affect search results
+     *
+     * @param string
+     * @returns String
+     */
+    escapeRegExp(string) {
+      return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    },
+
+    /**
+     * Strip HTML so we match against visible problem titles (omegaUp passes HTML in value).
+     */
+    stripHtmlForSearch(str) {
+      return String(str).replace(/<[^>]*>/g, '');
+    },
+
+    /**
+     * Case- and accent-insensitive text for matching user input to API results.
+     * Aligns with MySQL utf8mb4_0900_ai_ci for LIKE; fixes dropdown filtering that
+     * used String.prototype.search (accent-sensitive in JavaScript).
+     */
+    normalizeForSearch(str, { caseSensitive = false } = {}) {
+      let s = this.stripHtmlForSearch(str);
+      s = s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      return caseSensitive ? s : s.toLowerCase();
+    },
+
+    /**
+     * Add a tag whether from user input or from search results (typeahead)
+     *
+     * @param ignoreSearchResults
+     * @returns void
+     */
+    tagFromInput(ignoreSearchResults = false) {
+      if (this.composing) return;
+
+      // If we're choosing a tag from the search results
+      if (
+        this.searchResults.length &&
+        this.searchSelection >= 0 &&
+        !ignoreSearchResults
+      ) {
+        this.tagFromSearch(this.searchResults[this.searchSelection]);
+
+        this.input = '';
+      } else {
+        // If we're adding an unexisting tag
+        let text = this.input.trim();
+
+        // If the new tag is not an empty string and passes validation
+        if (!this.onlyExistingTags && text.length && this.validate(text)) {
+          this.input = '';
+
+          // Determine if the inputted tag exists in the typeagedTags
+          // array
+          let newTag = {
+            [this.idField]: '',
+            [this.textField]: text,
+          };
+
+          const needle = this.normalizeForSearch(newTag[this.textField], {
+            caseSensitive: this.caseSensitiveTags,
+          });
+
+          for (let tag of this.typeaheadTags) {
+            const haystack = this.normalizeForSearch(tag[this.textField], {
+              caseSensitive: this.caseSensitiveTags,
+            });
+
+            if (needle === haystack) {
+              newTag = Object.assign({}, tag);
+
+              break;
+            }
+          }
+
+          this.addTag(newTag);
+        }
+      }
+    },
+
+    /**
+     * Add a tag from search results when a user clicks on it
+     *
+     * @param tag
+     * @returns void
+     */
+    tagFromSearchOnClick(tag) {
+      this.tagFromSearch(tag);
+
+      this.$refs['taginput'].blur();
+    },
+
+    /**
+     * Add the selected tag from the search results.
+     * Clear search results.
+     * Clear user input.
+     *
+     * @param tag
+     * @return void
+     */
+    tagFromSearch(tag) {
+      this.clearSearchResults();
+      this.addTag(tag);
+
+      this.$nextTick(() => {
+        this.input = '';
+        this.oldInput = '';
+      });
+    },
+
+    /**
+     * Add/Select a tag
+     *
+     * @param tag
+     * @param force
+     * @returns void | Boolean
+     */
+    addTag(tag, force = false) {
+      if (this.disabled && !force) {
+        return;
+      }
+
+      if (!this.beforeAddingTag(tag)) {
+        return false;
+      }
+
+      // Check if the limit has been reached
+      if (this.limit > 0 && this.tags.length >= this.limit) {
+        this.$emit('limit-reached');
+
+        return false;
+      }
+
+      // Attach the tag if it hasn't been attached yet
+      if (!this.tagSelected(tag)) {
+        this.tags.push(tag);
+
+        // Emit events
+        this.$nextTick(() => {
+          this.$emit('tag-added', tag);
+          this.$emit('tags-updated');
+        });
+      }
+    },
+
+    /**
+     * Remove the last tag in the tags array.
+     *
+     * @returns void
+     */
+    removeLastTag() {
+      if (!this.input.length && this.deleteOnBackspace && this.tags.length) {
+        this.removeTag(this.tags.length - 1);
+      }
+    },
+
+    /**
+     * Remove the selected tag at the specified index.
+     *
+     * @param index
+     * @returns void
+     */
+    removeTag(index) {
+      if (this.disabled) {
+        return;
+      }
+
+      let tag = this.tags[index];
+
+      if (!this.beforeRemovingTag(tag)) {
+        return false;
+      }
+
+      this.tags.splice(index, 1);
+
+      // Emit events
+      this.$nextTick(() => {
+        this.$emit('tag-removed', tag);
+        this.$emit('tags-updated');
 
         if (this.typeaheadAlwaysShow) {
-            this.searchTag(false);
+          this.searchTag();
         }
+      });
     },
 
-    mounted () {
-        // Emit an event
-        this.$emit('initialized');
+    /**
+     * Search the currently entered text in the list of existing tags
+     *
+     * @returns void | Boolean
+     */
+    searchTag() {
+      if (this.typeahead !== true) {
+        return false;
+      }
 
-        document.addEventListener('click', (e) => {
-            if (e.target !== this.$refs['taginput']) {
-                this.clearSearchResults();
-            }
-        });
-    },
-
-    computed: {
-        hideInputField() {
-            return (this.hideInputOnLimit && this.limit > 0 && this.tags.length >= this.limit) || this.disabled;
+      if (
+        this.oldInput != this.input ||
+        (!this.searchResults.length &&
+          this.typeaheadActivationThreshold == 0) ||
+        this.typeaheadAlwaysShow ||
+        this.typeaheadShowOnFocus
+      ) {
+        if (!this.typeaheadUrl.length && !this.typeaheadCallback) {
+          this.searchResults = [];
         }
-    },
 
-    watch: {
-        input(newVal, oldVal) {
-            this.searchTag(false);
+        this.searchSelection = 0;
+        let input = this.input.trim();
 
-            if (newVal.length && newVal != oldVal) {
-                const diff = newVal.substring(oldVal.length, newVal.length);
+        if (
+          (input.length && input.length >= this.typeaheadActivationThreshold) ||
+          this.typeaheadActivationThreshold == 0 ||
+          this.typeaheadAlwaysShow
+        ) {
+          // Find all the existing tags which include the search text
+          const searchQuery = this.escapeRegExp(
+            this.caseSensitiveTags ? input : input.toLowerCase(),
+          );
+          const normalizedNeedle = this.normalizeForSearch(input, {
+            caseSensitive: this.caseSensitiveTags,
+          });
 
-                if (this.addTagsOnSpace) {
-                    if (newVal.endsWith(' ')) {
-                        // The space shouldn't actually be inserted
-                        this.input = newVal.trim();
-
-                        // Add the inputed tag
-                        this.tagFromInput(true);
-                    }
-                }
-
-                if (this.addTagsOnComma) {
-                    newVal = newVal.trim();
-
-                    if (newVal.endsWith(',')) {
-                        // The comma shouldn't actually be inserted
-                        this.input = newVal.substring(0, newVal.length - 1);
-
-                        // Add the inputed tag
-                        this.tagFromInput(true);
-                    }
-                }
-
-                this.$emit('change', newVal);
-            }
-        },
-
-        existingTags(newVal) {
+          // AJAX search
+          if (this.typeaheadCallback) {
+            this.typeaheadCallback(searchQuery).then((results) => {
+              this.typeaheadTags = results;
+              this.doSearch(normalizedNeedle);
+            });
+          } else if (this.typeaheadUrl.length > 0) {
             this.typeaheadTags.splice(0);
+            const xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = () => {
+              if (xhttp.readyState == 4 && xhttp.status == 200) {
+                this.typeaheadTags = JSON.parse(xhttp.responseText);
+                this.doSearch(normalizedNeedle);
+              }
+            };
 
-            this.typeaheadTags = this.cloneArray(newVal);
+            const endpoint = this.typeaheadUrl.replace(':search', searchQuery);
+            xhttp.open('GET', endpoint, true);
+            xhttp.send();
+          } else {
+            // Search the existing collection
+            this.doSearch(normalizedNeedle);
+          }
+        }
 
-            this.searchTag();
-        },
-
-        tags() {
-            // Updating the hidden input
-            this.hiddenInput = JSON.stringify(this.tags);
-
-            // Update the bound v-model value
-            this.$emit('input', this.tags);
-        },
-
-        value() {
-            this.tagsFromValue();
-        },
-
-        typeaheadAlwaysShow(newValue) {
-            if (newValue) {
-                this.searchTag(false);
-            } else {
-                this.clearSearchResults();
-            }
-        },
+        this.oldInput = this.input;
+      }
     },
 
-    methods: {
-        /**
-         * Remove reserved regex characters from a string so that they don't
-         * affect search results
-         *
-         * @param string
-         * @returns String
-         */
-        escapeRegExp(string) {
-            return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        },
-
-        /**
-         * Strip HTML so we match against visible problem titles (omegaUp passes HTML in value).
-         */
-        stripHtmlForSearch(str) {
-            return String(str).replace(/<[^>]*>/g, '');
-        },
-
-        /**
-         * Case- and accent-insensitive text for matching user input to API results.
-         * Aligns with MySQL utf8mb4_0900_ai_ci for LIKE; fixes dropdown filtering that
-         * used String.prototype.search (accent-sensitive in JavaScript).
-         */
-        normalizeForSearch(str, { caseSensitive = false } = {}) {
-            let s = this.stripHtmlForSearch(str);
-            s = s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-            return caseSensitive ? s : s.toLowerCase();
-        },
-
-        /**
-         * Add a tag whether from user input or from search results (typeahead)
-         *
-         * @param ignoreSearchResults
-         * @returns void
-         */
-        tagFromInput(ignoreSearchResults = false) {
-            if (this.composing) return;
-
-            // If we're choosing a tag from the search results
-            if (this.searchResults.length && this.searchSelection >= 0 && !ignoreSearchResults) {
-                this.tagFromSearch(this.searchResults[this.searchSelection]);
-
-                this.input = '';
-            } else {
-                // If we're adding an unexisting tag
-                let text = this.input.trim();
-
-                // If the new tag is not an empty string and passes validation
-                if (!this.onlyExistingTags && text.length && this.validate(text)) {
-                    this.input = '';
-
-                    // Determine if the inputted tag exists in the typeagedTags
-                    // array
-                    let newTag = {
-                        [this.idField]: '',
-                        [this.textField]: text
-                    };
-
-                    const needle = this.normalizeForSearch(newTag[this.textField], {
-                        caseSensitive: this.caseSensitiveTags,
-                    });
-
-                    for (let tag of this.typeaheadTags) {
-                        const haystack = this.normalizeForSearch(tag[this.textField], {
-                            caseSensitive: this.caseSensitiveTags,
-                        });
-
-                        if (needle === haystack) {
-                            newTag = Object.assign({}, tag);
-
-                            break;
-                        }
-                    }
-
-                    this.addTag(newTag);
-                }
-            }
-        },
-
-        /**
-         * Add a tag from search results when a user clicks on it
-         *
-         * @param tag
-         * @returns void
-         */
-        tagFromSearchOnClick(tag) {
-            this.tagFromSearch(tag);
-
-            this.$refs['taginput'].blur();
-        },
-
-        /**
-         * Add the selected tag from the search results.
-         * Clear search results.
-         * Clear user input.
-         *
-         * @param tag
-         * @return void
-         */
-        tagFromSearch(tag) {
-            this.clearSearchResults();
-            this.addTag(tag);
-
-            this.$nextTick(() => {
-                this.input = '';
-                this.oldInput = '';
-            });
-        },
-
-        /**
-         * Add/Select a tag
-         *
-         * @param tag
-         * @param force
-         * @returns void | Boolean
-         */
-        addTag(tag, force = false) {
-            if (this.disabled && !force) {
-                return;
-            }
-
-            if (!this.beforeAddingTag(tag)) {
-                return false;
-            }
-
-            // Check if the limit has been reached
-            if (this.limit > 0 && this.tags.length >= this.limit) {
-                this.$emit('limit-reached');
-
-                return false;
-            }
-
-            // Attach the tag if it hasn't been attached yet
-            if (!this.tagSelected(tag)) {
-                this.tags.push(tag);
-
-                // Emit events
-                this.$nextTick(() => {
-                    this.$emit('tag-added', tag);
-                    this.$emit('tags-updated');
-                });
-            }
-        },
-
-        /**
-         * Remove the last tag in the tags array.
-         *
-         * @returns void
-         */
-        removeLastTag() {
-            if (!this.input.length && this.deleteOnBackspace && this.tags.length) {
-                this.removeTag(this.tags.length - 1);
-            }
-        },
-
-        /**
-         * Remove the selected tag at the specified index.
-         *
-         * @param index
-         * @returns void
-         */
-        removeTag(index) {
-            if (this.disabled) {
-                return;
-            }
-
-            let tag = this.tags[index];
-
-            if (!this.beforeRemovingTag(tag)) {
-                return false;
-            }
-
-            this.tags.splice(index, 1);
-
-            // Emit events
-            this.$nextTick(() => {
-                this.$emit('tag-removed', tag);
-                this.$emit('tags-updated');
-
-                if (this.typeaheadAlwaysShow) {
-                    this.searchTag();
-                }
-            });
-        },
-
-        /**
-         * Search the currently entered text in the list of existing tags
-         *
-         * @returns void | Boolean
-         */
-        searchTag() {
-            if (this.typeahead !== true) {
-                return false;
-            }
-
-            if (this.oldInput != this.input || (!this.searchResults.length && this.typeaheadActivationThreshold == 0) || this.typeaheadAlwaysShow || this.typeaheadShowOnFocus) {
-                if (!this.typeaheadUrl.length && !this.typeaheadCallback) {
-                    this.searchResults = [];
-                }
-
-                this.searchSelection = 0;
-                let input = this.input.trim();
-
-                if ((input.length && input.length >= this.typeaheadActivationThreshold) || this.typeaheadActivationThreshold == 0 || this.typeaheadAlwaysShow) {
-                    // Find all the existing tags which include the search text
-                    const searchQuery = this.escapeRegExp(
-                        this.caseSensitiveTags ? input : input.toLowerCase()
-                    );
-                    const normalizedNeedle = this.normalizeForSearch(input, {
-                        caseSensitive: this.caseSensitiveTags,
-                    });
-
-                    // AJAX search
-                    if (this.typeaheadCallback) {
-                        this.typeaheadCallback(searchQuery)
-                            .then((results) => {
-                                this.typeaheadTags = results;
-                                this.doSearch(normalizedNeedle);
-                            });
-                    } else if (this.typeaheadUrl.length > 0) {
-                        this.typeaheadTags.splice(0);
-                        const xhttp = new XMLHttpRequest();
-                        const that = this;
-
-                        xhttp.onreadystatechange = function () {
-                            if (this.readyState == 4 && this.status == 200) {
-                                that.typeaheadTags = JSON.parse(xhttp.responseText);
-
-                                that.doSearch(normalizedNeedle);
-                            }
-                        }
-
-                        const endpoint = this.typeaheadUrl.replace(':search', searchQuery);
-                        xhttp.open('GET', endpoint, true);
-                        xhttp.send();
-                    } else {
-                        // Search the existing collection
-                        this.doSearch(normalizedNeedle);
-                    }
-                }
-
-                this.oldInput = this.input;
-            }
-        },
-
-        /**
-         * Perform the actual search
-         *
-         * @param {string} normalizedNeedle accent- and case-normalized query (see normalizeForSearch)
-         * @return void
-         */
-        doSearch(normalizedNeedle) {
-            this.searchResults = [];
-
-            for (let tag of this.typeaheadTags) {
-                const compareable = tag[this.textField];
-                const normalizedHaystack = this.normalizeForSearch(compareable, {
-                    caseSensitive: this.caseSensitiveTags,
-                });
-                const ids = this.searchResults.map((res) => (res[this.idField]));
-
-                if (normalizedHaystack.includes(normalizedNeedle) && ! this.tagSelected(tag) && ! ids.includes(tag[this.idField])) {
-                    this.searchResults.push(tag);
-                }
-            }
-
-            // Sort the search results alphabetically
-            if (this.sortSearchResults) {
-                this.searchResults.sort((a, b) => {
-                    if (a[this.textField] < b[this.textField]) return -1;
-                    if (a[this.textField] > b[this.textField]) return 1;
-
-                    return 0;
-                });
-            }
-
-            // Shorten Search results to desired length
-            if (this.typeaheadMaxResults > 0) {
-                this.searchResults = this.searchResults.slice(
-                    0,
-                    this.typeaheadMaxResults
-                );
-            }
-        },
-
-        /**
-         * Hide the typeahead if there's nothing intered into the input field.
-         *
-         * @returns void
-         */
-        hideTypeahead() {
-            if (! this.input.length) {
-                this.$nextTick(() => {
-                    this.clearSearchResults();
-                });
-            }
-        },
-
-        /**
-         * Select the next search result in typeahead.
-         *
-         * @returns void
-         */
-        nextSearchResult() {
-            if (this.searchSelection + 1 <= this.searchResults.length - 1) {
-                this.searchSelection++;
-            }
-        },
-
-        /**
-         * Select the previous search result in typeahead.
-         *
-         * @returns void
-         */
-        prevSearchResult() {
-            if (this.searchSelection > 0) {
-                this.searchSelection--;
-            }
-        },
-
-        /**
-         * Clear/Empty the search results.
-         *
-         * @reutrns void
-         */
-        clearSearchResults(returnFocus = false) {
-            this.searchResults = [];
-            this.searchSelection = 0;
-
-            if (this.typeaheadAlwaysShow) {
-                this.$nextTick(() => {
-                    this.searchTag();
-                });
-            }
-
-            if (returnFocus) {
-                this.$refs['taginput'].focus();
-            }
-        },
-
-        /**
-         * Clear the list of selected tags.
-         *
-         * @returns void
-         */
-        clearTags() {
-            this.tags.splice(0, this.tags.length);
-        },
-
-        /**
-         * Replace the currently selected tags with the tags from the value.
-         *
-         * @returns void
-         */
-        tagsFromValue() {
-            if (this.value && this.value.length) {
-                if (!Array.isArray(this.value)) {
-                    console.error('Voerro Tags Input: the v-model value must be an array!');
-
-                    return;
-                }
-
-                let tags = this.value;
-
-                // Don't update if nothing has changed
-                if (this.tags == tags) {
-                    return;
-                }
-
-                this.clearTags();
-
-                for (let tag of tags) {
-                    this.addTag(tag, true);
-                }
-            } else {
-                if (this.tags.length == 0) {
-                    return;
-                }
-
-                this.clearTags();
-            }
-        },
-
-        /**
-         * Check if a tag is already selected.
-         *
-         * @param tag
-         * @returns Boolean
-         */
-        tagSelected(tag) {
-            if (this.allowDuplicates) {
-                return false;
-            }
-
-            if (! tag) {
-                return false;
-            }
-
-            const searchQuery = this.escapeRegExp(
-                this.caseSensitiveTags ? tag[this.textField] : tag[this.textField].toLowerCase()
-            );
-
-            for (let selectedTag of this.tags) {
-                const compareable = this.caseSensitiveTags
-                    ? selectedTag[this.textField]
-                    : selectedTag[this.textField].toLowerCase();
-
-                if (selectedTag[this.idField] === tag[this.idField] && this.escapeRegExp(compareable).length == searchQuery.length && compareable.search(searchQuery) > -1) {
-                    return true;
-                }
-            }
-
-            return false;
-        },
-
-        /**
-         * Clear the input.
-         *
-         * @returns void
-         */
-        clearInput() {
-            this.input = '';
-        },
-
-        /**
-         * Process all the keyup events.
-         *
-         * @param e
-         * @returns void
-         */
-        onKeyUp(e) {
-            this.$emit('keyup', e);
-        },
-
-        /**
-         * Process all the keydown events.
-         *
-         * @param e
-         * @returns void
-         */
-        onKeyDown(e) {
-            this.$emit('keydown', e);
-        },
-
-        /**
-         * Process the onfocus event.
-         *
-         * @param e
-         * @returns void
-         */
-        onFocus(e) {
-            this.$emit('focus', e);
-
-            this.isActive = true;
-        },
-
-        /**
-         * Process the onClick event.
-         *
-         * @param e
-         * @returns void
-         */
-        onClick(e) {
-            this.$emit('click', e);
-
-            this.isActive = true;
-
-            this.searchTag();
-        },
-
-        /**
-         * Process the onblur event.
-         *
-         * @param e
-         * @returns void
-         */
-        onBlur(e) {
-            this.$emit('blur', e)
-
-            if (this.addTagsOnBlur) {
-                // Add the inputed tag
-                this.tagFromInput(true);
-            }
-
-            if (!this.typeaheadAlwaysShow) {
-                this.hideTypeahead();
-            } else {
-                this.searchTag();
-            }
-
-            this.isActive = false;
-        },
-
-        hiddenInputValue(tag) {
-            // Return all fields
-            if (!this.valueFields) {
-                return JSON.stringify(tag);
-            }
-
-            const fields = this.valueFields.replace(/\s/, '').split(',');
-
-            // A single field
-            if (fields.length === 1) {
-                return tag[fields[0]];
-            } else {
-                // Specified fields
-                return JSON.stringify(
-                    Object.assign(
-                        {},
-                        ...fields.map(field => ({ [field]: tag[field] }))
-                    )
-                );
-            }
-
-            return JSON.stringify(tag);
-        },
-
-        getDisplayField(tag) {
-            const hasDisplayField = this.displayField !== undefined
-                && this.displayField !== null
-                && tag[this.displayField] !== undefined
-                && tag[this.displayField] !== null
-                && tag[this.displayField] !== '';
-
-            return hasDisplayField
-                ? tag[this.displayField]
-                : tag[this.textField];
-        },
-
-        cloneArray(arr) {
-            return arr.map(el => Object.assign({}, el));
+    /**
+     * Perform the actual search
+     *
+     * @param {string} normalizedNeedle accent- and case-normalized query (see normalizeForSearch)
+     * @return void
+     */
+    doSearch(normalizedNeedle) {
+      this.searchResults = [];
+
+      for (let tag of this.typeaheadTags) {
+        const compareable = tag[this.textField];
+        const normalizedHaystack = this.normalizeForSearch(compareable, {
+          caseSensitive: this.caseSensitiveTags,
+        });
+        const ids = this.searchResults.map((res) => res[this.idField]);
+
+        if (
+          normalizedHaystack.includes(normalizedNeedle) &&
+          !this.tagSelected(tag) &&
+          !ids.includes(tag[this.idField])
+        ) {
+          this.searchResults.push(tag);
         }
-    }
-}
+      }
+
+      // Sort the search results alphabetically
+      if (this.sortSearchResults) {
+        this.searchResults.sort((a, b) => {
+          if (a[this.textField] < b[this.textField]) return -1;
+          if (a[this.textField] > b[this.textField]) return 1;
+
+          return 0;
+        });
+      }
+
+      // Shorten Search results to desired length
+      if (this.typeaheadMaxResults > 0) {
+        this.searchResults = this.searchResults.slice(
+          0,
+          this.typeaheadMaxResults,
+        );
+      }
+    },
+
+    /**
+     * Hide the typeahead if there's nothing intered into the input field.
+     *
+     * @returns void
+     */
+    hideTypeahead() {
+      if (!this.input.length) {
+        this.$nextTick(() => {
+          this.clearSearchResults();
+        });
+      }
+    },
+
+    /**
+     * Select the next search result in typeahead.
+     *
+     * @returns void
+     */
+    nextSearchResult() {
+      if (this.searchSelection + 1 <= this.searchResults.length - 1) {
+        this.searchSelection++;
+      }
+    },
+
+    /**
+     * Select the previous search result in typeahead.
+     *
+     * @returns void
+     */
+    prevSearchResult() {
+      if (this.searchSelection > 0) {
+        this.searchSelection--;
+      }
+    },
+
+    /**
+     * Clear/Empty the search results.
+     *
+     * @reutrns void
+     */
+    clearSearchResults(returnFocus = false) {
+      this.searchResults = [];
+      this.searchSelection = 0;
+
+      if (this.typeaheadAlwaysShow) {
+        this.$nextTick(() => {
+          this.searchTag();
+        });
+      }
+
+      if (returnFocus) {
+        this.$refs['taginput'].focus();
+      }
+    },
+
+    /**
+     * Clear the list of selected tags.
+     *
+     * @returns void
+     */
+    clearTags() {
+      this.tags.splice(0, this.tags.length);
+    },
+
+    /**
+     * Replace the currently selected tags with the tags from the value.
+     *
+     * @returns void
+     */
+    tagsFromValue() {
+      if (this.value && this.value.length) {
+        if (!Array.isArray(this.value)) {
+          console.error(
+            'Voerro Tags Input: the v-model value must be an array!',
+          );
+
+          return;
+        }
+
+        let tags = this.value;
+
+        // Don't update if nothing has changed
+        if (this.tags == tags) {
+          return;
+        }
+
+        this.clearTags();
+
+        for (let tag of tags) {
+          this.addTag(tag, true);
+        }
+      } else {
+        if (this.tags.length == 0) {
+          return;
+        }
+
+        this.clearTags();
+      }
+    },
+
+    /**
+     * Check if a tag is already selected.
+     *
+     * @param tag
+     * @returns Boolean
+     */
+    tagSelected(tag) {
+      if (this.allowDuplicates) {
+        return false;
+      }
+
+      if (!tag) {
+        return false;
+      }
+
+      const searchQuery = this.escapeRegExp(
+        this.caseSensitiveTags
+          ? tag[this.textField]
+          : tag[this.textField].toLowerCase(),
+      );
+
+      for (let selectedTag of this.tags) {
+        const compareable = this.caseSensitiveTags
+          ? selectedTag[this.textField]
+          : selectedTag[this.textField].toLowerCase();
+
+        if (
+          selectedTag[this.idField] === tag[this.idField] &&
+          this.escapeRegExp(compareable).length == searchQuery.length &&
+          compareable.search(searchQuery) > -1
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    },
+
+    /**
+     * Clear the input.
+     *
+     * @returns void
+     */
+    clearInput() {
+      this.input = '';
+    },
+
+    /**
+     * Process all the keyup events.
+     *
+     * @param e
+     * @returns void
+     */
+    onKeyUp(e) {
+      this.$emit('keyup', e);
+    },
+
+    /**
+     * Process all the keydown events.
+     *
+     * @param e
+     * @returns void
+     */
+    onKeyDown(e) {
+      this.$emit('keydown', e);
+    },
+
+    /**
+     * Process the onfocus event.
+     *
+     * @param e
+     * @returns void
+     */
+    onFocus(e) {
+      this.$emit('focus', e);
+
+      this.isActive = true;
+    },
+
+    /**
+     * Process the onClick event.
+     *
+     * @param e
+     * @returns void
+     */
+    onClick(e) {
+      this.$emit('click', e);
+
+      this.isActive = true;
+
+      this.searchTag();
+    },
+
+    /**
+     * Process the onblur event.
+     *
+     * @param e
+     * @returns void
+     */
+    onBlur(e) {
+      this.$emit('blur', e);
+
+      if (this.addTagsOnBlur) {
+        // Add the inputed tag
+        this.tagFromInput(true);
+      }
+
+      if (!this.typeaheadAlwaysShow) {
+        this.hideTypeahead();
+      } else {
+        this.searchTag();
+      }
+
+      this.isActive = false;
+    },
+
+    hiddenInputValue(tag) {
+      // Return all fields
+      if (!this.valueFields) {
+        return JSON.stringify(tag);
+      }
+
+      const fields = this.valueFields.replace(/\s/, '').split(',');
+
+      // A single field
+      if (fields.length === 1) {
+        return tag[fields[0]];
+      } else {
+        // Specified fields
+        return JSON.stringify(
+          Object.assign(
+            {},
+            ...fields.map((field) => ({ [field]: tag[field] })),
+          ),
+        );
+      }
+    },
+
+    getDisplayField(tag) {
+      const hasDisplayField =
+        this.displayField !== undefined &&
+        this.displayField !== null &&
+        tag[this.displayField] !== undefined &&
+        tag[this.displayField] !== null &&
+        tag[this.displayField] !== '';
+
+      return hasDisplayField ? tag[this.displayField] : tag[this.textField];
+    },
+
+    cloneArray(arr) {
+      return arr.map((el) => Object.assign({}, el));
+    },
+  },
+};
 </script>

--- a/frontend/www/js/omegaup/components/common/VoerroTagsInput.vue
+++ b/frontend/www/js/omegaup/components/common/VoerroTagsInput.vue
@@ -1,0 +1,922 @@
+<!--
+  Vendored from @voerro/vue-tagsinput@2.7.1 (src/VoerroTagsInput.vue).
+  OmegaUp-only changes: accent-insensitive typeahead matching (normalizeForSearch in doSearch
+  and tagFromInput). Upstream PR voerro/vue-tagsinput#177 was never merged.
+-->
+<template>
+    <div class="tags-input-root" style="position: relative;">
+        <div :class="{
+            [wrapperClass + ' tags-input']: true,
+            'active': isActive,
+            'disabled': disabled,
+        }">
+            <span v-for="(tag, index) in tags"
+                :key="index"
+                class="tags-input-badge tags-input-badge-pill tags-input-badge-selected-default"
+                :class="{ 'disabled': disabled }"
+            >
+                <slot name="selected-tag"
+                    :tag="tag"
+                    :index="index"
+                    :removeTag="removeTag"
+                >
+                    <span v-html="tag[textField]"></span>
+
+                    <a v-show="!disabled"
+                        href="#"
+                        class="tags-input-remove"
+                        @click.prevent="removeTag(index)"></a>
+                </slot>
+            </span>
+
+            <input type="text"
+                ref="taginput"
+                :id="inputId"
+                :name="inputId"
+                :placeholder="placeholder"
+                :value="input"
+                @input="e => input = e.target.value"
+                v-show="!hideInputField"
+                @compositionstart="composing=true"
+                @compositionend="composing=false"
+                @keydown.enter.prevent="tagFromInput(false)"
+                @keydown.8="removeLastTag"
+                @keydown.down="nextSearchResult"
+                @keydown.up="prevSearchResult"
+                @keydown="onKeyDown"
+                @keyup="onKeyUp"
+                @keyup.esc="clearSearchResults"
+                @focus="onFocus"
+                @click="onClick"
+                @blur="onBlur"
+                @value="tags">
+
+            <div style="display: none;" v-if="elementId">
+                <input v-for="(tag, index) in tags"
+                    :key="index"
+                    type="hidden"
+                    :name="`${elementId}[]`"
+                    :value="hiddenInputValue(tag)">
+            </div>
+        </div>
+
+        <!-- Typeahead/Autocomplete -->
+        <div v-show="searchResults.length">
+            <p v-if="typeaheadStyle === 'badges'"
+                :class="`typeahead-${typeaheadStyle}`"
+            >
+                <span v-if="!typeaheadHideDiscard"
+                    class="tags-input-badge typeahead-hide-btn tags-input-typeahead-item-default"
+                    @click.prevent="clearSearchResults(true)"
+                    v-text="discardSearchText"></span>
+
+                <span v-for="(tag, index) in searchResults"
+                    :key="index"
+                    v-html="tag[textField]"
+                    @mouseover="searchSelection = index"
+                    @mousedown.prevent="tagFromSearchOnClick(tag)"
+                    class="tags-input-badge"
+                    v-bind:class="{
+                        'tags-input-typeahead-item-default': index != searchSelection,
+                        'tags-input-typeahead-item-highlighted-default': index == searchSelection
+                    }"></span>
+            </p>
+
+            <ul v-else-if="typeaheadStyle === 'dropdown'"
+                :class="`typeahead-${typeaheadStyle}`"
+            >
+                <li v-if="!typeaheadHideDiscard"
+                    class="tags-input-typeahead-item-default typeahead-hide-btn"
+                    @click.prevent="clearSearchResults(true)"
+                    v-text="discardSearchText"></li>
+
+                <li v-for="(tag, index) in searchResults"
+                    :key="index"
+                    v-html="getDisplayField(tag)"
+                    @mouseover="searchSelection = index"
+                    @mousedown.prevent="tagFromSearchOnClick(tag)"
+                    v-bind:class="{
+                        'tags-input-typeahead-item-default': index != searchSelection,
+                        'tags-input-typeahead-item-highlighted-default': index == searchSelection
+                    }"></li>
+            </ul>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        elementId: String,
+
+        inputId: String,
+
+        existingTags: {
+            type: Array,
+            default: () => {
+                return [];
+            }
+        },
+
+        value: {
+            type: Array,
+            default: () => {
+                return [];
+            }
+        },
+
+        idField: {
+            type: String,
+            default: 'key',
+        },
+
+        textField: {
+            type: String,
+            default: 'value',
+        },
+
+        displayField: {
+          type: String,
+          default: null,
+        },
+
+        valueFields: {
+            type: String,
+            default: null,
+        },
+
+        disabled: {
+            type: Boolean,
+            default: false
+        },
+
+        typeahead: {
+            type: Boolean,
+            default: false
+        },
+
+        typeaheadStyle: {
+            type: String,
+            default: 'badges'
+        },
+
+        typeaheadActivationThreshold: {
+            type: Number,
+            default: 1
+        },
+
+        typeaheadMaxResults: {
+            type: Number,
+            default: 0
+        },
+
+        typeaheadAlwaysShow: {
+            type: Boolean,
+            default: false
+        },
+
+        typeaheadShowOnFocus: {
+            type: Boolean,
+            default: true
+        },
+
+        typeaheadHideDiscard: {
+            type: Boolean,
+            default: false
+        },
+
+        typeaheadUrl: {
+            type: String,
+            default: ''
+        },
+
+        typeaheadCallback: {
+            type: Function,
+            default: null
+        },
+
+        placeholder: {
+            type: String,
+            default: 'Add a tag'
+        },
+
+        discardSearchText: {
+            type: String,
+            default: 'Discard Search Results'
+        },
+
+        limit: {
+            type: Number,
+            default: 0
+        },
+
+        hideInputOnLimit: {
+            type: Boolean,
+            default: false
+        },
+
+        onlyExistingTags: {
+            type: Boolean,
+            default: false
+        },
+
+        deleteOnBackspace: {
+            type: Boolean,
+            default: true
+        },
+
+        allowDuplicates: {
+            type: Boolean,
+            default: false
+        },
+
+        validate: {
+            type: Function,
+            default: () => true
+        },
+
+        addTagsOnComma: {
+            type: Boolean,
+            default: false
+        },
+
+        addTagsOnSpace: {
+            type: Boolean,
+            default: false
+        },
+
+        addTagsOnBlur: {
+            type: Boolean,
+            default: false
+        },
+
+        wrapperClass: {
+            type: String,
+            default: 'tags-input-wrapper-default'
+        },
+
+        sortSearchResults: {
+            type: Boolean,
+            default: true
+        },
+
+        caseSensitiveTags: {
+            type: Boolean,
+            default: false
+        },
+
+        beforeAddingTag: {
+            type: Function,
+            default: () => true
+        },
+
+        beforeRemovingTag: {
+            type: Function,
+            default: () => true
+        },
+    },
+
+    data() {
+        return {
+            badgeId: 0,
+            tags: [],
+
+            input: '',
+            oldInput: '',
+            hiddenInput: '',
+
+            searchResults: [],
+            searchSelection: 0,
+
+            selectedTag: -1,
+
+            isActive: false,
+            composing: false,
+        };
+    },
+
+    created () {
+        this.typeaheadTags = this.cloneArray(this.existingTags);
+
+        this.tagsFromValue();
+
+        if (this.typeaheadAlwaysShow) {
+            this.searchTag(false);
+        }
+    },
+
+    mounted () {
+        // Emit an event
+        this.$emit('initialized');
+
+        document.addEventListener('click', (e) => {
+            if (e.target !== this.$refs['taginput']) {
+                this.clearSearchResults();
+            }
+        });
+    },
+
+    computed: {
+        hideInputField() {
+            return (this.hideInputOnLimit && this.limit > 0 && this.tags.length >= this.limit) || this.disabled;
+        }
+    },
+
+    watch: {
+        input(newVal, oldVal) {
+            this.searchTag(false);
+
+            if (newVal.length && newVal != oldVal) {
+                const diff = newVal.substring(oldVal.length, newVal.length);
+
+                if (this.addTagsOnSpace) {
+                    if (newVal.endsWith(' ')) {
+                        // The space shouldn't actually be inserted
+                        this.input = newVal.trim();
+
+                        // Add the inputed tag
+                        this.tagFromInput(true);
+                    }
+                }
+
+                if (this.addTagsOnComma) {
+                    newVal = newVal.trim();
+
+                    if (newVal.endsWith(',')) {
+                        // The comma shouldn't actually be inserted
+                        this.input = newVal.substring(0, newVal.length - 1);
+
+                        // Add the inputed tag
+                        this.tagFromInput(true);
+                    }
+                }
+
+                this.$emit('change', newVal);
+            }
+        },
+
+        existingTags(newVal) {
+            this.typeaheadTags.splice(0);
+
+            this.typeaheadTags = this.cloneArray(newVal);
+
+            this.searchTag();
+        },
+
+        tags() {
+            // Updating the hidden input
+            this.hiddenInput = JSON.stringify(this.tags);
+
+            // Update the bound v-model value
+            this.$emit('input', this.tags);
+        },
+
+        value() {
+            this.tagsFromValue();
+        },
+
+        typeaheadAlwaysShow(newValue) {
+            if (newValue) {
+                this.searchTag(false);
+            } else {
+                this.clearSearchResults();
+            }
+        },
+    },
+
+    methods: {
+        /**
+         * Remove reserved regex characters from a string so that they don't
+         * affect search results
+         *
+         * @param string
+         * @returns String
+         */
+        escapeRegExp(string) {
+            return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        },
+
+        /**
+         * Strip HTML so we match against visible problem titles (omegaUp passes HTML in value).
+         */
+        stripHtmlForSearch(str) {
+            return String(str).replace(/<[^>]*>/g, '');
+        },
+
+        /**
+         * Case- and accent-insensitive text for matching user input to API results.
+         * Aligns with MySQL utf8mb4_0900_ai_ci for LIKE; fixes dropdown filtering that
+         * used String.prototype.search (accent-sensitive in JavaScript).
+         */
+        normalizeForSearch(str, { caseSensitive = false } = {}) {
+            let s = this.stripHtmlForSearch(str);
+            s = s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+            return caseSensitive ? s : s.toLowerCase();
+        },
+
+        /**
+         * Add a tag whether from user input or from search results (typeahead)
+         *
+         * @param ignoreSearchResults
+         * @returns void
+         */
+        tagFromInput(ignoreSearchResults = false) {
+            if (this.composing) return;
+
+            // If we're choosing a tag from the search results
+            if (this.searchResults.length && this.searchSelection >= 0 && !ignoreSearchResults) {
+                this.tagFromSearch(this.searchResults[this.searchSelection]);
+
+                this.input = '';
+            } else {
+                // If we're adding an unexisting tag
+                let text = this.input.trim();
+
+                // If the new tag is not an empty string and passes validation
+                if (!this.onlyExistingTags && text.length && this.validate(text)) {
+                    this.input = '';
+
+                    // Determine if the inputted tag exists in the typeagedTags
+                    // array
+                    let newTag = {
+                        [this.idField]: '',
+                        [this.textField]: text
+                    };
+
+                    const needle = this.normalizeForSearch(newTag[this.textField], {
+                        caseSensitive: this.caseSensitiveTags,
+                    });
+
+                    for (let tag of this.typeaheadTags) {
+                        const haystack = this.normalizeForSearch(tag[this.textField], {
+                            caseSensitive: this.caseSensitiveTags,
+                        });
+
+                        if (needle === haystack) {
+                            newTag = Object.assign({}, tag);
+
+                            break;
+                        }
+                    }
+
+                    this.addTag(newTag);
+                }
+            }
+        },
+
+        /**
+         * Add a tag from search results when a user clicks on it
+         *
+         * @param tag
+         * @returns void
+         */
+        tagFromSearchOnClick(tag) {
+            this.tagFromSearch(tag);
+
+            this.$refs['taginput'].blur();
+        },
+
+        /**
+         * Add the selected tag from the search results.
+         * Clear search results.
+         * Clear user input.
+         *
+         * @param tag
+         * @return void
+         */
+        tagFromSearch(tag) {
+            this.clearSearchResults();
+            this.addTag(tag);
+
+            this.$nextTick(() => {
+                this.input = '';
+                this.oldInput = '';
+            });
+        },
+
+        /**
+         * Add/Select a tag
+         *
+         * @param tag
+         * @param force
+         * @returns void | Boolean
+         */
+        addTag(tag, force = false) {
+            if (this.disabled && !force) {
+                return;
+            }
+
+            if (!this.beforeAddingTag(tag)) {
+                return false;
+            }
+
+            // Check if the limit has been reached
+            if (this.limit > 0 && this.tags.length >= this.limit) {
+                this.$emit('limit-reached');
+
+                return false;
+            }
+
+            // Attach the tag if it hasn't been attached yet
+            if (!this.tagSelected(tag)) {
+                this.tags.push(tag);
+
+                // Emit events
+                this.$nextTick(() => {
+                    this.$emit('tag-added', tag);
+                    this.$emit('tags-updated');
+                });
+            }
+        },
+
+        /**
+         * Remove the last tag in the tags array.
+         *
+         * @returns void
+         */
+        removeLastTag() {
+            if (!this.input.length && this.deleteOnBackspace && this.tags.length) {
+                this.removeTag(this.tags.length - 1);
+            }
+        },
+
+        /**
+         * Remove the selected tag at the specified index.
+         *
+         * @param index
+         * @returns void
+         */
+        removeTag(index) {
+            if (this.disabled) {
+                return;
+            }
+
+            let tag = this.tags[index];
+
+            if (!this.beforeRemovingTag(tag)) {
+                return false;
+            }
+
+            this.tags.splice(index, 1);
+
+            // Emit events
+            this.$nextTick(() => {
+                this.$emit('tag-removed', tag);
+                this.$emit('tags-updated');
+
+                if (this.typeaheadAlwaysShow) {
+                    this.searchTag();
+                }
+            });
+        },
+
+        /**
+         * Search the currently entered text in the list of existing tags
+         *
+         * @returns void | Boolean
+         */
+        searchTag() {
+            if (this.typeahead !== true) {
+                return false;
+            }
+
+            if (this.oldInput != this.input || (!this.searchResults.length && this.typeaheadActivationThreshold == 0) || this.typeaheadAlwaysShow || this.typeaheadShowOnFocus) {
+                if (!this.typeaheadUrl.length && !this.typeaheadCallback) {
+                    this.searchResults = [];
+                }
+
+                this.searchSelection = 0;
+                let input = this.input.trim();
+
+                if ((input.length && input.length >= this.typeaheadActivationThreshold) || this.typeaheadActivationThreshold == 0 || this.typeaheadAlwaysShow) {
+                    // Find all the existing tags which include the search text
+                    const searchQuery = this.escapeRegExp(
+                        this.caseSensitiveTags ? input : input.toLowerCase()
+                    );
+                    const normalizedNeedle = this.normalizeForSearch(input, {
+                        caseSensitive: this.caseSensitiveTags,
+                    });
+
+                    // AJAX search
+                    if (this.typeaheadCallback) {
+                        this.typeaheadCallback(searchQuery)
+                            .then((results) => {
+                                this.typeaheadTags = results;
+                                this.doSearch(normalizedNeedle);
+                            });
+                    } else if (this.typeaheadUrl.length > 0) {
+                        this.typeaheadTags.splice(0);
+                        const xhttp = new XMLHttpRequest();
+                        const that = this;
+
+                        xhttp.onreadystatechange = function () {
+                            if (this.readyState == 4 && this.status == 200) {
+                                that.typeaheadTags = JSON.parse(xhttp.responseText);
+
+                                that.doSearch(normalizedNeedle);
+                            }
+                        }
+
+                        const endpoint = this.typeaheadUrl.replace(':search', searchQuery);
+                        xhttp.open('GET', endpoint, true);
+                        xhttp.send();
+                    } else {
+                        // Search the existing collection
+                        this.doSearch(normalizedNeedle);
+                    }
+                }
+
+                this.oldInput = this.input;
+            }
+        },
+
+        /**
+         * Perform the actual search
+         *
+         * @param {string} normalizedNeedle accent- and case-normalized query (see normalizeForSearch)
+         * @return void
+         */
+        doSearch(normalizedNeedle) {
+            this.searchResults = [];
+
+            for (let tag of this.typeaheadTags) {
+                const compareable = tag[this.textField];
+                const normalizedHaystack = this.normalizeForSearch(compareable, {
+                    caseSensitive: this.caseSensitiveTags,
+                });
+                const ids = this.searchResults.map((res) => (res[this.idField]));
+
+                if (normalizedHaystack.includes(normalizedNeedle) && ! this.tagSelected(tag) && ! ids.includes(tag[this.idField])) {
+                    this.searchResults.push(tag);
+                }
+            }
+
+            // Sort the search results alphabetically
+            if (this.sortSearchResults) {
+                this.searchResults.sort((a, b) => {
+                    if (a[this.textField] < b[this.textField]) return -1;
+                    if (a[this.textField] > b[this.textField]) return 1;
+
+                    return 0;
+                });
+            }
+
+            // Shorten Search results to desired length
+            if (this.typeaheadMaxResults > 0) {
+                this.searchResults = this.searchResults.slice(
+                    0,
+                    this.typeaheadMaxResults
+                );
+            }
+        },
+
+        /**
+         * Hide the typeahead if there's nothing intered into the input field.
+         *
+         * @returns void
+         */
+        hideTypeahead() {
+            if (! this.input.length) {
+                this.$nextTick(() => {
+                    this.clearSearchResults();
+                });
+            }
+        },
+
+        /**
+         * Select the next search result in typeahead.
+         *
+         * @returns void
+         */
+        nextSearchResult() {
+            if (this.searchSelection + 1 <= this.searchResults.length - 1) {
+                this.searchSelection++;
+            }
+        },
+
+        /**
+         * Select the previous search result in typeahead.
+         *
+         * @returns void
+         */
+        prevSearchResult() {
+            if (this.searchSelection > 0) {
+                this.searchSelection--;
+            }
+        },
+
+        /**
+         * Clear/Empty the search results.
+         *
+         * @reutrns void
+         */
+        clearSearchResults(returnFocus = false) {
+            this.searchResults = [];
+            this.searchSelection = 0;
+
+            if (this.typeaheadAlwaysShow) {
+                this.$nextTick(() => {
+                    this.searchTag();
+                });
+            }
+
+            if (returnFocus) {
+                this.$refs['taginput'].focus();
+            }
+        },
+
+        /**
+         * Clear the list of selected tags.
+         *
+         * @returns void
+         */
+        clearTags() {
+            this.tags.splice(0, this.tags.length);
+        },
+
+        /**
+         * Replace the currently selected tags with the tags from the value.
+         *
+         * @returns void
+         */
+        tagsFromValue() {
+            if (this.value && this.value.length) {
+                if (!Array.isArray(this.value)) {
+                    console.error('Voerro Tags Input: the v-model value must be an array!');
+
+                    return;
+                }
+
+                let tags = this.value;
+
+                // Don't update if nothing has changed
+                if (this.tags == tags) {
+                    return;
+                }
+
+                this.clearTags();
+
+                for (let tag of tags) {
+                    this.addTag(tag, true);
+                }
+            } else {
+                if (this.tags.length == 0) {
+                    return;
+                }
+
+                this.clearTags();
+            }
+        },
+
+        /**
+         * Check if a tag is already selected.
+         *
+         * @param tag
+         * @returns Boolean
+         */
+        tagSelected(tag) {
+            if (this.allowDuplicates) {
+                return false;
+            }
+
+            if (! tag) {
+                return false;
+            }
+
+            const searchQuery = this.escapeRegExp(
+                this.caseSensitiveTags ? tag[this.textField] : tag[this.textField].toLowerCase()
+            );
+
+            for (let selectedTag of this.tags) {
+                const compareable = this.caseSensitiveTags
+                    ? selectedTag[this.textField]
+                    : selectedTag[this.textField].toLowerCase();
+
+                if (selectedTag[this.idField] === tag[this.idField] && this.escapeRegExp(compareable).length == searchQuery.length && compareable.search(searchQuery) > -1) {
+                    return true;
+                }
+            }
+
+            return false;
+        },
+
+        /**
+         * Clear the input.
+         *
+         * @returns void
+         */
+        clearInput() {
+            this.input = '';
+        },
+
+        /**
+         * Process all the keyup events.
+         *
+         * @param e
+         * @returns void
+         */
+        onKeyUp(e) {
+            this.$emit('keyup', e);
+        },
+
+        /**
+         * Process all the keydown events.
+         *
+         * @param e
+         * @returns void
+         */
+        onKeyDown(e) {
+            this.$emit('keydown', e);
+        },
+
+        /**
+         * Process the onfocus event.
+         *
+         * @param e
+         * @returns void
+         */
+        onFocus(e) {
+            this.$emit('focus', e);
+
+            this.isActive = true;
+        },
+
+        /**
+         * Process the onClick event.
+         *
+         * @param e
+         * @returns void
+         */
+        onClick(e) {
+            this.$emit('click', e);
+
+            this.isActive = true;
+
+            this.searchTag();
+        },
+
+        /**
+         * Process the onblur event.
+         *
+         * @param e
+         * @returns void
+         */
+        onBlur(e) {
+            this.$emit('blur', e)
+
+            if (this.addTagsOnBlur) {
+                // Add the inputed tag
+                this.tagFromInput(true);
+            }
+
+            if (!this.typeaheadAlwaysShow) {
+                this.hideTypeahead();
+            } else {
+                this.searchTag();
+            }
+
+            this.isActive = false;
+        },
+
+        hiddenInputValue(tag) {
+            // Return all fields
+            if (!this.valueFields) {
+                return JSON.stringify(tag);
+            }
+
+            const fields = this.valueFields.replace(/\s/, '').split(',');
+
+            // A single field
+            if (fields.length === 1) {
+                return tag[fields[0]];
+            } else {
+                // Specified fields
+                return JSON.stringify(
+                    Object.assign(
+                        {},
+                        ...fields.map(field => ({ [field]: tag[field] }))
+                    )
+                );
+            }
+
+            return JSON.stringify(tag);
+        },
+
+        getDisplayField(tag) {
+            const hasDisplayField = this.displayField !== undefined
+                && this.displayField !== null
+                && tag[this.displayField] !== undefined
+                && tag[this.displayField] !== null
+                && tag[this.displayField] !== '';
+
+            return hasDisplayField
+                ? tag[this.displayField]
+                : tag[this.textField];
+        },
+
+        cloneArray(arr) {
+            return arr.map(el => Object.assign({}, el));
+        }
+    }
+}
+</script>

--- a/frontend/www/js/omegaup/components/common/accent.test.ts
+++ b/frontend/www/js/omegaup/components/common/accent.test.ts
@@ -45,9 +45,7 @@ describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () =
     wrapper.vm.searchTag();
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.vm.searchResults.map((t) => t.key)).toContain(
-      'division-ab',
-    );
+    expect(wrapper.vm.searchResults.map((t) => t.key)).toContain('division-ab');
   });
 
   it('strips HTML before matching so unaccented query hits accented title in label', async () => {

--- a/frontend/www/js/omegaup/components/common/accent.test.ts
+++ b/frontend/www/js/omegaup/components/common/accent.test.ts
@@ -2,6 +2,12 @@ import { mount } from '@vue/test-utils';
 import VoerroTagsInput from './VoerroTagsInput.vue';
 
 describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () => {
+  type TagsInputVm = {
+    $nextTick: () => Promise<void>;
+    searchTag: () => void;
+    searchResults: Array<{ key: string; value: string }>;
+  };
+
   const tags = [
     { key: 'ordenando-dos-numeros', value: 'Ordenando Números' },
     { key: 'division-ab', value: 'División a/b' },
@@ -21,13 +27,14 @@ describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () =
 
   it('matches accented titles when searching without accents', async () => {
     const wrapper = mountTypeahead();
+    const vm = (wrapper.vm as unknown) as TagsInputVm;
 
     await wrapper.setData({ input: 'ordenando nu' });
-    await wrapper.vm.$nextTick();
-    wrapper.vm.searchTag();
-    await wrapper.vm.$nextTick();
+    await vm.$nextTick();
+    vm.searchTag();
+    await vm.$nextTick();
 
-    expect(wrapper.vm.searchResults).toEqual(
+    expect(vm.searchResults).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           key: 'ordenando-dos-numeros',
@@ -39,13 +46,14 @@ describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () =
 
   it('matches División when query has no accent', async () => {
     const wrapper = mountTypeahead();
+    const vm = (wrapper.vm as unknown) as TagsInputVm;
 
     await wrapper.setData({ input: 'division' });
-    await wrapper.vm.$nextTick();
-    wrapper.vm.searchTag();
-    await wrapper.vm.$nextTick();
+    await vm.$nextTick();
+    vm.searchTag();
+    await vm.$nextTick();
 
-    expect(wrapper.vm.searchResults.map((t) => t.key)).toContain('division-ab');
+    expect(vm.searchResults.map((t) => t.key)).toContain('division-ab');
   });
 
   it('strips HTML before matching so unaccented query hits accented title in label', async () => {
@@ -64,13 +72,14 @@ describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () =
         typeaheadActivationThreshold: 2,
       },
     });
+    const vm = (wrapper.vm as unknown) as TagsInputVm;
 
     await wrapper.setData({ input: 'ordenando nu' });
-    await wrapper.vm.$nextTick();
-    wrapper.vm.searchTag();
-    await wrapper.vm.$nextTick();
+    await vm.$nextTick();
+    vm.searchTag();
+    await vm.$nextTick();
 
-    expect(wrapper.vm.searchResults).toEqual(
+    expect(vm.searchResults).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ key: 'ordenando-dos-numeros' }),
       ]),

--- a/frontend/www/js/omegaup/components/common/accent.test.ts
+++ b/frontend/www/js/omegaup/components/common/accent.test.ts
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import VoerroTagsInput from './VoerroTagsInput.vue';
+
+describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () => {
+  const tags = [
+    { key: 'ordenando-dos-numeros', value: 'Ordenando Números' },
+    { key: 'division-ab', value: 'División a/b' },
+    { key: 'calculo-dep', value: 'Cálculo Dependiente' },
+  ];
+
+  function mountTypeahead() {
+    return mount(VoerroTagsInput, {
+      propsData: {
+        existingTags: tags,
+        value: [],
+        typeahead: true,
+        typeaheadActivationThreshold: 2,
+      },
+    });
+  }
+
+  it('matches accented titles when searching without accents', async () => {
+    const wrapper = mountTypeahead();
+
+    await wrapper.setData({ input: 'ordenando nu' });
+    await wrapper.vm.$nextTick();
+    wrapper.vm.searchTag();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.searchResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'ordenando-dos-numeros',
+          value: 'Ordenando Números',
+        }),
+      ]),
+    );
+  });
+
+  it('matches División when query has no accent', async () => {
+    const wrapper = mountTypeahead();
+
+    await wrapper.setData({ input: 'division' });
+    await wrapper.vm.$nextTick();
+    wrapper.vm.searchTag();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.searchResults.map((t) => t.key)).toContain(
+      'division-ab',
+    );
+  });
+
+  it('strips HTML before matching so unaccented query hits accented title in label', async () => {
+    const withHtml = [
+      {
+        key: 'ordenando-dos-numeros',
+        value:
+          '01.- Ordenando Números (<strong>ordenando-dos-numeros</strong>)',
+      },
+    ];
+    const wrapper = mount(VoerroTagsInput, {
+      propsData: {
+        existingTags: withHtml,
+        value: [],
+        typeahead: true,
+        typeaheadActivationThreshold: 2,
+      },
+    });
+
+    await wrapper.setData({ input: 'ordenando nu' });
+    await wrapper.vm.$nextTick();
+    wrapper.vm.searchTag();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.searchResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'ordenando-dos-numeros' }),
+      ]),
+    );
+  });
+});

--- a/frontend/www/js/omegaup/components/problem/FinderWizard.vue
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.vue
@@ -81,7 +81,7 @@ import 'vue-form-wizard/dist/vue-form-wizard.min.css';
 // https://www.npmjs.com/package/vue-js-toggle-button
 import { ToggleButton } from 'vue-js-toggle-button';
 // https://github.com/voerro/vue-tagsinput
-import VoerroTagsInput from '@voerro/vue-tagsinput';
+import VoerroTagsInput from '../common/VoerroTagsInput.vue';
 import '@voerro/vue-tagsinput/dist/style.css';
 // https://nightcatsama.github.io/vue-slider-component/
 import VueSlider from 'vue-slider-component';


### PR DESCRIPTION
# Description

This PR fixes accent-insensitive search behavior in problem autocomplete/typeahead.

## What changed

- Vendored `@voerro/vue-tagsinput` into:
  - `frontend/www/js/omegaup/components/common/VoerroTagsInput.vue`
- Updated imports to use vendored component in:
  - `frontend/www/js/omegaup/components/common/Typeahead.vue`
  - `frontend/www/js/omegaup/components/common/MultiTypeahead.vue`
  - `frontend/www/js/omegaup/components/problem/FinderWizard.vue`
- Added accent-aware matching logic in the vendored component:
  - Normalize query/text using Unicode decomposition (`NFD`)
  - Strip combining marks (diacritics)
  - Strip HTML tags from candidate text before matching
  - Compare using normalized `includes(...)`

This ensures queries like `division` match titles like `División`, and mixed HTML labels still match correctly.

Fixes: #6889 

# Comments

The upstream library does not provide this behavior in the currently used version, so this PR vendors the component to keep the fix deterministic inside omegaUp.

## How I tested

### 1) Focused Jest test run

npx jest "frontend/www/js/omegaup/components/common/accent.test.ts" --verbose


### 2) Test cases added/verified

<img width="1557" height="312" alt="image" src="https://github.com/user-attachments/assets/ffcac61a-414f-4457-9266-997374b6e8d3" />

```tsx
import { mount } from '@vue/test-utils';
import VoerroTagsInput from './VoerroTagsInput.vue';

describe('VoerroTagsInput (omegaUp vendored) accent-insensitive typeahead', () => {
  const tags = [
    { key: 'ordenando-dos-numeros', value: 'Ordenando Números' },
    { key: 'division-ab', value: 'División a/b' },
  ];

  it('matches accented titles when searching without accents', async () => {
    const wrapper = mount(VoerroTagsInput, {
      propsData: { existingTags: tags, value: [], typeahead: true, typeaheadActivationThreshold: 2 },
    });

    await wrapper.setData({ input: 'ordenando nu' });
    wrapper.vm.searchTag();
    await wrapper.vm.$nextTick();

    expect(wrapper.vm.searchResults.map((t) => t.key)).toContain('ordenando-dos-numeros');
  });

  it('matches División when query has no accent', async () => {
    const wrapper = mount(VoerroTagsInput, {
      propsData: { existingTags: tags, value: [], typeahead: true, typeaheadActivationThreshold: 2 },
    });

    await wrapper.setData({ input: 'division' });
    wrapper.vm.searchTag();
    await wrapper.vm.$nextTick();

    expect(wrapper.vm.searchResults.map((t) => t.key)).toContain('division-ab');
  });
});
```
### 3) HTML-label match validation

Also verified that labels containing HTML (e.g. ...(<strong>alias</strong>)) still match plain unaccented queries after HTML stripping in search normalization.

# Checklist:

- [X] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [X] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [X] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
