### PR TITLE
Actualizando permisos para crear PRs en el repo

### DIFF
--- a/.github/workflows/check-pr-issue.yml
+++ b/.github/workflows/check-pr-issue.yml
@@ -49,8 +49,11 @@ jobs:
 
             console.log(`PR Author: ${prAuthor}, association: ${authorAssociation}`);
 
-            // Skip this check for organization members and Dependabot
-            if (authorAssociation === "MEMBER" || prAuthor === "dependabot[bot]") {
+            // Skip this check for organization members, owners, collaborators and Dependabot
+            if (authorAssociation === "OWNER" || 
+                authorAssociation === "MEMBER" || 
+                authorAssociation === "COLLABORATOR" || 
+                prAuthor === "dependabot[bot]") {
               console.log("Skipping linked-issue & assignee check for member/dependabot author.");
               return;
             }


### PR DESCRIPTION
# Description

Se omite el check de "PR Linked Issue & Assignee / check-issue-link" para los colaboradores y para los owners de la organización

# Comments

Anteriormente este sólo se omitía para los miembros de la organización y para Dependabot. Tampoco es necesario que se valide esto cuando el creador del PR es un Owner o colaborador

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.