### PR TITLE
Fix FinderWizard emitting close on ESC while hidden

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Collection.vue
+++ b/frontend/www/js/omegaup/components/problem/Collection.vue
@@ -120,6 +120,7 @@
             <!-- TODO: Migrar el problem finder a BS4 (solo para eliminar algunos estilos) -->
             <omegaup-problem-finder-wizard
               v-show="showFinderWizard"
+              :show="showFinderWizard"
               :possible-tags="allTags"
               @close="showFinderWizard = false"
               @search-problems="$emit('search-problems', $event)"

--- a/frontend/www/js/omegaup/components/problem/FinderWizard.test.ts
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.test.ts
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils';
+
+import problem_FinderWizard from './FinderWizard.vue';
+
+describe('FinderWizard.vue', () => {
+  const propsData = {
+    possibleTags: [] as { name: string }[],
+  };
+
+  it('Should not emit close on Escape when the wizard is hidden', async () => {
+    const wrapper = mount(problem_FinderWizard, {
+      propsData: { ...propsData, show: false },
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toBeUndefined();
+
+    wrapper.destroy();
+  });
+
+  it('Should emit close on Escape when the wizard is shown', async () => {
+    const wrapper = mount(problem_FinderWizard, {
+      propsData: { ...propsData, show: true },
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+
+    wrapper.destroy();
+  });
+});

--- a/frontend/www/js/omegaup/components/problem/FinderWizard.vue
+++ b/frontend/www/js/omegaup/components/problem/FinderWizard.vue
@@ -108,6 +108,7 @@ interface TagObject {
 })
 export default class ProblemFinderWizard extends Vue {
   @Prop() possibleTags!: { name: string }[];
+  @Prop({ default: false }) show!: boolean;
 
   T = T;
   karel = false;
@@ -176,7 +177,7 @@ export default class ProblemFinderWizard extends Vue {
   }
 
   onEsc(event: KeyboardEvent): void {
-    if (event.key === 'Escape') {
+    if (this.show && event.key === 'Escape') {
       this.$emit('close');
     }
   }

--- a/frontend/www/js/omegaup/components/problem/List.vue
+++ b/frontend/www/js/omegaup/components/problem/List.vue
@@ -29,6 +29,7 @@
     <!-- TODO: Migrar el problem finder a BS4 (solo para eliminar algunos estilos) -->
     <omegaup-problem-finder
       v-show="showFinderWizard"
+      :show="showFinderWizard"
       :possible-tags="wizardTags"
       @close="showFinderWizard = false"
       @search-problems="wizardSearch"


### PR DESCRIPTION
# Description

The `FinderWizard` component registers a document-level `keydown` listener and emits `close` on ESC. Because `Collection.vue` and `List.vue` render it with `v-show` (not `v-if`), it stays mounted while hidden, so pressing ESC anywhere on the page fired a stray `close` event and interfered with other ESC handlers.

This adds a `show` prop and guards the handler so `close` is only emitted when the wizard is actually visible. The parents bind `:show="showFinderWizard"` alongside the existing `v-show`.

Fixes: #9922

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.
