### PR TITLE
fix: add missing ensureNotInLockdown checks

### DIFF
--- a/frontend/server/src/Controllers/AiEditorial.php
+++ b/frontend/server/src/Controllers/AiEditorial.php
@@ -30,6 +30,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
      * @return array{status: string, job_id?: string}
      */
     public static function apiGenerate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $problemAlias = $r->ensureString(
             'problem_alias',
@@ -281,6 +282,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiReview(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $jobId = $r->ensureString('job_id');
         $action = $r->ensureString('action');
@@ -515,6 +517,7 @@ class AiEditorial extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiUpdateJob(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         // This endpoint is called by the worker using the original user's auth_token
         $r->ensureIdentity();
 

--- a/frontend/server/src/Controllers/CarouselItems.php
+++ b/frontend/server/src/Controllers/CarouselItems.php
@@ -23,6 +23,7 @@ class CarouselItems extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentity();
         if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
@@ -53,6 +54,7 @@ class CarouselItems extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiDelete(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentity();
         if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
@@ -89,6 +91,7 @@ class CarouselItems extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentity();
         if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();

--- a/frontend/server/src/Controllers/Clarification.php
+++ b/frontend/server/src/Controllers/Clarification.php
@@ -35,6 +35,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $message
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
 
         $problemAlias = $r->ensureString(
@@ -274,6 +275,7 @@ class Clarification extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param bool|null $public
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         // Authenticate user
         $r->ensureIdentity();
 

--- a/frontend/server/src/Controllers/GroupScoreboard.php
+++ b/frontend/server/src/Controllers/GroupScoreboard.php
@@ -88,6 +88,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param float $weight
      */
     public static function apiAddContest(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $groupAlias = $r->ensureString(
             'group_alias',
@@ -138,6 +139,7 @@ class GroupScoreboard extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $scoreboard_alias
      */
     public static function apiRemoveContest(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $groupAlias = $r->ensureString(
             'group_alias',

--- a/frontend/server/src/Controllers/Identity.php
+++ b/frontend/server/src/Controllers/Identity.php
@@ -79,7 +79,8 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $state_id
      * @omegaup-request-param string $username
      */
-    public static function apiCreate(\OmegaUp\Request $r): array {
+        public static function apiCreate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $group = self::validateGroupOwnership($r);
         if (is_null($group->alias)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
@@ -178,7 +179,8 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param mixed $name
      * @omegaup-request-param mixed $username
      */
-    public static function apiBulkCreate(\OmegaUp\Request $r): array {
+        public static function apiBulkCreate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $group = self::validateGroupOwnership($r);
         if (is_null($group->alias)) {
             throw new \OmegaUp\Exceptions\NotFoundException(
@@ -319,6 +321,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $team_identities
      */
     public static function apiBulkCreateForTeams(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentityIsOver13();
         if (!\OmegaUp\Authorization::isGroupIdentityCreator($r->identity)) {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException(
@@ -607,6 +610,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiUpdateIdentityTeam(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         self::validateUpdateRequest($r);
         $originalUsername = $r->ensureString('original_username');
         $username = $r->ensureString('username');
@@ -903,6 +907,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         self::validateUpdateRequest($r);
         $originalUsername = $r->ensureString('original_username');
         $username = $r->ensureString('username');
@@ -989,6 +994,7 @@ class Identity extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $username
      */
     public static function apiChangePassword(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['username'],
             'username'

--- a/frontend/server/src/Controllers/Notification.php
+++ b/frontend/server/src/Controllers/Notification.php
@@ -124,6 +124,7 @@ class Notification extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiReadNotifications(\OmegaUp\Request $r) {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentity();
         if (empty($r['notifications'])) {
             throw new \OmegaUp\Exceptions\InvalidParameterException(

--- a/frontend/server/src/Controllers/ProblemBookmark.php
+++ b/frontend/server/src/Controllers/ProblemBookmark.php
@@ -16,6 +16,7 @@ class ProblemBookmark extends \OmegaUp\Controllers\Controller {
      * @return array{status: 'ok', bookmarked: bool}
      */
     public static function apiToggle(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $problemAlias = $r->ensureString(
             'problem_alias',

--- a/frontend/server/src/Controllers/Reset.php
+++ b/frontend/server/src/Controllers/Reset.php
@@ -15,6 +15,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $email
      */
     public static function apiCreate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         self::validateCreateRequest($r);
 
         \OmegaUp\Validators::validateStringNonEmpty(
@@ -143,6 +144,7 @@ class Reset extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $reset_token
      */
     public static function apiUpdate(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         \OmegaUp\Validators::validateStringNonEmpty(
             $r['email'],
             'email'

--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -132,6 +132,7 @@ class School extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param null|string $state_id
      */
     public static function apiCreate(\OmegaUp\Request $r) {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
 
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');

--- a/frontend/server/src/Controllers/Submission.php
+++ b/frontend/server/src/Controllers/Submission.php
@@ -331,6 +331,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @return array{status: string, submissionFeedback: null|\OmegaUp\DAO\VO\SubmissionFeedback, submissionFeedbackThread: null|\OmegaUp\DAO\VO\SubmissionFeedbackThread}
      */
     public static function apiSetFeedback(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $guid = $r->ensureString('guid');
 
@@ -518,6 +519,7 @@ class Submission extends \OmegaUp\Controllers\Controller {
      * @return array{status: string}
      */
     public static function apiSetFeedbackList(\OmegaUp\Request $r): array {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureIdentity();
         $guid = $r->ensureString('guid');
 

--- a/frontend/server/src/Controllers/TeamsGroup.php
+++ b/frontend/server/src/Controllers/TeamsGroup.php
@@ -232,7 +232,8 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $name
      * @omegaup-request-param int|null $numberOfContestants
      */
-    public static function apiCreate(\OmegaUp\Request $r) {
+        public static function apiCreate(\OmegaUp\Request $r) {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentityIsOver13();
 
         $teamGroupAlias = $r->ensureString(
@@ -266,7 +267,8 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $name
      * @omegaup-request-param int|null $numberOfContestants
      */
-    public static function apiUpdate(\OmegaUp\Request $r) {
+        public static function apiUpdate(\OmegaUp\Request $r) {
+        \OmegaUp\Controllers\Controller::ensureNotInLockdown();
         $r->ensureMainUserIdentity();
 
         $teamsGroupAlias = $r->ensureString(


### PR DESCRIPTION
# Description
Added missing `ensureNotInLockdown()` checks to API endpoints that modify data but were missing this guard.

Controllers updated:
- AiEditorial (apiGenerate, apiReview, apiUpdateJob)
- CarouselItems (apiCreate, apiDelete, apiUpdate)
- Clarification (apiCreate, apiUpdate)
- GroupScoreboard (apiAddContest, apiRemoveContest)
- Identity (apiCreate, apiBulkCreate, apiBulkCreateForTeams, apiUpdateIdentityTeam, apiUpdate, apiChangePassword)
- Notification (apiReadNotifications)
- ProblemBookmark (apiToggle)
- Reset (apiCreate, apiUpdate)
- School (apiCreate)
- Submission (apiSetFeedback, apiSetFeedbackList)
- TeamsGroup (apiCreate, apiUpdate)

Fixes #9782