### PR TITLE
fix(arena): scroll to top when opening view-all contest list

### DIFF
--- a/frontend/www/js/omegaup/components/arena/ContestList.vue
+++ b/frontend/www/js/omegaup/components/arena/ContestList.vue
@@ -586,6 +586,7 @@ class ArenaContestList extends Vue {
     if (category) {
       this.currentTab = category;
       this.fetchInitialContests();
+      window.scrollTo(0, 0);
     } else {
       // Returning to summary, ensure we have data for all
       this.fetchInitialContests();


### PR DESCRIPTION
# Description

Scroll to the top of the page when opening the Arena v2 "View all" contest list view (Current, Future, and Past), so users don't land mid-page after scrolling through the summary sections.

https://github.com/user-attachments/assets/1ab2a356-e115-4aaf-90c0-ed8fd5f94105

Fixes: #9880

# Comments

Single-line frontend fix in `setViewAll()`. No backend changes.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.