### PR TITLE
[Milestone 2] Implement custom modal overlay UI in create form

### DIFF
--- a/frontend/www/js/omegaup/components/problem/CreatorWrapper.vue
+++ b/frontend/www/js/omegaup/components/problem/CreatorWrapper.vue
@@ -1,0 +1,39 @@
+<template>
+  <omegaup-problem-creator
+    ref="creator"
+    @download-zip-file="onDownloadZipFile"
+    @upload-zip-file="onUploadZipFile"
+    @show-update-success-message="onShowUpdateSuccessMessage"
+    @download-input-file="onDownloadInputFile"
+  />
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+import problem_Creator from './creator/Creator.vue';
+import creatorStore from '../../problem/creator/store';
+
+@Component({
+  components: {
+    'omegaup-problem-creator': problem_Creator,
+  },
+  store: creatorStore,
+})
+export default class CreatorWrapper extends Vue {
+  onDownloadZipFile(zipObject: unknown): void {
+    this.$emit('download-zip-file', zipObject);
+  }
+
+  onUploadZipFile(data: unknown): void {
+    this.$emit('upload-zip-file', data);
+  }
+
+  onShowUpdateSuccessMessage(): void {
+    this.$emit('show-update-success-message');
+  }
+
+  onDownloadInputFile(fileObject: unknown): void {
+    this.$emit('download-input-file', fileObject);
+  }
+}
+</script>

--- a/frontend/www/js/omegaup/components/problem/Form.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Form.test.ts
@@ -159,4 +159,33 @@ describe('Settings.vue', () => {
       wrapper.find('.introjs-creation-method .introjs-file').exists(),
     ).toBe(true);
   });
