### PR TITLE
[FEATURE] Add local, Docker-free translation compiler command (npm run i18n:compile)

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "build-development": "cross-env webpack --mode=development",
     "build-development-frontend": "cross-env webpack --config-name=frontend --mode=development",
     "refactor": "cross-env ./stuff/refactor.js",
+    "i18n:compile": "./stuff/venv/bin/python3 ./stuff/compile_i18n.py",
     "test:e2e": "cypress run --browser chrome",
     "storybook": "storybook dev -p 6006",
     "prepare": "husky"

--- a/stuff/compile_i18n.py
+++ b/stuff/compile_i18n.py
@@ -15,9 +15,11 @@ os.chdir(REPO_ROOT)
 
 from stuff.i18n_linter import I18nLinter
 
+
 def main() -> None:
+    """Main compilation entrypoint."""
     linter = I18nLinter()
-    
+
     def contents_callback(filename: str) -> bytes:
         try:
             with open(filename, 'rb') as f:
@@ -27,7 +29,7 @@ def main() -> None:
 
     # run_all returns linters.MultipleResults
     results = linter.run_all([], contents_callback)
-    
+
     if not results.new_contents:
         print('All translation files are up to date.')
         return
@@ -37,6 +39,7 @@ def main() -> None:
         print(f'Writing {filename}...')
         with open(filename, 'wb') as f:
             f.write(content)
+
 
 if __name__ == '__main__':
     main()

--- a/stuff/compile_i18n.py
+++ b/stuff/compile_i18n.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Compiles translation .lang templates into typescript and json assets."""
+
+import os
+import sys
+
+# Ensure we can import stuff/i18n_linter.py
+# The repository root is the parent directory of 'stuff'
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+# Ensure the working directory is set to the repository root
+os.chdir(REPO_ROOT)
+
+from stuff.i18n_linter import I18nLinter
+
+def main() -> None:
+    linter = I18nLinter()
+    
+    def contents_callback(filename: str) -> bytes:
+        try:
+            with open(filename, 'rb') as f:
+                return f.read()
+        except FileNotFoundError:
+            return b''
+
+    # run_all returns linters.MultipleResults
+    results = linter.run_all([], contents_callback)
+    
+    if not results.new_contents:
+        print('All translation files are up to date.')
+        return
+
+    # Write the generated contents back
+    for filename, content in results.new_contents.items():
+        print(f'Writing {filename}...')
+        with open(filename, 'wb') as f:
+            f.write(content)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION

## Description
Currently, compiling `.lang` translation source templates into the `lang.*.ts` and `lang.*.json` frontend assets requires running:
```bash
./stuff/lint.sh --linters=i18n fix --all
```
Because `./stuff/lint.sh` is bound to Docker, developers must have the Docker daemon running to compile translations. Spinning up a Docker container just to parse key-value text files adds unnecessary overhead and blocks frontend-only developers who want to test their translation changes locally.

This PR adds a native Python script and registers it as an npm command in `package.json` (`npm run i18n:compile`) to run natively inside the local `./stuff/venv/bin/python3` environment.

### Proposed Solution
1. **`stuff/compile_i18n.py`**:
   - Changes directory to the repository root to ensure absolute paths resolve correctly.
   - Instantiates and invokes `I18nLinter` (from `stuff/i18n_linter.py`) to parse `.lang` templates, build badges, and output the generated `.ts` and `.json` assets.
   - Implements a custom file loader `contents_callback` that loads file contents from the workspace filesystem, returning empty bytes on `FileNotFoundError` (for targets that don't exist yet).
   - Writes generated translation contents back to their respective targets if there's a mismatch.
2. **`package.json`**:
   - Registers `"i18n:compile"` using the repository's local `./stuff/venv/bin/python3` interpreter.

### Benefits
- **Frictionless Local Dev**: Allows frontend developers to add and test translation changes instantly without running Docker.
- **Speed**: Compiling locally takes less than a second compared to spinning up a Docker container.
- **Maintainability**: Directly reuses the existing, robust `I18nLinter` class logic, ensuring zero logic duplication.

---

## Verification Results
1. Tested compiling locally when all files are up to date:
   ```bash
   npm run i18n:compile
   ```
   **Output:**
   ```
   All translation files are up to date.
   ```

2. Simulating a translation change in `frontend/templates/en.lang` and running compiler:
   ```bash
   npm run i18n:compile
   ```
   **Output:**
   ```
   Entries in frontend/www/js/omegaup/lang.en.ts do not match the .lang file.
   Entries in frontend/www/js/omegaup/lang.en.json do not match the .lang file.
   Entries in frontend/templates/pseudo.lang do not match the .lang file.
   Entries in frontend/www/js/omegaup/lang.pseudo.ts do not match the .lang file.
   Entries in frontend/www/js/omegaup/lang.pseudo.json do not match the .lang file.
   Writing frontend/www/js/omegaup/lang.en.ts...
   Writing frontend/www/js/omegaup/lang.en.json...
   Writing frontend/templates/pseudo.lang...
   Writing frontend/www/js/omegaup/lang.pseudo.ts...
   Writing frontend/www/js/omegaup/lang.pseudo.json...
   ```

3. Verified the resulting `git diff` generated correct JSON, TS, and pseudo-localization assets matching the exact structure expected by the app.


### Fixes #9876 