### PR TITLE
fix: wire CreatorWrapper events in Form.vue modal (#9945)

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -520,7 +520,13 @@
     >
       <div class="problem-creator-modal-content">
         <div class="problem-creator-modal-body">
-          <omegaup-problem-creator v-if="showProblemCreator" />
+          <omegaup-problem-creator
+            v-if="showProblemCreator"
+            @download-zip-file="onDownloadZipFile"
+            @upload-zip-file="onUploadZipFile"
+            @show-update-success-message="onShowUpdateSuccessMessage"
+            @download-input-file="onDownloadInputFile"
+          />
         </div>
         <div class="problem-creator-modal-footer">
           <button
@@ -543,6 +549,8 @@ import problem_Settings from './Settings.vue';
 import problem_Tags from './Tags.vue';
 import problem_CreatorWrapper from './CreatorWrapper.vue';
 import T from '../../lang';
+import * as ui from '../../ui';
+import JSZip from 'jszip';
 import latinize from 'latinize';
 import { types } from '../../api_types';
 import 'intro.js/introjs.css';
@@ -841,6 +849,49 @@ export default class ProblemForm extends Vue {
         }
       }
     }
+  }
+
+  onDownloadZipFile({
+    fileName,
+    zipContent,
+  }: {
+    fileName: string;
+    zipContent: JSZip;
+  }): void {
+    zipContent.generateAsync({ type: 'blob' }).then((content) => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(content);
+      link.download = `${fileName}.zip`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+    });
+  }
+
+  onDownloadInputFile({
+    fileName,
+    fileContent,
+  }: {
+    fileName: string;
+    fileContent: string;
+  }): void {
+    const link = document.createElement('a');
+    const blob = new Blob([fileContent], { type: 'text/plain' });
+    link.href = URL.createObjectURL(blob);
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  }
+
+  onShowUpdateSuccessMessage(): void {
+    ui.success(T.problemCreatorUpdateAlert);
+  }
+
+  onUploadZipFile(data: unknown): void {
+    this.$emit('upload-zip-file', data);
   }
 
   @Watch('alias')


### PR DESCRIPTION
## Description
Add missing `@event` bindings to `<omegaup-problem-creator>` in `Form.vue` so that events emitted by `CreatorWrapper` are no longer silently dropped in Vue 2.

- `@download-zip-file`: generates blob from JSZip, triggers anchor download
- `@download-input-file`: creates text blob, triggers anchor download
- `@show-update-success-message`: calls `ui.success(T.problemCreatorUpdateAlert)`
- `@upload-zip-file`: bubbles event up (mirrors CreatorWrapper's existing pattern)

Also adds missing `ui` and `JSZip` imports (both already used in `creator.ts`).

Fixes: #9945

## Comments
- `@upload-zip-file` is included to mirror `CreatorWrapper.vue`'s existing pattern; the event is currently consumed at `Creator.vue` level — this is pre-existing behaviour, not introduced by this PR.
- `Form.test.ts` has a pre-existing TODO for interaction tests; handlers follow identical pattern to `creator.ts`.

## Checklist:
- [x] The code follows the coding guidelines of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.