### PR TITLE
Creando instancia mínima de Twig para no inicializar payload global

### DIFF
--- a/frontend/server/cmd/CompileTemplatesCmd.php
+++ b/frontend/server/cmd/CompileTemplatesCmd.php
@@ -4,7 +4,21 @@ require_once(dirname(__DIR__) . '/bootstrap.php');
 
 $dirname = dirname(__DIR__, 2) . '/www/js/dist';
 $suffix = '.deps.json';
-['twig' => $twig] = \OmegaUp\UITools::getTwigInstance();
+$loader = new \OmegaUp\Template\Loader();
+$twigOptions = [
+    'cache' => TEMPLATE_CACHE_DIR,
+];
+/** @psalm-suppress TypeDoesNotContainType this can change depending on environment */
+if (
+    defined('OMEGAUP_ENVIRONMENT') &&
+    OMEGAUP_ENVIRONMENT === 'development'
+) {
+    $twigOptions['debug'] = true;
+}
+$twig = new \Twig\Environment($loader, $twigOptions);
+$twig->addTokenParser(new \OmegaUp\Template\EntrypointParser());
+$twig->addTokenParser(new \OmegaUp\Template\VersionHashParser());
+$twig->addTokenParser(new \OmegaUp\Template\JsIncludeParser());
 if ($handle = opendir($dirname)) {
     while (false !== ($entry = readdir($handle))) {
         if ($entry == '.' || $entry == '..') {


### PR DESCRIPTION
# Description

Se evita que `CompileTemplatesCmd` inicialice `UITools` durante el build.

`UITools` construye el payload global del sitio, que ahora puede consultar configuraciones almacenadas en la DB. Durante la etapa de build esa dependencia no está disponible, por lo que la compilación de templates podía fallar.

Ahora el comando crea una instancia mínima de `Twig` con el loader y parsers necesarios para precompilar templates sin cargar dependencias runtime.

Fixes: #10038

# Comments

Esto ocasionó que se reompiera el deploy ya que no es posible construir los contenedores

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.