### PR TITLE
fix(arena): commit the polled scoreboard so the fallback keeps the arena alive

### DIFF
--- a/frontend/www/js/omegaup/arena/events_socket.test.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.test.ts
@@ -15,7 +15,13 @@ import { clarificationStoreConfig } from './clarificationsStore';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import fetchMock from 'jest-fetch-mock';
-import { onRankingChanged, onRankingEvents } from './ranking';
+import {
+  createChart,
+  onRankingChanged,
+  onRankingEvents,
+  onVirtualRankingChanged,
+} from './ranking';
+import rankingStore from './rankingStore';
 import { mocked } from 'ts-jest/utils';
 import { ScoreMode } from './navigation';
 
@@ -55,6 +61,25 @@ const options: SocketOptions = {
   intervalInMilliseconds: 500,
   scoreMode: ScoreMode.Partial,
 };
+
+// The polling fallback is several promise hops deep -- scoreboard fetch,
+// commit, scoreboardEvents fetch, chart. Fake timers are installed, so reach
+// past them to the real macrotask queue to let every hop settle.
+const { setImmediate: realSetImmediate } = jest.requireActual('timers');
+const flushPromises = (): Promise<void> =>
+  new Promise((resolve) => realSetImmediate(resolve));
+
+// Fallback intervals outlive the test that armed them, and afterEach's
+// runOnlyPendingTimers would fire them against a torn-down server.
+const stopPolling = (client: EventsSocket): void => {
+  const internals = client as any;
+  clearInterval(internals.clarificationInterval);
+  clearInterval(internals.rankingInterval);
+  internals.clarificationInterval = null;
+  internals.rankingInterval = null;
+  internals.pollingActive = false;
+};
+
 describe('EventsSocket', () => {
   let server: WS | null = null;
 
@@ -279,6 +304,150 @@ describe('EventsSocket', () => {
 
     // Clean up keepalive timer so afterEach's runOnlyPendingTimers doesn't fire on a closed socket
     (client as any).onclose();
+  });
+
+  it('should commit the polled scoreboard to the ranking store', async () => {
+    mocked(onRankingChanged, true).mockReset();
+    mocked(onRankingEvents, false).mockReset();
+    mocked(createChart, false).mockReset();
+
+    const ranking: types.ScoreboardRankingEntry[] = [
+      {
+        classname: 'user-rank-unranked',
+        country: 'MX',
+        is_invited: true,
+        place: 1,
+        problems: [],
+        total: { penalty: 20, points: 100 },
+        username: 'omegaUp',
+      },
+    ];
+    const miniRankingUsers = [
+      {
+        classname: 'user-rank-unranked',
+        country: 'MX',
+        position: 1,
+        penalty: 20,
+        points: 100,
+        username: 'omegaUp',
+      },
+    ];
+    const lastTimeUpdated = new Date(1674625378734);
+
+    mocked(onRankingChanged, true).mockReturnValue({
+      users: miniRankingUsers,
+      ranking,
+      currentRanking: { omegaUp: 0 },
+      maxPoints: 200,
+      lastTimeUpdated,
+    });
+    mocked(onRankingEvents, false).mockReturnValue({
+      series: [
+        {
+          type: 'line',
+          rank: 0,
+          data: [[1674625378734, 100]],
+          name: 'omegaUp',
+          step: 'right',
+        },
+      ],
+      navigatorData: [[1674625378734, 100]],
+    });
+
+    rankingStore.commit('updateRanking', []);
+    rankingStore.commit('updateMiniRankingUsers', []);
+    rankingStore.commit('updateLastTimeUpdated', null);
+
+    const client = new EventsSocket({ ...options, disableSockets: false });
+    (client as any).socket = null;
+    (client as any).setupPolls();
+    await flushPromises();
+
+    // The socket path commits all three of these; the fallback used to call
+    // onRankingChanged and drop the result on the floor.
+    expect(rankingStore.state.ranking).toEqual(ranking);
+    expect(rankingStore.state.miniRankingUsers).toEqual(miniRankingUsers);
+    expect(rankingStore.state.lastTimeUpdated).toEqual(lastTimeUpdated);
+    expect(createChart).toHaveBeenCalled();
+
+    stopPolling(client);
+  });
+
+  it('should route virtual contests through onVirtualRankingChanged while polling', async () => {
+    mocked(onRankingChanged, true).mockReset();
+    mocked(onVirtualRankingChanged, false).mockReset();
+
+    const client = new EventsSocket({
+      ...options,
+      disableSockets: false,
+      isVirtual: true,
+      originalProblemsetId: 2,
+    });
+    (client as any).socket = null;
+    (client as any).setupPolls();
+    await flushPromises();
+
+    expect(onVirtualRankingChanged).toHaveBeenCalled();
+    expect(onRankingChanged).not.toHaveBeenCalled();
+
+    stopPolling(client);
+  });
+
+  it('should start polling when the socket gives up reconnecting', () => {
+    const client = new EventsSocket({ ...options, disableSockets: false });
+
+    // A socket that connected once and then dropped for good: the retry
+    // budget is spent, so onclose takes the give-up branch.
+    client.shouldRetry = true;
+    client.retries = 0;
+    (client as any).onclose();
+
+    expect(client.socketStatus).toEqual(SocketStatus.Failed);
+    expect((client as any).clarificationInterval).not.toBeNull();
+    expect((client as any).rankingInterval).not.toBeNull();
+
+    stopPolling(client);
+  });
+
+  it('should arm the fallback only once across repeated close events', () => {
+    const client = new EventsSocket({ ...options, disableSockets: false });
+
+    client.shouldRetry = true;
+    client.retries = 0;
+    (client as any).onclose();
+
+    const clarificationInterval = (client as any).clarificationInterval;
+    const rankingInterval = (client as any).rankingInterval;
+    expect(clarificationInterval).not.toBeNull();
+    expect(rankingInterval).not.toBeNull();
+
+    (client as any).onclose();
+
+    expect((client as any).clarificationInterval).toBe(clarificationInterval);
+    expect((client as any).rankingInterval).toBe(rankingInterval);
+
+    stopPolling(client);
+  });
+
+  it('should spend the whole retry budget on repeated reconnect failures', () => {
+    const client = new EventsSocket({ ...options, disableSockets: false });
+
+    // connectSocket used to clear shouldRetry on every attempt, so the first
+    // failed reconnect fell through to the give-up branch and the remaining
+    // nine retries were never spent.
+    client.shouldRetry = true;
+    (client as any).connectSocket().catch(() => {});
+    expect(client.shouldRetry).toEqual(true);
+
+    (client as any).onclose();
+    expect(client.retries).toEqual(9);
+    expect(client.socketStatus).toEqual(SocketStatus.Waiting);
+
+    (client as any).onclose();
+    expect(client.retries).toEqual(8);
+    expect(client.socketStatus).toEqual(SocketStatus.Waiting);
+
+    stopPolling(client);
   });
 
   it('should handle a socket when server sends /run/update/ message', async () => {

--- a/frontend/www/js/omegaup/arena/events_socket.ts
+++ b/frontend/www/js/omegaup/arena/events_socket.ts
@@ -63,6 +63,7 @@ export class EventsSocket {
   socketStatus: SocketStatus = SocketStatus.Waiting;
   private clarificationInterval: ReturnType<typeof setTimeout> | null = null;
   private rankingInterval: ReturnType<typeof setTimeout> | null = null;
+  private pollingActive: boolean = false;
   private clarificationsOffset: number;
   private readonly clarificationsRowcount: number;
   private readonly currentUsername: string;
@@ -107,6 +108,7 @@ export class EventsSocket {
     this.socketStatus = SocketStatus.Waiting;
     this.clarificationInterval = null;
     this.rankingInterval = null;
+    this.pollingActive = false;
     this.intervalInMilliseconds = intervalInMilliseconds;
     this.scoreMode = scoreMode;
     this.onProblemListChanged = onProblemListChanged;
@@ -195,6 +197,18 @@ export class EventsSocket {
     if (scoreboard.finish_time != null) {
       scoreboard.finish_time = time.remoteTime(finishTime * 1000);
     }
+    this.updateRankings({ scoreboard });
+  }
+
+  // The socket path and the polling fallback have to leave the ranking store in
+  // the same state, and they drifted apart because each carried its own copy of
+  // this. processRankings normalizes the socket payload's epoch timestamps
+  // before delegating here.
+  private updateRankings({
+    scoreboard,
+  }: {
+    scoreboard: types.Scoreboard;
+  }): void {
     if (this.isVirtual) {
       api.Problemset.scoreboardEvents({
         problemset_id: this.originalProblemsetId,
@@ -288,6 +302,9 @@ export class EventsSocket {
       clearInterval(this.socketKeepalive);
       this.socketKeepalive = null;
     }
+    // The socket is down: keep the scoreboard moving until it comes back
+    // (`onopen` clears these intervals) or we stop trying altogether.
+    this.setupPolls();
     if (this.shouldRetry && this.retries > 0) {
       this.retries--;
       this.socketStatus = SocketStatus.Waiting;
@@ -303,7 +320,6 @@ export class EventsSocket {
   }
 
   private connectSocket(): Promise<void> {
-    this.shouldRetry = false;
     return new Promise((accept, reject) => {
       try {
         const socket = new WebSocket(this.uri, 'com.omegaup.events');
@@ -322,6 +338,7 @@ export class EventsSocket {
             clearInterval(this.rankingInterval);
             this.rankingInterval = null;
           }
+          this.pollingActive = false;
           this.socketKeepalive = setInterval(
             () => socket.send('"ping"'),
             this.intervalInMilliseconds,
@@ -365,32 +382,27 @@ export class EventsSocket {
       });
   }
 
-  private setupPolls(): void {
+  // The API layer has already turned time, start_time and finish_time into
+  // Date objects, so the payload goes to updateRankings as-is: the epoch
+  // conversion processRankings does would be wrong here.
+  private refreshRanking(): void {
     api.Problemset.scoreboard({
       problemset_id: this.problemsetId,
       token: this.scoreboardToken,
     })
-      .then((scoreboard) => {
-        const { currentRanking } = onRankingChanged({
-          scoreboard,
-          currentUsername: this.currentUsername,
-          navbarProblems: this.navbarProblems,
-          scoreMode: this.scoreMode,
-        });
-
-        api.Problemset.scoreboardEvents({
-          problemset_id: this.problemsetId,
-          token: this.scoreboardToken,
-        })
-          .then((response) =>
-            onRankingEvents({
-              events: response.events,
-              currentRanking,
-            }),
-          )
-          .catch(ui.ignoreError);
-      })
+      .then((scoreboard) => this.updateRankings({ scoreboard }))
       .catch(ui.ignoreError);
+  }
+
+  private setupPolls(): void {
+    // `onclose` reaches here on every failed reconnect, and the initial
+    // `connect()` failure schedules it as well. Without this the intervals
+    // below would be armed a second time and the old pair leaked.
+    if (this.pollingActive) {
+      return;
+    }
+
+    this.refreshRanking();
     if (!this.problemsetAlias) {
       return;
     }
@@ -402,6 +414,7 @@ export class EventsSocket {
     });
 
     if (!this.socket) {
+      this.pollingActive = true;
       this.clarificationInterval = setInterval(() => {
         this.clarificationsOffset = 0; // Return pagination to start on refresh
         if (this.problemsetAlias) {
@@ -415,31 +428,7 @@ export class EventsSocket {
       }, this.intervalInMilliseconds);
 
       this.rankingInterval = setInterval(() => {
-        api.Problemset.scoreboard({
-          problemset_id: this.problemsetId,
-          token: this.scoreboardToken,
-        })
-          .then((scoreboard) => {
-            const { currentRanking } = onRankingChanged({
-              scoreboard,
-              currentUsername: this.currentUsername,
-              navbarProblems: this.navbarProblems,
-              scoreMode: this.scoreMode,
-            });
-
-            api.Problemset.scoreboardEvents({
-              problemset_id: this.problemsetId,
-              token: this.scoreboardToken,
-            })
-              .then((response) =>
-                onRankingEvents({
-                  events: response.events,
-                  currentRanking,
-                }),
-              )
-              .catch(ui.ignoreError);
-          })
-          .catch(ui.ignoreError);
+        this.refreshRanking();
       }, this.intervalInMilliseconds);
     }
   }


### PR DESCRIPTION
# Description

Fixes: #10095

When the `/events/` WebSocket is unavailable, the arena's polling fallback fetched the scoreboard and then threw the result away, so the ranking table, mini-ranking and chart stopped updating while the client kept issuing two API calls per interval per open tab. Clarifications kept refreshing — `refreshContestClarifications` commits internally — which is likely why this went unnoticed: the page looks half alive.

Three changes, matching the scope agreed in the issue.

**1. The fallback produces the same store state as the socket path.** `setupPolls` called `onRankingChanged` and `onRankingEvents` — both pure functions that commit nothing — and dropped what they returned. The commit half of `processRankings` is extracted into `updateRankings`, and both paths now go through it, so `updateRanking`, `updateMiniRankingUsers`, `updateLastTimeUpdated` and the chart are all refreshed while polling. Virtual contests route through `onVirtualRankingChanged`, which `setupPolls` ignored entirely — without that it would have committed the wrong ranking for virtual contests as soon as the commits were added.

**2. Polling starts when the socket is down.** `setupPolls` was reachable only from the `.catch` of the *initial* `connect()`. The terminal branch of `onclose()` set `SocketStatus.Failed` and returned, so a socket that died *after* connecting left the arena with neither socket nor polling for the rest of the session. `onclose()` now arms the fallback, guarded by a `pollingActive` flag so repeated closes cannot stack a second pair of intervals. `onopen` already cleared the intervals on reconnect and now clears the flag with them.

**3. The retry budget is no longer reset on every attempt.** `connectSocket()` set `shouldRetry = false` on each call while only `onopen` set it back, so the first failed reconnect fell through to the give-up branch and nine of the ten retries were never spent. The field already defaults to `false`, so removing that line leaves initial-connect behaviour unchanged — still no retry, straight to the fallback — and lets a socket that has connected at least once actually spend its budget.

The shared helper is the mechanism of the fix rather than a refactor bolted onto it: the two paths drifted precisely because each had its own copy of "scoreboard payload → store state", so having one of them call the other is what makes them stay in agreement. It also shrinks the file — the two identical copies of the poll body inside `setupPolls`, the immediate call and the `setInterval` one, collapse into a single `refreshRanking()` — so it does not run into the "significantly larger" caveat you raised.

**Deliberately not done here:** the issue also notes that "scoreboard payload → store state" lives in three places — `processRankings`, `setupPolls`, and the inline `setInterval` in `arena/scoreboard.ts`. This PR unifies the first two because they are the defect; `arena/scoreboard.ts` is untouched, left for the follow-up you suggested.

# Comments

**One judgement call worth flagging.** You asked for the fallback to start "when the socket gives up reconnecting". It is armed on *every* close instead, not only on the give-up branch. The reason is change 3: once the retry budget is real, giving up takes up to ten backoffs of `Math.random() * intervalInMilliseconds / 2`, so binding the fallback to the give-up branch alone would leave the scoreboard frozen for that whole window — the very symptom being fixed. Arming on close costs one call site, reuses the `onopen` cleanup added in #9507, and still satisfies "starts when it gives up", because by then it is already running. Happy to move it to the give-up branch alone if you would rather keep the change literal.

A visible side effect of the same change: during a reconnect the status glyph now stays `↻` for the length of the retry budget instead of flipping to `✗` after a single failed attempt, and the scoreboard keeps moving underneath it.

**One overlap worth naming.** Of the five `EventsSocket` call sites, three — `contest_contestant.ts`, `contest_virtual.ts` and `course.ts` — have no other scoreboard refresh at all, and those are the ones that froze. The other two, the standalone token-scoreboard pages `arena/scoreboard.ts` and `course/scoreboard.ts`, already run their own unconditional 5-minute `setInterval`, so on those the fallback now overlaps an existing poll. It is not pure duplication — their inline interval commits only `updateRanking` and `updateLastTimeUpdated`, so the fallback is what fills in the mini-ranking and the chart — but it is a second identical fetch on the same 5-minute cadence. That overlap already existed on the initial-connect-failure path; this change makes it reachable when the socket dies later too. It is also the third copy of the ranking logic from the issue, so it resolves itself in the follow-up PR.

**Tests.** Five cases added to `frontend/www/js/omegaup/arena/events_socket.test.ts`, covering the scenarios above:

- `should commit the polled scoreboard to the ranking store` — the repro from the issue: asserts `rankingStore.state.ranking`, `miniRankingUsers` and `lastTimeUpdated`, plus that the chart is built.
- `should route virtual contests through onVirtualRankingChanged while polling`
- `should start polling when the socket gives up reconnecting`
- `should arm the fallback only once across repeated close events`
- `should spend the whole retry budget on repeated reconnect failures`

All five fail against `main` and pass here. Full frontend suite: 192 suites, 905 passed, 3 skipped, 0 failed (`yarn test`); `eslint` and `prettier --check` clean on both files.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.

<sub>The diff is 256 lines, of which 171 are the new Jest tests; the fix itself is ~85 lines in one file. It is entirely frontend + Jest, so the split the checklist describes (controllers/PHPUnit vs UI/Jest) does not apply — say the word if you would still prefer it broken up.</sub>
