### PR TITLE
Fix crash when editing course with no school assigned

### DIFF
--- a/frontend/www/js/omegaup/course/edit.ts
+++ b/frontend/www/js/omegaup/course/edit.ts
@@ -167,9 +167,9 @@ OmegaUp.on('ready', () => {
           },
           'submit-edit-course': (request: messages.CourseUpdateRequest) => {
             new Promise<number | null>((accept) => {
-              if (request.school.key) {
+              if (request.school?.key) {
                 accept(request.school.key);
-              } else if (request.school.value) {
+              } else if (request.school?.value) {
                 api.School.create({ name: request.school.value })
                   .then((response) => {
                     accept(response.school_id);


### PR DESCRIPTION
# Description

`request.school` can be `null` when a course has no school assigned to it. In `frontend/www/js/omegaup/course/edit.ts`, the `submit-edit-course` handler accessed `request.school.key` and `request.school.value` directly, which throws a TypeError when `request.school` is `null`.

Course creation (`course/new.ts`) already handles this correctly using optional chaining (`request.school?.key`). This PR applies the same fix to course editing.

Fixes: #4498

# Comments

This fixes the crash reported in the issue. I traced the root cause by comparing the edit flow against the working create flow in new.ts, which handles the same null case safely.

# Checklist:
- [x] The code follows the coding guidelines of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.