### PR TITLE
Update FinderWizard.vue

### DIFF
--- a/frontend/www/js/omegaup/components/problem/FinderWizard.vue
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="modal">
-    <div class="modal-mask">
+    <div class="modal-mask" @click.self="$emit('close')">
       <div class="modal-container">
         <div class="d-flex justify-content-end">
           <button class="btn" @click="$emit('close')">❌</button>
@@ -165,6 +165,20 @@ export default class ProblemFinderWizard extends Vue {
       queryParameters.tag = this.selectedTags.map((tag) => tag.key);
     }
     this.$emit('search-problems', queryParameters);
+  }
+
+  mounted(): void {
+    document.addEventListener('keydown', this.onEsc);
+  }
+
+  beforeDestroy(): void {
+    document.removeEventListener('keydown', this.onEsc);
+  }
+
+  onEsc(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.$emit('close');
+    }
   }
 }
 </script>


### PR DESCRIPTION
# Description

Allow closing wizard modal via ESC key or clicking outside.
- Add @click.self handler on modal-mask to emit close event.
- Add ESC key listener on mounted lifecycle hook.

Video:
<img width="1280" height="720" alt="2026-06-09-20-48-01" src="https://github.com/user-attachments/assets/fe4d866f-e856-45a9-a561-204bf9a03ab4" />

Fixes: #9700 

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
