### PR TITLE
add problem health checks table

### DIFF
--- a/frontend/database/00279_problem_health_checks.sql
+++ b/frontend/database/00279_problem_health_checks.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `Problem_Health_Checks` (
+  `check_id` int NOT NULL AUTO_INCREMENT,
+  `problem_id` int NOT NULL,
+  `check_type` enum('judge_errors','no_languages','never_solved','deprecated_public') NOT NULL COMMENT 'El tipo de revisión que detectó el problema',
+  `severity` enum('warning','error') NOT NULL DEFAULT 'warning',
+  `detail` varchar(255) DEFAULT NULL COMMENT 'Explicación legible de lo que se detectó',
+  `first_detected_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'La primera vez que se detectó, se conserva entre ejecuciones',
+  `last_seen_at` datetime NOT NULL COMMENT 'La última ejecución en la que se seguía detectando',
+  `resolved_at` datetime DEFAULT NULL COMMENT 'Cuando dejó de detectarse, NULL si sigue vigente',
+  PRIMARY KEY (`check_id`),
+  UNIQUE KEY `unique_problem_check` (`problem_id`,`check_type`),
+  KEY `idx_problem_health_open` (`resolved_at`,`severity`),
+  CONSTRAINT `fk_phc_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Hallazgos de las revisiones automáticas de salud de los problemas';
+
+INSERT INTO `Cron_Jobs` (`name`, `description`, `schedule`) VALUES
+  ('problem_health_check.py', 'Detects problems that silently stopped working and records the findings', '35 5 * * *');

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -760,6 +760,23 @@ CREATE TABLE `Problem_Bookmarks` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Problem_Health_Checks` (
+  `check_id` int NOT NULL AUTO_INCREMENT,
+  `problem_id` int NOT NULL,
+  `check_type` enum('judge_errors','no_languages','never_solved','deprecated_public') NOT NULL COMMENT 'El tipo de revisión que detectó el problema',
+  `severity` enum('warning','error') NOT NULL DEFAULT 'warning',
+  `detail` varchar(255) DEFAULT NULL COMMENT 'Explicación legible de lo que se detectó',
+  `first_detected_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'La primera vez que se detectó, se conserva entre ejecuciones',
+  `last_seen_at` datetime NOT NULL COMMENT 'La última ejecución en la que se seguía detectando',
+  `resolved_at` datetime DEFAULT NULL COMMENT 'Cuando dejó de detectarse, NULL si sigue vigente',
+  PRIMARY KEY (`check_id`),
+  UNIQUE KEY `unique_problem_check` (`problem_id`,`check_type`),
+  KEY `idx_problem_health_open` (`resolved_at`,`severity`),
+  CONSTRAINT `fk_phc_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Hallazgos de las revisiones automáticas de salud de los problemas';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Problem_Of_The_Week` (
   `problem_of_the_week_id` int NOT NULL AUTO_INCREMENT,
   `problem_id` int NOT NULL COMMENT 'El id del problema escogido como problema de la semana.',


### PR DESCRIPTION
# Description

adds the schema for the automated problem health checks: a `Problem_Health_Checks` table holding one row per finding, the problem it belongs to, which check found it, a severity, a readable detail, when it was first detected, when it was last seen and when it was resolved. it also seeds `problem_health_check.py` into the `Cron_Jobs` registry with a daily schedule so it registers as a scheduled job.

the unique key on problem and check type is what lets the job upsert its findings, so a finding keeps the date it was first detected, running the job twice does not create duplicates, and a finding that stops being detected is marked resolved instead of disappearing.

Part of #10064.

# Comments

this PR is the migration and `schema.sql` only, the job itself and the admin view come in the follow up PRs. it builds on the cron control plane since it registers the job in `Cron_Jobs`.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
