### PR TITLE
return open health findings from the crons api

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -12,7 +12,8 @@
   * @psalm-type CronJob=array{name: string, description: null|string, schedule: null|string, enabled: bool}
   * @psalm-type CronRunPhase=array{phase: string, status: string, duration: float, error_class: null|string}
   * @psalm-type CronRun=array{run_id: int, name: string, hostname: null|string, status: string, started_at: \OmegaUp\Timestamp|null, finished_at: \OmegaUp\Timestamp|null, duration_seconds: float|null, rows_affected: int|null, phases: list<CronRunPhase>, error_text: null|string}
-  * @psalm-type CronsDetailsPayload=array{jobs: list<CronJob>, runs: list<CronRun>}
+  * @psalm-type ProblemHealthFinding=array{problem_id: int, alias: string, title: string, check_type: string, severity: string, detail: null|string, first_detected_at: \OmegaUp\Timestamp}
+  * @psalm-type CronsDetailsPayload=array{jobs: list<CronJob>, runs: list<CronRun>, problemHealthFindings: list<ProblemHealthFinding>}
   */
 class Admin extends \OmegaUp\Controllers\Controller {
     const MAINTENANCE_MESSAGE_ES_KEY = 'maintenance_message_es';
@@ -32,6 +33,7 @@ class Admin extends \OmegaUp\Controllers\Controller {
     ];
 
     const CRON_RUNS_LIMIT = 50;
+    const PROBLEM_HEALTH_FINDINGS_LIMIT = 50;
 
     /**
      * Get stats for an overall platform report.
@@ -466,7 +468,7 @@ class Admin extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{jobs: list<CronJob>, runs: list<CronRun>}
+     * @return array{jobs: list<CronJob>, runs: list<CronRun>, problemHealthFindings: list<ProblemHealthFinding>}
      */
     private static function cronsPayload(): array {
         return [
@@ -474,13 +476,17 @@ class Admin extends \OmegaUp\Controllers\Controller {
             'runs' => self::cronRunsPayload(
                 \OmegaUp\DAO\CronRuns::getRecent(self::CRON_RUNS_LIMIT)
             ),
+            'problemHealthFindings' => \OmegaUp\DAO\ProblemHealthChecks::getOpenFindings(
+                self::PROBLEM_HEALTH_FINDINGS_LIMIT
+            ),
         ];
     }
 
     /**
-     * Lists the registered cron jobs and their most recent runs.
+     * Lists the registered cron jobs, their most recent runs and the open
+     * problem health findings.
      *
-     * @return array{jobs: list<CronJob>, runs: list<CronRun>}
+     * @return array{jobs: list<CronJob>, runs: list<CronRun>, problemHealthFindings: list<ProblemHealthFinding>}
      */
     public static function apiGetCrons(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -353,14 +353,16 @@ Returns the detail of a single cron run.
 
 ### Description
 
-Lists the registered cron jobs and their most recent runs.
+Lists the registered cron jobs, their most recent runs and the open
+problem health findings.
 
 ### Returns
 
-| Name   | Type                  |
-| ------ | --------------------- |
-| `jobs` | `List[types.CronJob]` |
-| `runs` | `List[types.CronRun]` |
+| Name                    | Type                               |
+| ----------------------- | ---------------------------------- |
+| `jobs`                  | `List[types.CronJob]`              |
+| `problemHealthFindings` | `List[types.ProblemHealthFinding]` |
+| `runs`                  | `List[types.CronRun]`              |
 
 ## `/api/admin/getMaintenanceMode/`
 

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -212,4 +212,43 @@ class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame(7, $runs[0]['rows_affected']);
         $this->assertSame([], $runs[0]['phases']);
     }
+
+    public function testGetCronsForTypeScriptReturnsTheOpenHealthFindings() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        $problem = \OmegaUp\Test\Factories\Problem::createProblem()['problem'];
+        $now = \OmegaUp\Time::get();
+        \OmegaUp\DAO\ProblemHealthChecks::create(
+            new \OmegaUp\DAO\VO\ProblemHealthChecks([
+                'problem_id' => $problem->problem_id,
+                'check_type' => \OmegaUp\ProblemHealthCheckType::NoLanguages->value,
+                'severity' => \OmegaUp\ProblemHealthSeverity::Error->value,
+                'detail' => 'the problem has no enabled language',
+                'first_detected_at' => new \OmegaUp\Timestamp($now),
+                'last_seen_at' => new \OmegaUp\Timestamp($now),
+            ])
+        );
+
+        $response = \OmegaUp\Controllers\Admin::getCronsForTypeScript(
+            new \OmegaUp\Request(['auth_token' => $login->auth_token])
+        );
+
+        $findings = array_values(array_filter(
+            $response['templateProperties']['payload']['problemHealthFindings'],
+            fn ($finding) => $finding['problem_id'] === intval(
+                $problem->problem_id
+            )
+        ));
+        $this->assertCount(1, $findings);
+        $this->assertSame($problem->alias, $findings[0]['alias']);
+        $this->assertSame(
+            \OmegaUp\ProblemHealthCheckType::NoLanguages->value,
+            $findings[0]['check_type']
+        );
+        $this->assertSame(
+            \OmegaUp\ProblemHealthSeverity::Error->value,
+            $findings[0]['severity']
+        );
+    }
 }

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -118,6 +118,17 @@ export const Admin = {
     messages._AdminGetCronsServerResponse,
     messages.AdminGetCronsResponse
   >('/api/admin/getCrons/', (x) => {
+    x.problemHealthFindings = ((x) => {
+      if (!Array.isArray(x)) {
+        return x;
+      }
+      return x.map((x) => {
+        x.first_detected_at = ((x: number) => new Date(x * 1000))(
+          x.first_detected_at,
+        );
+        return x;
+      });
+    })(x.problemHealthFindings);
     x.runs = ((x) => {
       if (!Array.isArray(x)) {
         return x;

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1606,6 +1606,17 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CronsDetailsPayload {
       return ((x) => {
+        x.problemHealthFindings = ((x) => {
+          if (!Array.isArray(x)) {
+            return x;
+          }
+          return x.map((x) => {
+            x.first_detected_at = ((x: number) => new Date(x * 1000))(
+              x.first_detected_at,
+            );
+            return x;
+          });
+        })(x.problemHealthFindings);
         x.runs = ((x) => {
           if (!Array.isArray(x)) {
             return x;
@@ -3843,6 +3854,7 @@ export namespace types {
 
   export interface CronsDetailsPayload {
     jobs: types.CronJob[];
+    problemHealthFindings: types.ProblemHealthFinding[];
     runs: types.CronRun[];
   }
 
@@ -4417,6 +4429,16 @@ export namespace types {
     alias: string;
     name: string;
     role: string;
+  }
+
+  export interface ProblemHealthFinding {
+    alias: string;
+    check_type: string;
+    detail?: string;
+    first_detected_at: Date;
+    problem_id: number;
+    severity: string;
+    title: string;
   }
 
   export interface ProblemInfo {
@@ -5415,6 +5437,7 @@ export namespace messages {
   export type _AdminGetCronsServerResponse = any;
   export type AdminGetCronsResponse = {
     jobs: types.CronJob[];
+    problemHealthFindings: types.ProblemHealthFinding[];
     runs: types.CronRun[];
   };
   export type AdminGetMaintenanceModeRequest = { [key: string]: any };


### PR DESCRIPTION
# Description

the server half of #10069, split off the way you asked on that pr and on #10008.

`apiGetCrons` now returns `problemHealthFindings` next to the jobs and the runs, from `ProblemHealthChecks::getOpenFindings`, which merged with #10149. the nightly job in #10066 is what fills the table.

the findings come back worst first, errors before warnings, and within a severity the oldest first, since something broken for a month matters more than something broken last night. each one carries the problem it belongs to, what the check found, how bad it is, the detail and when it was first detected.

both `apiGetCrons` and `getCronsForTypeScript` read it through the private `cronsPayload` helper, so the page still does not call the endpoint. the limit is a constant rather than a literal, like `CRON_RUNS_LIMIT` next to it.

part of #10064. the ui that renders this is #10069, and that is what closes the issue.

# Comments

the test creates a finding against a real problem and asserts it comes back through `getCronsForTypeScript` with the right alias, check type and severity. it filters to the problem it created rather than assuming it owns the table.

`check_type` and `severity` are `enum` columns, so the test uses `\OmegaUp\ProblemHealthCheckType` and `\OmegaUp\ProblemHealthSeverity` from #10149 instead of string literals.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
