### PR TITLE
Migrando el almacenamiento de Modo Mantenimiento a SystemSettings

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -11,11 +11,11 @@
   * @psalm-type MaintenanceModeStatus=array{enabled: bool, message_es: null|string, message_en: null|string, message_pt: null|string, type: string}
   */
 class Admin extends \OmegaUp\Controllers\Controller {
-    const MAINTENANCE_MESSAGE_ES_KEY = 'system:maintenance_message_es';
-    const MAINTENANCE_MESSAGE_EN_KEY = 'system:maintenance_message_en';
-    const MAINTENANCE_MESSAGE_PT_KEY = 'system:maintenance_message_pt';
-    const MAINTENANCE_ENABLED_KEY = 'system:maintenance_enabled';
-    const MAINTENANCE_MESSAGE_TYPE_KEY = 'system:maintenance_message_type';
+    const MAINTENANCE_MESSAGE_ES_KEY = 'maintenance_message_es';
+    const MAINTENANCE_MESSAGE_EN_KEY = 'maintenance_message_en';
+    const MAINTENANCE_MESSAGE_PT_KEY = 'maintenance_message_pt';
+    const MAINTENANCE_ENABLED_KEY = 'maintenance_enabled';
+    const MAINTENANCE_MESSAGE_TYPE_KEY = 'maintenance_message_type';
 
     const INFO = 0;
     const WARNING = 1;
@@ -131,37 +131,52 @@ class Admin extends \OmegaUp\Controllers\Controller {
             self::MAINTENANCE_MESSAGE_TYPES
         ) ?? self::MAINTENANCE_MESSAGE_TYPES[self::INFO];
 
-        $cacheEnabled = new \OmegaUp\Cache(self::MAINTENANCE_ENABLED_KEY);
-        $cacheMessageEs = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_ES_KEY);
-        $cacheMessageEn = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_EN_KEY);
-        $cacheMessagePt = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_PT_KEY);
-        $cacheMessageType = new \OmegaUp\Cache(
-            self::MAINTENANCE_MESSAGE_TYPE_KEY
-        );
-        if ($enabled) {
-            $cacheEnabled->set(value: true, timeout: 0); // No expiration
-            $cacheMessageEs->set($messageEs, timeout: 0);
-            $cacheMessageEn->set($messageEn, timeout: 0);
-            $cacheMessagePt->set($messagePt, timeout: 0);
-
-            // Store the index, not the string value
-            $typeIndex = array_search(
-                $type,
-                self::MAINTENANCE_MESSAGE_TYPES,
-                strict: true
+        try {
+            \OmegaUp\DAO\DAO::transBegin();
+            \OmegaUp\DAO\SystemSettings::setBooleanSetting(
+                self::MAINTENANCE_ENABLED_KEY,
+                $enabled
             );
-            $cacheMessageType->set(
-                $typeIndex !== false ? $typeIndex : self::INFO,
-                timeout: 0
-            );
-        } else {
-            $cacheEnabled->delete();
-            $cacheMessageEs->delete();
-            $cacheMessageEn->delete();
-            $cacheMessagePt->delete();
-            $cacheMessageType->delete();
+            if ($enabled) {
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_ES_KEY,
+                    $messageEs
+                );
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_EN_KEY,
+                    $messageEn
+                );
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_PT_KEY,
+                    $messagePt
+                );
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_TYPE_KEY,
+                    $type
+                );
+            } else {
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_ES_KEY,
+                    ''
+                );
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_EN_KEY,
+                    ''
+                );
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_PT_KEY,
+                    ''
+                );
+                \OmegaUp\DAO\SystemSettings::setStringSetting(
+                    self::MAINTENANCE_MESSAGE_TYPE_KEY,
+                    self::MAINTENANCE_MESSAGE_TYPES[self::INFO]
+                );
+            }
+            \OmegaUp\DAO\DAO::transEnd();
+        } catch (\Exception $e) {
+            \OmegaUp\DAO\DAO::transRollback();
+            throw $e;
         }
-
         return ['status' => 'ok'];
     }
 
@@ -181,22 +196,20 @@ class Admin extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * Get the message type from cache
+     * Get the message type from system settings
      *
      * @return string
      */
