### PR TITLE
Definir y validar el formato de la allowlist de consultas ineficientes

### DIFF
--- a/stuff/inefficient_queries_allowlist.yml
+++ b/stuff/inefficient_queries_allowlist.yml
@@ -1,0 +1,2 @@
+version: 1
+entries: []

--- a/stuff/process_mysql_explain_logs.py
+++ b/stuff/process_mysql_explain_logs.py
@@ -11,8 +11,26 @@ from typing import Any, Iterable, Tuple, Optional, List, Dict, Set
 import configparser
 import re
 import mysql.connector
+import yaml
 from mysql.connector import Error  # type: ignore
 from tqdm import tqdm  # type: ignore
+
+
+ALLOWLIST_VERSION = 1
+ALLOWLIST_ENTRY_FIELDS = {
+    'normalized_query',
+    'table',
+    'issue',
+    'reason',
+}
+DEFAULT_ALLOWLIST_PATH = os.path.join(
+    os.path.dirname(__file__),
+    'inefficient_queries_allowlist.yml',
+)
+
+
+class AllowlistValidationError(ValueError):
+    '''Raised when the inefficient queries allowlist is not valid.'''
 
 
 def normalize_query(query: str) -> str:
@@ -39,6 +57,118 @@ def build_query_family(normalized_query: str) -> str:
         normalized_query,
         flags=re.IGNORECASE,
     )
