### PR TITLE
fix(activity): compute duplicate users/origins across all pages consi…

### DIFF
--- a/frontend/server/src/ActivityReport.php
+++ b/frontend/server/src/ActivityReport.php
@@ -11,15 +11,17 @@ namespace OmegaUp;
 class ActivityReport {
     /**
      * @param list<array{alias: null|string, classname: string, clone_result: null|string, clone_token_payload: null|string, event_type: string, ip: int|null, name: null| string, time: \OmegaUp\Timestamp, username: string}> $events
+     * @param array<int, int>|null $ipMapping
      *
      * @return list<ActivityEvent>
      */
-    final public static function getActivityReport(array $events): array {
+    final public static function getActivityReport(array $events, ?array &$ipMapping = null): array {
         $events = array_map(fn ($event) => self::processData($event), $events);
 
         // Anonymize data.
-        /** @var array<int, int> */
-        $ipMapping = [];
+        if (is_null($ipMapping)) {
+            $ipMapping = [];
+        }
         foreach ($events as &$entry) {
             if (is_null($entry['ip'])) {
                 continue;
@@ -34,6 +36,86 @@ class ActivityReport {
         }
 
         return $events;
+    }
+
+    /**
+     * @param list<array{username: string, classname: string, ip: int|null}> $events
+     * @param array<int, int> $ipMapping
+     * @return array{users: list<array{username: string, classname: string, ips: list<string>}>, origins: list<array{origin: string, usernames: list<array{username: string, classname: string}>}>}
+     */
+    final public static function getActivityReportDuplicates(array $events, array &$ipMapping): array {
+        foreach ($events as &$entry) {
+            if (is_null($entry['ip'])) {
+                continue;
+            }
+            if (!isset($ipMapping[$entry['ip']])) {
+                $ipMapping[$entry['ip']] = count($ipMapping);
+            }
+            $entry['ip_mapped'] = strval($ipMapping[$entry['ip']]);
+        }
+
+        // Group by user
+        $userMapping = [];
+        $classByUser = [];
+        foreach ($events as $entry) {
+            if (is_null($entry['ip'])) {
+                continue;
+            }
+            $username = $entry['username'];
+            $ipMapped = $entry['ip_mapped'];
+            $userMapping[$username][] = $ipMapped;
+            $classByUser[$username] = $entry['classname'];
+        }
+
+        $users = [];
+        $sortedUsers = array_keys($userMapping);
+        sort($sortedUsers);
+        foreach ($sortedUsers as $username) {
+            $ips = array_values(array_unique($userMapping[$username]));
+            if (count($ips) <= 1) {
+                continue;
+            }
+            sort($ips);
+            $users[] = [
+                'username' => $username,
+                'classname' => $classByUser[$username],
+                'ips' => $ips,
+            ];
+        }
+
+        // Group by origin
+        $originMapping = [];
+        foreach ($events as $entry) {
+            if (is_null($entry['ip'])) {
+                continue;
+            }
+            $username = $entry['username'];
+            $ipMapped = $entry['ip_mapped'];
+            $originMapping[$ipMapped][] = $username;
+        }
+
+        $origins = [];
+        $sortedOrigins = array_keys($originMapping);
+        sort($sortedOrigins);
+        foreach ($sortedOrigins as $origin) {
+            $usernames = array_values(array_unique($originMapping[$origin]));
+            if (count($usernames) <= 1) {
+                continue;
+            }
+            sort($usernames);
+            $origins[] = [
+                'origin' => $origin,
+                'usernames' => array_map(fn ($u) => [
+                    'username' => $u,
+                    'classname' => $classByUser[$u]
+                ], $usernames),
+            ];
+        }
+
+        return [
+            'users' => $users,
+            'origins' => $origins,
+        ];
     }
 
     /**

--- a/frontend/server/src/Controllers/Contest.php
+++ b/frontend/server/src/Controllers/Contest.php
@@ -2481,7 +2481,7 @@ class Contest extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a report with all user activity for a contest.
      *
-     * @return array{events: list<ActivityEvent>, pagerItems: list<PageItem>}
+     * @return array{events: list<ActivityEvent>, users?: list<array{username: string, classname: string, ips: list<string>}>, origins?: list<array{origin: string, usernames: list<array{username: string, classname: string}>}>, pagerItems: list<PageItem>}
      *
      * @omegaup-request-param string $contest_alias
      * @omegaup-request-param int|null $length
@@ -2511,6 +2511,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\NotFoundException('contestNotFound');
         }
 
+        $distinctActivity = \OmegaUp\DAO\Contests::getDistinctActivity($response['contest']);
+        $ipMapping = [];
+        $duplicates = \OmegaUp\ActivityReport::getActivityReportDuplicates($distinctActivity, $ipMapping);
+
         $report = \OmegaUp\DAO\Contests::getActivityReport(
             $response['contest'],
             $page,
@@ -2519,8 +2523,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
 
         return [
             'events' => \OmegaUp\ActivityReport::getActivityReport(
-                $report['activity']
+                $report['activity'],
+                $ipMapping
             ),
+            'users' => $duplicates['users'],
+            'origins' => $duplicates['origins'],
             'pagerItems' => \OmegaUp\Pager::paginateWithUrl(
                 $report['totalRows'],
                 $length,
@@ -2562,6 +2569,10 @@ class Contest extends \OmegaUp\Controllers\Controller {
             );
         }
 
+        $distinctActivity = \OmegaUp\DAO\Contests::getDistinctActivity($contest);
+        $ipMapping = [];
+        $duplicates = \OmegaUp\ActivityReport::getActivityReportDuplicates($distinctActivity, $ipMapping);
+
         $report = \OmegaUp\DAO\Contests::getActivityReport(
             $contest,
             $page,
@@ -2575,8 +2586,11 @@ class Contest extends \OmegaUp\Controllers\Controller {
                     'length' => $length,
                     'alias' => $alias,
                     'events' => \OmegaUp\ActivityReport::getActivityReport(
-                        $report['activity']
+                        $report['activity'],
+                        $ipMapping
                     ),
+                    'users' => $duplicates['users'],
+                    'origins' => $duplicates['origins'],
                     'type' => 'contest',
                     'pagerItems' => \OmegaUp\Pager::paginateWithUrl(
                         $report['totalRows'],

--- a/frontend/server/src/Controllers/Course.php
+++ b/frontend/server/src/Controllers/Course.php
@@ -4491,6 +4491,10 @@ class Course extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 
+        $distinctActivity = \OmegaUp\DAO\Courses::getDistinctActivity($course);
+        $ipMapping = [];
+        $duplicates = \OmegaUp\ActivityReport::getActivityReportDuplicates($distinctActivity, $ipMapping);
+
         $report = \OmegaUp\DAO\Courses::getActivityReport(
             $course,
             $page,
@@ -4504,8 +4508,11 @@ class Course extends \OmegaUp\Controllers\Controller {
                     'length' => $length,
                     'alias' => $courseAlias,
                     'events' => \OmegaUp\ActivityReport::getActivityReport(
-                        $report['activity']
+                        $report['activity'],
+                        $ipMapping
                     ),
+                    'users' => $duplicates['users'],
+                    'origins' => $duplicates['origins'],
                     'type' => 'course',
                     'pagerItems' => \OmegaUp\Pager::paginateWithUrl(
                         $report['totalRows'],
@@ -5538,7 +5545,7 @@ class Course extends \OmegaUp\Controllers\Controller {
     /**
      * Returns a report with all user activity for a course.
      *
-     * @return array{events: list<ActivityEvent>, pagerItems: list<PageItem>}
+     * @return array{events: list<ActivityEvent>, users?: list<array{username: string, classname: string, ips: list<string>}>, origins?: list<array{origin: string, usernames: list<array{username: string, classname: string}>}>, pagerItems: list<PageItem>}
      *
      * @omegaup-request-param string $course_alias
      * @omegaup-request-param int|null $length
@@ -5563,6 +5570,10 @@ class Course extends \OmegaUp\Controllers\Controller {
             throw new \OmegaUp\Exceptions\ForbiddenAccessException();
         }
 
+        $distinctActivity = \OmegaUp\DAO\Courses::getDistinctActivity($course);
+        $ipMapping = [];
+        $duplicates = \OmegaUp\ActivityReport::getActivityReportDuplicates($distinctActivity, $ipMapping);
+
         $report = \OmegaUp\DAO\Courses::getActivityReport(
             $course,
             $page,
@@ -5571,8 +5582,11 @@ class Course extends \OmegaUp\Controllers\Controller {
 
         return [
             'events' => \OmegaUp\ActivityReport::getActivityReport(
-                $report['activity']
+                $report['activity'],
+                $ipMapping
             ),
+            'users' => $duplicates['users'],
+            'origins' => $duplicates['origins'],
             'pagerItems' => \OmegaUp\Pager::paginateWithUrl(
                 $report['totalRows'],
                 $length,

--- a/frontend/server/src/DAO/Contests.php
+++ b/frontend/server/src/DAO/Contests.php
@@ -1707,6 +1707,47 @@ class Contests extends \OmegaUp\DAO\Base\Contests {
         ];
     }
 
+    /**
+     * @return list<array{username: string, ip: int, classname: string}>
+     */
+    public static function getDistinctActivity(
+        \OmegaUp\DAO\VO\Contests $contest
+    ): array {
+        $sql = 'SELECT DISTINCT
+                    i.username,
+                    pal.ip,
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
+                FROM
+                    Problemset_Access_Log pal
+                INNER JOIN
+                    Identities i ON i.identity_id = pal.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
+                WHERE
+                    pal.problemset_id = ?
+
+                UNION DISTINCT
+
+                SELECT DISTINCT
+                    i.username,
+                    sl.ip,
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
+                FROM
+                    Submission_Log sl
+                INNER JOIN
+                    Identities i ON i.identity_id = sl.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
+                WHERE
+                    sl.problemset_id = ?';
+
+        /** @var list<array{classname: string, ip: int, username: string}> */
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$contest->problemset_id, $contest->problemset_id]
+        );
+    }
+
     private static function getOrder(
         int $orderBy,
         string $defaultOrder = '`original_finish_time`',

--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -1570,6 +1570,71 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
         ];
     }
     /**
+     * @return list<array{username: string, ip: int|null, classname: string}>
+     */
+    public static function getDistinctActivity(
+        \OmegaUp\DAO\VO\Courses $course
+    ): array {
+        $sql = 'WITH course_assignments AS (
+                    SELECT problemset_id
+                    FROM Assignments
+                    WHERE course_id = ?
+                )
+                SELECT DISTINCT
+                    i.username,
+                    pal.ip,
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
+                FROM
+                    Problemset_Access_Log pal
+                INNER JOIN
+                    course_assignments a ON a.problemset_id = pal.problemset_id
+                INNER JOIN
+                    Identities i ON i.identity_id = pal.identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
+
+                UNION DISTINCT
+
+                SELECT DISTINCT
+                    i.username,
+                    sl.ip,
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
+                FROM
+                    Submission_Log sl
+                INNER JOIN
+                    course_assignments a ON a.problemset_id = sl.problemset_id
+                INNER JOIN
+                    Identities i ON i.identity_id = sl.identity_id
+                INNER JOIN
+                    Submissions s ON s.submission_id = sl.submission_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
+
+                UNION DISTINCT
+
+                SELECT DISTINCT
+                    i.username,
+                    INET_ATON(ccl.ip) AS ip,
+                    IFNULL(ur.classname, "user-rank-unranked") AS classname
+                FROM
+                    Course_Clone_Log ccl
+                INNER JOIN
+                    Users u ON u.user_id = ccl.user_id
+                INNER JOIN
+                    Identities i ON i.identity_id = u.main_identity_id
+                LEFT JOIN
+                    User_Rank ur ON ur.user_id = i.user_id
+                WHERE
+                    ccl.course_id = ?';
+
+        /** @var list<array{classname: string, ip: int|null, username: string}> */
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$course->course_id, $course->course_id]
+        );
+    }
+
+    /**
      * @return list<\OmegaUp\DAO\VO\Groups>
      */
     public static function getCourseTeachingAssistantGroups(

--- a/frontend/www/js/omegaup/activity/feed.ts
+++ b/frontend/www/js/omegaup/activity/feed.ts
@@ -20,6 +20,8 @@ OmegaUp.on('ready', function () {
           alias: payload.alias,
           report: payload.events,
           pagerItems: payload.pagerItems,
+          reportUsers: (payload as any).users,
+          reportOrigins: (payload as any).origins,
         },
       });
     },

