### PR TITLE
Logs submission

### DIFF
--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -357,7 +357,7 @@ def get_user_problems(
                      problem_ids_str=problem_ids_str)
     cur_readonly.execute('EXPLAIN ' + sql)
     for row in cur_readonly.fetchall():
-        logging.debug(
+        logging.info(
             "[get_user_problems] EXPLAIN id=%s table=%s "
             "type=%s key=%s rows=%s Extra=%s",
             row.get('id'), row.get('table'), row.get('type'), row.get(

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -353,12 +353,15 @@ def get_user_problems(
             GROUP BY
                 s.identity_id, s.problem_id;
     '''
-    logging.info('EXPLAIN get_user_problems result')
     sql = sql.format(identity_ids_str=identity_ids_str,
                      problem_ids_str=problem_ids_str)
     cur_readonly.execute('EXPLAIN ' + sql)
     for row in cur_readonly.fetchall():
-        logging.info("EXPLAIN result: %s", row)
+        logging.info(
+            "[get_user_problems] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s",
+            row.get('id'), row.get('table'), row.get('type'), row.get(
+                'key'), row.get('rows'), row.get('Extra')
+        )
     cur_readonly.execute(sql)
     # Populate user_problems dictionary with the problems solved by each user
     for row in cur_readonly.fetchall():

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -356,6 +356,11 @@ def get_user_problems(
     sql = sql.format(identity_ids_str=identity_ids_str,
                      problem_ids_str=problem_ids_str)
     cur_readonly.execute('EXPLAIN ' + sql)
+
+    logging.info("Evaluating [get_user_problems] for %d "
+                 "users and %d problems",
+                 len(eligible_users), len(problems_admins))
+
     for row in cur_readonly.fetchall():
         logging.info(
             "[get_user_problems] EXPLAIN id=%s table=%s "

--- a/stuff/cron/database/coder_of_the_month.py
+++ b/stuff/cron/database/coder_of_the_month.py
@@ -357,8 +357,9 @@ def get_user_problems(
                      problem_ids_str=problem_ids_str)
     cur_readonly.execute('EXPLAIN ' + sql)
     for row in cur_readonly.fetchall():
-        logging.info(
-            "[get_user_problems] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s",
+        logging.debug(
+            "[get_user_problems] EXPLAIN id=%s table=%s "
+            "type=%s key=%s rows=%s Extra=%s",
             row.get('id'), row.get('table'), row.get('type'), row.get(
                 'key'), row.get('rows'), row.get('Extra')
         )

--- a/stuff/cron/database/school_of_the_month.py
+++ b/stuff/cron/database/school_of_the_month.py
@@ -142,8 +142,9 @@ def get_current_problems_solved_per_month(
     '''
     cur_readonly.execute('EXPLAIN ' + sql, {'months': months})
     for row in cur_readonly.fetchall():
-        logging.info(
-            "[get_current_problems_solved_per_month] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s",
+        logging.debug(
+            "[get_current_problems_solved_per_month] EXPLAIN id=%s "
+            "table=%s type=%s key=%s rows=%s Extra=%s",
             row.get('id'), row.get('table'), row.get('type'), row.get(
                 'key'), row.get('rows'), row.get('Extra')
         )
@@ -274,8 +275,9 @@ def get_school_of_the_month_candidates(
                                             first_day_of_next_month,
                                             first_day_of_next_month))
     for row in cur_readonly.fetchall():
-        logging.info(
-            "[get_school_of_the_month_candidates] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s",
+        logging.debug(
+            "[get_school_of_the_month_candidates] EXPLAIN "
+            "id=%s table=%s type=%s key=%s rows=%s Extra=%s",
             row.get('id'), row.get('table'), row.get('type'), row.get(
                 'key'), row.get('rows'), row.get('Extra')
         )

--- a/stuff/cron/database/school_of_the_month.py
+++ b/stuff/cron/database/school_of_the_month.py
@@ -160,7 +160,7 @@ def get_current_problems_solved_per_month(
             )
         )
     logging.info(
-        "Evaluating [get_current_problems_solved_per_month] "
+        "Evaluated [get_current_problems_solved_per_month] "
         "for %d problems", len(problems))
     return problems
 

--- a/stuff/cron/database/school_of_the_month.py
+++ b/stuff/cron/database/school_of_the_month.py
@@ -159,6 +159,9 @@ def get_current_problems_solved_per_month(
                 problems_solved=row['problems_solved'],
             )
         )
+    logging.info(
+        "Evaluating [get_current_problems_solved_per_month] "
+        "for %d problems", len(problems))
     return problems
 
 
@@ -274,6 +277,7 @@ def get_school_of_the_month_candidates(
     cur_readonly.execute('EXPLAIN ' + sql, (first_day_of_current_month,
                                             first_day_of_next_month,
                                             first_day_of_next_month))
+
     for row in cur_readonly.fetchall():
         logging.info(
             "[get_school_of_the_month_candidates] EXPLAIN "
@@ -294,6 +298,9 @@ def get_school_of_the_month_candidates(
                 score=row['score'],
             )
         )
+    logging.info(
+        "Evaluated [get_school_of_the_month_candidates] "
+        "for %d schools", len(candidates))
     return candidates
 
 

--- a/stuff/cron/database/school_of_the_month.py
+++ b/stuff/cron/database/school_of_the_month.py
@@ -142,7 +142,7 @@ def get_current_problems_solved_per_month(
     '''
     cur_readonly.execute('EXPLAIN ' + sql, {'months': months})
     for row in cur_readonly.fetchall():
-        logging.debug(
+        logging.info(
             "[get_current_problems_solved_per_month] EXPLAIN id=%s "
             "table=%s type=%s key=%s rows=%s Extra=%s",
             row.get('id'), row.get('table'), row.get('type'), row.get(
@@ -275,7 +275,7 @@ def get_school_of_the_month_candidates(
                                             first_day_of_next_month,
                                             first_day_of_next_month))
     for row in cur_readonly.fetchall():
-        logging.debug(
+        logging.info(
             "[get_school_of_the_month_candidates] EXPLAIN "
             "id=%s table=%s type=%s key=%s rows=%s Extra=%s",
             row.get('id'), row.get('table'), row.get('type'), row.get(

--- a/stuff/cron/database/school_of_the_month.py
+++ b/stuff/cron/database/school_of_the_month.py
@@ -140,10 +140,13 @@ def get_current_problems_solved_per_month(
         ORDER BY
             `time` ASC
     '''
-    logging.info('EXPLAIN get_current_problems_solved_per_month result')
     cur_readonly.execute('EXPLAIN ' + sql, {'months': months})
     for row in cur_readonly.fetchall():
-        logging.info("EXPLAIN result: %s", row)
+        logging.info(
+            "[get_current_problems_solved_per_month] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s",
+            row.get('id'), row.get('table'), row.get('type'), row.get(
+                'key'), row.get('rows'), row.get('Extra')
+        )
 
     cur_readonly.execute(sql, {'months': months})
     problems: List[ProblemSolved] = []
@@ -267,12 +270,15 @@ def get_school_of_the_month_candidates(
         LIMIT 100;
     '''
 
-    logging.info('EXPLAIN get_school_of_the_month_candidates result')
     cur_readonly.execute('EXPLAIN ' + sql, (first_day_of_current_month,
                                             first_day_of_next_month,
                                             first_day_of_next_month))
     for row in cur_readonly.fetchall():
-        logging.info("EXPLAIN result: %s", row)
+        logging.info(
+            "[get_school_of_the_month_candidates] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s",
+            row.get('id'), row.get('table'), row.get('type'), row.get(
+                'key'), row.get('rows'), row.get('Extra')
+        )
 
     cur_readonly.execute(
         sql, (first_day_of_current_month, first_day_of_next_month,

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -66,12 +66,6 @@ from utils import (
     get_first_day_of_next_month,
 )
 
-logging.basicConfig(
-    filename='update_ranks.log',
-    level=logging.DEBUG,
-    format='%(asctime)s %(levelname)s %(message)s'
-)
-
 sys.path.insert(
     0,
     os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),

--- a/stuff/cron/update_ranks.py
+++ b/stuff/cron/update_ranks.py
@@ -66,6 +66,11 @@ from utils import (
     get_first_day_of_next_month,
 )
 
+logging.basicConfig(
+    filename='update_ranks.log',
+    level=logging.DEBUG,
+    format='%(asctime)s %(levelname)s %(message)s'
+)
 
 sys.path.insert(
     0,


### PR DESCRIPTION
# Description

Ejemplos de logs formateado:

```
[get_current_problems_solved_per_month] EXPLAIN id=3 table=r3 type=eq_ref key=PRIMARY rows=1 Extra=Using where; Distinct
[get_user_problems] EXPLAIN id=1 table=pf type=ALL key=None rows=1 Extra=Using where; Using join buffer (hash join)
[get_school_of_the_month_candidates] EXPLAIN id=%s table=%s type=%s key=%s rows=%s Extra=%s
```

Añadido nuevo log al inicio/final:
```
logging.info("Evaluating [get_user_problems] for %d "
                 "users and %d problems",
                 len(eligible_users), len(problems_admins))
logging.info(
        "Evaluated [get_school_of_the_month_candidates] "
        "for %d schools", len(candidates))
logging.info(
        "Evaluated [get_current_problems_solved_per_month] "
        "for %d problems", len(problems))
```

Fixes: #9822

# Comments

La consulta explain no devuelve los datos de la consulta (id del usuario, problema escuela). Podría añadir un log de los identificadores antes, pero va a estar separado e irá en otro log, creo que no conviene en este caso hacer logs a esos datos. 

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.