### PR TITLE
Comparar consultas detectadas con la allowlist

### DIFF
--- a/stuff/process_mysql_explain_logs.py
+++ b/stuff/process_mysql_explain_logs.py
@@ -7,7 +7,16 @@ import logging
 import sys
 import os
 import csv
-from typing import Any, Iterable, Tuple, Optional, List, Dict, Set
+from typing import (
+    Any,
+    Iterable,
+    Tuple,
+    Optional,
+    List,
+    Dict,
+    Set,
+    NamedTuple,
+)
 import configparser
 import re
 import mysql.connector
@@ -31,6 +40,14 @@ DEFAULT_ALLOWLIST_PATH = os.path.join(
 
 class AllowlistValidationError(ValueError):
     '''Raised when the inefficient queries allowlist is not valid.'''
+
+
+class AllowlistComparison(NamedTuple):
+    '''Results grouped by their relationship with the allowlist.'''
+
+    known_results: List[Dict[str, str]]
+    new_results: List[Dict[str, str]]
+    not_detected_entries: List[Dict[str, Any]]
 
 
 def normalize_query(query: str) -> str:
@@ -176,6 +193,55 @@ def build_inefficiency_key(
 ) -> Tuple[str, str]:
     '''Return the stable identity of an inefficient EXPLAIN row.'''
     return (result['Normalized Query'], result['Table'])
+
+
+def compare_results_with_allowlist(
+    results: Iterable[Dict[str, str]],
+    allowlist: Iterable[Dict[str, Any]],
+) -> AllowlistComparison:
+    '''Group detected results according to their allowlist status.'''
+    allowlist_entries = list(allowlist)
+    allowlist_by_key = {
+        (entry['normalized_query'], entry['table']): entry
+        for entry in allowlist_entries
+    }
+    detected_keys: Set[Tuple[str, str]] = set()
+    known_results: List[Dict[str, str]] = []
+    new_results: List[Dict[str, str]] = []
+
+    for result in results:
+        key = build_inefficiency_key(result)
+        detected_keys.add(key)
+        if key in allowlist_by_key:
+            known_results.append(result)
+        else:
+            new_results.append(result)
+
+    not_detected_entries = [
+        entry for entry in allowlist_entries
+        if (entry['normalized_query'], entry['table']) not in detected_keys
+    ]
+    return AllowlistComparison(
+        known_results=known_results,
+        new_results=new_results,
+        not_detected_entries=not_detected_entries,
+    )
+
+
+def log_allowlist_comparison(comparison: AllowlistComparison) -> None:
+    '''Log a summary and the identity of each new inefficient result.'''
+    logging.warning(
+        '%d known, %d new, %d allowlist entries not detected',
+        len(comparison.known_results),
+        len(comparison.new_results),
+        len(comparison.not_detected_entries),
+    )
+    for result in comparison.new_results:
+        logging.warning(
+            'New inefficient query for table %s: %s',
+            result['Table'],
+            result['Normalized Query'],
+        )
 
 
 def deduplicate_results(
@@ -445,7 +511,7 @@ def _main() -> None:
     Main function to handle the logic.
     """
     try:
-        load_allowlist(DEFAULT_ALLOWLIST_PATH)
+        allowlist = load_allowlist(DEFAULT_ALLOWLIST_PATH)
     except (OSError, AllowlistValidationError) as exc:
         logging.error('Failed to load allowlist: %s', exc)
         sys.exit(1)
@@ -482,6 +548,9 @@ def _main() -> None:
                 logging.error("Failed to save CSV: %s", exc)
         else:
             logging.warning("0 inefficient queries")
+
+        comparison = compare_results_with_allowlist(rows, allowlist)
+        log_allowlist_comparison(comparison)
 
         sys.exit(0)
     finally:

--- a/stuff/process_mysql_explain_logs.py
+++ b/stuff/process_mysql_explain_logs.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     Set,
     NamedTuple,
+    TypedDict,
 )
 import configparser
 import re
@@ -42,12 +43,21 @@ class AllowlistValidationError(ValueError):
     '''Raised when the inefficient queries allowlist is not valid.'''
 
 
+class KnownQuery(TypedDict):
+    '''Validated entry from the inefficient queries allowlist.'''
+
+    normalized_query: str
+    table: str
+    issue: int
+    reason: str
+
+
 class AllowlistComparison(NamedTuple):
     '''Results grouped by their relationship with the allowlist.'''
 
     known_results: List[Dict[str, str]]
     new_results: List[Dict[str, str]]
-    not_detected_entries: List[Dict[str, Any]]
+    not_detected_entries: List[KnownQuery]
 
 
 def normalize_query(query: str) -> str:
@@ -96,7 +106,7 @@ def _get_non_empty_string(
     return value
 
 
-def load_allowlist(path: str) -> List[Dict[str, Any]]:
+def load_allowlist(path: str) -> List[KnownQuery]:
     '''Load and validate the inefficient queries allowlist.'''
     try:
         with open(path, 'r', encoding='utf-8') as allowlist_file:
@@ -138,7 +148,7 @@ def load_allowlist(path: str) -> List[Dict[str, Any]]:
             'Allowlist field "entries" must be a list.'
         )
 
-    validated_entries: List[Dict[str, Any]] = []
+    validated_entries: List[KnownQuery] = []
     seen: Set[Tuple[str, str]] = set()
     for entry_number, entry in enumerate(entries, start=1):
         if not isinstance(entry, dict):
@@ -163,7 +173,7 @@ def load_allowlist(path: str) -> List[Dict[str, Any]]:
             )
 
         table = _get_non_empty_string(entry, 'table', entry_number)
-        _get_non_empty_string(entry, 'reason', entry_number)
+        reason = _get_non_empty_string(entry, 'reason', entry_number)
 
         issue = entry['issue']
         if (
@@ -183,7 +193,12 @@ def load_allowlist(path: str) -> List[Dict[str, Any]]:
                 f'{identity}.'
             )
         seen.add(identity)
-        validated_entries.append(entry)
+        validated_entries.append(KnownQuery(
+            normalized_query=normalized_query,
+            table=table,
+            issue=issue,
+            reason=reason,
+        ))
 
     return validated_entries
 
@@ -197,12 +212,12 @@ def build_inefficiency_key(
 
 def compare_results_with_allowlist(
     results: Iterable[Dict[str, str]],
-    allowlist: Iterable[Dict[str, Any]],
+    allowlist: Iterable[KnownQuery],
 ) -> AllowlistComparison:
     '''Group detected results according to their allowlist status.'''
     allowlist_entries = list(allowlist)
-    allowlist_by_key = {
-        (entry['normalized_query'], entry['table']): entry
+    allowlist_keys: Set[Tuple[str, str]] = {
+        (entry['normalized_query'], entry['table'])
         for entry in allowlist_entries
     }
     detected_keys: Set[Tuple[str, str]] = set()
@@ -212,7 +227,7 @@ def compare_results_with_allowlist(
     for result in results:
         key = build_inefficiency_key(result)
         detected_keys.add(key)
-        if key in allowlist_by_key:
+        if key in allowlist_keys:
             known_results.append(result)
         else:
             new_results.append(result)
@@ -230,7 +245,7 @@ def compare_results_with_allowlist(
 
 def log_allowlist_comparison(comparison: AllowlistComparison) -> None:
     '''Log a summary and the identity of each new inefficient result.'''
-    logging.warning(
+    logging.info(
         '%d known, %d new, %d allowlist entries not detected',
         len(comparison.known_results),
         len(comparison.new_results),

--- a/stuff/process_mysql_explain_logs_test.py
+++ b/stuff/process_mysql_explain_logs_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 '''Unit tests for the MySQL EXPLAIN log processor.'''
 
+import logging
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
 
@@ -10,8 +11,10 @@ from process_mysql_explain_logs import (
     AllowlistValidationError,
     build_inefficiency_key,
     build_query_family,
+    compare_results_with_allowlist,
     deduplicate_results,
     load_allowlist,
+    log_allowlist_comparison,
     normalize_query,
     sort_results_for_csv,
 )
@@ -27,6 +30,18 @@ def _result(
         'Normalized Query': normalized_query,
         'Query Family': build_query_family(normalized_query),
         'Table': table,
+    }
+
+
+def _allowlist_entry(
+    normalized_query: str,
+    table: str,
+) -> Dict[str, Any]:
+    return {
+        'normalized_query': normalized_query,
+        'table': table,
+        'issue': 10108,
+        'reason': 'Known query pending optimization',
     }
 
 
@@ -115,6 +130,69 @@ def test_inefficiency_key_includes_table() -> None:
     courses = _result('1', 'SELECT * FROM Users JOIN Courses', 'Courses')
 
     assert build_inefficiency_key(users) != build_inefficiency_key(courses)
+
+
+def test_compare_results_with_allowlist_classifies_each_identity() -> None:
+    '''Results are grouped using the normalized query and table.'''
+    normalized_query = 'SELECT * FROM Users JOIN Courses'
+    known = _result('1', normalized_query, 'Users')
+    new = _result('1', normalized_query, 'Courses')
+    not_detected = _allowlist_entry(
+        'SELECT * FROM Problems',
+        'Problems',
+    )
+
+    comparison = compare_results_with_allowlist(
+        [known, new],
+        [
+            _allowlist_entry(normalized_query, 'Users'),
+            not_detected,
+        ],
+    )
+
+    assert comparison.known_results == [known]
+    assert comparison.new_results == [new]
+    assert comparison.not_detected_entries == [not_detected]
+
+
+def test_compare_results_with_allowlist_does_not_use_query_family() -> None:
+    '''Queries in one family still need their own allowlist entry.'''
+    detected = _result(
+        '1',
+        'SELECT * FROM Users WHERE user_id IN (?, ?, ?)',
+        'Users',
+    )
+    allowlist_entry = _allowlist_entry(
+        'SELECT * FROM Users WHERE user_id IN (?, ?)',
+        'Users',
+    )
+
+    comparison = compare_results_with_allowlist(
+        [detected],
+        [allowlist_entry],
+    )
+
+    assert not comparison.known_results
+    assert comparison.new_results == [detected]
+    assert comparison.not_detected_entries == [allowlist_entry]
+
+
+def test_log_allowlist_comparison_reports_new_results(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    '''The summary identifies new inefficient query-table pairs.'''
+    detected = _result('1', 'SELECT * FROM Users', 'Users')
+    comparison = compare_results_with_allowlist([detected], [])
+
+    with caplog.at_level(logging.WARNING):
+        log_allowlist_comparison(comparison)
+
+    assert '0 known, 1 new, 0 allowlist entries not detected' in (
+        caplog.messages
+    )
+    assert 'New inefficient query for table Users: SELECT * FROM Users' in (
+        caplog.messages
+    )
 
 
 def test_deduplicate_results_uses_query_and_table() -> None:

--- a/stuff/process_mysql_explain_logs_test.py
+++ b/stuff/process_mysql_explain_logs_test.py
@@ -3,12 +3,13 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict
 
 import pytest
 
 from process_mysql_explain_logs import (
     AllowlistValidationError,
+    KnownQuery,
     build_inefficiency_key,
     build_query_family,
     compare_results_with_allowlist,
@@ -36,7 +37,7 @@ def _result(
 def _allowlist_entry(
     normalized_query: str,
     table: str,
-) -> Dict[str, Any]:
+) -> KnownQuery:
     return {
         'normalized_query': normalized_query,
         'table': table,
@@ -184,7 +185,7 @@ def test_log_allowlist_comparison_reports_new_results(
     detected = _result('1', 'SELECT * FROM Users', 'Users')
     comparison = compare_results_with_allowlist([detected], [])
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         log_allowlist_comparison(comparison)
 
     assert '0 known, 1 new, 0 allowlist entries not detected' in (
@@ -193,6 +194,10 @@ def test_log_allowlist_comparison_reports_new_results(
     assert 'New inefficient query for table Users: SELECT * FROM Users' in (
         caplog.messages
     )
+    assert [record.levelno for record in caplog.records] == [
+        logging.INFO,
+        logging.WARNING,
+    ]
 
 
 def test_deduplicate_results_uses_query_and_table() -> None:


### PR DESCRIPTION
# Description

Se comparan los resultados del detector con la allowlist utilizando la combinacion `(Normalized Query, Table)`.

Cada resultado se clasifica de la siguiente manera:

```text
Presente en ambos        -> consulta conocida
Solo en los resultados   -> posible consulta nueva
Solo en la allowlist     -> no detectada en esta ejecucion
```

El script muestra un resumen de la comparacion y los datos de las consultas nuevas. Las entradas no detectadas se conservan porque el conjunto de consultas puede variar entre ejecuciones.

Este cambio solo realiza la comparacion; el fallo de CI se agregara en el siguiente paso.

Fixes #10109

# Checklist:

- [ ] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
