### PR TITLE
fix: move cache invalidation after transaction commit in apiSetMaintenanceMode

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -184,18 +184,10 @@ class Admin extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\DAO::transEnd();
 
             \OmegaUp\DAO\SystemSettings::invalidateCache(
-                self::MAINTENANCE_ENABLED_KEY
-            );
-            \OmegaUp\DAO\SystemSettings::invalidateCache(
-                self::MAINTENANCE_MESSAGE_ES_KEY
-            );
-            \OmegaUp\DAO\SystemSettings::invalidateCache(
-                self::MAINTENANCE_MESSAGE_EN_KEY
-            );
-            \OmegaUp\DAO\SystemSettings::invalidateCache(
-                self::MAINTENANCE_MESSAGE_PT_KEY
-            );
-            \OmegaUp\DAO\SystemSettings::invalidateCache(
+                self::MAINTENANCE_ENABLED_KEY,
+                self::MAINTENANCE_MESSAGE_ES_KEY,
+                self::MAINTENANCE_MESSAGE_EN_KEY,
+                self::MAINTENANCE_MESSAGE_PT_KEY,
                 self::MAINTENANCE_MESSAGE_TYPE_KEY
             );
         } catch (\Exception $e) {

--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -135,44 +135,69 @@ class Admin extends \OmegaUp\Controllers\Controller {
             \OmegaUp\DAO\DAO::transBegin();
             \OmegaUp\DAO\SystemSettings::setBooleanSetting(
                 self::MAINTENANCE_ENABLED_KEY,
-                $enabled
+                $enabled,
+                invalidateCache: false
             );
             if ($enabled) {
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_ES_KEY,
-                    $messageEs
+                    $messageEs,
+                    invalidateCache: false
                 );
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_EN_KEY,
-                    $messageEn
+                    $messageEn,
+                    invalidateCache: false
                 );
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_PT_KEY,
-                    $messagePt
+                    $messagePt,
+                    invalidateCache: false
                 );
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_TYPE_KEY,
-                    $type
+                    $type,
+                    invalidateCache: false
                 );
             } else {
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_ES_KEY,
-                    ''
+                    '',
+                    invalidateCache: false
                 );
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_EN_KEY,
-                    ''
+                    '',
+                    invalidateCache: false
                 );
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_PT_KEY,
-                    ''
+                    '',
+                    invalidateCache: false
                 );
                 \OmegaUp\DAO\SystemSettings::setStringSetting(
                     self::MAINTENANCE_MESSAGE_TYPE_KEY,
-                    self::MAINTENANCE_MESSAGE_TYPES[self::INFO]
+                    self::MAINTENANCE_MESSAGE_TYPES[self::INFO],
+                    invalidateCache: false
                 );
             }
             \OmegaUp\DAO\DAO::transEnd();
+
+            \OmegaUp\DAO\SystemSettings::invalidateCache(
+                self::MAINTENANCE_ENABLED_KEY
+            );
+            \OmegaUp\DAO\SystemSettings::invalidateCache(
+                self::MAINTENANCE_MESSAGE_ES_KEY
+            );
+            \OmegaUp\DAO\SystemSettings::invalidateCache(
+                self::MAINTENANCE_MESSAGE_EN_KEY
+            );
+            \OmegaUp\DAO\SystemSettings::invalidateCache(
+                self::MAINTENANCE_MESSAGE_PT_KEY
+            );
+            \OmegaUp\DAO\SystemSettings::invalidateCache(
+                self::MAINTENANCE_MESSAGE_TYPE_KEY
+            );
         } catch (\Exception $e) {
             \OmegaUp\DAO\DAO::transRollback();
             throw $e;

--- a/frontend/server/src/DAO/SystemSettings.php
+++ b/frontend/server/src/DAO/SystemSettings.php
@@ -65,7 +65,10 @@ class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
      */
     public static function invalidateCache(string ...$keys): void {
         foreach ($keys as $key) {
-            (new \OmegaUp\Cache(\OmegaUp\Cache::SYSTEM_SETTINGS, $key))->delete();
+            (new \OmegaUp\Cache(
+                \OmegaUp\Cache::SYSTEM_SETTINGS,
+                $key
+            ))->delete();
         }
     }
 

--- a/frontend/server/src/DAO/SystemSettings.php
+++ b/frontend/server/src/DAO/SystemSettings.php
@@ -76,7 +76,8 @@ class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
      */
     public static function setBooleanSetting(
         string $key,
-        bool $value
+        bool $value,
+        bool $invalidateCache = true
     ): int {
         $setting = self::getByKey($key);
         if (is_null($setting)) {
@@ -90,7 +91,9 @@ class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
             $setting->setting_value = $value ? '1' : '0';
             $affectedRows = self::update($setting);
         }
-        self::invalidateCache($key);
+        if ($invalidateCache) {
+            self::invalidateCache($key);
+        }
         return $affectedRows;
     }
 
@@ -128,7 +131,8 @@ class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
      */
     public static function setStringSetting(
         string $key,
-        string $value
+        string $value,
+        bool $invalidateCache = true
     ): int {
         $setting = self::getByKey($key);
         if (is_null($setting)) {
@@ -142,7 +146,9 @@ class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
             $setting->setting_value = $value;
             $affectedRows = self::update($setting);
         }
-        self::invalidateCache($key);
+        if ($invalidateCache) {
+            self::invalidateCache($key);
+        }
         return $affectedRows;
     }
 }

