### PR TITLE
Optimizar getLatestSubmissions quitando index hint

### DIFF
--- a/frontend/server/src/DAO/Submissions.php
+++ b/frontend/server/src/DAO/Submissions.php
@@ -296,11 +296,6 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
     ): array {
         $rowsPerPage = min(100, max(1, intval($rowsPerPage)));
         $limitDate = gmdate('Y-m-d H:i:s', time() - 24 * 3600);
-        if (is_null($identityId)) {
-            $indexHint = 'USE INDEX(PRIMARY)';
-        } else {
-            $indexHint = '';
-        }
         $sql = "
             SELECT
                 s.`time`,
@@ -316,7 +311,7 @@ class Submissions extends \OmegaUp\DAO\Base\Submissions {
                 r.memory,
                 IFNULL(ur.classname, 'user-rank-unranked') AS classname
             FROM
-                Submissions s $indexHint
+                Submissions s
             INNER JOIN
                 Identities i ON i.identity_id = s.identity_id
             LEFT JOIN


### PR DESCRIPTION
# Descripcion

Se quitó el `USE INDEX(PRIMARY)` en `Submissions::getLatestSubmissions()` para permitir que MySQL pueda elegir índices más adecuados para resolver la consulta.

La consulta filtra por `s.time >= ...` y `s.status = 'ready'`, y ya existe el índice `idx_time_status` sobre `Submissions (time, status)`. Al forzar `PRIMARY`, MySQL no podía considerar ese índice y terminaba haciendo full table scan sobre `Submissions`.

Con este cambio, MySQL usa `idx_time_status` para `Submissions`. Además, el plan de ejecución también mejora el acceso a `User_Rank`, que pasa a usar su llave primaria `PRIMARY (user_id)` en el `LEFT JOIN`.

Fixes: #10054

# Antes

| Table | Type | Key | Extra |
| --- | --- | --- | --- |
| s (`Submissions`) | ALL | NULL | Using where |
| ur (`User_Rank`) | ALL | NULL | NULL |

# Después

| Table | Type | Key | Extra |
| --- | --- | --- | --- |
| s (`Submissions`) | range | idx_time_status | Using index condition; Using where; Using filesort |
| ur (`User_Rank`) | eq_ref | PRIMARY | NULL |

# Notas

No se agregó un índice nuevo. El cambio permite que MySQL use índices existentes: `idx_time_status` en `Submissions` y `PRIMARY` en `User_Rank`.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests.