### PR TITLE
Normalizar consultas SQL para detectar patrones equivalentes

### DIFF
--- a/frontend/badges/javaExpert/query.sql
+++ b/frontend/badges/javaExpert/query.sql
@@ -14,7 +14,7 @@ WHERE
     `r`.`verdict` = "AC" AND
     `s`.`type` = "normal" AND
     `p`.`visibility` >= 2 AND
-    `s`.`language`= 'java'
+    `s`.`language` = 'java'
 GROUP BY
     `u`.`user_id`
 HAVING

--- a/stuff/process_mysql_explain_logs.py
+++ b/stuff/process_mysql_explain_logs.py
@@ -22,11 +22,13 @@ def normalize_query(query: str) -> str:
     Replaces:
     - numbers with '?'
     - single-quoted and double-quoted strings with '?'
+    - consecutive whitespace with a single space
     '''
     query = re.sub(r'\b\d+\b', '?', query)
     query = re.sub(r"'[^']*'", '?', query)
     query = re.sub(r'"[^"]*"', '?', query)
-    return query
+    query = re.sub(r'\s+', ' ', query)
+    return query.strip()
 
 
 def create_connection(

--- a/stuff/process_mysql_explain_logs_test.py
+++ b/stuff/process_mysql_explain_logs_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+'''Unit tests for the MySQL EXPLAIN log processor.'''
+
+import pytest
+
+from process_mysql_explain_logs import normalize_query
+
+
+@pytest.mark.parametrize(
+    ('query', 'expected'),
+    [
+        (
+            'SELECT * FROM Users WHERE user_id = 123',
+            'SELECT * FROM Users WHERE user_id = ?',
+        ),
+        (
+            "SELECT * FROM Users WHERE username = 'alice'",
+            'SELECT * FROM Users WHERE username = ?',
+        ),
+        (
+            'SELECT * FROM Users WHERE username = "alice"',
+            'SELECT * FROM Users WHERE username = ?',
+        ),
+    ],
+)
+def test_normalize_query_replaces_literals(
+    query: str,
+    expected: str,
+) -> None:
+    '''Literal values are replaced with placeholders.'''
+    assert normalize_query(query) == expected
+
+
+def test_normalize_query_collapses_whitespace() -> None:
+    '''Equivalent formatting produces the same normalized query.'''
+    single_line = 'SELECT * FROM Users WHERE user_id = 10'
+    multiline = '''
+        SELECT  *
+        FROM Users
+        WHERE user_id = 20
+    '''
+
+    expected = 'SELECT * FROM Users WHERE user_id = ?'
+    assert normalize_query(single_line) == expected
+    assert normalize_query(multiline) == expected
+
+
+def test_normalize_query_preserves_query_structure() -> None:
+    '''Structurally different queries remain different.'''
+    select_all = 'SELECT * FROM Users WHERE user_id = 10'
+    select_username = 'SELECT username FROM Users WHERE user_id = 10'
+
+    assert normalize_query(select_all) != normalize_query(select_username)


### PR DESCRIPTION
# Description

Se mejora `normalize_query()` para que consultas equivalentes tengan la misma representación aunque contengan espacios repetidos, tabulaciones o saltos de línea.

Antes, estas consultas podían considerarse diferentes por su formato:

```sql
SELECT * FROM Users WHERE user_id = 10;
```

```sql
SELECT  *
FROM Users
WHERE user_id = 20;
```

Ahora ambas se normalizan como:

```sql
SELECT * FROM Users WHERE user_id = ?;
```

El cambio mantiene el reemplazo actual de números y cadenas, y no modifica todavía la deduplicación ni el comportamiento de CI.

Fixes: #10103

# Cambios

- Se normalizan espacios, tabulaciones y saltos de línea.
- Se eliminan espacios al inicio y al final.
- Se agregan pruebas para literales, formatos equivalentes y consultas estructuralmente diferentes.