+
+
+def _get_non_empty_string(
+    entry: Dict[str, Any],
+    field: str,
+    entry_number: int,
+) -> str:
+    '''Return a required string field from an allowlist entry.'''
+    value = entry.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise AllowlistValidationError(
+            f'Allowlist entry {entry_number} field "{field}" must be '
+            'a non-empty string.'
+        )
+    if value != value.strip():
+        raise AllowlistValidationError(
+            f'Allowlist entry {entry_number} field "{field}" must not '
+            'have leading or trailing whitespace.'
+        )
+    return value
+
+
+def load_allowlist(path: str) -> List[Dict[str, Any]]:
+    '''Load and validate the inefficient queries allowlist.'''
+    try:
+        with open(path, 'r', encoding='utf-8') as allowlist_file:
+            data = yaml.safe_load(allowlist_file)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f'Allowlist file not found: {path}'
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise AllowlistValidationError(
+            f'Invalid YAML in allowlist {path}: {exc}'
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise AllowlistValidationError(
+            'Allowlist must be a mapping with "version" and "entries".'
+        )
+
+    expected_top_level_fields = {'version', 'entries'}
+    if set(data) != expected_top_level_fields:
+        raise AllowlistValidationError(
+            'Allowlist must contain exactly the fields "version" and '
+            '"entries".'
+        )
+
+    version = data['version']
+    if (
+        not isinstance(version, int)
+        or isinstance(version, bool)
+        or version != ALLOWLIST_VERSION
+    ):
+        raise AllowlistValidationError(
+            f'Allowlist version must be {ALLOWLIST_VERSION}.'
+        )
+
+    entries = data['entries']
+    if not isinstance(entries, list):
+        raise AllowlistValidationError(
+            'Allowlist field "entries" must be a list.'
+        )
+
+    validated_entries: List[Dict[str, Any]] = []
+    seen: Set[Tuple[str, str]] = set()
+    for entry_number, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise AllowlistValidationError(
+                f'Allowlist entry {entry_number} must be a mapping.'
+            )
+        if set(entry) != ALLOWLIST_ENTRY_FIELDS:
+            raise AllowlistValidationError(
+                f'Allowlist entry {entry_number} must contain exactly: '
+                'normalized_query, table, issue, reason.'
+            )
+
+        normalized_query = _get_non_empty_string(
+            entry,
+            'normalized_query',
+            entry_number,
+        )
+        if normalize_query(normalized_query) != normalized_query:
+            raise AllowlistValidationError(
+                f'Allowlist entry {entry_number} field '
+                '"normalized_query" must already be normalized.'
+            )
+
+        table = _get_non_empty_string(entry, 'table', entry_number)
+        _get_non_empty_string(entry, 'reason', entry_number)
+
+        issue = entry['issue']
+        if (
+            not isinstance(issue, int)
+            or isinstance(issue, bool)
+            or issue <= 0
+        ):
+            raise AllowlistValidationError(
+                f'Allowlist entry {entry_number} field "issue" must be '
+                'a positive integer.'
+            )
+
+        identity = (normalized_query, table)
+        if identity in seen:
+            raise AllowlistValidationError(
+                f'Allowlist entry {entry_number} duplicates the identity '
+                f'{identity}.'
+            )
+        seen.add(identity)
+        validated_entries.append(entry)
+
+    return validated_entries
 
 
 def build_inefficiency_key(
@@ -314,6 +444,12 @@ def _main() -> None:
     """
     Main function to handle the logic.
     """
+    try:
+        load_allowlist(DEFAULT_ALLOWLIST_PATH)
+    except (OSError, AllowlistValidationError) as exc:
+        logging.error('Failed to load allowlist: %s', exc)
+        sys.exit(1)
+
     connection = create_connection(
         host_name="mysql",
         port=13306,

--- a/stuff/process_mysql_explain_logs_test.py
+++ b/stuff/process_mysql_explain_logs_test.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 '''Unit tests for the MySQL EXPLAIN log processor.'''
 
+from pathlib import Path
 from typing import Dict
 
 import pytest
 
 from process_mysql_explain_logs import (
+    AllowlistValidationError,
     build_inefficiency_key,
     build_query_family,
     deduplicate_results,
+    load_allowlist,
     normalize_query,
     sort_results_for_csv,
 )
@@ -163,3 +166,162 @@ def test_sort_results_for_csv_uses_review_order() -> None:
         first_family,
         first_id,
     ]) == [first_family, other_table, first_id, second_id]
+
+
+def test_load_allowlist_accepts_an_empty_list(
+    tmp_path: Path,
+) -> None:
+    '''An empty versioned allowlist is valid.'''
+    allowlist = tmp_path / 'allowlist.yml'
+    allowlist.write_text(
+        'version: 1\nentries: []\n',
+        encoding='utf-8',
+    )
+
+    assert not load_allowlist(str(allowlist))
+
+
+def test_load_allowlist_accepts_valid_entries(
+    tmp_path: Path,
+) -> None:
+    '''Valid entries preserve their order and fields.'''
+    allowlist = tmp_path / 'allowlist.yml'
+    allowlist.write_text(
+        '''
+version: 1
+entries:
+  - normalized_query: SELECT * FROM Contests WHERE contest_id = ?
+    table: Contests
+    issue: 10130
+    reason: Known query pending optimization
+  - normalized_query: SELECT * FROM Problems WHERE alias = ?
+    table: Problems
+    issue: 10131
+    reason: Full scan accepted for this small table
+'''.lstrip(),
+        encoding='utf-8',
+    )
+
+    assert load_allowlist(str(allowlist)) == [
+        {
+            'normalized_query': (
+                'SELECT * FROM Contests WHERE contest_id = ?'
+            ),
+            'table': 'Contests',
+            'issue': 10130,
+            'reason': 'Known query pending optimization',
+        },
+        {
+            'normalized_query': 'SELECT * FROM Problems WHERE alias = ?',
+            'table': 'Problems',
+            'issue': 10131,
+            'reason': 'Full scan accepted for this small table',
+        },
+    ]
+
+
+def test_load_allowlist_rejects_a_missing_file(
+    tmp_path: Path,
+) -> None:
+    '''A missing allowlist has a clear error.'''
+    missing_path = tmp_path / 'missing.yml'
+
+    with pytest.raises(FileNotFoundError, match='Allowlist file not found'):
+        load_allowlist(str(missing_path))
+
+
+def test_load_allowlist_rejects_invalid_yaml(
+    tmp_path: Path,
+) -> None:
+    '''Invalid YAML has a clear validation error.'''
+    allowlist = tmp_path / 'allowlist.yml'
+    allowlist.write_text(
+        'version: 1\nentries: [\n',
+        encoding='utf-8',
+    )
+
+    with pytest.raises(AllowlistValidationError, match='Invalid YAML'):
+        load_allowlist(str(allowlist))
+
+
+@pytest.mark.parametrize(
+    ('content', 'message'),
+    [
+        (
+            'version: 2\nentries: []\n',
+            'version must be 1',
+        ),
+        (
+            'version: 1\nentries: {}\n',
+            'entries.*must be a list',
+        ),
+        (
+            '''
+version: 1
+entries:
+  - normalized_query: SELECT * FROM Contests
+    table: Contests
+    issue: 10130
+'''.lstrip(),
+            'must contain exactly',
+        ),
+        (
+            '''
+version: 1
+entries:
+  - normalized_query: SELECT * FROM Contests
+    table: Contests
+    issue: "10130"
+    reason: Known query
+'''.lstrip(),
+            'issue.*must be a positive integer',
+        ),
+        (
+            '''
+version: 1
+entries:
+  - normalized_query: SELECT * FROM Contests WHERE contest_id = 10
+    table: Contests
+    issue: 10130
+    reason: Known query
+'''.lstrip(),
+            'must already be normalized',
+        ),
+    ],
+)
+def test_load_allowlist_rejects_invalid_schemas(
+    tmp_path: Path,
+    content: str,
+    message: str,
+) -> None:
+    '''Invalid schema values are rejected with a useful message.'''
+    allowlist = tmp_path / 'allowlist.yml'
+    allowlist.write_text(content, encoding='utf-8')
+
+    with pytest.raises(AllowlistValidationError, match=message):
+        load_allowlist(str(allowlist))
+
+
+def test_load_allowlist_rejects_duplicate_identities(
+    tmp_path: Path,
+) -> None:
+    '''The same normalized query and table cannot appear twice.'''
+    allowlist = tmp_path / 'allowlist.yml'
+    allowlist.write_text(
+        '''
+version: 1
+entries:
+  - normalized_query: SELECT * FROM Contests
+    table: Contests
+    issue: 10130
+    reason: First entry
+  - normalized_query: SELECT * FROM Contests
+    table: Contests
+    issue: 10131
+    reason: Duplicate entry
+'''.lstrip(),
+        encoding='utf-8',
+    )
+
+    with pytest.raises(AllowlistValidationError, match='duplicates'):
+        load_allowlist(str(allowlist))


### PR DESCRIPTION
# Descripcion

Se agrega una allowlist para registrar consultas ineficientes que ya son conocidas y evitar que más adelante se confundan con nuevas regresiones.

El archivo comienza vacío:

```yaml
version: 1
entries: []
```

Cada entrada identificará la consulta normalizada y la tabla, además del issue relacionado y el motivo por el que se permite temporalmente.

También se valida el archivo al cargarlo para detectar formatos incorrectos, campos faltantes o entradas duplicadas. Las consultas reales se agregarán en un cambio posterior, después de revisar una ejecución limpia de `main`.

Fixes #10106

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
