### PR TITLE
Fixes Issue #9390

### DIFF
--- a/frontend/database/00271_add_idx_category_time_selected_to_coder_of_the_month.sql
+++ b/frontend/database/00271_add_idx_category_time_selected_to_coder_of_the_month.sql
@@ -1,0 +1,4 @@
+-- Add covering index on (category, time, selected_by) to speed up the
+-- getCodersOfTheMonth query which filters and joins on these three columns.
+ALTER TABLE `Coder_Of_The_Month`
+ADD INDEX `idx_category_time_selected` (`category`, `time`, `selected_by`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -198,6 +198,7 @@ CREATE TABLE `Coder_Of_The_Month` (
   KEY `school_id` (`school_id`),
   KEY `rank_time_category` (`category`,`ranking`,`time`),
   KEY `time_category` (`category`,`time`),
+  KEY `idx_category_time_selected` (`category`,`time`,`selected_by`),
   CONSTRAINT `fk_coms_school_id` FOREIGN KEY (`school_id`) REFERENCES `Schools` (`school_id`),
   CONSTRAINT `fk_cotmi_identity_id` FOREIGN KEY (`selected_by`) REFERENCES `Identities` (`identity_id`),
   CONSTRAINT `fk_cotmu_user_id` FOREIGN KEY (`user_id`) REFERENCES `Users` (`user_id`)

--- a/frontend/server/src/DAO/CoderOfTheMonth.php
+++ b/frontend/server/src/DAO/CoderOfTheMonth.php
@@ -80,24 +80,16 @@ class CoderOfTheMonth extends \OmegaUp\DAO\Base\CoderOfTheMonth {
           INNER JOIN
               Identities i ON i.identity_id = u.main_identity_id
           LEFT JOIN
-              Emails e ON e.user_id = u.user_id
+              Emails e ON e.email_id = u.main_email_id
           LEFT JOIN
               User_Rank ur ON ur.user_id = cm.user_id
+          LEFT JOIN (
+              SELECT DISTINCT `time`
+              FROM Coder_Of_The_Month
+              WHERE selected_by IS NOT NULL AND category = ?
+          ) AS manual_sel ON manual_sel.time = cm.time
           WHERE
-              (cm.selected_by IS NOT NULL
-              OR (
-                  cm.`ranking` = 1 AND
-                  NOT EXISTS (
-                      SELECT
-                          *
-                      FROM
-                          Coder_Of_The_Month
-                      WHERE
-                          time = cm.time AND
-                          selected_by IS NOT NULL AND
-                          category = ?
-                  )
-              ))
+              (cm.selected_by IS NOT NULL OR (cm.`ranking` = 1 AND manual_sel.time IS NULL))
               AND cm.category = ?
               AND cm.time <= ?
           ORDER BY

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -90,24 +90,16 @@ def get_last_12_coders_of_the_month(
           INNER JOIN
               Identities i ON i.identity_id = u.main_identity_id
           LEFT JOIN
-              Emails e ON e.user_id = u.user_id
+              Emails e ON e.email_id = u.main_email_id
           LEFT JOIN
               User_Rank ur ON ur.user_id = cm.user_id
+          LEFT JOIN (
+              SELECT DISTINCT `time`
+              FROM Coder_Of_The_Month
+              WHERE selected_by IS NOT NULL AND category = %s
+          ) AS manual_sel ON manual_sel.time = cm.time
           WHERE
-              (cm.selected_by IS NOT NULL
-              OR (
-                  cm.`ranking` = 1 AND
-                  NOT EXISTS (
-                      SELECT
-                          *
-                      FROM
-                          Coder_Of_The_Month
-                      WHERE
-                          time = cm.time AND
-                          selected_by IS NOT NULL AND
-                          category = %s
-                  )
-              ))
+              (cm.selected_by IS NOT NULL OR (cm.`ranking` = 1 AND manual_sel.time IS NULL))
               AND cm.category = %s
               AND cm.time <= %s
               AND cm.time > DATE_SUB(%s, INTERVAL 12 MONTH)

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -99,7 +99,8 @@ def get_last_12_coders_of_the_month(
               WHERE selected_by IS NOT NULL AND category = %s
           ) AS manual_sel ON manual_sel.time = cm.time
           WHERE
-              (cm.selected_by IS NOT NULL OR (cm.`ranking` = 1 AND manual_sel.time IS NULL))
+              (cm.selected_by IS NOT NULL OR
+               (cm.`ranking` = 1 AND manual_sel.time IS NULL))
               AND cm.category = %s
               AND cm.time <= %s
               AND cm.time > DATE_SUB(%s, INTERVAL 12 MONTH)


### PR DESCRIPTION
Description

Fixes #9390

Optimizes the getCodersOfTheMonth / get_last_12_coders_of_the_month query which showed poor performance (Using join buffer (hash join), type ALL on join tables in EXPLAIN).

Changes
1. Add covering index (frontend/database/00271_...sql, schema.sql)
Adds idx_category_time_selected on (category, time, selected_by) to Coder_Of_The_Month, enabling indexed lookups for both the outer query filter and the derived subquery.

2. Replace correlated NOT EXISTS with LEFT JOIN (CoderOfTheMonth.php, coder_of_the_month.py)
The old NOT EXISTS subquery was re-executed once per row. Replaced with a LEFT JOIN on a pre-computed SELECT DISTINCT time derived table, evaluated once for the entire query.

3. Fix Emails join (CoderOfTheMonth.php, coder_of_the_month.py)
Changed LEFT JOIN Emails e ON e.user_id = u.user_id to LEFT JOIN Emails e ON e.email_id = u.main_email_id — guarantees one row per user and aligns with how other COTM queries (getMonthlyList) already do this join.

Both files are kept in sync as required by the comment in each.