### PR TITLE
Add archived field to Groups

### DIFF
--- a/frontend/database/00271_add_archived_to_groups.sql
+++ b/frontend/database/00271_add_archived_to_groups.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `Groups_`
+  ADD COLUMN `archived` tinyint(1) NOT NULL DEFAULT '0'
+    COMMENT 'Indicates whether the group has been archived (soft delete)';

--- a/frontend/database/00271_add_archived_to_groups.sql
+++ b/frontend/database/00271_add_archived_to_groups.sql
@@ -1,3 +1,3 @@
 ALTER TABLE `Groups_`
   ADD COLUMN `archived` tinyint(1) NOT NULL DEFAULT '0'
-    COMMENT 'Indicates whether the group has been archived (soft delete)';
+    COMMENT 'Indica si el grupo ha sido archivado.';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -493,7 +493,7 @@ CREATE TABLE `Groups_` (
   `alias` varchar(50) NOT NULL,
   `name` varchar(50) NOT NULL,
   `description` varchar(256) DEFAULT NULL,
-  `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indicates whether the group has been archived (soft delete)',
+  `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si el grupo ha sido archivado por el administrador.',
   PRIMARY KEY (`group_id`),
   UNIQUE KEY `groups_alias` (`alias`),
   KEY `acl_id` (`acl_id`),

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -493,6 +493,7 @@ CREATE TABLE `Groups_` (
   `alias` varchar(50) NOT NULL,
   `name` varchar(50) NOT NULL,
   `description` varchar(256) DEFAULT NULL,
+  `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indicates whether the group has been archived (soft delete)',
   PRIMARY KEY (`group_id`),
   UNIQUE KEY `groups_alias` (`alias`),
   KEY `acl_id` (`acl_id`),


### PR DESCRIPTION
# Description

This is the first part of the implementation for regular group archiving (soft delete).

To ensure safe deployment and allow easy rollbacks, this PR only includes the database schema changes and migration script.

Changes included:

* Added `frontend/database/00271_add_archived_to_groups.sql` to introduce the `archived` field (`TINYINT(1) DEFAULT 0`) to the `Groups_` table.
* Updated `frontend/database/schema.sql` to reflect the updated table structure.

The DAO updates, controller changes, and UI changes will be submitted in a separate follow-up PR after this schema change is reviewed and verified.

Related to: #9754

# Comments

This PR follows a similar split deployment strategy used for Team_Groups archiving.

Please review only the database/schema changes in this PR.

# Checklist:

* [x] The code follows the coding guidelines of omegaUp.
* [ ] The tests were executed and all of them passed.
* [ ] If you are creating a feature, the new tests were added.
* [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.
