### PR TITLE
add cron admin api

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -9,6 +9,9 @@
   * @psalm-type MessageLanguages=array{es: string, en: string, pt: string}
   * @psalm-type PredefinedTemplate=array{id: string, title: MessageLanguages, message: MessageLanguages, type: string}
   * @psalm-type MaintenanceModeStatus=array{enabled: bool, message_es: null|string, message_en: null|string, message_pt: null|string, type: string}
+  * @psalm-type CronJob=array{name: string, description: null|string, schedule: null|string, enabled: bool}
+  * @psalm-type CronRunPhase=array{phase: string, status: string, duration: float, error_class: null|string}
+  * @psalm-type CronRun=array{run_id: int, name: string, hostname: null|string, status: string, started_at: \OmegaUp\Timestamp|null, finished_at: \OmegaUp\Timestamp|null, duration_seconds: float|null, rows_affected: int|null, phases: list<CronRunPhase>, error_text: null|string}
   */
 class Admin extends \OmegaUp\Controllers\Controller {
     const MAINTENANCE_MESSAGE_ES_KEY = 'maintenance_message_es';
@@ -412,5 +415,87 @@ class Admin extends \OmegaUp\Controllers\Controller {
                 'payload' => [],
             ],
         ];
+    }
+
+    /**
+     * @return list<CronJob>
+     */
+    private static function cronJobsPayload(): array {
+        $jobs = [];
+        foreach (\OmegaUp\DAO\CronJobs::getAllOrdered() as $job) {
+            $jobs[] = [
+                'name' => strval($job->name),
+                'description' => $job->description,
+                'schedule' => $job->schedule,
+                'enabled' => boolval($job->enabled),
+            ];
+        }
+        return $jobs;
+    }
+
+    /**
+     * @param list<\OmegaUp\DAO\VO\CronRuns> $runs
+     *
+     * @return list<CronRun>
+     */
+    private static function cronRunsPayload(array $runs): array {
+        $result = [];
+        foreach ($runs as $run) {
+            /** @var list<CronRunPhase> */
+            $phases = is_null($run->phases) ? [] : json_decode(
+                $run->phases,
+                associative: true
+            );
+            $result[] = [
+                'run_id' => intval($run->run_id),
+                'name' => strval($run->name),
+                'hostname' => $run->hostname,
+                'status' => strval($run->status),
+                'started_at' => $run->started_at,
+                'finished_at' => $run->finished_at,
+                'duration_seconds' => $run->duration_seconds,
+                'rows_affected' => $run->rows_affected,
+                'phases' => $phases,
+                'error_text' => $run->error_text,
+            ];
+        }
+        return $result;
+    }
+
+    /**
+     * Lists the registered cron jobs and their most recent runs.
+     *
+     * @return array{jobs: list<CronJob>, runs: list<CronRun>}
+     */
+    public static function apiGetCrons(\OmegaUp\Request $r): array {
+        $r->ensureMainUserIdentity();
+        if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException();
+        }
+        return [
+            'jobs' => self::cronJobsPayload(),
+            'runs' => self::cronRunsPayload(
+                \OmegaUp\DAO\CronRuns::getRecent(50)
+            ),
+        ];
+    }
+
+    /**
+     * Returns the detail of a single cron run.
+     *
+     * @return array{run: CronRun|null}
+     *
+     * @omegaup-request-param int $run_id
+     */
+    public static function apiGetCronRun(\OmegaUp\Request $r): array {
+        $r->ensureMainUserIdentity();
+        if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException();
+        }
+        $run = \OmegaUp\DAO\CronRuns::getByPK($r->ensureInt('run_id'));
+        if (is_null($run)) {
+            return ['run' => null];
+        }
+        return ['run' => self::cronRunsPayload([$run])[0]];
     }
 }

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -1,6 +1,8 @@
 - [ACL](#acl)
   - [`/api/aCL/userOwnedAclReport/`](#apiacluserownedaclreport)
 - [Admin](#admin)
+  - [`/api/admin/getCronRun/`](#apiadmingetcronrun)
+  - [`/api/admin/getCrons/`](#apiadmingetcrons)
   - [`/api/admin/getMaintenanceMode/`](#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](#apiadminplatformreportstats)
@@ -313,6 +315,52 @@ Returns all ACLs owned by the current user along with assigned roles for each.
 # Admin
 
 Admin Controller
+
+## `/api/admin/getCronRun/`
+
+### Description
+
+Returns the detail of a single cron run.
+
+### Parameters
+
+| Name     | Type  | Description | Required |
+| -------- | ----- | ----------- | -------- |
+| `run_id` | `int` |             | ✓        |
+
+### Returns
+
+| Name  | Type            |
+| ----- | --------------- |
+| `run` | `types.CronRun` |
+
+**`types.CronRun` fields:**
+
+| Name               | Type                       | Required |
+| ------------------ | -------------------------- | -------- |
+| `duration_seconds` | `number`                   |          |
+| `error_text`       | `string`                   |          |
+| `finished_at`      | `Date`                     |          |
+| `hostname`         | `string`                   |          |
+| `name`             | `string`                   | ✓        |
+| `phases`           | `List[types.CronRunPhase]` | ✓        |
+| `rows_affected`    | `number`                   |          |
+| `run_id`           | `number`                   | ✓        |
+| `started_at`       | `Date`                     |          |
+| `status`           | `string`                   | ✓        |
+
+## `/api/admin/getCrons/`
+
+### Description
+
+Lists the registered cron jobs and their most recent runs.
+
+### Returns
+
+| Name   | Type                  |
+| ------ | --------------------- |
+| `jobs` | `List[types.CronJob]` |
+| `runs` | `List[types.CronRun]` |
 
 ## `/api/admin/getMaintenanceMode/`
 

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Tests for the cron control plane admin endpoints.
+ */
+class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
+    public function testGetCronsRequiresAdmin() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiGetCrons(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ]));
+            $this->fail('Should not have allowed access to non-admin');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertSame('userNotAllowed', $e->getMessage());
+        }
+    }
+
+    public function testGetCronsReturnsSeededJobs() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        $response = \OmegaUp\Controllers\Admin::apiGetCrons(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
+
+        $names = array_map(fn ($job) => $job['name'], $response['jobs']);
+        $this->assertContains('update_ranks.py', $names);
+        $this->assertContains('assign_badges.py', $names);
+        $this->assertContains('aggregate_feedback.py', $names);
+    }
+
+    public function testGetCronRunReturnsInsertedRun() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        $run = new \OmegaUp\DAO\VO\CronRuns([
+            'name' => 'update_ranks.py',
+            'status' => 'success',
+            'started_at' => new \OmegaUp\Timestamp(\OmegaUp\Time::get()),
+        ]);
+        \OmegaUp\DAO\CronRuns::create($run);
+
+        $response = \OmegaUp\Controllers\Admin::apiGetCronRun(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'run_id' => $run->run_id,
+        ]));
+
+        $this->assertNotNull($response['run']);
+        $this->assertSame('update_ranks.py', $response['run']['name']);
+        $this->assertSame('success', $response['run']['status']);
+    }
+
+    public function testGetCronRunReturnsNullForUnknownRun() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        $response = \OmegaUp\Controllers\Admin::apiGetCronRun(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'run_id' => 999999999,
+        ]));
+
+        $this->assertNull($response['run']);
+    }
+}

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -53,6 +53,61 @@ class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame('success', $response['run']['status']);
     }
 
