### PR TITLE
fix: truncate long usernames and optimize score column for mobile

### DIFF
--- a/frontend/www/js/omegaup/components/course/StudentProgress.vue
+++ b/frontend/www/js/omegaup/components/course/StudentProgress.vue
@@ -1,6 +1,10 @@
 <template>
   <tr :class="studentProgress.username">
-    <th scope="row" class="text-center align-middle">
+    <th
+      scope="row"
+      class="text-center align-middle username-cell"
+      :title="studentProgress.username"
+    >
       <a :href="studentProgressUrl">
         <omegaup-user-username
           :classname="studentProgress.classname"
@@ -10,7 +14,10 @@
         ></omegaup-user-username>
       </a>
     </th>
-    <td data-global-score class="text-center font-weight-bold align-middle">
+    <td
+      data-global-score
+      class="text-center font-weight-bold align-middle global-score-cell"
+    >
       <span class="d-block"
         >{{ studentProgress.courseProgress.toFixed(0) }}%</span
       >
@@ -194,6 +201,41 @@ th {
   left: 0;
   background: white;
   z-index: 1;
+  min-width: 120px;
+  max-width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.username-cell {
+  max-width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 480px) {
+  .username-cell {
+    max-width: 80px;
+  }
+
+  .global-score-cell {
+    font-size: 0.75rem;
+    padding: 4px !important;
+    min-width: 80px;
+    max-width: 80px;
+  }
+
+  tr {
+    display: flex;
+    width: 100%;
+  }
+
+  th, td {
+    flex: 1;
+    min-width: 0;
+  }
 }
 
 .box {


### PR DESCRIPTION
## Problem
Fixes #9791

On mobile devices (e.g., iPhone SE), the student progress table
had readability issues due to long usernames and wide score column.

## Changes Made
- Added `username-cell` class with `text-overflow: ellipsis` to
  truncate long usernames in StudentProgress.vue
- Added `:title` attribute so full username is visible on hover
- Added `global-score-cell` class for mobile optimization
- Applied `@media (max-width: 480px)` styles for better
  readability on small screens

## Testing
- Tested on mobile view (320px - iPhone SE) in Chrome DevTools
- Usernames truncate correctly with ellipsis
- Full username visible on hover via title attribute
- ESLint + Prettier checks passed
<img width="1919" height="869" alt="image" src="https://github.com/user-attachments/assets/218875ce-9d57-4912-b7c2-1cab3b8a87d7" />
