### PR TITLE
[F2] Actualizando la interfaz de la sección "Readme" como función experimental

### DIFF
--- a/frontend/templates/en.lang
+++ b/frontend/templates/en.lang
@@ -1,6 +1,7 @@
 U13CannotPerform = "Coder under 13 years can not perform this action."
 aboutSectionAlreadyReported = "You have already reported this profile."
 aboutToStart = "You are about to start the contest. Once you click Start Contest your time will begin."
+aboutTooLongError = "The text exceeds the permitted character limit."
 acceptCodeOfConduct = "I have read and accept the [Code of Conduct](%(CodeofConductPolicyURL))."
 acceptPrivacyPolicy = "I have read and accept the site's [Use and Privacy Policy](%(PrivacyPolicyURL))."
 accountDeleteCancel = "Cancel"

--- a/frontend/templates/es.lang
+++ b/frontend/templates/es.lang
@@ -1,6 +1,7 @@
 U13CannotPerform = "Coder menor de 13 años no puede realizar esta acción."
 aboutSectionAlreadyReported = "Ya has reportado este perfil."
 aboutToStart = "Estás a punto de iniciar el concurso. Una vez que hagas clic en entrar, tu tiempo iniciará."
+aboutTooLongError = "El texto excede el límite de caracteres permitido."
 acceptCodeOfConduct = "He leído y acepto el [Código de Conducta](%(CodeofConductPolicyURL))."
 acceptPrivacyPolicy = "He leído y acepto la [Política de Uso y Privacidad](%(PrivacyPolicyURL)) del sitio."
 accountDeleteCancel = "Cancelar"

--- a/frontend/templates/pseudo.lang
+++ b/frontend/templates/pseudo.lang
@@ -1,6 +1,7 @@
 U13CannotPerform = "(C0d3r und3r 13 y3ar5 can n07 p3rf0rm 7hi5 ac7i0n.)"
 aboutSectionAlreadyReported = "(Y0u hav3 a1r3ady r3p0r73d 7hi5 pr0fi13.)"
 aboutToStart = "(Y0u ar3 ab0u7 70 57ar7 7h3 c0n7357. Onc3 y0u c1ick S7ar7 C0n7357 y0ur 7im3 wi11 b3gin.)"
+aboutTooLongError = "(Th3 73x7 3xc33d5 7h3 p3rmi773d charac73r 1imi7.)"
 acceptCodeOfConduct = "(I hav3 r3ad and acc3p7 7h3 [C0d3 0f C0nduc7](%(CodeofConductPolicyURL)).)"
 acceptPrivacyPolicy = "(I hav3 r3ad and acc3p7 7h3 5i73'5 [U53 and Privacy P01icy](%(PrivacyPolicyURL)).)"
 accountDeleteCancel = "(Canc31)"

--- a/frontend/templates/pt.lang
+++ b/frontend/templates/pt.lang
@@ -1,6 +1,7 @@
 U13CannotPerform = "Coder menor de 13 anos não pode realizar esta ação."
 aboutSectionAlreadyReported = "Você já denunciou este perfil."
 aboutToStart = "Você está prestes a iniciar o concurso. Seu tempo começará depois de clicar em Começar Concurso."
+aboutTooLongError = "O texto ultrapassa o limite de caracteres permitido."
 acceptCodeOfConduct = "Li e aceito o [Código de Conduta](%(CodeofConductPolicyURL))."
 acceptPrivacyPolicy = "Li e aceito a [Política de Uso e Privacidade](%(PrivacyPolicyURL)) do site."
 accountDeleteCancel = "Cancelar"

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -45,11 +45,37 @@
               </p>
             </template>
             <template v-else>
+              <div
+                ref="aboutMarkdownButtonBar"
+                class="wmd-button-bar mb-2"
+              ></div>
               <textarea
+                ref="aboutMarkdownInput"
                 v-model="readmeEditContent"
-                class="form-control mb-2"
-                rows="10"
+                class="form-control wmd-input mb-2"
+                :maxlength="MAX_ABOUT_LENGTH"
+                @input="enforceLimit"
               ></textarea>
+              <div class="d-flex justify-content-end mt-1">
+                <small
+                  :class="{
+                    'text-danger': isOverLimit,
+                    'text-warning': isNearLimit,
+                    'text-muted': !isNearLimit,
+                  }"
+                >
+                  {{ charCount }} / {{ MAX_ABOUT_LENGTH }}
+                </small>
+              </div>
+              <div
+                v-if="readmeEditContent"
+                class="border p-3 mb-2 readme-preview"
+              >
+                <omegaup-markdown
+                  :markdown="readmeEditContent"
+                  :full-width="true"
+                />
+              </div>
               <button class="btn btn-primary btn-sm mr-2" @click="saveReadme">
                 {{ T.wordsSaveChanges }}
               </button>