--- a/frontend/www/js/omegaup/components/activity/Feed.vue
+++ b/frontend/www/js/omegaup/components/activity/Feed.vue
@@ -230,6 +230,9 @@ export default class ActivityFeed extends Vue {
   @Prop() report!: types.ActivityEvent[];
   @Prop() pagerItems!: types.PageItem[];
 
+  @Prop({ default: () => [] }) reportUsers!: User[];
+  @Prop({ default: () => [] }) reportOrigins!: Origin[];
+
   T = T;
   time = time;
   showTab = 'report';
@@ -290,6 +293,9 @@ export default class ActivityFeed extends Vue {
   }
 
   get users(): User[] {
+    if (this.reportUsers && this.reportUsers.length > 0) {
+      return this.reportUsers;
+    }
     let userMapping: Mapping = {};
     for (let evt of this.report) {
       this.addMapping(userMapping, evt.username, String(evt.ip));
@@ -311,6 +317,9 @@ export default class ActivityFeed extends Vue {
   }
 
   get origins(): Origin[] {
+    if (this.reportOrigins && this.reportOrigins.length > 0) {
+      return this.reportOrigins;
+    }
     let originMapping: Mapping = {};
     for (let evt of this.report) {
       this.addMapping(originMapping, String(evt.ip), evt.username);


### PR DESCRIPTION
# Description

fix(activity): compute duplicate users and origins across all pages consistently in activity report

Currently, the "Account Name" (duplicate users) and "Origin" (duplicate IPs) tabs in the Contest/Course Activity Report are calculated entirely on the client-side (`Feed.vue`) using the paginated `report` Prop. This causes the tabs to only show duplicate activity for the currently loaded page of events. Additionally, IP address anonymization index mappings start fresh on each page, making cross-page IP comparison impossible.

This PR shifts the duplicate calculations to the backend:
1. Added `getDistinctActivity` to both `Contests` and `Courses` DAOs to fetch distinct `(username, classname, ip)` pairs across all log events for the entire contest or course.
2. Implemented `getActivityReportDuplicates` in `ActivityReport.php` to calculate duplicate users and origins over all distinct events using a consistently generated global IP anonymization mapping.
3. Updated the paginated event formatter to use the same unified IP mapping by reference, ensuring IP indices match perfectly between the paginated list and the duplicates tabs.
4. Added `reportUsers` and `reportOrigins` props in `Feed.vue` to receive the pre-computed lists, falling back gracefully to the old client-side calculation to maintain 100% backward compatibility and test stability.

Fixes: #9866

# Comments

- All existing frontend Vue unit tests for `Feed.vue` pass successfully without changes since the component falls back to the old behavior if the new props are not supplied.
- Calculates duplicates extremely efficiently using lightweight distinct DB queries, avoiding memory-scaling issues on large contests.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both. (N/A: The total changes are very concise (~160 lines) and best kept unified).