### PR TITLE
Refactor `$once('hook:beforeDestroy')` usage to `beforeDestroy` lifecycle hook

### DIFF
--- a/frontend/www/js/omegaup/group/edit.ts
+++ b/frontend/www/js/omegaup/group/edit.ts
@@ -40,6 +40,9 @@ OmegaUp.on('ready', () => {
       searchResultUsers: [] as types.ListItem[],
       searchResultSchools: searchResultSchools,
     }),
+    beforeDestroy() {
+      window.removeEventListener('hashchange', onHashChange);
+    },
     methods: {
       refreshGroupScoreboards: (): void => {
         api.Group.details({ group_alias: payload.groupAlias })
@@ -329,7 +332,7 @@ OmegaUp.on('ready', () => {
       });
     },
   });
-  const onHashChange = () => {
+  function onHashChange(): void {
     const hash = window.location.hash.substring(1).split('#')[0];
 
     if (!Object.values(AvailableTabs).includes(hash as AvailableTabs)) {
@@ -338,12 +341,8 @@ OmegaUp.on('ready', () => {
     }
 
     groupEdit.tab = hash as AvailableTabs;
-  };
+  }
 
   window.addEventListener('hashchange', onHashChange);
   onHashChange();
-
-  groupEdit.$once('hook:beforeDestroy', () => {
-    window.removeEventListener('hashchange', onHashChange);
-  });
 });

--- a/frontend/www/js/omegaup/teamsgroup/edit.ts
+++ b/frontend/www/js/omegaup/teamsgroup/edit.ts
@@ -41,6 +41,9 @@ OmegaUp.on('ready', () => {
       isLoading: false,
       searchResultSchools: searchResultSchools,
     }),
+    beforeDestroy() {
+      window.removeEventListener('hashchange', onHashChange);
+    },
     methods: {
       refreshTeamsList: (): void => {
         api.TeamsGroup.teams({ team_group_alias: payload.teamGroup.alias })
@@ -398,7 +401,7 @@ OmegaUp.on('ready', () => {
       });
     },
   });
-  const onHashChange = () => {
+  function onHashChange(): void {
     const hash = window.location.hash.substring(1).split('#')[0];
 
     if (!Object.values(AvailableTabs).includes(hash as AvailableTabs)) {
@@ -407,12 +410,8 @@ OmegaUp.on('ready', () => {
     }
 
     teamsGroupEdit.tab = hash as AvailableTabs;
-  };
+  }
 
   window.addEventListener('hashchange', onHashChange);
   onHashChange();
-
-  teamsGroupEdit.$once('hook:beforeDestroy', () => {
-    window.removeEventListener('hashchange', onHashChange);
-  });
 });


### PR DESCRIPTION


## Description

This PR replaces the usage of `$once('hook:beforeDestroy', ...)` with the standard Vue `beforeDestroy` lifecycle hook to simplify cleanup logic and improve maintainability.

## Changes

- Replaced `$once('hook:beforeDestroy', ...)` with `beforeDestroy`
- Ensured event listeners are properly removed during component teardown
- Maintained existing functionality without regressions

## Affected Files

- `omegaup/frontend/www/js/omegaup/group/edit.ts`
- `omegaup/frontend/www/js/omegaup/teamsgroup/edit.ts`

---

## Before

```ts
groupEdit.$once('hook:beforeDestroy', () => {
  window.removeEventListener('hashchange', onHashChange);
});
```


## After

```ts
beforeDestroy() {
  window.removeEventListener('hashchange', onHashChange);
},
```
---

## Benefits

- Improves code clarity and readability  
- Aligns with Vue lifecycle conventions  
- Easier to understand and maintain  
- Consistent with existing patterns (e.g., `contest_listv2.ts`)  

## Testing

- Verified event listeners are cleaned up on component destroy  
- No functional regressions observed  
- Existing tests pass  

---

## Checklist

- [x] Code follows project conventions  
- [x] No breaking changes  
- [x] Tested locally  
- [x] Ready for review  

### Fixes https://github.com/omegaup/omegaup/issues/9829