+    public function testGetCronRunRequiresAdmin() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiGetCronRun(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'run_id' => 1,
+            ]));
+            $this->fail('Should not have allowed access to non-admin');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertSame('userNotAllowed', $e->getMessage());
+        }
+    }
+
+    public function testGetCronRunDecodesPhases() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        $run = new \OmegaUp\DAO\VO\CronRuns([
+            'name' => 'update_ranks.py',
+            'status' => 'failure',
+            'started_at' => new \OmegaUp\Timestamp(\OmegaUp\Time::get()),
+            'phases' => json_encode([
+                [
+                    'phase' => 'update_users_stats',
+                    'status' => 'success',
+                    'duration' => 1.25,
+                    'error_class' => null,
+                ],
+                [
+                    'phase' => 'update_schools_stats',
+                    'status' => 'failure',
+                    'duration' => 0.5,
+                    'error_class' => 'ValueError',
+                ],
+            ]),
+        ]);
+        \OmegaUp\DAO\CronRuns::create($run);
+
+        $response = \OmegaUp\Controllers\Admin::apiGetCronRun(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'run_id' => $run->run_id,
+        ]));
+
+        $phases = $response['run']['phases'];
+        $this->assertCount(2, $phases);
+        $this->assertSame('update_users_stats', $phases[0]['phase']);
+        $this->assertSame('success', $phases[0]['status']);
+        $this->assertSame(1.25, $phases[0]['duration']);
+        $this->assertNull($phases[0]['error_class']);
+        $this->assertSame('failure', $phases[1]['status']);
+        $this->assertSame('ValueError', $phases[1]['error_class']);
+    }
+
     public function testGetCronRunReturnsNullForUnknownRun() {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);

