### PR TITLE
fix: handle creator modal events in problem Form.vue

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Form.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Form.test.ts
@@ -2,6 +2,7 @@ import { shallowMount } from '@vue/test-utils';
 import { types } from '../../api_types';
 
 import T from '../../lang';
+import * as ui from '../../ui';
 
 import Form from './Form.vue';
 import { CreationMethods } from './Form.vue';
@@ -187,5 +188,84 @@ describe('Settings.vue', () => {
     await wrapper.find('[data-problem-creator-close]').trigger('click');
 
     expect((wrapper.vm as any).showProblemCreator).toBe(false);
+  });
+});
+
+describe('Form.vue creator modal events', () => {
+  async function mountWithOpenCreator() {
+    const wrapper = shallowMount(Form, {
+      propsData: {
+        data: props,
+        showCreationMethodSelector: true,
+      },
+    });
+    await wrapper.setData({ showProblemCreator: true });
+    return wrapper;
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Should show success notification on show-update-success-message', async () => {
+    const successSpy = jest
+      .spyOn(ui, 'success')
+      .mockImplementation(() => undefined);
+    const wrapper = await mountWithOpenCreator();
+
+    const creator = wrapper.find('omegaup-problem-creator-stub');
+    expect(creator.exists()).toBe(true);
+    creator.vm.$emit('show-update-success-message');
+
+    expect(successSpy).toHaveBeenCalledWith(T.problemCreatorUpdateAlert);
+  });
+
+  it('Should download a file on download-input-file', async () => {
+    const wrapper = await mountWithOpenCreator();
+
+    const link = document.createElement('a');
+    const clickSpy = jest
+      .spyOn(link, 'click')
+      .mockImplementation(() => undefined);
+    jest.spyOn(document, 'createElement').mockReturnValue(link);
+    (URL as any).createObjectURL = jest.fn(() => 'blob:mock');
+    (URL as any).revokeObjectURL = jest.fn();
+
+    wrapper
+      .find('omegaup-problem-creator-stub')
+      .vm.$emit('download-input-file', {
+        fileName: 'case.txt',
+        fileContent: '1 2 3',
+      });
+
+    expect(clickSpy).toHaveBeenCalled();
+    expect(link.download).toBe('case.txt');
+  });
+
+  it('Should download a zip on download-zip-file', async () => {
+    const wrapper = await mountWithOpenCreator();
+
+    const link = document.createElement('a');
+    const clickSpy = jest
+      .spyOn(link, 'click')
+      .mockImplementation(() => undefined);
+    jest.spyOn(document, 'createElement').mockReturnValue(link);
+    (URL as any).createObjectURL = jest.fn(() => 'blob:mock');
+    (URL as any).revokeObjectURL = jest.fn();
+
+    const zipContent = {
+      generateAsync: jest.fn().mockResolvedValue(new Blob(['zip'])),
+    };
+
+    wrapper.find('omegaup-problem-creator-stub').vm.$emit('download-zip-file', {
+      fileName: 'problem',
+      zipContent,
+    });
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+
+    expect(zipContent.generateAsync).toHaveBeenCalledWith({ type: 'blob' });
+    expect(clickSpy).toHaveBeenCalled();
+    expect(link.download).toBe('problem.zip');
   });
 });

--- a/frontend/www/js/omegaup/components/problem/Form.vue
+++ b/frontend/www/js/omegaup/components/problem/Form.vue
@@ -520,7 +520,12 @@
     >
       <div class="problem-creator-modal-content">
         <div class="problem-creator-modal-body">
-          <omegaup-problem-creator v-if="showProblemCreator" />
+          <omegaup-problem-creator
+            v-if="showProblemCreator"
+            @download-zip-file="onDownloadZipFile"
+            @download-input-file="onDownloadInputFile"
+            @show-update-success-message="onShowUpdateSuccessMessage"
+          />
         </div>
         <div class="problem-creator-modal-footer">
           <button
@@ -543,8 +548,10 @@ import problem_Settings from './Settings.vue';
 import problem_Tags from './Tags.vue';
 import problem_CreatorWrapper from './CreatorWrapper.vue';
 import T from '../../lang';
+import * as ui from '../../ui';
 import latinize from 'latinize';
 import { types } from '../../api_types';
+import JSZip from 'jszip';
 import 'intro.js/introjs.css';
 import introJs from 'intro.js';
 import VueCookies from 'vue-cookies';
@@ -677,6 +684,45 @@ export default class ProblemForm extends Vue {
 
   closeProblemCreatorModal(): void {
     this.showProblemCreator = false;
+  }
+
+  onShowUpdateSuccessMessage(): void {
+    ui.success(T.problemCreatorUpdateAlert);
+  }
+
+  onDownloadInputFile({
+    fileName,
+    fileContent,
+  }: {
+    fileName: string;
+    fileContent: string;
+  }): void {
+    const link = document.createElement('a');
+    const blob = new Blob([fileContent], { type: 'text/plain' });
+    link.href = URL.createObjectURL(blob);
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  }
+
+  onDownloadZipFile({
+    fileName,
+    zipContent,
+  }: {
+    fileName: string;
+    zipContent: JSZip;
+  }): void {
+    zipContent.generateAsync({ type: 'blob' }).then((content) => {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(content);
+      link.download = `${fileName}.zip`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+    });
   }
 
   get howToWriteProblemLink(): string {


### PR DESCRIPTION
# Description

The `CreatorWrapper` rendered inside the problem creator modal in `Form.vue` re-emits `download-zip-file`, `download-input-file` and `show-update-success-message`, but `Form.vue` bound no listeners on it (line 523), so Vue 2 silently dropped those custom events. As a result, clicking **Download ZIP** / **Download Input** inside the modal produced no file, and success notifications after saving code/solution/statement never appeared.

This wires those three events to handlers in `Form.vue` that mirror the standalone `creator.ts` entry point: file downloads via a temporary anchor element, and the success toast via `ui.success`. Functionality inside the modal now matches the standalone creator page.

Fixes: #9945

# Comments

The standalone `frontend/www/js/omegaup/problem/creator/creator.ts` (lines 26-62) already handles these same events for the non-modal page; the new handlers replicate that behavior so both entry points behave identically. `upload-zip-file` is intentionally not handled here — it is consumed internally by `Creator.vue` (`populateProps`) and never propagates to the parent, matching `creator.ts`.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
