### PR TITLE
Agregando incWithTTL() para incrementos atómicos en cache

### DIFF
--- a/frontend/server/src/Cache.php
+++ b/frontend/server/src/Cache.php
@@ -75,6 +75,17 @@ abstract class CacheAdapter {
     }
 
     /**
+     * Atomically increments a counter with TTL support.
+     * If the key doesn't exist, initializes it to 1 and sets the TTL.
+     * If it exists, increments it (TTL is preserved).
+     *
+     * @param string $key
+     * @param int $ttl Time to live in seconds (only set on initialization)
+     * @return int The new value after incrementing
+     */
+    abstract public function incWithTTL(string $key, int $ttl): int;
+
+    /**
      * If the specified $id exists in cache, gets its associated value from the
      * cache.  Otherwise, executes $setFunc() to generate the associated
      * value, stores it, and returns it.
@@ -306,6 +317,28 @@ class RedisCacheAdapter extends CacheAdapter {
     }
 
     /**
+     * Atomically increments a counter with TTL support.
+     * Uses Redis INCR + EXPIRE in a Lua script for true atomicity.
+     *
+     * @param string $key
+     * @param int $ttl Time to live in seconds
+     * @return int The new value after incrementing
+     */
+    public function incWithTTL(string $key, int $ttl): int {
+        // Lua script ensures INCR + EXPIRE are atomic
+        $script = <<<LUA
+        local count = redis.call('INCR', KEYS[1])
+        if count == 1 then
+            redis.call('EXPIRE', KEYS[1], ARGV[1])
+        end
+        return count
+        LUA;
+        /** @var int */
+        $result = $this->redis->eval($script, [$key, $ttl], 1);
+        return $result;
+    }
+
+    /**
      * @return array{0: string, 1: string}|false
      */
     private function acquireLock(string $lockGroup): array|false {
@@ -458,6 +491,24 @@ class APCCacheAdapter extends CacheAdapter {
     public function store(string $key, $var, int $ttl = 0): bool {
         return apcu_store($key, $var, $ttl);
     }
+
+    /**
+     * Atomically increments a counter with TTL support.
+     * Uses apcu_entry() for atomic initialization, then CAS loop.
+     *
+     * @param string $key
+     * @param int $ttl Time to live in seconds
+     * @return int The new value after incrementing
+     */
+    public function incWithTTL(string $key, int $ttl): int {
+        // Must do this in a loop to avoid race condition
+        do {
+            // Ensure the key exists with TTL (atomic initialization)
+            $current = $this->entry($key, 0, $ttl);
+            $newValue = $current + 1;
+        } while (!$this->cas($key, $current, $newValue));
+        return $newValue;
+    }
 }
 
 /**
@@ -539,6 +590,22 @@ class InProcessCacheAdapter extends CacheAdapter {
     public function store(string $key, $var, int $ttl = 0): bool {
         $this->cache[$key] = $var;
         return true;
+    }
+
+    /**
+     * Atomically increments a counter.
+     * TTL is ignored in the in-process cache (no expiration needed).
+     *
+     * @param string $key
+     * @param int $ttl Time to live in seconds (ignored)
+     * @return int The new value after incrementing
+     */
+    public function incWithTTL(string $key, int $ttl): int {
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = 0;
+        }
+        $this->cache[$key]++;
+        return $this->cache[$key];
     }
 }
 
@@ -673,6 +740,28 @@ class Cache {
         }
         $this->log->debug("Cache hit for key: {$this->key}");
         return $result;
+    }
+
+    /**
+     * Atomically increments a counter with TTL support.
+     * If the key doesn't exist, initializes it to 1 and sets the TTL.
+     * If it exists, increments it (TTL is preserved).
+     *
+     * @param int $ttl Time to live in seconds (only set on initialization)
+     * @return int The new value after incrementing, or 0 if cache is disabled
+     */
+    public function incWithTTL(int $ttl): int {
+        if (!self::isEnabled()) {
+            return 0;
+        }
+        $newValue = CacheAdapter::getInstance()->incWithTTL(
+            $this->key,
+            $ttl
+        );
+        $this->log->debug(
+            "Cache counter incremented to {$newValue} for key: {$this->key}"
+        );
+        return $newValue;
     }
 
     /**

--- a/frontend/tests/controllers/CacheTest.php
+++ b/frontend/tests/controllers/CacheTest.php
@@ -137,4 +137,34 @@ class CacheTest extends \OmegaUp\Test\ControllerTestCase {
         );
         $this->assertSame(1, $invocations);
     }
+
+    /**
+     * @dataProvider cacheAdapterProvider
+     */
+    public function testCacheIncWithTTL(\OmegaUp\CacheAdapter $cache) {
+        $key = uniqid('incwithttl-');
+        $ttl = 2; // 2 seconds TTL
+
+        // First increment should return 1
+        $this->assertSame(1, $cache->incWithTTL($key, $ttl));
+
+        // Second increment should return 2
+        $this->assertSame(2, $cache->incWithTTL($key, $ttl));
+
+        // Third increment should return 3
+        $this->assertSame(3, $cache->incWithTTL($key, $ttl));
+
+        // Verify by doing another increment (should be 4)
+        $this->assertSame(4, $cache->incWithTTL($key, $ttl));
+
+        // TTL expiration test only for Redis and APCu
+        // InProcessCacheAdapter doesn't support TTL
+        if (!($cache instanceof \OmegaUp\InProcessCacheAdapter)) {
+            // Wait for TTL to expire
+            sleep($ttl + 1);
+
+            // After expiry, should start at 1 again
+            $this->assertSame(1, $cache->incWithTTL($key, $ttl));
+        }
+    }
 }


### PR DESCRIPTION
# Description

Se agrega el método `incWithTTL()` al sistema de cache para soportar incrementos atómicos de contadores con expiración.

### Implementaciones

- **Redis**: Script Lua con `INCR` + `EXPIRE` atómico
- **APCu**: Loop CAS con `apcu_entry()` para inicialización
- **InProcess**: Incremento simple (sin TTL)
- **Cache wrapper**: Método público con logging


# Comments

Se prepara la infraestructura para corregir race condition en `RateLimiter`, donde operaciones no atómicas `get()` + `set()` permiten que requests concurrentes excedan los límites.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