--- a/frontend/server/src/DAO/SystemSettings.php
+++ b/frontend/server/src/DAO/SystemSettings.php
@@ -59,12 +59,14 @@ class SystemSettings extends \OmegaUp\DAO\Base\SystemSettings {
     }
 
     /**
-     * Drop the cached value for a setting so the next read hits the database.
+     * Drop the cached value for one or more settings so the next read hits the database.
      *
-     * @param string $key The setting key
+     * @param string ...$keys The setting keys to invalidate
      */
-    public static function invalidateCache(string $key): void {
-        (new \OmegaUp\Cache(\OmegaUp\Cache::SYSTEM_SETTINGS, $key))->delete();
+    public static function invalidateCache(string ...$keys): void {
+        foreach ($keys as $key) {
+            (new \OmegaUp\Cache(\OmegaUp\Cache::SYSTEM_SETTINGS, $key))->delete();
+        }
     }
 
     /**

--- a/frontend/tests/controllers/SystemSettingsDAOTest.php
+++ b/frontend/tests/controllers/SystemSettingsDAOTest.php
@@ -86,4 +86,67 @@ class SystemSettingsDAOTest extends \OmegaUp\Test\ControllerTestCase {
             \OmegaUp\DAO\SystemSettings::getStringSetting($key)
         );
     }
+
+    public function testSetBooleanSettingWithInvalidateCacheFalse() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        \OmegaUp\DAO\SystemSettings::setBooleanSetting($key, true);
+        $this->assertTrue(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, false)
+        );
+
+        \OmegaUp\DAO\SystemSettings::setBooleanSetting(
+            $key,
+            false,
+            invalidateCache: false
+        );
+        $this->assertTrue(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, false)
+        );
+
+        \OmegaUp\DAO\SystemSettings::invalidateCache($key);
+        $this->assertFalse(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, true)
+        );
+    }
+
+    public function testSetStringSettingWithInvalidateCacheFalse() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        \OmegaUp\DAO\SystemSettings::setStringSetting($key, 'first');
+        $this->assertSame(
+            'first',
+            \OmegaUp\DAO\SystemSettings::getStringSetting($key)
+        );
+
+        \OmegaUp\DAO\SystemSettings::setStringSetting(
+            $key,
+            'second',
+            invalidateCache: false
+        );
+        $this->assertSame(
+            'first',
+            \OmegaUp\DAO\SystemSettings::getStringSetting($key)
+        );
+
+        \OmegaUp\DAO\SystemSettings::invalidateCache($key);
+        $this->assertSame(
+            'second',
+            \OmegaUp\DAO\SystemSettings::getStringSetting($key)
+        );
+    }
+
+    public function testExplicitInvalidateCacheAfterDbWrite() {
+        $key = \OmegaUp\Test\Utils::createRandomString();
+
+        \OmegaUp\DAO\SystemSettings::setBooleanSetting(
+            $key,
+            true,
+            invalidateCache: false
+        );
+        \OmegaUp\DAO\SystemSettings::invalidateCache($key);
+        $this->assertTrue(
+            \OmegaUp\DAO\SystemSettings::getBooleanSetting($key, false)
+        );
+    }
 }


### PR DESCRIPTION
# Description

Cache invalidation in `apiSetMaintenanceMode` was happening inside the transaction, before the commit. This created a race condition where a concurrent reader could get a cache miss, read the old pre-commit DB value, and cache it indefinitely (TTL=0).

**Root cause:** `setBooleanSetting` and `setStringSetting` in `SystemSettings.php` call `self::invalidateCache($key)` after updating the DB, regardless of whether the caller is inside a transaction.

**Fix:**
1. Added an optional `$invalidateCache` parameter (default `true`) to both `setBooleanSetting` and `setStringSetting`.
2. In `apiSetMaintenanceMode`, all calls use `invalidateCache: false` inside the transaction.
3. After `transEnd()`, the cache is explicitly invalidated for all 5 maintenance mode keys via direct `invalidateCache()` calls.

This ensures cache invalidation only happens after the transaction commits, closing the race window entirely.

Fixes: #10043

# Checklist:

- [x] The code follows the coding guidelines of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