--- a/frontend/www/docs/Controllers.md
+++ b/frontend/www/docs/Controllers.md
@@ -7,6 +7,8 @@ For more information about the API controllers, please refer to the [Controllers
 - [ACL](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#acl)
   - [`/api/aCL/userOwnedAclReport/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiacluserownedaclreport)
 - [Admin](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#admin)
+  - [`/api/admin/getCronRun/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetcronrun)
+  - [`/api/admin/getCrons/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetcrons)
   - [`/api/admin/getMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminplatformreportstats)

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -98,6 +98,40 @@ export const ACL = {
 };
 
 export const Admin = {
+  getCronRun: apiCall<
+    messages.AdminGetCronRunRequest,
+    messages._AdminGetCronRunServerResponse,
+    messages.AdminGetCronRunResponse
+  >('/api/admin/getCronRun/', (x) => {
+    if (typeof x.run !== 'undefined' && x.run !== null)
+      x.run = ((x) => {
+        if (typeof x.finished_at !== 'undefined' && x.finished_at !== null)
+          x.finished_at = ((x: number) => new Date(x * 1000))(x.finished_at);
+        if (typeof x.started_at !== 'undefined' && x.started_at !== null)
+          x.started_at = ((x: number) => new Date(x * 1000))(x.started_at);
+        return x;
+      })(x.run);
+    return x;
+  }),
+  getCrons: apiCall<
+    messages.AdminGetCronsRequest,
+    messages._AdminGetCronsServerResponse,
+    messages.AdminGetCronsResponse
+  >('/api/admin/getCrons/', (x) => {
+    x.runs = ((x) => {
+      if (!Array.isArray(x)) {
+        return x;
+      }
+      return x.map((x) => {
+        if (typeof x.finished_at !== 'undefined' && x.finished_at !== null)
+          x.finished_at = ((x: number) => new Date(x * 1000))(x.finished_at);
+        if (typeof x.started_at !== 'undefined' && x.started_at !== null)
+          x.started_at = ((x: number) => new Date(x * 1000))(x.started_at);
+        return x;
+      });
+    })(x.runs);
+    return x;
+  }),
   getMaintenanceMode: apiCall<
     messages.AdminGetMaintenanceModeRequest,
     messages.AdminGetMaintenanceModeResponse

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -3788,6 +3788,33 @@ export namespace types {
     teachingAssistant: types.FilteredCourse[];
   }
 
+  export interface CronJob {
+    description?: string;
+    enabled: boolean;
+    name: string;
+    schedule?: string;
+  }
+
+  export interface CronRun {
+    duration_seconds?: number;
+    error_text?: string;
+    finished_at?: Date;
+    hostname?: string;
+    name: string;
+    phases: types.CronRunPhase[];
+    rows_affected?: number;
+    run_id: number;
+    started_at?: Date;
+    status: string;
+  }
+
+  export interface CronRunPhase {
+    duration: number;
+    error_class?: string;
+    phase: string;
+    status: string;
+  }
+
   export interface CurrentSession {
     apiTokenId?: number;
     api_tokens: types.ApiToken[];
@@ -5350,6 +5377,15 @@ export namespace messages {
   };
 
   // Admin
+  export type AdminGetCronRunRequest = { [key: string]: any };
+  export type _AdminGetCronRunServerResponse = any;
+  export type AdminGetCronRunResponse = { run?: types.CronRun };
+  export type AdminGetCronsRequest = { [key: string]: any };
+  export type _AdminGetCronsServerResponse = any;
+  export type AdminGetCronsResponse = {
+    jobs: types.CronJob[];
+    runs: types.CronRun[];
+  };
   export type AdminGetMaintenanceModeRequest = { [key: string]: any };
   export type AdminGetMaintenanceModeResponse = types.MaintenanceModeStatus;
   export type AdminGetSystemSettingsRequest = { [key: string]: any };
@@ -6371,6 +6407,12 @@ export namespace controllers {
   }
 
   export interface Admin {
+    getCronRun: (
+      params?: messages.AdminGetCronRunRequest,
+    ) => Promise<messages.AdminGetCronRunResponse>;
+    getCrons: (
+      params?: messages.AdminGetCronsRequest,
+    ) => Promise<messages.AdminGetCronsResponse>;
     getMaintenanceMode: (
       params?: messages.AdminGetMaintenanceModeRequest,
     ) => Promise<messages.AdminGetMaintenanceModeResponse>;


### PR DESCRIPTION
# Description

adds admin only `Admin::apiGetCrons` (the job registry plus recent runs) and `apiGetCronRun` (one run's detail with its per phase breakdown), both guarded by `ensureMainUserIdentity` and `isSystemAdmin`, with the `@psalm-type`s and the regenerated `api.ts` / `api_types.ts` so the frontend gets typed clients. covered by `CronControlPlaneAdminTest`.

Fixes: #9999

# Comments

part of the cron control plane epic #9992. both things it needed, the tables migration and the daos, are merged now, so this is rebased onto main and the diff is just the controller, its test and the regenerated api types.

# Checklist:

- [x] The code follows the coding guidelines of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests.

