### PR TITLE
add problem health checks dao

### DIFF
--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -262,7 +262,7 @@ CREATE TABLE `Contests` (
   `penalty_calc_policy` enum('sum','max') NOT NULL COMMENT 'Indica como afecta el penalty al score.',
   `show_scoreboard_after` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'Mostrar el scoreboard automáticamente después del concurso',
   `urgent` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si el concurso es de alta prioridad y requiere mejor QoS.',
-  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar en un concurso',
+  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','rk','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar en un concurso',
   `recommended` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Mostrar el concurso en la lista de recomendados.',
   `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si el concurso ha sido archivado por el administrador.',
   `certificate_cutoff` int DEFAULT NULL COMMENT 'Número de concursantes a premiar con diplomas que mencionan su lugar en el ranking',
@@ -368,7 +368,7 @@ CREATE TABLE `Courses` (
   `needs_basic_information` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Un campo opcional para indicar si es obligatorio que el usuario pueda ingresar a un curso sólo si ya llenó su información de perfil',
   `requests_user_information` enum('no','optional','required') NOT NULL DEFAULT 'no' COMMENT 'Se solicita información de los participantes para contactarlos posteriormente.',
   `show_scoreboard` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Los estudiantes pueden visualizar el scoreboard de un curso.',
-  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar en un curso',
+  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','rk','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar en un curso',
   `archived` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Indica si el curso ha sido archivado por el administrador.',
   `minimum_progress_for_certificate` int DEFAULT NULL COMMENT 'Progreso mínimo que debe cumplir el estudiante para que se le otorgue el diploma del curso. NULL indica que el curso no da diplomas.',
   `certificates_status` enum('uninitiated','queued','generated','retryable_error','fatal_error') NOT NULL DEFAULT 'uninitiated' COMMENT 'Estado de la petición de generar diplomas',
@@ -760,6 +760,23 @@ CREATE TABLE `Problem_Bookmarks` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Problem_Health_Checks` (
+  `check_id` int NOT NULL AUTO_INCREMENT,
+  `problem_id` int NOT NULL,
+  `check_type` enum('judge_errors','no_languages','never_solved','deprecated_public') NOT NULL COMMENT 'El tipo de revisión que detectó el problema',
+  `severity` enum('warning','error') NOT NULL DEFAULT 'warning',
+  `detail` varchar(255) DEFAULT NULL COMMENT 'Explicación legible de lo que se detectó',
+  `first_detected_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'La primera vez que se detectó, se conserva entre ejecuciones',
+  `last_seen_at` datetime NOT NULL COMMENT 'La última ejecución en la que se seguía detectando',
+  `resolved_at` datetime DEFAULT NULL COMMENT 'Cuando dejó de detectarse, NULL si sigue vigente',
+  PRIMARY KEY (`check_id`),
+  UNIQUE KEY `unique_problem_check` (`problem_id`,`check_type`),
+  KEY `idx_problem_health_open` (`resolved_at`,`severity`),
+  CONSTRAINT `fk_phc_problem_id` FOREIGN KEY (`problem_id`) REFERENCES `Problems` (`problem_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Hallazgos de las revisiones automáticas de salud de los problemas';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Problem_Of_The_Week` (
   `problem_of_the_week_id` int NOT NULL AUTO_INCREMENT,
   `problem_id` int NOT NULL COMMENT 'El id del problema escogido como problema de la semana.',
@@ -794,7 +811,7 @@ CREATE TABLE `Problems` (
   `alias` varchar(32) NOT NULL,
   `commit` char(40) NOT NULL DEFAULT 'published' COMMENT 'El hash SHA1 del commit en la rama master del problema.',
   `current_version` char(40) NOT NULL COMMENT 'El hash SHA1 del árbol de la rama private.',
-  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua','go','rs','js') NOT NULL DEFAULT 'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,cpp20-gcc,cpp20-clang,java,kt,py2,py3,rb,cs,pas,hs,lua,go,rs,js',
+  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','rk','cat','hs','lua','go','rs','js') NOT NULL DEFAULT 'c11-gcc,c11-clang,cpp11-gcc,cpp11-clang,cpp17-gcc,cpp17-clang,cpp20-gcc,cpp20-clang,java,kt,py2,py3,rb,cs,pas,hs,lua,go,rs,js',
   `input_limit` int NOT NULL DEFAULT '10240',
   `visits` int NOT NULL DEFAULT '0',
   `submissions` int NOT NULL DEFAULT '0',
@@ -963,7 +980,7 @@ CREATE TABLE `Problemsets` (
   `problemset_id` int NOT NULL AUTO_INCREMENT COMMENT 'El identificador único para cada conjunto de problemas',
   `acl_id` int NOT NULL COMMENT 'La lista de control de acceso compartida con su container',
   `access_mode` enum('private','public','registration') NOT NULL DEFAULT 'public' COMMENT 'La modalidad de acceso a este conjunto de problemas',
-  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar para resolver los problemas',
+  `languages` set('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','rk','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'Un filtro (opcional) de qué lenguajes se pueden usar para resolver los problemas',
   `needs_basic_information` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Un campo opcional para indicar si es obligatorio que el usuario pueda ingresar a un concurso sólo si ya llenó su información de perfil',
   `requests_user_information` enum('no','optional','required') NOT NULL DEFAULT 'no' COMMENT 'Se solicita información de los participantes para contactarlos posteriormente.',
   `scoreboard_url` varchar(30) NOT NULL COMMENT 'Token para la url del scoreboard en problemsets',
@@ -1235,7 +1252,7 @@ CREATE TABLE `Submissions` (
   `problem_id` int NOT NULL,
   `problemset_id` int DEFAULT NULL,
   `guid` char(32) NOT NULL,
-  `language` enum('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua','go','rs','js') NOT NULL,
+  `language` enum('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','rk','cat','hs','lua','go','rs','js') NOT NULL,
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `status` enum('new','waiting','compiling','running','ready','uploading') NOT NULL DEFAULT 'new',
   `verdict` enum('AC','PA','PE','WA','TLE','OLE','MLE','RTE','RFE','CE','JE','VE') NOT NULL,
@@ -1454,7 +1471,7 @@ CREATE TABLE `Users` (
   `hide_problem_tags` tinyint(1) DEFAULT NULL COMMENT 'Determina si el usuario quiere ocultar las etiquetas de los problemas',
   `in_mailing_list` tinyint(1) NOT NULL DEFAULT '0',
   `is_private` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Determina si el usuario eligió no compartir su información de manera pública',
-  `preferred_language` enum('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'El lenguaje de programación de preferencia de este usuario',
+  `preferred_language` enum('c','c11-gcc','c11-clang','cpp','cpp11','cpp11-gcc','cpp11-clang','cpp17-gcc','cpp17-clang','cpp20-gcc','cpp20-clang','java','kt','py','py2','py3','rb','pl','cs','pas','kp','kj','rk','cat','hs','lua','go','rs','js') DEFAULT NULL COMMENT 'El lenguaje de programación de preferencia de este usuario',
   `parent_verified` tinyint(1) DEFAULT NULL COMMENT 'Almacena la respuesta del padre cuando este verifica la cuenta de su hijo',
   `creation_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Almacena la hora y fecha en que se creó la cuenta de usuario',
   `parental_verification_token` varchar(25) DEFAULT NULL COMMENT 'Token que se generará para los usuarios menores de 13 años al momento de registrar su cuenta, el cuál será enviado por correo electrónico al padre',

--- a/frontend/server/src/DAO/Base/ProblemHealthChecks.php
+++ b/frontend/server/src/DAO/Base/ProblemHealthChecks.php
@@ -1,0 +1,331 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** ProblemHealthChecks Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\ProblemHealthChecks}.
+ * @access public
+ * @abstract
+ */
+abstract class ProblemHealthChecks {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\ProblemHealthChecks $Problem_Health_Checks El objeto de tipo ProblemHealthChecks a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\ProblemHealthChecks $Problem_Health_Checks
+    ): int {
+        $sql = '
+            UPDATE
+                `Problem_Health_Checks`
+            SET
+                `problem_id` = ?,
+                `check_type` = ?,
+                `severity` = ?,
+                `detail` = ?,
+                `first_detected_at` = ?,
+                `last_seen_at` = ?,
+                `resolved_at` = ?
+            WHERE
+                (
+                    `check_id` = ?
+                );';
+        $params = [
+            (
+                is_null($Problem_Health_Checks->problem_id) ?
+                null :
+                intval($Problem_Health_Checks->problem_id)
+            ),
+            $Problem_Health_Checks->check_type,
+            $Problem_Health_Checks->severity,
+            $Problem_Health_Checks->detail,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Problem_Health_Checks->first_detected_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Problem_Health_Checks->last_seen_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Problem_Health_Checks->resolved_at
+            ),
+            intval($Problem_Health_Checks->check_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\ProblemHealthChecks} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\ProblemHealthChecks}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\ProblemHealthChecks Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\ProblemHealthChecks} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $check_id
+    ): ?\OmegaUp\DAO\VO\ProblemHealthChecks {
+        $sql = '
+            SELECT
+                `Problem_Health_Checks`.`check_id`,
+                `Problem_Health_Checks`.`problem_id`,
+                `Problem_Health_Checks`.`check_type`,
+                `Problem_Health_Checks`.`severity`,
+                `Problem_Health_Checks`.`detail`,
+                `Problem_Health_Checks`.`first_detected_at`,
+                `Problem_Health_Checks`.`last_seen_at`,
+                `Problem_Health_Checks`.`resolved_at`
+            FROM
+                `Problem_Health_Checks`
+            WHERE
+                (
+                    `check_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$check_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\ProblemHealthChecks($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\ProblemHealthChecks} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\ProblemHealthChecks}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $check_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problem_Health_Checks`
+            WHERE
+                (
+                    `check_id` = ?
+                );';
+        $params = [$check_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `Problem_Health_Checks`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Problem_Health_Checks`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\ProblemHealthChecks} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\ProblemHealthChecks $Problem_Health_Checks El
+     * objeto de tipo \OmegaUp\DAO\VO\ProblemHealthChecks a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\ProblemHealthChecks $Problem_Health_Checks
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Problem_Health_Checks`
+            WHERE
+                (
+                    `check_id` = ?
+                );';
+        $params = [
+            $Problem_Health_Checks->check_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\ProblemHealthChecks}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\ProblemHealthChecks> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\ProblemHealthChecks}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'check_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `Problem_Health_Checks`.`check_id`,
+                `Problem_Health_Checks`.`problem_id`,
+                `Problem_Health_Checks`.`check_type`,
+                `Problem_Health_Checks`.`severity`,
+                `Problem_Health_Checks`.`detail`,
+                `Problem_Health_Checks`.`first_detected_at`,
+                `Problem_Health_Checks`.`last_seen_at`,
+                `Problem_Health_Checks`.`resolved_at`
+            FROM
+                `Problem_Health_Checks`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\ProblemHealthChecks(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\ProblemHealthChecks}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\ProblemHealthChecks $Problem_Health_Checks El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\ProblemHealthChecks}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\ProblemHealthChecks $Problem_Health_Checks
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Problem_Health_Checks` (
+                    `problem_id`,
+                    `check_type`,
+                    `severity`,
+                    `detail`,
+                    `first_detected_at`,
+                    `last_seen_at`,
+                    `resolved_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            (
+                is_null($Problem_Health_Checks->problem_id) ?
+                null :
+                intval($Problem_Health_Checks->problem_id)
+            ),
+            $Problem_Health_Checks->check_type,
+            $Problem_Health_Checks->severity,
+            $Problem_Health_Checks->detail,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Problem_Health_Checks->first_detected_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Problem_Health_Checks->last_seen_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Problem_Health_Checks->resolved_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Problem_Health_Checks->check_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/ProblemHealthChecks.php
+++ b/frontend/server/src/DAO/ProblemHealthChecks.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * ProblemHealthChecks Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\ProblemHealthChecks}.
+ */
+class ProblemHealthChecks extends \OmegaUp\DAO\Base\ProblemHealthChecks {
+    /**
+     * Returns the open findings, worst first, with the problem they belong to.
+     *
+     * @return list<array{alias: string, check_type: string, detail: null|string, first_detected_at: \OmegaUp\Timestamp, problem_id: int, severity: string, title: string}>
+     */
+    public static function getOpenFindings(int $limit = 100): array {
+        $sql = 'SELECT
+                    phc.`problem_id`,
+                    phc.`check_type`,
+                    phc.`severity`,
+                    phc.`detail`,
+                    phc.`first_detected_at`,
+                    p.`alias`,
+                    p.`title`
+                FROM Problem_Health_Checks phc
+                INNER JOIN Problems p ON p.problem_id = phc.problem_id
+                WHERE phc.`resolved_at` IS NULL
+                ORDER BY
+                    FIELD(phc.`severity`, ?, ?),
+                    phc.`first_detected_at` ASC
+                LIMIT ?;';
+        /** @var list<array{alias: string, check_type: string, detail: null|string, first_detected_at: \OmegaUp\Timestamp, problem_id: int, severity: string, title: string}> */
+        return \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [
+                \OmegaUp\ProblemHealthSeverity::Error->value,
+                \OmegaUp\ProblemHealthSeverity::Warning->value,
+                $limit,
+            ]
+        );
+    }
+}

--- a/frontend/server/src/DAO/VO/ProblemHealthChecks.php
+++ b/frontend/server/src/DAO/VO/ProblemHealthChecks.php
@@ -1,0 +1,160 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Problem_Health_Checks`.
+ *
+ * @access public
+ */
+class ProblemHealthChecks extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'check_id' => true,
+        'problem_id' => true,
+        'check_type' => true,
+        'severity' => true,
+        'detail' => true,
+        'first_detected_at' => true,
+        'last_seen_at' => true,
+        'resolved_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['check_id'])) {
+            $this->check_id = intval(
+                $data['check_id']
+            );
+        }
+        if (isset($data['problem_id'])) {
+            $this->problem_id = intval(
+                $data['problem_id']
+            );
+        }
+        if (isset($data['check_type'])) {
+            $this->check_type = is_scalar(
+                $data['check_type']
+            ) ? strval($data['check_type']) : '';
+        }
+        if (isset($data['severity'])) {
+            $this->severity = is_scalar(
+                $data['severity']
+            ) ? strval($data['severity']) : '';
+        }
+        if (isset($data['detail'])) {
+            $this->detail = is_scalar(
+                $data['detail']
+            ) ? strval($data['detail']) : '';
+        }
+        if (isset($data['first_detected_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['first_detected_at']
+             * @var \OmegaUp\Timestamp $this->first_detected_at
+             */
+            $this->first_detected_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['first_detected_at']
+                )
+            );
+        } else {
+            $this->first_detected_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['last_seen_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['last_seen_at']
+             * @var \OmegaUp\Timestamp $this->last_seen_at
+             */
+            $this->last_seen_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['last_seen_at']
+                )
+            );
+        }
+        if (isset($data['resolved_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['resolved_at']
+             * @var \OmegaUp\Timestamp $this->resolved_at
+             */
+            $this->resolved_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['resolved_at']
+                )
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $check_id = 0;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var int|null
+     */
+    public $problem_id = null;
+
+    /**
+     * El tipo de revisión que detectó el problema
+     *
+     * @var string|null
+     */
+    public $check_type = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var string
+     */
+    public $severity = 'warning';
+
+    /**
+     * Explicación legible de lo que se detectó
+     *
+     * @var string|null
+     */
+    public $detail = null;
+
+    /**
+     * La primera vez que se detectó, se conserva entre ejecuciones
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $first_detected_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * La última ejecución en la que se seguía detectando
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $last_seen_at = null;
+
+    /**
+     * Cuando dejó de detectarse, NULL si sigue vigente
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $resolved_at = null;
+}

--- a/frontend/server/src/ProblemHealthCheckType.php
+++ b/frontend/server/src/ProblemHealthCheckType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * The checks that can flag a problem, mirroring the
+ * `Problem_Health_Checks.check_type` column.
+ */
+enum ProblemHealthCheckType: string {
+    case JudgeErrors = 'judge_errors';
+    case NoLanguages = 'no_languages';
+    case NeverSolved = 'never_solved';
+    case DeprecatedPublic = 'deprecated_public';
+}

--- a/frontend/server/src/ProblemHealthSeverity.php
+++ b/frontend/server/src/ProblemHealthSeverity.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * How bad a problem health finding is, mirroring the
+ * `Problem_Health_Checks.severity` column. Declared worst first.
+ */
+enum ProblemHealthSeverity: string {
+    case Error = 'error';
+    case Warning = 'warning';
+}

--- a/frontend/tests/controllers/ProblemHealthChecksDAOTest.php
+++ b/frontend/tests/controllers/ProblemHealthChecksDAOTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\ProblemHealthChecks data access object.
+ */
+class ProblemHealthChecksDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    private function createFinding(
+        int $problemId,
+        string $checkType,
+        string $severity,
+        int $firstDetectedAt,
+        ?int $resolvedAt = null
+    ): void {
+        \OmegaUp\DAO\ProblemHealthChecks::create(
+            new \OmegaUp\DAO\VO\ProblemHealthChecks([
+                'problem_id' => $problemId,
+                'check_type' => $checkType,
+                'severity' => $severity,
+                'detail' => "detail for {$checkType}",
+                'first_detected_at' => new \OmegaUp\Timestamp(
+                    $firstDetectedAt
+                ),
+                'last_seen_at' => new \OmegaUp\Timestamp($firstDetectedAt),
+                'resolved_at' => is_null(
+                    $resolvedAt
+                ) ? null : new \OmegaUp\Timestamp(
+                    $resolvedAt
+                ),
+            ])
+        );
+    }
+
+    public function testGetOpenFindingsReturnsTheProblemAliasAndTitle() {
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+        $problem = $problemData['problem'];
+        $this->createFinding(
+            intval($problem->problem_id),
+            \OmegaUp\ProblemHealthCheckType::NeverSolved->value,
+            \OmegaUp\ProblemHealthSeverity::Warning->value,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $findings = array_values(array_filter(
+            \OmegaUp\DAO\ProblemHealthChecks::getOpenFindings(200),
+            fn ($finding) => $finding['problem_id'] === intval(
+                $problem->problem_id
+            )
+        ));
+
+        $this->assertCount(1, $findings);
+        $this->assertSame($problem->alias, $findings[0]['alias']);
+        $this->assertSame($problem->title, $findings[0]['title']);
+        $this->assertSame(
+            \OmegaUp\ProblemHealthCheckType::NeverSolved->value,
+            $findings[0]['check_type']
+        );
+        $this->assertSame(
+            'detail for never_solved',
+            $findings[0]['detail']
+        );
+    }
+
+    public function testGetOpenFindingsPutsErrorsBeforeWarnings() {
+        $warned = \OmegaUp\Test\Factories\Problem::createProblem();
+        $broken = \OmegaUp\Test\Factories\Problem::createProblem();
+        $now = \OmegaUp\Time::get();
+        // The warning is older, so only the severity can put the error first.
+        $this->createFinding(
+            intval($warned['problem']->problem_id),
+            \OmegaUp\ProblemHealthCheckType::NeverSolved->value,
+            \OmegaUp\ProblemHealthSeverity::Warning->value,
+            $now - 500
+        );
+        $this->createFinding(
+            intval($broken['problem']->problem_id),
+            \OmegaUp\ProblemHealthCheckType::NoLanguages->value,
+            \OmegaUp\ProblemHealthSeverity::Error->value,
+            $now - 10
+        );
+
+        $problemIds = array_map(
+            fn ($finding) => $finding['problem_id'],
+            \OmegaUp\DAO\ProblemHealthChecks::getOpenFindings(200)
+        );
+        $errorPosition = array_search(
+            intval($broken['problem']->problem_id),
+            $problemIds,
+            true
+        );
+        $warningPosition = array_search(
+            intval($warned['problem']->problem_id),
+            $problemIds,
+            true
+        );
+
+        $this->assertNotFalse($errorPosition);
+        $this->assertNotFalse($warningPosition);
+        $this->assertLessThan($warningPosition, $errorPosition);
+    }
+
+    public function testGetOpenFindingsSkipsResolvedOnes() {
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+        $problem = $problemData['problem'];
+        $now = \OmegaUp\Time::get();
+        $this->createFinding(
+            intval($problem->problem_id),
+            \OmegaUp\ProblemHealthCheckType::JudgeErrors->value,
+            \OmegaUp\ProblemHealthSeverity::Error->value,
+            $now - 100,
+            $now - 50
+        );
+
+        $problemIds = array_map(
+            fn ($finding) => $finding['problem_id'],
+            \OmegaUp\DAO\ProblemHealthChecks::getOpenFindings(200)
+        );
+
+        $this->assertNotContains(intval($problem->problem_id), $problemIds);
+    }
+
+    public function testGetOpenFindingsHonorsTheLimit() {
+        $problemData = \OmegaUp\Test\Factories\Problem::createProblem();
+        $this->createFinding(
+            intval($problemData['problem']->problem_id),
+            \OmegaUp\ProblemHealthCheckType::DeprecatedPublic->value,
+            \OmegaUp\ProblemHealthSeverity::Warning->value,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $this->assertCount(
+            1,
+            \OmegaUp\DAO\ProblemHealthChecks::getOpenFindings(1)
+        );
+    }
+}


### PR DESCRIPTION
# Description

split out of #10069 at your request, so the dao layer can be reviewed and merged on its own.

the `Problem_Health_Checks` table is already in main, it merged as #10065 with migration `00279`, but `dao_schema.sql` was never caught up. this adds the table there and the generated dao that goes with it, so `dao_schema.sql` is byte identical to `schema.sql` again.

what is here:

- `frontend/database/dao_schema.sql`, the table added, nothing else changed
- `frontend/server/src/DAO/Base/ProblemHealthChecks.php` and `frontend/server/src/DAO/VO/ProblemHealthChecks.php`, both generated by `stuff/update-dao.py`
- `frontend/server/src/DAO/ProblemHealthChecks.php` with one query, `getOpenFindings`, which returns the findings that are still open, worst first, joined to the problem they belong to
- `frontend/server/src/ProblemHealthCheckType.php` and `frontend/server/src/ProblemHealthSeverity.php`, two backed enums for the `check_type` and `severity` column values
- `frontend/tests/controllers/ProblemHealthChecksDAOTest.php`

the tests cover the alias and title coming back from the join, errors sorting ahead of warnings even when the warning is older, resolved findings being left out, and the limit being honoured.

the enums come from your comment on #10008 about known sets of values. both columns are already `enum` in the schema, so the php side now matches them, and the severity ordering in `getOpenFindings` is bound from the enum instead of two string literals inside the query.

part of #10064, split out of #10069 so it can land on its own. #10069 is what closes the issue.

# Comments

this shape follows #9996, which is the dao pr of the cron control plane and had the same set of files.

nothing calls `getOpenFindings` yet. the admin endpoint and the ui that use it stay in #10069, which is the rest of that pr once this is taken out.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
