### PR TITLE
Agrupar consultas similares con Query Family

### DIFF
--- a/stuff/process_mysql_explain_logs.py
+++ b/stuff/process_mysql_explain_logs.py
@@ -31,6 +31,16 @@ def normalize_query(query: str) -> str:
     return query.strip()
 
 
+def build_query_family(normalized_query: str) -> str:
+    '''Return a broader representation used only to group CSV rows.'''
+    return re.sub(
+        r'\bIN\s*\(\s*\?(?:\s*,\s*\?)*\s*\)',
+        'IN (?)',
+        normalized_query,
+        flags=re.IGNORECASE,
+    )
+
+
 def build_inefficiency_key(
     result: Dict[str, str],
 ) -> Tuple[str, str]:
@@ -51,6 +61,21 @@ def deduplicate_results(
         seen.add(key)
         deduplicated.append(result)
     return deduplicated
+
+
+def sort_results_for_csv(
+    results: Iterable[Dict[str, str]],
+) -> List[Dict[str, str]]:
+    '''Sort results so similar query families are adjacent in the CSV.'''
+    return sorted(
+        results,
+        key=lambda result: (
+            result['Query Family'],
+            result['Normalized Query'],
+            result['Table'],
+            int(result['Query ID']),
+        ),
+    )
 
 
 def create_connection(
@@ -164,6 +189,7 @@ def explain_queries(
     try:
         for query in queries_list:
             query_text = query[0]
+            normalized_query = normalize_query(query_text)
             if query_text not in query_id_map:
                 query_id_map[query_text] = len(query_id_map) + 1
 
@@ -231,7 +257,8 @@ def explain_queries(
                     results.append({
                         "Query ID": str(query_id_map[query_text]),
                         "Query": query_text,
-                        "Normalized Query": normalize_query(query_text),
+                        "Normalized Query": normalized_query,
+                        "Query Family": build_query_family(normalized_query),
                         "Table": table_name,
                         "Type": str(row[type_idx]),
                         "Key": "" if key_val is None else str(key_val),
@@ -266,6 +293,7 @@ def save_to_csv(results: List[Dict[str, str]]) -> Optional[str]:
             "Query ID",
             "Query",
             "Normalized Query",
+            "Query Family",
             "Table",
             "Type",
             "Key",
@@ -275,7 +303,7 @@ def save_to_csv(results: List[Dict[str, str]]) -> Optional[str]:
         with open(path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
-            writer.writerows(results)
+            writer.writerows(sort_results_for_csv(results))
         return path
     except Error as exc:
         logging.error("Failed to save CSV: %s", exc)

--- a/stuff/process_mysql_explain_logs_test.py
+++ b/stuff/process_mysql_explain_logs_test.py
@@ -7,8 +7,10 @@ import pytest
 
 from process_mysql_explain_logs import (
     build_inefficiency_key,
+    build_query_family,
     deduplicate_results,
     normalize_query,
+    sort_results_for_csv,
 )
 
 
@@ -20,6 +22,7 @@ def _result(
     return {
         'Query ID': query_id,
         'Normalized Query': normalized_query,
+        'Query Family': build_query_family(normalized_query),
         'Table': table,
     }
 
@@ -71,6 +74,30 @@ def test_normalize_query_preserves_query_structure() -> None:
     assert normalize_query(select_all) != normalize_query(select_username)
 
 
+@pytest.mark.parametrize(
+    'normalized_query',
+    [
+        'SELECT * FROM Users WHERE user_id IN (?)',
+        'SELECT * FROM Users WHERE user_id IN (?, ?)',
+        'SELECT * FROM Users WHERE user_id IN (?,?,?)',
+    ],
+)
+def test_build_query_family_groups_variable_in_lists(
+    normalized_query: str,
+) -> None:
+    '''Placeholder lists of different sizes belong to the same family.'''
+    expected = 'SELECT * FROM Users WHERE user_id IN (?)'
+    assert build_query_family(normalized_query) == expected
+
+
+def test_build_query_family_preserves_query_structure() -> None:
+    '''Structurally different predicates remain in different families.'''
+    equals = 'SELECT * FROM Users WHERE user_id = ?'
+    in_list = 'SELECT * FROM Users WHERE user_id IN (?, ?)'
+
+    assert build_query_family(equals) != build_query_family(in_list)
+
+
 def test_inefficiency_key_does_not_depend_on_query_id() -> None:
     '''Log ordering does not affect an inefficiency identity.'''
     first = _result('1', 'SELECT * FROM Users', 'Users')
@@ -102,3 +129,37 @@ def test_deduplicate_results_uses_query_and_table() -> None:
         duplicate,
         other_table,
     ]) == [first, other_table]
+
+
+def test_deduplicate_results_does_not_use_query_family() -> None:
+    '''Queries in the same family are not removed as duplicates.'''
+    two_values = _result(
+        '1',
+        'SELECT * FROM Users WHERE user_id IN (?, ?)',
+        'Users',
+    )
+    three_values = _result(
+        '2',
+        'SELECT * FROM Users WHERE user_id IN (?, ?, ?)',
+        'Users',
+    )
+
+    assert deduplicate_results([
+        two_values,
+        three_values,
+    ]) == [two_values, three_values]
+
+
+def test_sort_results_for_csv_uses_review_order() -> None:
+    '''CSV rows are ordered by family, normalized query, table and ID.'''
+    second_id = _result('2', 'SELECT * FROM B', 'Users')
+    first_id = _result('1', 'SELECT * FROM B', 'Users')
+    other_table = _result('3', 'SELECT * FROM B', 'Courses')
+    first_family = _result('4', 'SELECT * FROM A', 'Users')
+
+    assert sort_results_for_csv([
+        second_id,
+        other_table,
+        first_family,
+        first_id,
+    ]) == [first_family, other_table, first_id, second_id]


### PR DESCRIPTION
# Descripcion

Agregue `Query Family` al reporte de consultas ineficientes para mostrar juntas las consultas que tienen la misma estructura, pero diferente cantidad de valores en una clausula `IN`.

Por ejemplo:

```text
IN (?, ?)
IN (?, ?, ?)
    ↓
IN (?)
```

`Query Family` se utiliza unicamente para agrupar y ordenar el CSV. La deduplicación continúa utilizando `(Normalized Query, Table)`, por lo que no se pierde ningún resultado.

Tambien agregue la nueva columna al CSV y se ordenan los registros porfamilia, consulta normalizada, tabla y `Query ID`.

- Este PR esta construido sobre #10114, ya que mantiene la deduplicacion definida en ese cambio y agrega la agrupacion visual.

Fixes: #10113