-    private static function getMessageTypeFromCache(): string {
-        $cacheMessageType = new \OmegaUp\Cache(
-            self::MAINTENANCE_MESSAGE_TYPE_KEY
+    private static function getMessageTypeFromSettings(): string {
+        $messageType = \OmegaUp\DAO\SystemSettings::getStringSetting(
+            self::MAINTENANCE_MESSAGE_TYPE_KEY,
+            self::MAINTENANCE_MESSAGE_TYPES[self::INFO]
         );
-        $messageTypeIndex = $cacheMessageType->get();
-        return (is_int(
-            $messageTypeIndex
-        ) && isset(
-            self::MAINTENANCE_MESSAGE_TYPES[$messageTypeIndex]
-        ))
-            ? self::MAINTENANCE_MESSAGE_TYPES[$messageTypeIndex]
-            : self::MAINTENANCE_MESSAGE_TYPES[self::INFO];
+        return in_array(
+            $messageType,
+            self::MAINTENANCE_MESSAGE_TYPES,
+            strict: true
+        ) ? $messageType : self::MAINTENANCE_MESSAGE_TYPES[self::INFO];
     }
 
     /**
@@ -205,31 +218,21 @@ class Admin extends \OmegaUp\Controllers\Controller {
      * @return MaintenanceModeStatus
      */
     public static function getMaintenanceModeStatus(): array {
-        $cacheEnabled = new \OmegaUp\Cache(self::MAINTENANCE_ENABLED_KEY);
-        $enabled = boolval($cacheEnabled->get());
-
-        $cacheMessageEs = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_ES_KEY);
-        $messageEs = is_null(
-            $cacheMessageEs->get()
-        ) ? null : strval(
-            $cacheMessageEs->get()
+        $enabled = \OmegaUp\DAO\SystemSettings::getBooleanSetting(
+            self::MAINTENANCE_ENABLED_KEY,
+            false
+        );
+        $messageEs = \OmegaUp\DAO\SystemSettings::getStringSetting(
+            self::MAINTENANCE_MESSAGE_ES_KEY
+        );
+        $messageEn = \OmegaUp\DAO\SystemSettings::getStringSetting(
+            self::MAINTENANCE_MESSAGE_EN_KEY
+        );
+        $messagePt = \OmegaUp\DAO\SystemSettings::getStringSetting(
+            self::MAINTENANCE_MESSAGE_PT_KEY
         );
 
-        $cacheMessageEn = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_EN_KEY);
-        $messageEn = is_null(
-            $cacheMessageEn->get()
-        ) ? null : strval(
-            $cacheMessageEn->get()
-        );
-
-        $cacheMessagePt = new \OmegaUp\Cache(self::MAINTENANCE_MESSAGE_PT_KEY);
-        $messagePt = is_null(
-            $cacheMessagePt->get()
-        ) ? null : strval(
-            $cacheMessagePt->get()
-        );
-
-        $type = self::getMessageTypeFromCache();
+        $type = self::getMessageTypeFromSettings();
 
         return [
             'enabled' => $enabled,

--- a/frontend/tests/controllers/AdminTest.php
+++ b/frontend/tests/controllers/AdminTest.php
@@ -1,11 +1,8 @@
 <?php
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
-/** @psalm-suppress MissingDependency we need to add PHPUnit */
 class AdminTest extends \OmegaUp\Test\ControllerTestCase {
     public function testPlatformReportStatsRequiresAdmin() {
         [
-            'user' => $user,
             'identity' => $identity,
         ] = \OmegaUp\Test\Factories\User::createUser();
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);
@@ -22,7 +19,6 @@ class AdminTest extends \OmegaUp\Test\ControllerTestCase {
 
     public function testPlatformReportStats() {
         [
-            'user' => $admin,
             'identity' => $identity,
         ] = \OmegaUp\Test\Factories\User::createAdminUser();
         $adminLogin = \OmegaUp\Test\ControllerTestCase::login($identity);
@@ -31,5 +27,63 @@ class AdminTest extends \OmegaUp\Test\ControllerTestCase {
             'auth_token' => $adminLogin->auth_token,
         ]));
         $this->assertNotEmpty($response['report']);
+    }
+
+    public function testMaintenanceModePersistsOutsideCache() {
+        [
+            'identity' => $supportIdentity,
+        ] = \OmegaUp\Test\Factories\User::createSupportUser();
+        $supportLogin = \OmegaUp\Test\ControllerTestCase::login(
+            $supportIdentity
+        );
+
+        try {
+            $response = \OmegaUp\Controllers\Admin::apiSetMaintenanceMode(
+                new \OmegaUp\Request([
+                    'auth_token' => $supportLogin->auth_token,
+                    'enabled' => true,
+                    'message_es' => '<b>Mantenimiento editado</b><br>Volvemos pronto.',
+                    'message_en' => '<b>Edited maintenance</b><br>Back soon.',
+                    'message_pt' => '<b>Manutencao editada</b><br>Voltamos em breve.',
+                    'type' => 'warning',
+                ])
+            );
+
+            $this->assertSame('ok', $response['status']);
+
+            \OmegaUp\Cache::clearCacheForTesting();
+            $status = \OmegaUp\Controllers\Admin::getMaintenanceModeStatus();
+
+            $this->assertTrue($status['enabled']);
+            $this->assertSame(
+                '<b>Mantenimiento editado</b><br>Volvemos pronto.',
+                $status['message_es']
+            );
+            $this->assertSame(
+                '<b>Edited maintenance</b><br>Back soon.',
+                $status['message_en']
+            );
+            $this->assertSame(
+                '<b>Manutencao editada</b><br>Voltamos em breve.',
+                $status['message_pt']
+            );
+            $this->assertSame('warning', $status['type']);
+
+            $message = \OmegaUp\Controllers\Admin::getMaintenanceMessage('en');
+            $this->assertNotNull($message);
+            $this->assertSame(
+                '<b>Edited maintenance</b><br>Back soon.',
+                $message['message']
+            );
+            $this->assertSame('warning', $message['type']);
+        } finally {
+            \OmegaUp\Controllers\Admin::apiSetMaintenanceMode(
+                new \OmegaUp\Request([
+                    'auth_token' => $supportLogin->auth_token,
+                    'enabled' => false,
+                ])
+            );
+            \OmegaUp\Cache::clearCacheForTesting();
+        }
     }
 }


### PR DESCRIPTION
# Description

El modo mantenimiento ahora se persiste en `System_Settings` en lugar de guardarse directamente en `OmegaUp\Cache`.

Se almacenan:
- El estado activo
- Los mensajes por idioma 
- El tipo de alerta 

usando `DAO\SystemSettings` dentro de una transacción explícita. De esta forma la base de datos queda como fuente de verdad y el cache solo funciona como capa de lectura.

También se agrega una prueba que activa el modo mantenimiento, limpia cache y valida que la configuración siga disponible.

## Comments

Anteriormente se usaba el cache como fuente de verdad que hacía que el comportamiento fuera inconsistente: dependiendo de la implementación de cache, del worker que atendiera la petición o de reinicios/invalidaciones, el estado podía desaparecer o no estar disponible para todos los procesos.


# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
