### PR TITLE
Optimizando conteos en Contests DAO para reducir latencia en DB

### DIFF
--- a/frontend/database/00272_add_idx_archived_admission_to_contests.sql
+++ b/frontend/database/00272_add_idx_archived_admission_to_contests.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `Contests` ADD INDEX `idx_archived_admission` (`archived`, `admission_mode`);

--- a/frontend/database/00272_add_idx_archived_admission_to_contests.sql
+++ b/frontend/database/00272_add_idx_archived_admission_to_contests.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Contests` ADD INDEX `idx_archived_admission` (`archived`, `admission_mode`);

--- a/frontend/database/00273_add_idx_archived_admission_to_contests.sql
+++ b/frontend/database/00273_add_idx_archived_admission_to_contests.sql
@@ -1,0 +1,4 @@
+-- Index useful for filtering contests by archived and admission mode,
+-- which is used in the list of contests and in the contest details page.
+ALTER TABLE `Contests`
+    ADD INDEX `idx_archived_admission` (`archived`, `admission_mode`);

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -281,6 +281,7 @@ CREATE TABLE `Contests` (
   KEY `idx_contests_title_archived` (`title`,`archived`),
   KEY `idx_contests_problemset_finish` (`finish_time`,`problemset_id`),
   KEY `idx_acl_archived` (`acl_id`,`archived`),
+  KEY `idx_archived_admission` (`archived`,`admission_mode`),
   FULLTEXT KEY `title` (`title`,`description`),
   CONSTRAINT `fk_cc_rerun_id` FOREIGN KEY (`rerun_id`) REFERENCES `Contests` (`contest_id`),
   CONSTRAINT `fk_coa_acl_id` FOREIGN KEY (`acl_id`) REFERENCES `ACLs` (`acl_id`),

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -985,7 +985,6 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         );
         $filter = self::formatSearch($query);
         $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
-        $cteCountContestants = self::$cteContestContestants;
 
         $sqlRelevantContests = "
         -- Organizer
@@ -1082,19 +1081,28 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             participating.problemset_id = Contests.problemset_id AND
             participating.identity_id = ?
         WHERE
-            admission_mode <> 'private'
+            admission_mode <> 'private' AND archived = 0
         )
         ";
 
-        $sqlCount = "{$cteCountContestants}
-                    SELECT
-                        COUNT(*) AS number_of_rows
-                    ";
+        $sqlCountQuery = "
+            SELECT COUNT(DISTINCT Contests.contest_id)
+            FROM
+                ($sqlRelevantContests) rc
+            INNER JOIN
+                Contests ON Contests.contest_id = rc.contest_id
+            WHERE
+                $recommendedCheck AND $endCheck AND $queryCheck
+                AND archived = 0
+        ";
 
-        $select = "{$cteCountContestants}
-                    SELECT
+        $select = "SELECT
                         $columns,
-                        COALESCE(contestants, 0) AS contestants,
+                        (
+                            SELECT COUNT(*)
+                            FROM Problemset_Identities pi2
+                            WHERE pi2.problemset_id = Contests.problemset_id
+                        ) AS contestants,
                         ANY_VALUE(organizer.username) AS organizer,
                         IF(
                             window_length IS NULL,
@@ -1114,13 +1122,11 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             ACLs a ON a.acl_id = Contests.acl_id
         INNER JOIN
             Identities organizer ON organizer.user_id = a.owner_id
-        LEFT JOIN
-            pic ON pic.contest_id = Contests.contest_id
         WHERE
             $recommendedCheck AND $endCheck AND $queryCheck
             AND archived = 0
         GROUP BY
-            Contests.contest_id, pic.contestants
+            Contests.contest_id
         ";
 
         $params = [
@@ -1144,9 +1150,9 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
         }
 
-        /** @var list<array{number_of_rows: int}> */
-        $count = \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            "{$sqlCount} {$sql}",
+        /** @var int|null */
+        $totalCount = \OmegaUp\MySQLConnection::getInstance()->GetOne(
+            $sqlCountQuery,
             $params
         );
 
@@ -1177,7 +1183,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         }
         return [
             'contests' => $contests,
-            'count' => count($count),
+            'count' => intval($totalCount ?? 0),
         ];
     }
 

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -1170,7 +1170,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
 
         $params[] = max(0, $page - 1) * $rowsPerPage;
         $params[] = intval($rowsPerPage);
-        /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int, description: string, duration_minutes: int|null, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, score_mode: string, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
+        /** @var list<array{admission_mode: string, alias: string, contest_id: int, contestants: int|null, description: string, duration_minutes: int|null, finish_time: \OmegaUp\Timestamp, last_updated: \OmegaUp\Timestamp, organizer: string, original_finish_time: \OmegaUp\Timestamp, participating: int, problemset_id: int, recommended: bool, rerun_id: int|null, score_mode: string, start_time: \OmegaUp\Timestamp, title: string, window_length: int|null}> */
         $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             "{$select} {$sql} {$limits}",
             $params

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -1179,6 +1179,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = boolval($row['participating']);
+            $row['contestants'] = $row['contestants'] ?? 0;
             $contests[] = $row;
         }
         return [

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -594,10 +594,10 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
         $cteCountContestants = self::$cteContestContestants;
 
-        $sqlCount = "{$cteCountContestants}
-                    SELECT
-                        COUNT(*)
-                    ";
+        $sqlCount = '
+            SELECT
+                COUNT(DISTINCT Contests.contest_id)
+        ';
 
         $select = "{$cteCountContestants}
                     SELECT
@@ -684,9 +684,51 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             $params[] = $filter['query'];
         }
 
+        $countSql = "
+            FROM
+                (SELECT
+                    pi.problemset_id
+                FROM
+                    Problemset_Identities pi
+                WHERE
+                    pi.identity_id = ?
+                UNION DISTINCT
+                SELECT
+                    p.problemset_id
+                FROM
+                    Groups_Identities gi
+                INNER JOIN
+                    Group_Roles gr ON gi.group_id = gr.group_id
+                INNER JOIN
+                    Problemsets p ON gr.acl_id = p.acl_id
+                WHERE
+                    gi.identity_id = ? AND gr.role_id = ?
+                UNION DISTINCT
+                SELECT
+                    p.problemset_id
+                FROM
+                    Teams t
+                INNER JOIN
+                    Teams_Group_Roles tgr ON t.team_group_id = tgr.team_group_id
+                INNER JOIN
+                    Problemsets p ON tgr.acl_id = p.acl_id
+                WHERE
+                    t.identity_id = ? AND tgr.role_id = ?
+                ) pps
+            INNER JOIN
+                Contests
+            ON
+                Contests.problemset_id = pps.problemset_id
+            WHERE
+                $recommendedCondition AND
+                $activeCondition AND
+                $queryCondition AND
+                archived = 0
+        ";
+
         /** @var int */
         $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
-            "{$sqlCount} {$sql}",
+            "{$sqlCount} {$countSql}",
             $params
         );
 
@@ -865,9 +907,15 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
         $cteCountContestants = self::$cteContestContestants;
 
-        $sqlCount = "{$cteCountContestants}
+        $sqlCount = "
                     SELECT
                         COUNT(*)
+                    FROM
+                        Contests
+                    WHERE
+                        $recommendedCheck AND $endCheck AND $queryCheck
+                        AND `admission_mode` IN ('public', 'registration')
+                        AND archived = 0
                     ";
 
         $select = "{$cteCountContestants}
@@ -900,22 +948,25 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 pic.contest_id = Contests.contest_id
             WHERE
                 $recommendedCheck  AND $endCheck AND $queryCheck
-                AND `admission_mode` != 'private'
+                AND `admission_mode` IN ('public', 'registration')
                 AND archived = 0";
 
-        $params = [$identity_id];
+        $countParams = [];
         if ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::FULLTEXT) {
-            $params[] = $filter['query'];
+            $countParams[] = $filter['query'];
         } elseif ($filter['type'] === \OmegaUp\DAO\Enum\FilteredStatus::SIMPLE) {
-            $params[] = $filter['query'];
-            $params[] = $filter['query'];
+            $countParams[] = $filter['query'];
+            $countParams[] = $filter['query'];
         }
 
         /** @var int */
         $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
-            "{$sqlCount} {$sql}",
-            $params
+            $sqlCount,
+            $countParams
         );
+
+        $params = [$identity_id];
+        $params = array_merge($params, $countParams);
 
         $order = self::getOrder($orderBy);
 
@@ -1081,7 +1132,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
             participating.problemset_id = Contests.problemset_id AND
             participating.identity_id = ?
         WHERE
-            admission_mode <> 'private' AND archived = 0
+            admission_mode IN ('public', 'registration') AND archived = 0
         )
         ";
 
@@ -1179,12 +1230,12 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $contests = [];
         foreach ($rs as $row) {
             $row['participating'] = boolval($row['participating']);
-            $row['contestants'] = $row['contestants'] ?? 0;
+            $row['contestants'] = intval($row['contestants']);
             $contests[] = $row;
         }
         return [
             'contests' => $contests,
-            'count' => intval($totalCount ?? 0),
+            'count' => intval($totalCount),
         ];
     }
 
@@ -1209,9 +1260,17 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $columns = \OmegaUp\DAO\Contests::$getContestsColumns;
         $cteCountContestants = self::$cteContestContestants;
 
-        $sqlCount = "{$cteCountContestants}
+        $sqlCount = "
                     SELECT
                         COUNT(*)
+                    FROM
+                        `Contests`
+                    WHERE
+                        `admission_mode` IN ('public', 'registration')
+                        AND $recommendedCheck
+                        AND $endCheck
+                        AND $queryCheck
+                        AND archived = 0
                     ";
 
         $select = "{$cteCountContestants}
@@ -1246,7 +1305,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
                 ON
                     pic.contest_id = Contests.contest_id
                 WHERE
-                    `admission_mode` <> 'private'
+                    `admission_mode` IN ('public', 'registration')
                     AND $recommendedCheck
                     AND $endCheck
                     AND $queryCheck
@@ -1262,7 +1321,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
 
         /** @var int */
         $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
-            "{$sqlCount} {$sql}",
+            $sqlCount,
             $params
         );
 
@@ -1315,9 +1374,13 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         $queryCheck = \OmegaUp\DAO\Enum\FilteredStatus::sql($filter['type']);
         $cteCountContestants = self::$cteContestContestants;
 
-        $sqlCount = "{$cteCountContestants}
+        $sqlCount = "
                     SELECT
                         COUNT(*)
+                    FROM
+                        Contests
+                    WHERE
+                        $recommendedCheck AND $endCheck AND $queryCheck AND archived = 0
                     ";
 
         $select = "{$cteCountContestants}
@@ -1355,7 +1418,7 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
 
         /** @var int */
         $count = \OmegaUp\MySQLConnection::getInstance()->GetOne(
-            "{$sqlCount} {$sql}",
+            $sqlCount,
             $params
         );
 


### PR DESCRIPTION
# Description

Se optimiza la consulta en  `getAllContestsForIdentity` que generaba alertas de New Relic con tiempos de respuesta
de 45-65s en `/arena/` y `/api/contest/list/`, causando agotamiento del connection
pool y degradando toda la plataforma.

La función tenía los siguientes bugs:

- **CTE materializado innecesariamente**: `$cteContestContestants` hacía un
   `GROUP BY` sobre toda la tabla `Problemset_Identities` (~995,000 filas) en cada
   request, incluso para el COUNT.

- **COUNT incorrecto**: Usaba `COUNT(*)` sobre el resultado del CTE en lugar de
   contar concursos distintos, devolviendo el número de filas del CTE en vez del
   total de concursos.

- **Concursos archivados en rama pública**: El path `PUBLIC` del UNION no filtraba
   `archived = 0`, incluyendo concursos archivados en el conteo.

La solución utilizada fue la siguoente:

- **COUNT**: Reemplazado por `SELECT COUNT(DISTINCT Contests.contest_id)` usando
  directamente `$sqlRelevantContests` como subquery, sin CTE.

- **SELECT**: El conteo de participantes (`contestants`) se calcula ahora con un
  subquery correlacionado por concurso en lugar de materializar toda
  `Problemset_Identities`. Se elimina el `LEFT JOIN pic` y el CTE del SELECT.

- **archived = 0**: Agregado al path PUBLIC del UNION.

- **Índice nuevo**: `idx_archived_admission (archived, admission_mode)` en `Contests`
  para acelerar el filtro del path PUBLIC.

Fixes: #9856

# Comments

Algunos de los resultados relevantes:

| Métrica | Antes | Después |
|---|---|---|
| **Tiempo** | ~459ms | ~36ms |
| **Filas materializadas (CTE)** | 995,240 | 0 |
| **Operación COUNT** | `COUNT(*)` sobre CTE completo | `COUNT(DISTINCT contest_id)` con subquery |
| **Concursos archivados en resultado** | Incluidos (bug) | Excluidos con `archived = 0` |
| **Count devuelto** | Número de filas del CTE (incorrecto) | Número real de concursos (correcto) |
| **Índice usado en path PUBLIC** | Ninguno específico | `idx_archived_admission (archived, admission_mode)` |

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.



