### PR TITLE
Fix tab hash history navigation on Arena Problem page (#9971)

### DIFF
--- a/frontend/www/js/omegaup/components/problem/Details.test.ts
+++ b/frontend/www/js/omegaup/components/problem/Details.test.ts
@@ -465,4 +465,32 @@ int main() {
 
     expect(wrapper.findComponent(arena_EphemeralGrader).exists()).toBe(false);
   });
+
+  it('Should update selected tab when activeTab prop changes', async () => {
+    const wrapper = mount(problem_Details, {
+      propsData: {
+        problem,
+        user: { loggedIn: true, admin: true, reviewer: false },
+        nominationStatus,
+        activeTab: 'problems',
+        runs: [],
+        allRuns: [],
+        clarifications: [] as types.Clarification[],
+        histogram,
+        shouldShowTabs: true,
+      },
+    });
+
+    expect(wrapper.find('a[aria-controls="problems"]').classes()).toContain(
+      'active',
+    );
+
+    await wrapper.setProps({ activeTab: 'runs' });
+    expect(wrapper.find('a[aria-controls="runs"]').classes()).toContain(
+      'active',
+    );
+    expect(wrapper.find('a[aria-controls="problems"]').classes()).not.toContain(
+      'active',
+    );
+  });
 });

--- a/frontend/www/js/omegaup/components/problem/Details.vue
+++ b/frontend/www/js/omegaup/components/problem/Details.vue
@@ -787,6 +787,11 @@ export default class ProblemDetails extends Vue {
     return this.selectedTab;
   }
 
+  @Watch('activeTab')
+  onActiveTabChanged(newTab: string): void {
+    this.selectedTab = newTab;
+  }
+
   @Watch('clarifications')
   onInitialClarificationsChanged(newValue: types.Clarification[]): void {
     this.currentClarifications = newValue;

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import problem_Details, {
   PopupDisplayed,
 } from '../components/problem/Details.vue';
+import { pushLocationHash } from '../location';
 import {
   getOptionsFromLocation,
   getProblemAndRunDetails,
@@ -382,6 +383,9 @@ OmegaUp.on('ready', async () => {
           },
           'update:activeTab': (tabName: string) => {
             problemDetailsView.activeTab = tabName;
+            if (window.location.hash !== `#${tabName}`) {
+              pushLocationHash(`#${tabName}`);
+            }
           },
           'redirect-login-page': () => {
             window.location.href = `/login/?redirect=${encodeURIComponent(

--- a/frontend/www/js/omegaup/problem/details.ts
+++ b/frontend/www/js/omegaup/problem/details.ts
@@ -93,6 +93,10 @@ OmegaUp.on('ready', async () => {
       isBookmarked: payload.isBookmarked,
       isLoadingBookmark: false,
     }),
+    // eslint-disable-next-line vue/no-deprecated-destroyed-lifecycle
+    beforeDestroy() {
+      window.removeEventListener('hashchange', onHashChange);
+    },
     render: function (createElement) {
       return createElement('omegaup-problem-details', {
         props: {
@@ -377,7 +381,7 @@ OmegaUp.on('ready', async () => {
               .catch(ui.apiError);
           },
           'update:activeTab': (tabName: string) => {
-            history.replaceState({ tabName }, 'updateTab', `#${tabName}`);
+            problemDetailsView.activeTab = tabName;
           },
           'redirect-login-page': () => {
             window.location.href = `/login/?redirect=${encodeURIComponent(
@@ -600,4 +604,11 @@ OmegaUp.on('ready', async () => {
   ) {
     problemDetailsView.popupDisplayed = PopupDisplayed.Promotion;
   }
+
+  const onHashChange = () => {
+    const hash = window.location.hash.substring(1).split('/')[0];
+    problemDetailsView.activeTab = hash || 'problems';
+  };
+
+  window.addEventListener('hashchange', onHashChange);
 });


### PR DESCRIPTION
Fixes #9971

## Description
On the `/arena/problem/<alias>/` page, navigating between tabs was not creating history stack entries and did not respond to browser Back/Forward navigation. Pressing the browser Back button navigated away from the page entirely.

## Cause
1. `frontend/www/js/omegaup/problem/details.ts` was calling `history.replaceState(...)` instead of pushing location hashes to history when a tab was selected.
2. `details.ts` lacked a `hashchange` event listener on `window` to handle browser Back/Forward history navigation.
3. `frontend/www/js/omegaup/components/problem/Details.vue` lacked a `@Watch('activeTab')` decorator, so updating `activeTab` on the root instance did not update the component's internal `selectedTab`.

## Solution
1. Updated `update:activeTab` in `details.ts` to use `pushLocationHash(...)` so clicking a tab updates `window.location.hash` and pushes a history entry.
2. Added an `onHashChange` handler and `hashchange` event listener in `details.ts` with cleanup in `beforeDestroy()`.
3. Added `@Watch('activeTab')` in `Details.vue` to reactively update `selectedTab` when `activeTab` changes.
4. Added unit tests in `Details.test.ts` to verify tab state synchronization.

### Checklist
- [x] I have searched existing issues and confirmed this is not a duplicate.
- [x] Unit tests added and passing.
- [x] Linting checks passed (`./stuff/lint.sh`).


## Screenrecording 

### Previous-
https://github.com/user-attachments/assets/80fc21b7-2d29-494b-b7ad-ef5df9fb2c52

### Current- 

https://github.com/user-attachments/assets/8da6b481-8ddf-4175-9d9c-88af675c16db

