### PR TITLE
Arreglando configuración a MySQL desde el script de queries ineficientes

### DIFF
--- a/stuff/mysql_types.sh
+++ b/stuff/mysql_types.sh
@@ -7,20 +7,36 @@ set -e
 
 OMEGAUP_ROOT=$(/usr/bin/git rev-parse --show-toplevel)
 
+MYSQL_CONFIG_FILE="${OMEGAUP_MYSQL_CONFIG_FILE:-${HOME}/.my.cnf}"
+MYSQL_ARGS=()
+if [[ -f "${MYSQL_CONFIG_FILE}" ]]; then
+	MYSQL_ARGS+=("--defaults-file=${MYSQL_CONFIG_FILE}")
+else
+	MYSQL_HOST="${OMEGAUP_MYSQL_HOST:-mysql}"
+	MYSQL_USER="${OMEGAUP_MYSQL_USER:-root}"
+	MYSQL_PASSWORD="${OMEGAUP_MYSQL_PASSWORD:-${MYSQL_ROOT_PASSWORD:-}}"
+	MYSQL_ARGS+=("--protocol=TCP" "-h" "${MYSQL_HOST}" "-u${MYSQL_USER}")
+	if [[ -n "${MYSQL_PASSWORD}" ]]; then
+		MYSQL_ARGS+=("--password=${MYSQL_PASSWORD}")
+	else
+		MYSQL_ARGS+=("--skip-password")
+	fi
+fi
+
 # Clean up anything that might have been left from a previous run.
 if [[ -d "${OMEGAUP_ROOT}/frontend/tests/runfiles/" ]]; then
 	find "${OMEGAUP_ROOT}/frontend/tests/runfiles/" -mindepth 2 -name mysql_types.log -exec rm -f {} \;
 fi
 
 # Enable General Query Log
-mysql -h mysql -uroot -e "TRUNCATE TABLE mysql.general_log;"
-mysql -h mysql -uroot -e "SET GLOBAL general_log = 'ON';"
-mysql -h mysql -uroot -e "SET GLOBAL log_output = 'TABLE';"
+mysql "${MYSQL_ARGS[@]}" -e "TRUNCATE TABLE mysql.general_log;"
+mysql "${MYSQL_ARGS[@]}" -e "SET GLOBAL general_log = 'ON';"
+mysql "${MYSQL_ARGS[@]}" -e "SET GLOBAL log_output = 'TABLE';"
 
 "${OMEGAUP_ROOT}/stuff/run-php-tests.sh"
 
 # Disable General Query Log
-mysql -h mysql -uroot -e "SET GLOBAL general_log = 'OFF';"
+mysql "${MYSQL_ARGS[@]}" -e "SET GLOBAL general_log = 'OFF';"
 
 sort --unique \
 	--output "${OMEGAUP_ROOT}/frontend/tests/runfiles/mysql_types.log" \

--- a/stuff/process_mysql_explain_logs.py
+++ b/stuff/process_mysql_explain_logs.py
@@ -8,6 +8,7 @@ import sys
 import os
 import csv
 from typing import Any, Iterable, Tuple, Optional, List, Dict
+import configparser
 import re
 import mysql.connector
 from mysql.connector import Error  # type: ignore
@@ -38,24 +39,37 @@ def create_connection(
     """
     Open a MySQL Connection
     """
+    defaults: Dict[str, str] = {}
+    config_file = os.getenv('OMEGAUP_MYSQL_CONFIG_FILE')
+    if not config_file:
+        config_file = os.path.join(os.path.expanduser('~'), '.my.cnf')
+    if os.path.isfile(config_file):
+        parser = configparser.ConfigParser()
+        parser.read(config_file)
+        if parser.has_section('client'):
+            defaults = dict(parser['client'])
+
     host = os.getenv(
         'OMEGAUP_MYSQL_HOST',
-        os.getenv('MYSQL_HOST', host_name),
+        os.getenv('MYSQL_HOST', defaults.get('host', host_name)),
     )
     port = int(
         os.getenv(
             'OMEGAUP_MYSQL_PORT',
-            os.getenv('MYSQL_TCP_PORT', port),
+            os.getenv('MYSQL_TCP_PORT', defaults.get('port', port)),
         )
     )
-    user = os.getenv('OMEGAUP_MYSQL_USER', user_name)
+    user = os.getenv('OMEGAUP_MYSQL_USER', defaults.get('user', user_name))
     db = os.getenv(
         'OMEGAUP_MYSQL_DB',
         os.getenv('MYSQL_DATABASE', db_name),
     )
     pw_env = os.getenv(
         'OMEGAUP_MYSQL_PASSWORD',
-        os.getenv('MYSQL_ROOT_PASSWORD', user_password),
+        os.getenv(
+            'MYSQL_ROOT_PASSWORD',
+            defaults.get('password', user_password)
+        ),
     )
 
     try:


### PR DESCRIPTION
# Description

Se arregla el script de quieries ineficientes para permitir conexión a MySQL configurable.

- `mysql_types.sh` ahora usa configuración de MySQL desde `OMEGAUP_MYSQL_CONFIG_FILE` (o `~/.my.cnf`), y si no existe, toma los datos desde variables de entorno.
- Se elimina la dependencia de conexión hardcodeada (`mysql -h mysql -uroot`) para que funcione correctamente en CI y en entornos locales distintos.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.