### PR TITLE
Add `archived` field for Team Groups (Soft Delete Support) (Backend)

### DIFF
--- a/frontend/database/00271_add_team_groups_archived_field.sql
+++ b/frontend/database/00271_add_team_groups_archived_field.sql
@@ -1,4 +1,4 @@
 ALTER TABLE
     `Team_Groups`
 ADD COLUMN
-    `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Whether the team group has been archived.';
+    `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si el grupo de equipos ha sido archivado.';

--- a/frontend/database/00271_add_team_groups_archived_field.sql
+++ b/frontend/database/00271_add_team_groups_archived_field.sql
@@ -1,4 +1,4 @@
-ALTER TABLE 
+ALTER TABLE
     `Team_Groups`
-ADD COLUMN 
+ADD COLUMN
     `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Whether the team group has been archived.';

--- a/frontend/database/00271_add_team_groups_archived_field.sql
+++ b/frontend/database/00271_add_team_groups_archived_field.sql
@@ -1,0 +1,4 @@
+ALTER TABLE 
+    `Team_Groups`
+ADD COLUMN 
+    `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Whether the team group has been archived.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1261,7 +1261,7 @@ CREATE TABLE `Team_Groups` (
   `name` varchar(50) NOT NULL,
   `description` varchar(256) DEFAULT NULL,
   `number_of_contestants` int NOT NULL DEFAULT '3' COMMENT 'Número de concursantes para los equipos del grupo',
-  `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Whether the team group has been archived.',
+  `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si el grupo de equipos ha sido archivado.',
   PRIMARY KEY (`team_group_id`),
   UNIQUE KEY `team_group_alias` (`alias`),
   KEY `acl_id` (`acl_id`),

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1261,6 +1261,7 @@ CREATE TABLE `Team_Groups` (
   `name` varchar(50) NOT NULL,
   `description` varchar(256) DEFAULT NULL,
   `number_of_contestants` int NOT NULL DEFAULT '3' COMMENT 'Número de concursantes para los equipos del grupo',
+  `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Whether the team group has been archived.',
   PRIMARY KEY (`team_group_id`),
   UNIQUE KEY `team_group_alias` (`alias`),
   KEY `acl_id` (`acl_id`),

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -4830,9 +4830,9 @@ Details of a team group
 
 ### Returns
 
-| Name         | Type                                                                         |
-| ------------ | ---------------------------------------------------------------------------- |
-| `team_group` | `{ alias: string; create_time: number; description: string; name: string; }` |
+| Name         | Type                                                                                            |
+| ------------ | ----------------------------------------------------------------------------------------------- |
+| `team_group` | `{ alias: string; archived: boolean; create_time: number; description: string; name: string; }` |
 
 ## `/api/teamsGroup/list/`
 
@@ -4935,12 +4935,13 @@ Update an existing teams group
 
 ### Parameters
 
-| Name                  | Type        | Description | Required |
-| --------------------- | ----------- | ----------- | -------- |
-| `alias`               | `string`    |             | ✓        |
-| `description`         | `string`    |             | ✓        |
-| `name`                | `string`    |             | ✓        |
-| `numberOfContestants` | `int\|null` |             |          |
+| Name                  | Type         | Description | Required |
+| --------------------- | ------------ | ----------- | -------- |
+| `alias`               | `string`     |             | ✓        |
+| `description`         | `string`     |             | ✓        |
+| `name`                | `string`     |             | ✓        |
+| `archived`            | `bool\|null` |             |          |
+| `numberOfContestants` | `int\|null`  |             |          |
 
 ### Returns
 

--- a/frontend/server/src/Controllers/TeamsGroup.php
+++ b/frontend/server/src/Controllers/TeamsGroup.php
@@ -8,9 +8,9 @@
  * @psalm-type Identity=array{classname?: string, country: null|string, country_id: null|string, gender: null|string, name: null|string, password?: string, school: null|string, school_id: int|null, school_name?: string, state: null|string, state_id: null|string, username: string}
  * @psalm-type Participant=array{country_id?: string, gender?: string, name?: string, password?: string, school_name?: string, state_id?: string, username: string, participant_username: string, participant_password?: string}
  * @psalm-type TeamMember=array{classname: string, isMainUserIdentity: bool, name: null|string, team_alias: string, team_name: null|string, username: string}
- * @psalm-type TeamGroupEditPayload=array{countries: list<\OmegaUp\DAO\VO\Countries>, identities: list<Identity>, isOrganizer: bool, maxNumberOfContestants: int, teamGroup: array{alias: string, description: null|string, name: null|string, numberOfContestants: int}, teamsMembers: list<TeamMember>}
+ * @psalm-type TeamGroupEditPayload=array{countries: list<\OmegaUp\DAO\VO\Countries>, identities: list<Identity>, isOrganizer: bool, maxNumberOfContestants: int, teamGroup: array{alias: string, archived: bool, description: null|string, name: null|string, numberOfContestants: int}, teamsMembers: list<TeamMember>}
  * @psalm-type TeamGroupNewPayload=array{numberOfContestants: int, maxNumberOfContestants: int}
- * @psalm-type TeamsGroup=array{alias: string, create_time: \OmegaUp\Timestamp, description: null|string, name: string}
+ * @psalm-type TeamsGroup=array{alias: string, archived: bool, create_time: \OmegaUp\Timestamp, description: null|string, name: string}
  * @psalm-type TeamsGroupListPayload=array{teamsGroups: list<TeamsGroup>}
  * @psalm-type ListItem=array{key: string, value: string}
  */
@@ -45,7 +45,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
      *
      * @param \OmegaUp\Request $r
      *
-     * @return array{team_group: array{create_time: int, alias: null|string, name: null|string, description: null|string}}
+     * @return array{team_group: array{create_time: int, archived: bool, alias: null|string, name: null|string, description: null|string}}
      *
      * @omegaup-request-param string $team_group_alias
      */
@@ -63,9 +63,10 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('groupNotFound');
         }
 
-        /** @var array{create_time: int, alias: null|string, name: null|string, description: null|string} */
+        /** @var array{create_time: int, archived: bool, alias: null|string, name: null|string, description: null|string} */
         $filteredTeamGroup = $teamGroup->asFilteredArray([
             'create_time',
+            'archived',
             'alias',
             'name',
             'description',
@@ -154,6 +155,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
                         'name' => $teamGroup->name,
                         'description' => $teamGroup->description,
                         'numberOfContestants' => $teamGroup->number_of_contestants,
+                        'archived' => $teamGroup->archived,
                     ],
                     'maxNumberOfContestants' => self::MAX_NUMBER_OF_CONTESTANTS,
                     'countries' => \OmegaUp\DAO\Countries::getAll(
@@ -265,6 +267,7 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $description
      * @omegaup-request-param string $name
      * @omegaup-request-param int|null $numberOfContestants
+     * @omegaup-request-param bool|null $archived
      */
     public static function apiUpdate(\OmegaUp\Request $r) {
         $r->ensureMainUserIdentity();
@@ -292,6 +295,9 @@ class TeamsGroup extends \OmegaUp\Controllers\Controller {
             lowerBound: 1,
             upperBound: self::MAX_NUMBER_OF_CONTESTANTS,
         );
+        $teamsGroup->archived = $r->ensureOptionalBool(
+            'archived'
+        ) ?? $teamsGroup->archived;
         \OmegaUp\DAO\TeamGroups::update($teamsGroup);
         self::$log->info(
             "Teams group {$teamsGroup->alias} updated successfully."

--- a/frontend/server/src/DAO/Base/TeamGroups.php
+++ b/frontend/server/src/DAO/Base/TeamGroups.php
@@ -37,7 +37,8 @@ abstract class TeamGroups {
                 `alias` = ?,
                 `name` = ?,
                 `description` = ?,
-                `number_of_contestants` = ?
+                `number_of_contestants` = ?,
+                `archived` = ?
             WHERE
                 (
                     `team_group_id` = ?
@@ -55,6 +56,7 @@ abstract class TeamGroups {
             $Team_Groups->name,
             $Team_Groups->description,
             intval($Team_Groups->number_of_contestants),
+            intval($Team_Groups->archived),
             intval($Team_Groups->team_group_id),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
@@ -82,7 +84,8 @@ abstract class TeamGroups {
                 `Team_Groups`.`alias`,
                 `Team_Groups`.`name`,
                 `Team_Groups`.`description`,
-                `Team_Groups`.`number_of_contestants`
+                `Team_Groups`.`number_of_contestants`,
+                `Team_Groups`.`archived`
             FROM
                 `Team_Groups`
             WHERE
@@ -229,7 +232,8 @@ abstract class TeamGroups {
                 `Team_Groups`.`alias`,
                 `Team_Groups`.`name`,
                 `Team_Groups`.`description`,
-                `Team_Groups`.`number_of_contestants`
+                `Team_Groups`.`number_of_contestants`,
+                `Team_Groups`.`archived`
             FROM
                 `Team_Groups`
             ORDER BY
@@ -279,8 +283,10 @@ abstract class TeamGroups {
                     `alias`,
                     `name`,
                     `description`,
-                    `number_of_contestants`
+                    `number_of_contestants`,
+                    `archived`
                 ) VALUES (
+                    ?,
                     ?,
                     ?,
                     ?,
@@ -301,6 +307,7 @@ abstract class TeamGroups {
             $Team_Groups->name,
             $Team_Groups->description,
             intval($Team_Groups->number_of_contestants),
+            intval($Team_Groups->archived),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();

--- a/frontend/server/src/DAO/Base/TeamGroups.php
+++ b/frontend/server/src/DAO/Base/TeamGroups.php
@@ -37,8 +37,7 @@ abstract class TeamGroups {
                 `alias` = ?,
                 `name` = ?,
                 `description` = ?,
-                `number_of_contestants` = ?,
-                `archived` = ?
+                `number_of_contestants` = ?
             WHERE
                 (
                     `team_group_id` = ?
@@ -56,7 +55,6 @@ abstract class TeamGroups {
             $Team_Groups->name,
             $Team_Groups->description,
             intval($Team_Groups->number_of_contestants),
-            intval($Team_Groups->archived),
             intval($Team_Groups->team_group_id),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
@@ -84,8 +82,7 @@ abstract class TeamGroups {
                 `Team_Groups`.`alias`,
                 `Team_Groups`.`name`,
                 `Team_Groups`.`description`,
-                `Team_Groups`.`number_of_contestants`,
-                `Team_Groups`.`archived`
+                `Team_Groups`.`number_of_contestants`
             FROM
                 `Team_Groups`
             WHERE
@@ -232,8 +229,7 @@ abstract class TeamGroups {
                 `Team_Groups`.`alias`,
                 `Team_Groups`.`name`,
                 `Team_Groups`.`description`,
-                `Team_Groups`.`number_of_contestants`,
-                `Team_Groups`.`archived`
+                `Team_Groups`.`number_of_contestants`
             FROM
                 `Team_Groups`
             ORDER BY
@@ -283,10 +279,8 @@ abstract class TeamGroups {
                     `alias`,
                     `name`,
                     `description`,
-                    `number_of_contestants`,
-                    `archived`
+                    `number_of_contestants`
                 ) VALUES (
-                    ?,
                     ?,
                     ?,
                     ?,
@@ -307,7 +301,6 @@ abstract class TeamGroups {
             $Team_Groups->name,
             $Team_Groups->description,
             intval($Team_Groups->number_of_contestants),
-            intval($Team_Groups->archived),
         ];
         \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
         $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();

--- a/frontend/server/src/DAO/TeamGroups.php
+++ b/frontend/server/src/DAO/TeamGroups.php
@@ -55,11 +55,12 @@ class TeamGroups extends \OmegaUp\DAO\Base\TeamGroups {
     /**
      * Returns all teams groups that a user can manage.
      * @param int $userId
-     * @return list<array{alias: string, create_time: \OmegaUp\Timestamp, description: null|string, name: string}>
+     * @return list<array{alias: string, archived: bool, create_time: \OmegaUp\Timestamp, description: null|string, name: string}>
      */
     final public static function getAllTeamsGroupsAdminedByUser(int $userId) {
         $sql = 'SELECT
                     tg.alias,
+                    tg.archived,
                     tg.create_time,
                     tg.description,
                     tg.name
@@ -72,7 +73,7 @@ class TeamGroups extends \OmegaUp\DAO\Base\TeamGroups {
                 ORDER BY
                     tg.create_time DESC;';
 
-        /** @var list<array{alias: string, create_time: \OmegaUp\Timestamp, description: null|string, name: string}> */
+        /** @var list<array{alias: string, archived: bool, create_time: \OmegaUp\Timestamp, description: null|string, name: string}> */
         return \OmegaUp\MySQLConnection::getInstance()->GetAll($sql, [$userId]);
     }
 

--- a/frontend/server/src/DAO/VO/TeamGroups.php
+++ b/frontend/server/src/DAO/VO/TeamGroups.php
@@ -23,7 +23,6 @@ class TeamGroups extends \OmegaUp\DAO\VO\VO {
         'name' => true,
         'description' => true,
         'number_of_contestants' => true,
-        'archived' => true,
     ];
 
     public function __construct(?array $data = null) {
@@ -81,11 +80,6 @@ class TeamGroups extends \OmegaUp\DAO\VO\VO {
                 $data['number_of_contestants']
             );
         }
-        if (isset($data['archived'])) {
-            $this->archived = boolval(
-                $data['archived']
-            );
-        }
     }
 
     /**
@@ -138,11 +132,4 @@ class TeamGroups extends \OmegaUp\DAO\VO\VO {
      * @var int
      */
     public $number_of_contestants = 3;
-
-    /**
-     * Whether the team group has been archived.
-     *
-     * @var bool
-     */
-    public $archived = false;
 }

--- a/frontend/server/src/DAO/VO/TeamGroups.php
+++ b/frontend/server/src/DAO/VO/TeamGroups.php
@@ -23,6 +23,7 @@ class TeamGroups extends \OmegaUp\DAO\VO\VO {
         'name' => true,
         'description' => true,
         'number_of_contestants' => true,
+        'archived' => true,
     ];
 
     public function __construct(?array $data = null) {
@@ -80,6 +81,11 @@ class TeamGroups extends \OmegaUp\DAO\VO\VO {
                 $data['number_of_contestants']
             );
         }
+        if (isset($data['archived'])) {
+            $this->archived = boolval(
+                $data['archived']
+            );
+        }
     }
 
     /**
@@ -132,4 +138,11 @@ class TeamGroups extends \OmegaUp\DAO\VO\VO {
      * @var int
      */
     public $number_of_contestants = 3;
+
+    /**
+     * Whether the team group has been archived.
+     *
+     * @var bool
+     */
+    public $archived = false;
 }

--- a/frontend/tests/controllers/TeamGroupsTest.php
+++ b/frontend/tests/controllers/TeamGroupsTest.php
@@ -125,6 +125,7 @@ class TeamGroupsTest extends \OmegaUp\Test\ControllerTestCase {
                 'name' => $teamGroup->name,
                 'description' => $teamGroup->description,
                 'numberOfContestants' => $teamGroup->number_of_contestants,
+                'archived' => false,
             ]
         );
     }

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5081,6 +5081,7 @@ export namespace types {
     maxNumberOfContestants: number;
     teamGroup: {
       alias: string;
+      archived: boolean;
       description?: string;
       name?: string;
       numberOfContestants: number;
@@ -5104,6 +5105,7 @@ export namespace types {
 
   export interface TeamsGroup {
     alias: string;
+    archived: boolean;
     create_time: Date;
     description?: string;
     name: string;
@@ -6187,6 +6189,7 @@ export namespace messages {
   export type TeamsGroupDetailsResponse = {
     team_group: {
       alias?: string;
+      archived: boolean;
       create_time: number;
       description?: string;
       name?: string;


### PR DESCRIPTION

## Motivation

Currently, team groups cannot be removed or hidden, leading to the accumulation of temporary, duplicate, or outdated groups. This makes management difficult for organizers and clutters the UI.

This PR introduces a soft-delete (archive) mechanism by adding an `archived` field to the `Team_Groups` table. This allows groups to be marked as inactive while preserving referential integrity for existing data.

## Proposed Solution

Following the design pattern used in other core tables (e.g., `Courses`, `Contests`), an `archived` column has been introduced along with full backend support.

---

## Implemented Changes

### 1. Database Schema

- **Migration**: Added `frontend/database/00271_add_team_groups_archived_field.sql` to introduce the `archived` column  
- **Schema**: Updated `frontend/database/schema.sql` to include the `archived` column in the `Team_Groups` table definition  

### 2. DAO Layer

- **VO (Value Object)**: Updated `TeamGroups` VO to include the `archived` property and map it in the constructor  
- **Base DAO**: Updated to include `archived` in `create`, `update`, `getByPK`, and `getAll` methods  
- **Main DAO**: Updated custom queries (e.g., `getAllTeamsGroupsAdminedByUser`) to fetch the `archived` field  

### 3. API & Controller Support

- **`TeamsGroup::apiUpdate`**: Extended to accept an optional `archived` boolean parameter  
- **`TeamsGroup::apiDetails`**: Included `archived` in the response  
- **Edit Payload**: Added `archived` to `getTeamGroupEditDetailsForTypeScript`  
- **Type Safety**: Updated Psalm type definitions across the controller  

---

## Design Considerations

- **Naming Consistency**: Used `archived` to match conventions in other tables (`Courses`, `Contests`, `Problems`)  
- **Backward Compatibility**: Defaults to `0` (active), ensuring no disruption  
- **Non-Breaking API**: `apiUpdate` remains backward compatible if `archived` is omitted  

## Testing

- Verified creation, update, and retrieval of team groups with `archived` field  
- Confirmed backward compatibility with existing workflows  
- No regressions observed  

---

### Additional Context

Frontend - https://github.com/omegaup/omegaup/pull/9798 , will finish that once approval of the backend changes

## Checklist

- [x] Migration added and tested  
- [x] Schema updated  
- [x] DAO layer updated  
- [x] API updated (non-breaking)  
- [x] Type definitions updated  
- [x] Tested locally  
- [x] Ready for review  


## Fixes - https://github.com/omegaup/omegaup/issues/9833