### PR TITLE
docs: fix malformed response table in Contests-API.md

### DIFF
--- a/frontend/www/docs/Contests-API.md
+++ b/frontend/www/docs/Contests-API.md
@@ -1,6 +1,6 @@
 **NOTE**: This documentation is outdated.
 
-For a more recent version, visit the following link: [apiContest](https://github.com/omegaup/omegaup/blob/master/frontend/server/src/Controllers/README.md#contest)
+For a more recent version, visit the following link: [apiContest](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#contest)
 
 ## GET `contests/`
 
@@ -26,7 +26,8 @@ Returns an array with the following information for each contest:
 |`finish_time`|int|Contest end time in UNIX timestamp format|
 |`public`|int|If `0`, the contest is private. If `1`, the contest is public|
 |`director_id`|int|ID of the user who is the contest director|
-|`window_length`|int| If not null, the contest duration will be `window_length` in minutes, and the contest timer will be specific to each user instead of general to all. The timer will start when the contestant first enters the contest. `start_time` will then determine the time at which users can start opening the contest (USACO style). The default is `null`. |`duration`|int|The duration of the contest, taking into account the value of `window_length`|
+|`window_length`|int| If not null, the contest duration will be `window_length` in minutes, and the contest timer will be specific to each user instead of general to all. The timer will start when the contestant first enters the contest. `start_time` will then determine the time at which users can start opening the contest (USACO style). The default is `null`. |
+|`duration`|int|The duration of the contest, taking into account the value of `window_length`|
 
 ## GET `contests/:contest_alias/`
 


### PR DESCRIPTION
## What

Fixes the malformed "Returns" table for `GET contests/` in `frontend/www/docs/Contests-API.md`, and updates the stale `master` branch link at the top of the file to `main`.

## Why

The last row of the `GET contests/` response table had the `duration` row glued onto the end of the `window_length` row on a single line:

```
|`window_length`|int| ...The default is `null`. |`duration`|int|The duration of the contest...|
```

Because a Markdown table row is delimited by newlines, not by pipe count, this rendered as one oversized `window_length` row whose Description cell spilled the literal text `duration | int | The duration of the contest...`, and `duration` was never documented as its own field. Splitting it onto its own line restores both rows.

Separately, the "For a more recent version" pointer linked to `https://github.com/omegaup/omegaup/blob/master/...`. omegaUp's default branch is `main` (the maintained `Controllers.md` in the same directory already uses `blob/main`), so the `master` URL is part of what makes this file read as outdated. Updating it keeps the escape hatch to the current API docs working.

No other content was rewritten: the file is explicitly marked as outdated and defers to `frontend/server/src/Controllers/README.md`, so re-deriving every field against today's API is out of scope for this issue.

## How tested

- Scanned every table row in the file for a pipe count outside the expected 4–5; line 29 was the only offender, and it is now clean.
- Verified the `#contest` anchor still resolves — `frontend/server/src/Controllers/README.md` has a `# Contest` heading.
- `npm test` → 191/191 suites, 896 tests passed, 3 skipped.
- `.lint.config.json` has no allowlist entry matching `.md`, so no repo linter covers this file (and `stuff/lint.sh` requires the Docker hook-tools image).

Fixes #9519

---

Drafted with AI assistance (Claude); the change, its reasoning and its tests were reviewed before submission.