@@ -311,7 +337,7 @@
 
 <script lang="ts">
 import * as Highcharts from 'highcharts/highstock';
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch, Ref } from 'vue-property-decorator';
 import { types } from '../../api_types';
 import T from '../../lang';
 import {
@@ -322,6 +348,8 @@ import {
 } from '../../linkable_resource';
 import { Experiments } from '../../omegaup';
 import * as ui from '../../ui';
+import * as Markdown from '@/third_party/js/pagedown/Markdown.Editor.js';
+import * as markdown from '../../markdown';
 import badge_List from '../badge/List.vue';
 import common_GridPaginator from '../common/GridPaginator.vue';
 import common_TablePaginator from '../common/TablePaginator.vue';
@@ -354,6 +382,11 @@ function getInitialSelectedTab(
   return selectedTab ?? ViewProfileTabs.Badges;
 }
 
+const aboutMarkdownConverter = new markdown.Converter({
+  preview: true,
+});
+const MAX_ABOUT_LENGTH = 1000;
+
 @Component({
   components: {
     'omegaup-markdown': common_Markdown,
@@ -371,6 +404,8 @@ function getInitialSelectedTab(
   },
 })
 export default class ViewProfile extends Vue {
+  @Ref() readonly aboutMarkdownButtonBar!: HTMLDivElement;
+  @Ref() readonly aboutMarkdownInput!: HTMLTextAreaElement;
   @Prop() data!: types.ExtraProfileDetails | null;
   @Prop() profile!: types.UserProfileInfo;
   @Prop() profileBadges!: Set<string>;
@@ -403,14 +438,54 @@ export default class ViewProfile extends Vue {
   ViewProfileTabs = ViewProfileTabs;
   T = T;
   ui = ui;
+  aboutMarkdownEditor: Markdown.Editor | null = null;
   columns = 3;
   currentSelectedTab = getInitialSelectedTab(this.profile, this.selectedTab);
   normalizedRunCounts: Highcharts.PointOptionsObject[] = [];
-  currentReadme: string | null = this.profile.readme ?? null;
+  currentReadme: string = this.profile.readme ?? '';
   isEditingReadme = false;
-  readmeEditContent: string | null = null;
+  readmeEditContent: string = '';
   readmeReportSubmitted = false;
   isReadmeEnabled = Experiments.loadGlobal().isEnabled('user_readme');
+  MAX_ABOUT_LENGTH = MAX_ABOUT_LENGTH;
+
+  mounted(): void {
+    if (this.isEditingReadme) {
+      this.$nextTick(() => {
+        this.initAboutEditor();
+      });
+    }
+  }
+
+  private initAboutEditor(): void {
+    if (this.aboutMarkdownEditor) return;
+
+    this.aboutMarkdownEditor = new Markdown.Editor(
+      aboutMarkdownConverter.converter,
+      '',
+      {
+        panels: {
+          buttonBar: this.aboutMarkdownButtonBar,
+          preview: null,
+          input: this.aboutMarkdownInput,
+        },
+      },
+    );
+
+    this.aboutMarkdownEditor.run();
+  }
+
+  get charCount(): number {
+    return this.readmeEditContent?.length || 0;
+  }
+
+  get isNearLimit(): boolean {
+    return this.charCount >= MAX_ABOUT_LENGTH * 0.9;
+  }
+
+  get isOverLimit(): boolean {
+    return this.charCount > MAX_ABOUT_LENGTH;
+  }
 
   get createdContests(): Contest[] {
     if (!this.data?.createdContests) return [];
@@ -473,23 +548,47 @@ export default class ViewProfile extends Vue {
     }
   }
 
+  enforceLimit(event: Event): void {
+    const target = event.target as HTMLTextAreaElement;
+    if (target.value.length > MAX_ABOUT_LENGTH) {
+      ui.error(T.aboutTooLongError);
+      target.value = target.value.substring(0, MAX_ABOUT_LENGTH);
+      this.readmeEditContent = target.value;
+    }
+  }
+
   startEditReadme(): void {
     this.readmeEditContent = this.currentReadme;
     this.isEditingReadme = true;
+    this.$nextTick(() => {
+      this.initAboutEditor();
+      if (this.aboutMarkdownInput) {
+        this.aboutMarkdownInput.focus();
+        const length = this.aboutMarkdownInput.value.length;
+        this.aboutMarkdownInput.setSelectionRange(length, length);
+      }
+    });
   }
 
   cancelEditReadme(): void {
     this.isEditingReadme = false;
-    this.readmeEditContent = null;
+    this.readmeEditContent = '';
+    this.aboutMarkdownEditor = null;
   }
 
   saveReadme(): void {
+    if (this.isOverLimit) {
+      ui.error(T.aboutTooLongError);
+      return;
+    }
+
     const content = this.readmeEditContent ?? '';
     this.$emit('save-readme', {
       readme: content,
       onSuccess: () => {
         this.currentReadme = content;
         this.isEditingReadme = false;
+        this.aboutMarkdownEditor = null;
       },
     });
   }
@@ -515,10 +614,20 @@ export default class ViewProfile extends Vue {
   onCurrentSelectedTabChanged(newValue: string) {
     this.$emit('update:selectedTab', newValue);
   }
+
+  @Watch('isEditingReadme')
+  onEditingReadmeChanged(newValue: boolean): void {
+    if (newValue) {
+      this.$nextTick(() => {
+        this.initAboutEditor();
+      });
+    }
+  }
 }
 </script>
 
 <style lang="scss">
+@import '../../../../third_party/js/pagedown/demo/browser/demo.css';
 a:hover {
   cursor: pointer;
 }
@@ -548,5 +657,25 @@ a:hover {
 
 .statistics-boxes-row > [class*='col-'] {
   display: flex;
+}
+
+.wmd-button-bar {
+  background-color: var(--wmd-button-bar-background-color);
+}
+
+.wmd-input {
+  font-family: monospace;
+  resize: vertical;
+  min-height: 200px;
+}
+
+.readme-preview {
+  min-height: 150px;
+  max-height: 500px;
+  overflow-y: auto;
+  background-color: var(
+    --markdown-preview-background,
+    var(--background-color-secondary)
+  );
 }
 </style>

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -45,46 +45,65 @@
               </p>
             </template>
             <template v-else>
-              <div
-                ref="aboutMarkdownButtonBar"
-                class="wmd-button-bar mb-2"
-              ></div>
-              <textarea
-                ref="aboutMarkdownInput"
-                v-model="readmeEditContent"
-                class="form-control wmd-input mb-2"
-                :maxlength="MAX_ABOUT_LENGTH"
-                @input="enforceLimit"
-              ></textarea>
-              <div class="d-flex justify-content-end mt-1">
+              <div class="d-flex align-items-center mb-2">
+                <div class="btn-group btn-group-sm ml-auto">
+                  <button
+                    type="button"
+                    class="btn"
+                    :class="readmeEditMode ? 'btn-primary' : 'btn-outline-secondary'"
+                    @click="readmeEditMode = true"
+                  >
+                    {{ T.wordsEdit }}
+                  </button>
+                  <button
+                    type="button"
+                    class="btn"
+                    :class="!readmeEditMode ? 'btn-primary' : 'btn-outline-secondary'"
+                    @click="readmeEditMode = false"
+                  >
+                    {{ T.wordsPreview }}
+                  </button>
+                </div>
+              </div>
+
+              <template v-if="readmeEditMode">
+                <div ref="aboutMarkdownButtonBar" class="wmd-button-bar mb-2"></div>
+                <textarea
+                  ref="aboutMarkdownInput"
+                  v-model="readmeEditContent"
+                  class="form-control wmd-input mb-2"
+                  :maxlength="MAX_ABOUT_LENGTH"
+                  @input="enforceLimit"
+                  rows="8"
+                ></textarea>
+              </template>
+
+              <omegaup-markdown
+                v-else
+                :markdown="readmeEditContent || ''"
+                class="wmd-preview border rounded p-3 mb-2"
+                :full-width="true"
+              ></omegaup-markdown>
+
+              <div class="d-flex justify-content-between align-items-center">
                 <small
-                  :class="{
-                    'text-danger': isOverLimit,
-                    'text-warning': isNearLimit,
-                    'text-muted': !isNearLimit,
+                  :class="{ 
+                    'text-danger': isOverLimit, 
+                    'text-warning': isNearLimit, 
+                    'text-muted': !isNearLimit 
                   }"
                 >
                   {{ charCount }} / {{ MAX_ABOUT_LENGTH }}
                 </small>
+                <div>
+                  <button class="btn btn-primary btn-sm mr-2" @click="saveReadme">
+                    {{ T.wordsSaveChanges }}
+                  </button>
+                  <button class="btn btn-secondary btn-sm" @click="cancelEditReadme">
+                    {{ T.wordsCancel }}
+                  </button>
+                </div>
               </div>
-              <div
-                v-if="readmeEditContent"
-                class="border p-3 mb-2 readme-preview"
-              >
-                <omegaup-markdown
-                  :markdown="readmeEditContent"
-                  :full-width="true"
-                />
-              </div>
-              <button class="btn btn-primary btn-sm mr-2" @click="saveReadme">
-                {{ T.wordsSaveChanges }}
-              </button>
-              <button
-                class="btn btn-secondary btn-sm"
-                @click="cancelEditReadme"
-              >
-                {{ T.wordsCancel }}
-              </button>
             </template>
           </div>
         </div>
@@ -439,23 +458,40 @@ export default class ViewProfile extends Vue {
   T = T;
   ui = ui;
   aboutMarkdownEditor: Markdown.Editor | null = null;
-  columns = 3;
   currentSelectedTab = getInitialSelectedTab(this.profile, this.selectedTab);
-  normalizedRunCounts: Highcharts.PointOptionsObject[] = [];
   currentReadme: string = this.profile.readme ?? '';
   isEditingReadme = false;
+  normalizedRunCounts: Highcharts.PointOptionsObject[] = [];
+  readmeEditMode = true;
   readmeEditContent: string = '';
   readmeReportSubmitted = false;
   isReadmeEnabled = Experiments.loadGlobal().isEnabled('user_readme');
   MAX_ABOUT_LENGTH = MAX_ABOUT_LENGTH;
 
-  mounted(): void {
-    if (this.isEditingReadme) {
-      this.$nextTick(() => {
-        this.initAboutEditor();
-      });
+  @Watch('selectedTab')
+  onSelectedTabPropChanged(newValue: string | null): void {
+    if (newValue !== null) {
+      this.currentSelectedTab = getInitialSelectedTab(this.profile, newValue);
     }
   }
+
+  @Watch('currentSelectedTab')
+  onCurrentSelectedTabChanged(newValue: string): void {
+    this.$emit('update:selectedTab', newValue);
+  }
+
+  @Watch('readmeEditMode')
+  onReadmeEditModeChanged(newValue: boolean): void {
+    if (newValue) {
+      this.$nextTick(() => {
+        this.initAboutEditor();
+        this.removeDisabledButtons();
+        if (this.aboutMarkdownInput) {
+          this.aboutMarkdownInput.focus();
+        }
+      });
+    }
+  }  
 
   private initAboutEditor(): void {
     if (this.aboutMarkdownEditor) return;
@@ -473,6 +509,33 @@ export default class ViewProfile extends Vue {
     );
 
     this.aboutMarkdownEditor.run();
+  }
+
+  private removeDisabledButtons(): void {
+    // Remove Link button from DOM
+    const linkButton = this.aboutMarkdownButtonBar?.querySelector('#wmd-link-button');
+    if (linkButton) {
+      linkButton.remove();
+    }
+
+    // Remove Image button from DOM
+    const imageButton = this.aboutMarkdownButtonBar?.querySelector('#wmd-image-button');
+    if (imageButton) {
+      imageButton.remove();
+    }
+
+    // Block keyboard shortcuts for Link (Ctrl+L) and Image (Ctrl+G)
+    this.aboutMarkdownInput?.addEventListener(
+      'keydown',
+      (event: KeyboardEvent) => {
+        if ((event.ctrlKey || event.metaKey) && 
+            (event.key.toLowerCase() === 'l' || event.key.toLowerCase() === 'g')) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+        }
+      },
+      true,
+    );
   }
 
   get charCount(): number {
@@ -560,8 +623,10 @@ export default class ViewProfile extends Vue {
   startEditReadme(): void {
     this.readmeEditContent = this.currentReadme;
     this.isEditingReadme = true;
+    this.readmeEditMode = true;
     this.$nextTick(() => {
       this.initAboutEditor();
+      this.removeDisabledButtons();
       if (this.aboutMarkdownInput) {
         this.aboutMarkdownInput.focus();
         const length = this.aboutMarkdownInput.value.length;
@@ -573,6 +638,7 @@ export default class ViewProfile extends Vue {
   cancelEditReadme(): void {
     this.isEditingReadme = false;
     this.readmeEditContent = '';
+    this.readmeEditMode = true;
     this.aboutMarkdownEditor = null;
   }
 
@@ -601,27 +667,6 @@ export default class ViewProfile extends Vue {
         ui.success(T.profileAboutSectionReportSuccess);
       },
     });
-  }
-
-  @Watch('selectedTab')
-  onSelectedTabPropChanged(newValue: string | null) {
-    if (newValue !== null) {
-      this.currentSelectedTab = getInitialSelectedTab(this.profile, newValue);
-    }
-  }
-
-  @Watch('currentSelectedTab')
-  onCurrentSelectedTabChanged(newValue: string) {
-    this.$emit('update:selectedTab', newValue);
-  }
-
-  @Watch('isEditingReadme')
-  onEditingReadmeChanged(newValue: boolean): void {
-    if (newValue) {
-      this.$nextTick(() => {
-        this.initAboutEditor();
-      });
-    }
   }
 }
 </script>

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -50,7 +50,9 @@
                   <button
                     type="button"
                     class="btn"
-                    :class="readmeEditMode ? 'btn-primary' : 'btn-outline-secondary'"
+                    :class="
+                      readmeEditMode ? 'btn-primary' : 'btn-outline-secondary'
+                    "
                     @click="readmeEditMode = true"
                   >
                     {{ T.wordsEdit }}
@@ -58,7 +60,9 @@
                   <button
                     type="button"
                     class="btn"
-                    :class="!readmeEditMode ? 'btn-primary' : 'btn-outline-secondary'"
+                    :class="
+                      !readmeEditMode ? 'btn-primary' : 'btn-outline-secondary'
+                    "
                     @click="readmeEditMode = false"
                   >
                     {{ T.wordsPreview }}
@@ -85,19 +89,25 @@
 
               <div class="d-flex justify-content-between align-items-center">
                 <small
-                  :class="{ 
-                    'text-danger': isOverLimit, 
-                    'text-warning': isNearLimit, 
-                    'text-muted': !isNearLimit 
+                  :class="{
+                    'text-danger': isOverLimit,
+                    'text-warning': isNearLimit,
+                    'text-muted': !isNearLimit,
                   }"
                 >
                   {{ charCount }} / {{ MAX_ABOUT_LENGTH }}
                 </small>
                 <div>
-                  <button class="btn btn-primary btn-sm mr-2" @click="saveReadme">
+                  <button
+                    class="btn btn-primary btn-sm mr-2"
+                    @click="saveReadme"
+                  >
                     {{ T.wordsSaveChanges }}
                   </button>
-                  <button class="btn btn-secondary btn-sm" @click="cancelEditReadme">
+                  <button
+                    class="btn btn-secondary btn-sm"
+                    @click="cancelEditReadme"
+                  >
                     {{ T.wordsCancel }}
                   </button>
                 </div>
@@ -467,12 +477,16 @@ export default class ViewProfile extends Vue {
   MAX_ABOUT_LENGTH = MAX_ABOUT_LENGTH;
 
   private removeDisabledButtons(): void {
-    const linkButton = this.aboutMarkdownButtonBar.querySelector('#wmd-link-button');
+    const linkButton = this.aboutMarkdownButtonBar.querySelector(
+      '#wmd-link-button',
+    );
     if (linkButton) {
       linkButton.remove();
     }
 
-    const imageButton = this.aboutMarkdownButtonBar.querySelector('#wmd-image-button');
+    const imageButton = this.aboutMarkdownButtonBar.querySelector(
+      '#wmd-image-button',
+    );
     if (imageButton) {
       imageButton.remove();
     }

--- a/frontend/www/js/omegaup/components/user/ViewProfile.vue
+++ b/frontend/www/js/omegaup/components/user/ViewProfile.vue
@@ -45,7 +45,7 @@
               </p>
             </template>
             <template v-else>
-              <div class="d-flex align-items-center mb-2">
+              <div class="d-flex align-items-center mb-1">
                 <div class="btn-group btn-group-sm ml-auto">
                   <button
                     type="button"
@@ -67,22 +67,20 @@
               </div>
 
               <template v-if="readmeEditMode">
-                <div ref="aboutMarkdownButtonBar" class="wmd-button-bar mb-2"></div>
+                <div ref="aboutMarkdownButtonBar" class="wmd-button-bar"></div>
                 <textarea
                   ref="aboutMarkdownInput"
                   v-model="readmeEditContent"
-                  class="form-control wmd-input mb-2"
+                  class="form-control wmd-input"
                   :maxlength="MAX_ABOUT_LENGTH"
                   @input="enforceLimit"
-                  rows="8"
                 ></textarea>
               </template>
 
               <omegaup-markdown
                 v-else
                 :markdown="readmeEditContent || ''"
-                class="wmd-preview border rounded p-3 mb-2"
-                :full-width="true"
+                class="wmd-preview border rounded p-2"
               ></omegaup-markdown>
 
               <div class="d-flex justify-content-between align-items-center">
@@ -462,11 +460,37 @@ export default class ViewProfile extends Vue {
   currentReadme: string = this.profile.readme ?? '';
   isEditingReadme = false;
   normalizedRunCounts: Highcharts.PointOptionsObject[] = [];
-  readmeEditMode = true;
+  readmeEditMode = false;
   readmeEditContent: string = '';
   readmeReportSubmitted = false;
   isReadmeEnabled = Experiments.loadGlobal().isEnabled('user_readme');
   MAX_ABOUT_LENGTH = MAX_ABOUT_LENGTH;
+
+  private removeDisabledButtons(): void {
+    const linkButton = this.aboutMarkdownButtonBar.querySelector('#wmd-link-button');
+    if (linkButton) {
+      linkButton.remove();
+    }
+
+    const imageButton = this.aboutMarkdownButtonBar.querySelector('#wmd-image-button');
+    if (imageButton) {
+      imageButton.remove();
+    }
+
+    this.aboutMarkdownInput.addEventListener(
+      'keydown',
+      (event: KeyboardEvent) => {
+        if (
+          (event.ctrlKey || event.metaKey) &&
+          (event.key.toLowerCase() === 'l' || event.key.toLowerCase() === 'g')
+        ) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+        }
+      },
+      true,
+    );
+  }
 
   @Watch('selectedTab')
   onSelectedTabPropChanged(newValue: string | null): void {
@@ -484,58 +508,25 @@ export default class ViewProfile extends Vue {
   onReadmeEditModeChanged(newValue: boolean): void {
     if (newValue) {
       this.$nextTick(() => {
-        this.initAboutEditor();
+        this.aboutMarkdownEditor = new Markdown.Editor(
+          aboutMarkdownConverter.converter,
+          '',
+          {
+            panels: {
+              buttonBar: this.aboutMarkdownButtonBar,
+              preview: null,
+              input: this.aboutMarkdownInput,
+            },
+          },
+        );
+        this.aboutMarkdownEditor.run();
         this.removeDisabledButtons();
+
         if (this.aboutMarkdownInput) {
           this.aboutMarkdownInput.focus();
         }
       });
     }
-  }  
-
-  private initAboutEditor(): void {
-    if (this.aboutMarkdownEditor) return;
-
-    this.aboutMarkdownEditor = new Markdown.Editor(
-      aboutMarkdownConverter.converter,
-      '',
-      {
-        panels: {
-          buttonBar: this.aboutMarkdownButtonBar,
-          preview: null,
-          input: this.aboutMarkdownInput,
-        },
-      },
-    );
-
-    this.aboutMarkdownEditor.run();
-  }
-
-  private removeDisabledButtons(): void {
-    // Remove Link button from DOM
-    const linkButton = this.aboutMarkdownButtonBar?.querySelector('#wmd-link-button');
-    if (linkButton) {
-      linkButton.remove();
-    }
-
-    // Remove Image button from DOM
-    const imageButton = this.aboutMarkdownButtonBar?.querySelector('#wmd-image-button');
-    if (imageButton) {
-      imageButton.remove();
-    }
-
-    // Block keyboard shortcuts for Link (Ctrl+L) and Image (Ctrl+G)
-    this.aboutMarkdownInput?.addEventListener(
-      'keydown',
-      (event: KeyboardEvent) => {
-        if ((event.ctrlKey || event.metaKey) && 
-            (event.key.toLowerCase() === 'l' || event.key.toLowerCase() === 'g')) {
-          event.preventDefault();
-          event.stopImmediatePropagation();
-        }
-      },
-      true,
-    );
   }
 
   get charCount(): number {
@@ -624,21 +615,12 @@ export default class ViewProfile extends Vue {
     this.readmeEditContent = this.currentReadme;
     this.isEditingReadme = true;
     this.readmeEditMode = true;
-    this.$nextTick(() => {
-      this.initAboutEditor();
-      this.removeDisabledButtons();
-      if (this.aboutMarkdownInput) {
-        this.aboutMarkdownInput.focus();
-        const length = this.aboutMarkdownInput.value.length;
-        this.aboutMarkdownInput.setSelectionRange(length, length);
-      }
-    });
   }
 
   cancelEditReadme(): void {
     this.isEditingReadme = false;
     this.readmeEditContent = '';
-    this.readmeEditMode = true;
+    this.readmeEditMode = false;
     this.aboutMarkdownEditor = null;
   }
 
@@ -648,12 +630,13 @@ export default class ViewProfile extends Vue {
       return;
     }
 
-    const content = this.readmeEditContent ?? '';
+    const content = this.readmeEditContent;
     this.$emit('save-readme', {
       readme: content,
       onSuccess: () => {
         this.currentReadme = content;
         this.isEditingReadme = false;
+        this.readmeEditMode = false;
         this.aboutMarkdownEditor = null;
       },
     });

--- a/frontend/www/js/omegaup/lang.en.json
+++ b/frontend/www/js/omegaup/lang.en.json
@@ -2,6 +2,7 @@
 	"U13CannotPerform": "Coder under 13 years can not perform this action.",
 	"aboutSectionAlreadyReported": "You have already reported this profile.",
 	"aboutToStart": "You are about to start the contest. Once you click Start Contest your time will begin.",
+	"aboutTooLongError": "The text exceeds the permitted character limit.",
 	"acceptCodeOfConduct": "I have read and accept the [Code of Conduct](%(CodeofConductPolicyURL)).",
 	"acceptPrivacyPolicy": "I have read and accept the site's [Use and Privacy Policy](%(PrivacyPolicyURL)).",
 	"accountDeleteCancel": "Cancel",

--- a/frontend/www/js/omegaup/lang.en.ts
+++ b/frontend/www/js/omegaup/lang.en.ts
@@ -3,6 +3,7 @@ const translations: { [key: string]: string; } = {
   U13CannotPerform: "Coder under 13 years can not perform this action.",
   aboutSectionAlreadyReported: "You have already reported this profile.",
   aboutToStart: "You are about to start the contest. Once you click Start Contest your time will begin.",
+  aboutTooLongError: "The text exceeds the permitted character limit.",
   acceptCodeOfConduct: "I have read and accept the [Code of Conduct](%(CodeofConductPolicyURL)).",
   acceptPrivacyPolicy: "I have read and accept the site's [Use and Privacy Policy](%(PrivacyPolicyURL)).",
   accountDeleteCancel: "Cancel",

--- a/frontend/www/js/omegaup/lang.es.json
+++ b/frontend/www/js/omegaup/lang.es.json
@@ -2,6 +2,7 @@
 	"U13CannotPerform": "Coder menor de 13 a\u00f1os no puede realizar esta acci\u00f3n.",
 	"aboutSectionAlreadyReported": "Ya has reportado este perfil.",
 	"aboutToStart": "Est\u00e1s a punto de iniciar el concurso. Una vez que hagas clic en entrar, tu tiempo iniciar\u00e1.",
+	"aboutTooLongError": "El texto excede el l\u00edmite de caracteres permitido.",
 	"acceptCodeOfConduct": "He le\u00eddo y acepto el [C\u00f3digo de Conducta](%(CodeofConductPolicyURL)).",
 	"acceptPrivacyPolicy": "He le\u00eddo y acepto la [Pol\u00edtica de Uso y Privacidad](%(PrivacyPolicyURL)) del sitio.",
 	"accountDeleteCancel": "Cancelar",

--- a/frontend/www/js/omegaup/lang.es.ts
+++ b/frontend/www/js/omegaup/lang.es.ts
@@ -3,6 +3,7 @@ const translations: { [key: string]: string; } = {
   U13CannotPerform: "Coder menor de 13 a\u00f1os no puede realizar esta acci\u00f3n.",
   aboutSectionAlreadyReported: "Ya has reportado este perfil.",
   aboutToStart: "Est\u00e1s a punto de iniciar el concurso. Una vez que hagas clic en entrar, tu tiempo iniciar\u00e1.",
+  aboutTooLongError: "El texto excede el l\u00edmite de caracteres permitido.",
   acceptCodeOfConduct: "He le\u00eddo y acepto el [C\u00f3digo de Conducta](%(CodeofConductPolicyURL)).",
   acceptPrivacyPolicy: "He le\u00eddo y acepto la [Pol\u00edtica de Uso y Privacidad](%(PrivacyPolicyURL)) del sitio.",
   accountDeleteCancel: "Cancelar",

--- a/frontend/www/js/omegaup/lang.pseudo.json
+++ b/frontend/www/js/omegaup/lang.pseudo.json
@@ -2,6 +2,7 @@
 	"U13CannotPerform": "(C0d3r und3r 13 y3ar5 can n07 p3rf0rm 7hi5 ac7i0n.)",
 	"aboutSectionAlreadyReported": "(Y0u hav3 a1r3ady r3p0r73d 7hi5 pr0fi13.)",
 	"aboutToStart": "(Y0u ar3 ab0u7 70 57ar7 7h3 c0n7357. Onc3 y0u c1ick S7ar7 C0n7357 y0ur 7im3 wi11 b3gin.)",
+	"aboutTooLongError": "(Th3 73x7 3xc33d5 7h3 p3rmi773d charac73r 1imi7.)",
 	"acceptCodeOfConduct": "(I hav3 r3ad and acc3p7 7h3 [C0d3 0f C0nduc7](%(CodeofConductPolicyURL)).)",
 	"acceptPrivacyPolicy": "(I hav3 r3ad and acc3p7 7h3 5i73'5 [U53 and Privacy P01icy](%(PrivacyPolicyURL)).)",
 	"accountDeleteCancel": "(Canc31)",

--- a/frontend/www/js/omegaup/lang.pseudo.ts
+++ b/frontend/www/js/omegaup/lang.pseudo.ts
@@ -3,6 +3,7 @@ const translations: { [key: string]: string; } = {
   U13CannotPerform: "(C0d3r und3r 13 y3ar5 can n07 p3rf0rm 7hi5 ac7i0n.)",
   aboutSectionAlreadyReported: "(Y0u hav3 a1r3ady r3p0r73d 7hi5 pr0fi13.)",
   aboutToStart: "(Y0u ar3 ab0u7 70 57ar7 7h3 c0n7357. Onc3 y0u c1ick S7ar7 C0n7357 y0ur 7im3 wi11 b3gin.)",
+  aboutTooLongError: "(Th3 73x7 3xc33d5 7h3 p3rmi773d charac73r 1imi7.)",
   acceptCodeOfConduct: "(I hav3 r3ad and acc3p7 7h3 [C0d3 0f C0nduc7](%(CodeofConductPolicyURL)).)",
   acceptPrivacyPolicy: "(I hav3 r3ad and acc3p7 7h3 5i73'5 [U53 and Privacy P01icy](%(PrivacyPolicyURL)).)",
   accountDeleteCancel: "(Canc31)",

--- a/frontend/www/js/omegaup/lang.pt.json
+++ b/frontend/www/js/omegaup/lang.pt.json
@@ -2,6 +2,7 @@
 	"U13CannotPerform": "Coder menor de 13 anos n\u00e3o pode realizar esta a\u00e7\u00e3o.",
 	"aboutSectionAlreadyReported": "Voc\u00ea j\u00e1 denunciou este perfil.",
 	"aboutToStart": "Voc\u00ea est\u00e1 prestes a iniciar o concurso. Seu tempo come\u00e7ar\u00e1 depois de clicar em Come\u00e7ar Concurso.",
+	"aboutTooLongError": "O texto ultrapassa o limite de caracteres permitido.",
 	"acceptCodeOfConduct": "Li e aceito o [C\u00f3digo de Conduta](%(CodeofConductPolicyURL)).",
 	"acceptPrivacyPolicy": "Li e aceito a [Pol\u00edtica de Uso e Privacidade](%(PrivacyPolicyURL)) do site.",
 	"accountDeleteCancel": "Cancelar",

--- a/frontend/www/js/omegaup/lang.pt.ts
+++ b/frontend/www/js/omegaup/lang.pt.ts
@@ -3,6 +3,7 @@ const translations: { [key: string]: string; } = {
   U13CannotPerform: "Coder menor de 13 anos n\u00e3o pode realizar esta a\u00e7\u00e3o.",
   aboutSectionAlreadyReported: "Voc\u00ea j\u00e1 denunciou este perfil.",
   aboutToStart: "Voc\u00ea est\u00e1 prestes a iniciar o concurso. Seu tempo come\u00e7ar\u00e1 depois de clicar em Come\u00e7ar Concurso.",
+  aboutTooLongError: "O texto ultrapassa o limite de caracteres permitido.",
   acceptCodeOfConduct: "Li e aceito o [C\u00f3digo de Conduta](%(CodeofConductPolicyURL)).",
   acceptPrivacyPolicy: "Li e aceito a [Pol\u00edtica de Uso e Privacidade](%(PrivacyPolicyURL)) do site.",
   accountDeleteCancel: "Cancelar",


### PR DESCRIPTION
# Description

Para permitir una interfaz más amigables entre usuarios nuevos y experimentados en la edición y creación de su perfil de usuario se ha diseñado la sección "About Me", un espacio escrito en markdown dónde el usuario podrá contarnos sobre su experiencia y cualquier cosa que le parezca interesante. Para ello:
1. Se agregó una barra de herramientas Pagedown sobre el textarea para ofrecer atajos visuales de formato Markdown, mejorando la UX al crear/editar el README.
2. Para prevenir spam o saturación de texto se ha limitado el número de caracteres permitidos a 1000.
3. Se implementó una vista previa que se va actualizando según se vaya escribiendo en el text area.

Esto permitió actualizar la interfaz del usuario:

## Antes
<img width="1184" height="603" alt="image" src="https://github.com/user-attachments/assets/2b78a55a-6f95-43c2-8e67-245a13bba2e2" />

## Después
<img width="1183" height="590" alt="image" src="https://github.com/user-attachments/assets/62e75d9a-1245-4dfb-ac50-535736de5390" />

Fixes: #9981 

# Comments
Para el futuro y evitar mal uso de esta función se ha creado el issue #9989 que permitirá bloquear comandos no autorizados o que puedan causar problemas en esta interfaz.
Adicional a esto, este PR es continuación directa de #9990.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
