### PR TITLE
Optimizar actualización de max_points en assignments

### DIFF
--- a/frontend/server/src/DAO/Courses.php
+++ b/frontend/server/src/DAO/Courses.php
@@ -1252,16 +1252,12 @@ class Courses extends \OmegaUp\DAO\Base\Courses {
         string $assignment_alias
     ): int {
         $sql = 'UPDATE Assignments a
-                JOIN (
-                    SELECT assignment_id, sum(psp.points) as max_points
-                    FROM Assignments a
-                    INNER JOIN Problemset_Problems psp
-                        ON a.problemset_id = psp.problemset_id
-                    GROUP BY a.assignment_id
-                ) q
-                ON a.assignment_id = q.assignment_id
-                SET a.max_points = q.max_points
-                WHERE alias = ? AND course_id = ?;';
+                SET a.max_points = (
+                    SELECT IFNULL(SUM(psp.points), 0.0)
+                    FROM Problemset_Problems psp
+                    WHERE psp.problemset_id = a.problemset_id
+                )
+                WHERE a.alias = ? AND a.course_id = ?;';
 
         $params = [$assignment_alias, $course->course_id];
 

--- a/frontend/tests/controllers/AssignmentProblemsTest.php
+++ b/frontend/tests/controllers/AssignmentProblemsTest.php
@@ -170,6 +170,15 @@ class AssignmentProblemsTest extends \OmegaUp\Test\ControllerTestCase {
             'assignment' => $assignmentAlias,
         ]));
         $this->assertSame(0, sizeof($getAssignmentResponse['problems']));
+
+        $courseId = $courseData['course']->course_id;
+        $this->assertNotNull($courseId);
+        $assignment = \OmegaUp\DAO\Assignments::getByAliasAndCourse(
+            $assignmentAlias,
+            $courseId
+        );
+        $this->assertNotNull($assignment);
+        $this->assertSame(0.0, $assignment->max_points);
     }
 
     public function testAddRemoveProblems() {


### PR DESCRIPTION
# Description

Se optimiza la forma en la que se actualiza `max_points` en `Courses::updateAssignmentMaxPoints()`.

Antes, la consulta armaba una subconsulta con la suma de puntos de todos los assignments y despues filtraba el assignment que realmente se queria actualizar con `alias` y `course_id`.

Ahora primero se ubica ese assignment especifico y solo se suman los puntos de los problemas que pertenecen a su `problemset_id`.

Fixes: #10059

# Courses::updateAssignmentMaxPoints()

## Antes

| etapa | tipo | indice | rows |
|-------|------|--------|------|
| Assignment objetivo | const | assignment_alias | 1 |
| Subconsulta derivada | ref | auto_key | 1 |
| Assignments usados para calcular sumas | index | PRIMARY | N assignments |
| Problemas por assignment | ref | PRIMARY | M problemas |

Aunque el `UPDATE` terminaba afectando un solo assignment, la subconsulta derivada recorria `Assignments` y agrupaba por `assignment_id`.

Eso hacia que se calculara `SUM(points)` para assignments que no estaban relacionados con el cambio.

## Despues

| etapa | tipo | indice | rows |
|-------|------|--------|------|
| Assignment objetivo | const | assignment_alias | 1 |
| Problemas del assignment objetivo | ref | PRIMARY | M problemas |

Con el cambio, MySQL usa el indice de `course_id` y `alias` para encontrar el assignment, y despues usa `problemset_id` para sumar solo sus problemas en `Problemset_Problems`.

La mejora no cambia las tablas involucradas; lo que se evita es calcular la suma para todos los assignments cuando solo se necesita uno.

# Cambios

- DAO: se actualiza `updateAssignmentMaxPoints()` para quitar la subconsulta derivada que agrupaba todos los assignments.
- DAO: se calcula `max_points` a partir de los problemas del `problemset_id` del assignment actualizado.
- DAO: se usa `IFNULL(SUM(...), 0.0)` para que `max_points` quede en `0.0` si el assignment ya no tiene problemas.
- Tests: se agrega una validacion para confirmar que `max_points` vuelve a `0.0` al remover el ultimo problema de un assignment.
