### PR TITLE
fix(admin): preserve original exception when cache invalidation fails after commit

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -185,18 +185,18 @@ class Admin extends \OmegaUp\Controllers\Controller {
                 );
             }
             \OmegaUp\DAO\DAO::transEnd();
-
-            \OmegaUp\DAO\SystemSettings::invalidateCache(
-                self::MAINTENANCE_ENABLED_KEY,
-                self::MAINTENANCE_MESSAGE_ES_KEY,
-                self::MAINTENANCE_MESSAGE_EN_KEY,
-                self::MAINTENANCE_MESSAGE_PT_KEY,
-                self::MAINTENANCE_MESSAGE_TYPE_KEY
-            );
         } catch (\Exception $e) {
             \OmegaUp\DAO\DAO::transRollback();
             throw $e;
         }
+
+        \OmegaUp\DAO\SystemSettings::invalidateCache(
+            self::MAINTENANCE_ENABLED_KEY,
+            self::MAINTENANCE_MESSAGE_ES_KEY,
+            self::MAINTENANCE_MESSAGE_EN_KEY,
+            self::MAINTENANCE_MESSAGE_PT_KEY,
+            self::MAINTENANCE_MESSAGE_TYPE_KEY
+        );
         return ['status' => 'ok'];
     }
 

--- a/frontend/tests/controllers/AdminTest.php
+++ b/frontend/tests/controllers/AdminTest.php
@@ -86,4 +86,56 @@ class AdminTest extends \OmegaUp\Test\ControllerTestCase {
             \OmegaUp\Cache::clearCacheForTesting();
         }
     }
+
+    public function testMaintenanceModePreservesOriginalExceptionWhenCacheInvalidationFails() {
+        [
+            'identity' => $supportIdentity,
+        ] = \OmegaUp\Test\Factories\User::createSupportUser();
+        $supportLogin = \OmegaUp\Test\ControllerTestCase::login($supportIdentity);
+
+        $reflection = new \ReflectionClass(\OmegaUp\CacheAdapter::class);
+        $instanceProperty = $reflection->getProperty('_instance');
+        $instanceProperty->setAccessible(true);
+        $originalAdapter = $instanceProperty->getValue();
+        $throwingAdapter = new class extends \OmegaUp\InProcessCacheAdapter {
+            public function delete(string $key): bool {
+                throw new \RuntimeException('Simulated cache backend failure');
+            }
+        };
+        $instanceProperty->setValue($throwingAdapter);
+
+        $exception = null;
+        try {
+            \OmegaUp\Controllers\Admin::apiSetMaintenanceMode(
+                new \OmegaUp\Request([
+                    'auth_token' => $supportLogin->auth_token,
+                    'enabled' => true,
+                ])
+            );
+        } catch (\Exception $e) {
+            $exception = $e;
+        } finally {
+            $instanceProperty->setValue($originalAdapter);
+            \OmegaUp\Controllers\Admin::apiSetMaintenanceMode(
+                new \OmegaUp\Request([
+                    'auth_token' => $supportLogin->auth_token,
+                    'enabled' => false,
+                ])
+            );
+            \OmegaUp\Cache::clearCacheForTesting();
+        }
+
+        $this->assertNotNull(
+            $exception,
+            'Expected the cache failure to propagate as an exception'
+        );
+        $this->assertStringContainsString(
+            'Simulated cache backend failure',
+            $exception->getMessage()
+        );
+        $this->assertStringNotContainsString(
+            'Called FailTrans() outside of a transaction',
+            $exception->getMessage()
+        );
+    }
 }

--- a/frontend/tests/controllers/AdminTest.php
+++ b/frontend/tests/controllers/AdminTest.php
@@ -91,7 +91,9 @@ class AdminTest extends \OmegaUp\Test\ControllerTestCase {
         [
             'identity' => $supportIdentity,
         ] = \OmegaUp\Test\Factories\User::createSupportUser();
-        $supportLogin = \OmegaUp\Test\ControllerTestCase::login($supportIdentity);
+        $supportLogin = \OmegaUp\Test\ControllerTestCase::login(
+            $supportIdentity
+        );
 
         $reflection = new \ReflectionClass(\OmegaUp\CacheAdapter::class);
         $instanceProperty = $reflection->getProperty('_instance');


### PR DESCRIPTION
## Descripción

`Admin::apiSetMaintenanceMode` llamaba a `SystemSettings::invalidateCache()` dentro del bloque `try`, justo después de `transEnd()` (que ya había hecho commit y dejado la transacción en `_transactionCount = 0`). Si la invalidación de cache fallaba (por ejemplo, Redis caído), el `catch` ejecutaba `transRollback()` → `FailTrans()` con la transacción ya cerrada, lo que lanzaba una nueva `DatabaseOperationException("Called FailTrans() outside of a transaction")` y **descartaba silenciosamente** la excepción original.

Este cambio mueve `invalidateCache()` fuera del bloque `try/catch` de la transacción. Como la transacción ya fue comprometida exitosamente, una falla posterior en la cache se propaga directamente sin intentar un rollback espurio, de modo que el cliente y los logs ven el error real (p. ej. "Redis connection refused") en lugar del mensaje engañoso de `FailTrans`.

## Cambios

- `frontend/server/src/Controllers/Admin.php`: reubicar `SystemSettings::invalidateCache(...)` después del `catch`, fuera del alcance transaccional.
- `frontend/tests/controllers/AdminTest.php`: agregar `testMaintenanceModePreservesOriginalExceptionWhenCacheInvalidationFails`, que inyecta un `CacheAdapter` que falla en `delete()` y verifica que la excepción original se propague y que no aparezca el error de `FailTrans`.

## Pruebas

- Test nuevo: `testMaintenanceModePreservesOriginalExceptionWhenCacheInvalidationFails`
- Test existente: `testMaintenanceModePersistsOutsideCache` sigue cubriendo el camino feliz.

Fixes #10097
