### PR TITLE
fix: extract hashchange listener into named function for cleanup

### DIFF
--- a/frontend/www/js/omegaup/arena/course.ts
+++ b/frontend/www/js/omegaup/arena/course.ts
@@ -671,7 +671,7 @@ OmegaUp.on('ready', async () => {
 
   const component = arenaCourse.$refs.component as arena_Course;
 
-  window.addEventListener('hashchange', async () => {
+  const onHashChange = async () => {
     const { problem, guid } = getOptionsFromLocation(window.location.hash);
     if (guid != null && problem != null) {
       navigateToProblem({
@@ -716,5 +716,10 @@ OmegaUp.on('ready', async () => {
         });
       component.currentPopupDisplayed = PopupDisplayed.RunDetails;
     }
+  };
+  window.addEventListener('hashchange', onHashChange);
+
+  arenaCourse.$once('hook:beforeDestroy', () => {
+    window.removeEventListener('hashchange', onHashChange);
   });
 });


### PR DESCRIPTION
Fixes #9783

Extracted the anonymous `hashchange` event listener in `arena/course.ts` 
into a named function `onHashChange` so it can be properly removed via 
`removeEventListener` when the component is destroyed, preventing listener 
accumulation across remounts.

Reference: PR #8776