### PR TITLE
Fix #10116: Allow skipping assignee check for self-authored issues

### DIFF
--- a/.github/workflows/check-pr-issue.yml
+++ b/.github/workflows/check-pr-issue.yml
@@ -23,6 +23,9 @@ jobs:
                     closingIssuesReferences(first: 10) {
                       nodes {
                         number
+                        author {
+                          login
+                        }
                         assignees(first: 10) {
                           nodes {
                             login
@@ -78,9 +81,10 @@ jobs:
                 });
 
                 const assignees = issue.data.assignees.map(node => node.login.toLowerCase());
-                console.log(`Issue #${issueNumber} assignees: ${JSON.stringify(assignees)}`);
+                const issueAuthor = issue.data.user ? issue.data.user.login.toLowerCase() : "";
+                console.log(`Issue #${issueNumber} assignees: ${JSON.stringify(assignees)}, author: ${issueAuthor}`);
 
-                if (assignees.includes(prAuthor)) {
+                if (assignees.includes(prAuthor) || prAuthor === issueAuthor) {
                   isAssigned = true;
                   break;
                 }
@@ -101,9 +105,10 @@ jobs:
             for (const issue of linkedIssues) {
               linkedIssueNumbers.push("#" + issue.number);
               const assignees = issue.assignees.nodes.map(node => node.login.toLowerCase());
-              console.log(`Issue #${issue.number} assignees: ${JSON.stringify(assignees)}`);
+              const issueAuthor = (issue.author && issue.author.login) ? issue.author.login.toLowerCase() : "";
+              console.log(`Issue #${issue.number} assignees: ${JSON.stringify(assignees)}, author: ${issueAuthor}`);
               
-              if (assignees.includes(prAuthor)) {
+              if (assignees.includes(prAuthor) || prAuthor === issueAuthor) {
                 isAssigned = true;
                 break;
               }


### PR DESCRIPTION
Resolves #10116

**What this PR does / why we need it**:
This PR updates the `.github/workflows/check-pr-issue.yml` workflow to resolve an issue where external contributors who create an issue and resolve it in a PR are blocked by the CI checks if they are not assigned to the issue. 

Since contributors often do not have permissions to self-assign their own issues, this PR implements a native exemption: if the PR author is the exact same user who authored the linked issue, the assignee requirement is safely skipped. 

**Changes made**:
- Updated the GraphQL query to fetch the `author` login for `closingIssuesReferences`.
- Updated the REST API fallback logic to correctly identify the issue's author (`issue.data.user.login`).
- Relaxed the assignee validation check (`assignees.includes(prAuthor)`) to automatically pass if `prAuthor === issueAuthor`. 
- Existing permission exemptions (OWNER, MEMBER, COLLABORATOR, Dependabot) and the core linked-issue requirement remain strictly enforced.

**Which issue(s) this PR fixes**:
Fixes #10116
