### PR TITLE
Fix staleWhileRevalidate returning undefined when offline with cold cache

### DIFF
--- a/frontend/www/sw.js
+++ b/frontend/www/sw.js
@@ -67,7 +67,7 @@ async function staleWhileRevalidate(request) {
 
       return response;
     })
-    .catch(() => cached);
+    .catch(() => cached || Response.error());
 
   return cached || networkFetch;
 }


### PR DESCRIPTION
# Description

`staleWhileRevalidate` in `frontend/www/sw.js` used `.catch(() => cached)` as the network-failure fallback, but `cached` is `undefined` when `cache.match()` found nothing. With a cold cache and a failed fetch (e.g. offline media request), `networkFetch` resolved to `undefined`, so `respondWith()` received a non-Response value and the service worker failed with an internal error instead of a graceful network error.

Guarded the fallback with `Response.error()`, mirroring the existing `networkFirst` behavior.

Fixes: #9977

# Checklist:

- [x] The code follows the coding guidelines of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.