+
+  it('Should open creator modal when clicking open creator button', async () => {
+    const wrapper = shallowMount(Form, {
+      propsData: {
+        data: props,
+        showCreationMethodSelector: true,
+      },
+    });
+
+    await wrapper.setData({ currentCreationMethod: CreationMethods.Creator });
+    await wrapper.find('.introjs-open-creator button').trigger('click');
+
+    expect((wrapper.vm as any).showProblemCreator).toBe(true);
+    expect(wrapper.find('.problem-creator-modal').exists()).toBe(true);
+  });
+
+  it('Should close creator modal when clicking close button', async () => {
+    const wrapper = shallowMount(Form, {
+      propsData: {
+        data: props,
+        showCreationMethodSelector: true,
+      },
+    });
+
+    await wrapper.setData({ showProblemCreator: true });
+    await wrapper.find('[data-problem-creator-close]').trigger('click');
+
+    expect((wrapper.vm as any).showProblemCreator).toBe(false);
+  });
 });

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -865,7 +865,7 @@ export default class ProblemForm extends Vue {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--problem-creator-modal-overlay-background-color);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -873,13 +873,13 @@ export default class ProblemForm extends Vue {
 }
 
 .problem-creator-modal-content {
-  background-color: white;
+  background-color: var(--problem-creator-modal-content-background-color);
   height: 81vh;
   width: 78%;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--problem-creator-modal-box-shadow-color);
 }
 
 .problem-creator-modal-body {
@@ -890,7 +890,7 @@ export default class ProblemForm extends Vue {
 
 .problem-creator-modal-footer {
   padding: 20px;
-  border-top: 1px solid #dee2e6;
+  border-top: 1px solid var(--problem-creator-modal-footer-border-color);
   display: flex;
   justify-content: flex-end;
   gap: 10px;

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -115,7 +115,7 @@
                     <button
                       type="button"
                       class="btn btn-info"
-                      @click="$emit('open-problem-creator')"
+                      @click="openProblemCreatorModal()"
                     >
                       {{ T.openProblemCreator }}
                     </button>
@@ -512,6 +512,28 @@
         </div>
       </form>
     </div>
+    <div
+      v-if="showCreationMethodSelector"
+      v-show="showProblemCreator"
+      class="problem-creator-modal"
+      @click.self="closeProblemCreatorModal"
+    >
+      <div class="problem-creator-modal-content">
+        <div class="problem-creator-modal-body">
+          <omegaup-problem-creator v-if="showProblemCreator" />
+        </div>
+        <div class="problem-creator-modal-footer">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-problem-creator-close
+            @click="closeProblemCreatorModal"
+          >
+            {{ T.wordsClose }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -519,6 +541,7 @@
 import { Vue, Component, Prop, Watch, Ref } from 'vue-property-decorator';
 import problem_Settings from './Settings.vue';
 import problem_Tags from './Tags.vue';
+import problem_CreatorWrapper from './CreatorWrapper.vue';
 import T from '../../lang';
 import latinize from 'latinize';
 import { types } from '../../api_types';
@@ -536,6 +559,7 @@ export enum CreationMethods {
   components: {
     'omegaup-problem-settings': problem_Settings,
     'omegaup-problem-tags': problem_Tags,
+    'omegaup-problem-creator': problem_CreatorWrapper,
   },
 })
 export default class ProblemForm extends Vue {
@@ -582,6 +606,7 @@ export default class ProblemForm extends Vue {
   currentLanguages = this.data.languages;
   CreationMethods = CreationMethods;
   currentCreationMethod: CreationMethods = this.creationMethod;
+  showProblemCreator = false;
 
   mounted() {
     const title = T.createProblemInteractiveGuideTitle;
@@ -644,6 +669,14 @@ export default class ProblemForm extends Vue {
 
   setCurrentCreationMethod(method: CreationMethods): void {
     this.currentCreationMethod = method;
+  }
+
+  openProblemCreatorModal(): void {
+    this.showProblemCreator = true;
+  }
+
+  closeProblemCreatorModal(): void {
+    this.showProblemCreator = false;
   }
 
   get howToWriteProblemLink(): string {
@@ -824,5 +857,65 @@ export default class ProblemForm extends Vue {
 .problem-form .languages {
   padding: 0;
   width: 100%;
+}
+
+.problem-creator-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1060;
+}
+
+.problem-creator-modal-content {
+  background-color: white;
+  height: 81vh;
+  width: 78%;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.problem-creator-modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.problem-creator-modal-footer {
+  padding: 20px;
+  border-top: 1px solid #dee2e6;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+@media (max-width: 768px) {
+  .problem-creator-modal {
+    align-items: stretch;
+    justify-content: stretch;
+  }
+
+  .problem-creator-modal-content {
+    width: 100vw;
+    height: 100vh;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+  }
+
+  .problem-creator-modal-body {
+    padding: 0;
+  }
+
+  .problem-creator-modal-footer {
+    padding: 8px 12px;
+  }
 }
 </style>

--- a/frontend/www/js/omegaup/problem/new.ts
+++ b/frontend/www/js/omegaup/problem/new.ts
@@ -1,11 +1,16 @@
 import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
-import T from '../lang';
 import Vue from 'vue';
 import problem_New from '../components/problem/Form.vue';
 import { CreationMethods } from '../components/problem/Form.vue';
 import * as ui from '../ui';
 import * as api from '../api';
+import { BootstrapVue, BootstrapVueIcons } from 'bootstrap-vue';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue/dist/bootstrap-vue.css';
+
+Vue.use(BootstrapVue);
+Vue.use(BootstrapVueIcons);
 
 OmegaUp.on('ready', () => {
   const payload = types.payloadParsers.ProblemFormPayload();
@@ -37,9 +42,6 @@ OmegaUp.on('ready', () => {
           creationMethod,
         },
         on: {
-          'open-problem-creator': (): void => {
-            ui.info(T.openProblemCreator);
-          },
           'alias-changed': (alias: string): void => {
             if (!alias) {
               problemNew.errors.push('problem_alias');

--- a/frontend/www/js/omegaup/problem/new.ts
+++ b/frontend/www/js/omegaup/problem/new.ts
@@ -1,5 +1,6 @@
 import { OmegaUp } from '../omegaup';
 import { types } from '../api_types';
+import T from '../lang';
 import Vue from 'vue';
 import problem_New from '../components/problem/Form.vue';
 import { CreationMethods } from '../components/problem/Form.vue';

--- a/frontend/www/sass/base/_variables.scss
+++ b/frontend/www/sass/base/_variables.scss
@@ -398,4 +398,10 @@
   --diff-editor-divider-background-color: #e5e7eb;
   --diff-editor-readonly-badge-color: #6b7280;
   --diff-editor-readonly-badge-background-color: #e5e7eb;
+
+  // PROBLEM CREATOR MODAL
+  --problem-creator-modal-overlay-background-color: rgba(0, 0, 0, 0.5);
+  --problem-creator-modal-content-background-color: #fff;
+  --problem-creator-modal-box-shadow-color: rgba(0, 0, 0, 0.1);
+  --problem-creator-modal-footer-border-color: #dee2e6;
 }


### PR DESCRIPTION
# Description
- Created a UI for displaying modal overlay When clicking `Open Problem creator` button.
This pull request introduces a modal dialog for the problem creator within the problem creation form, allowing users to open and close the problem creator UI without leaving the current page. It also adds a new wrapper component for the creator and updates related tests and styles to support the modal behavior.

**Problem Creator Modal Integration:**
- Added a modal dialog to display the problem creator UI (`omegaup-problem-creator`) inside the problem creation form. Users can now open the creator in a modal by clicking the "open creator" button and close it with a dedicated close button or by clicking outside the modal. [[1]](diffhunk://#diff-9d03d7ae1df6b2f991b6d098d3c6d815259f9645ec94364149d92eff14580b09R515-R544) [[2]](diffhunk://#diff-9d03d7ae1df6b2f991b6d098d3c6d815259f9645ec94364149d92eff14580b09R674-R681) [[3]](diffhunk://#diff-9d03d7ae1df6b2f991b6d098d3c6d815259f9645ec94364149d92eff14580b09R609) [[4]](diffhunk://#diff-9d03d7ae1df6b2f991b6d098d3c6d815259f9645ec94364149d92eff14580b09R562)

**Component and Code Structure:**
- Introduced a new `CreatorWrapper.vue` component to encapsulate the problem creator logic and event handling.
- Updated the parent form to use the new wrapper component.

**Styling and Responsiveness:**
- Added new CSS styles for the modal, including desktop and mobile responsiveness for the creator modal dialog.

**Testing Improvements:**
- Added tests to verify opening and closing the problem creator modal via button clicks.

**BootstrapVue Integration:**
- Registered `BootstrapVue` and `BootstrapVueIcons` in the problem creation page entry point to ensure modal and UI components render correctly.

These changes together provide a more integrated and user-friendly experience for creating problems, while keeping the UI consistent and responsive.
If you modify the **User Interface**, please include a screenshot or a video.

<img width="1791" height="1009" alt="604087077-c117e0c7-2af6-4a53-b6b8-0fe7dc910b6a" src="https://github.com/user-attachments/assets/17c72227-9651-40a2-b1de-2de7608053a1" />

Fixes: #9891 

# Comments
- As this is just UI so some things will break:
   - Intro JS for custom modal.
   - Submitting a new problem in create form with the help of `Open problem creator` path.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
