### PR TITLE
fix: revoke object URL after zip download to prevent memory leak

### DIFF
--- a/frontend/www/js/omegaup/grader/Ephemeral.vue
+++ b/frontend/www/js/omegaup/grader/Ephemeral.vue
@@ -574,6 +574,7 @@ export default class Ephemeral extends Vue {
     zip
       .generateAsync({ type: 'blob' })
       .then((blob) => {
+        if (this.zipHref) URL.revokeObjectURL(this.zipHref);
         this.zipDownload = `${store.getters['moduleName']}.zip`;
         this.zipHref = window.URL.createObjectURL(blob);
 


### PR DESCRIPTION
## Description
Fixes a memory leak in `handleDownload`: each time the user downloads 
the zip, a new blob URL was created via `URL.createObjectURL` but the 
previous one was never revoked, causing memory to accumulate in long 
sessions.

Added a call to `URL.revokeObjectURL` before creating a new blob URL 
so the old one is properly released.

## Comments
One-line fix, no UI changes. The change is minimal but prevents 
a real memory leak that accumulates on repeated zip downloads 
within the same session.

Note: tests were not run locally (no Docker available). 
Happy to run them if required before merge.

## Checklist:
- [x] The code follows the coding guidelines of omegaUp.
- [ ] The tests were executed and all of them passed.
- [x ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.