### PR TITLE
fix(controllers): don't rate-limit internal School::apiCreate from profile updates

### DIFF
--- a/frontend/server/src/Controllers/School.php
+++ b/frontend/server/src/Controllers/School.php
@@ -131,10 +131,15 @@ class School extends \OmegaUp\Controllers\Controller {
      * @omegaup-request-param string $name
      * @omegaup-request-param null|string $state_id
      */
-    public static function apiCreate(\OmegaUp\Request $r) {
+    public static function apiCreate(
+        \OmegaUp\Request $r,
+        bool $internal = false
+    ) {
         $r->ensureIdentity();
 
-        \OmegaUp\RateLimiter::assertWithinLimit($r->identity);
+        if (!$internal) {
+            \OmegaUp\RateLimiter::assertWithinLimit($r->identity);
+        }
 
         \OmegaUp\Validators::validateStringNonEmpty($r['name'], 'name');
         \OmegaUp\Validators::validateOptionalStringNonEmpty(

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -2646,7 +2646,8 @@ class User extends \OmegaUp\Controllers\Controller {
                     ) ? $state->country_id : null,
                     'state_id' => !is_null($state) ? $state->state_id : null,
                     'auth_token' => $r['auth_token'],
-                ])
+                ]),
+                internal: true
             );
             $newSchoolId = $response['school_id'];
         }

--- a/frontend/tests/controllers/RateLimiterTest.php
+++ b/frontend/tests/controllers/RateLimiterTest.php
@@ -304,6 +304,8 @@ class RateLimiterTest extends \OmegaUp\Test\ControllerTestCase {
             \OmegaUp\Controllers\User::apiUpdateBasicInfo(
                 new \OmegaUp\Request([
                     'auth_token' => $login->auth_token,
+                    'username' => $identity->username,
+                    'password' => 'anypassword',
                     'school_name' => "Profile School RL {$i}",
                 ])
             );

--- a/frontend/tests/controllers/RateLimiterTest.php
+++ b/frontend/tests/controllers/RateLimiterTest.php
@@ -288,6 +288,51 @@ class RateLimiterTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
+     * Test that updating a user's basic info with a new school name does not
+     * consume the user-facing School::apiCreate rate limit. School creation
+     * triggered internally from User::apiUpdateBasicInfo must not count against
+     * the external /api/school/create quota (see #10077).
+     */
+    public function testSchoolCreateViaProfileUpdateNotRateLimited(): void {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = self::login($identity);
+
+        // 6 profile updates, each with a distinct new school name. If the
+        // internal School::apiCreate call consumed the external rate limit
+        // bucket, the 6th would throw RateLimitExceededException.
+        for ($i = 0; $i < 6; $i++) {
+            \OmegaUp\Controllers\User::apiUpdateBasicInfo(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'school_name' => "Profile School RL {$i}",
+                ])
+            );
+        }
+
+        // Direct school creation still counts against its own limit.
+        for ($i = 0; $i < 5; $i++) {
+            \OmegaUp\Controllers\School::apiCreate(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'name' => "Direct School RL {$i}",
+                ])
+            );
+        }
+
+        try {
+            \OmegaUp\Controllers\School::apiCreate(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'name' => 'Direct School RL Excess',
+                ])
+            );
+            $this->fail('Expected RateLimitExceededException');
+        } catch (\OmegaUp\Exceptions\RateLimitExceededException $e) {
+            $this->assertSame(429, $e->getCode());
+        }
+    }
+
+    /**
      * Test that Problem::apiCreate is rate limited to 20 per hour.
      */
     public function testProblemCreateRateLimit(): void {


### PR DESCRIPTION
## Summary

`School::apiCreate` called `RateLimiter::assertWithinLimit` unconditionally, and `User::apiUpdateBasicInfo` invokes it internally when a user enters a new school name. Because `RateLimiter::assertWithinLimit` keys the bucket on the immediate caller (`School::apiCreate`), both the direct `/api/school/create` endpoint and the internal profile-update path share the same rate-limit bucket. A user who updates their profile with new school names ~6 times in the same window could hit `contentCreationRateLimitExceeded` without ever calling the school-create endpoint directly.

## Changes

`frontend/server/src/Controllers/School.php`:
- Added a `bool $internal = false` parameter to `apiCreate`. When `true`, the user-facing `RateLimiter::assertWithinLimit` is skipped, so internal controller-to-controller calls don't consume the external quota.

`frontend/server/src/Controllers/User.php`:
- `apiUpdateBasicInfo` now calls `School::apiCreate(..., internal: true)` for the internal school creation.

`frontend/tests/controllers/RateLimiterTest.php`:
- Added `testSchoolCreateViaProfileUpdateNotRateLimited`: 6 profile updates with distinct new school names must not throw, while direct `School::apiCreate` calls still hit their own limit on the 6th.

## Test plan

- `testSchoolCreateViaProfileUpdateNotRateLimited` covers the regression (internal path not rate-limited; direct path still limited).
- Existing `testSchoolCreateRateLimit` continues to verify the direct endpoint is limited.
- The fix is minimal and does not change the public `/api/school/create` behavior for external callers.

Fixes #10077
