### PR TITLE
return model quality from the crons api

### DIFF
--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -1067,6 +1067,25 @@ CREATE TABLE `QualityNominations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Recommendation_Model_Runs` (
+  `model_run_id` int NOT NULL AUTO_INCREMENT,
+  `cron_run_id` int DEFAULT NULL COMMENT 'La ejecución de cron que entrenó este modelo, NULL si se corrió a mano',
+  `map_score` double NOT NULL COMMENT 'MAP@k sobre los usuarios de prueba, la medida con la que se compara contra el último modelo publicado',
+  `dataset_size` int NOT NULL COMMENT 'Cuántos envíos aceptados se usaron para entrenar',
+  `num_followups` int NOT NULL COMMENT 'Parámetro de entrenamiento: cuántos problemas siguientes se consideran por usuario',
+  `followup_decay` double NOT NULL COMMENT 'Parámetro de entrenamiento: qué tan rápido pierde peso cada problema siguiente',
+  `train_fraction` double NOT NULL COMMENT 'Parámetro de entrenamiento: qué fracción de los usuarios se usa para entrenar',
+  `rng_seed` int DEFAULT NULL COMMENT 'Parámetro de entrenamiento: la semilla con la que se partieron los usuarios entre entrenamiento y prueba, NULL si no se fijó ninguna',
+  `output_path` varchar(255) DEFAULT NULL COMMENT 'Dónde quedó el modelo entrenado',
+  `published` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Si este modelo reemplazó al que estaba en uso',
+  `skip_reason` varchar(255) DEFAULT NULL COMMENT 'Por qué no se publicó, NULL si sí se publicó',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`model_run_id`),
+  KEY `idx_rec_model_runs_published_created` (`published`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Historial de entrenamientos del modelo de recomendación de problemas';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Roles` (
   `role_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL COMMENT 'El nombre corto del rol.',

--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -12,7 +12,8 @@
   * @psalm-type CronJob=array{name: string, description: null|string, schedule: null|string, enabled: bool}
   * @psalm-type CronRunPhase=array{phase: string, status: string, duration: float, error_class: null|string}
   * @psalm-type CronRun=array{run_id: int, name: string, hostname: null|string, status: string, started_at: \OmegaUp\Timestamp|null, finished_at: \OmegaUp\Timestamp|null, duration_seconds: float|null, rows_affected: int|null, phases: list<CronRunPhase>, error_text: null|string}
-  * @psalm-type CronsDetailsPayload=array{jobs: list<CronJob>, runs: list<CronRun>}
+  * @psalm-type RecommendationModelRun=array{map_score: float, dataset_size: int, rng_seed: int|null, published: bool, skip_reason: null|string, created_at: \OmegaUp\Timestamp}
+  * @psalm-type CronsDetailsPayload=array{jobs: list<CronJob>, runs: list<CronRun>, recommendationModelRuns: list<RecommendationModelRun>}
   */
 class Admin extends \OmegaUp\Controllers\Controller {
     const MAINTENANCE_MESSAGE_ES_KEY = 'maintenance_message_es';
@@ -32,6 +33,7 @@ class Admin extends \OmegaUp\Controllers\Controller {
     ];
 
     const CRON_RUNS_LIMIT = 50;
+    const RECOMMENDATION_MODEL_RUNS_LIMIT = 20;
 
     /**
      * Get stats for an overall platform report.
@@ -466,7 +468,29 @@ class Admin extends \OmegaUp\Controllers\Controller {
     }
 
     /**
-     * @return array{jobs: list<CronJob>, runs: list<CronRun>}
+     * @param list<\OmegaUp\DAO\VO\RecommendationModelRuns> $modelRuns
+     *
+     * @return list<RecommendationModelRun>
+     */
+    private static function recommendationModelRunsPayload(
+        array $modelRuns
+    ): array {
+        $result = [];
+        foreach ($modelRuns as $modelRun) {
+            $result[] = [
+                'map_score' => floatval($modelRun->map_score),
+                'dataset_size' => intval($modelRun->dataset_size),
+                'rng_seed' => $modelRun->rng_seed,
+                'published' => boolval($modelRun->published),
+                'skip_reason' => $modelRun->skip_reason,
+                'created_at' => $modelRun->created_at,
+            ];
+        }
+        return $result;
+    }
+
+    /**
+     * @return array{jobs: list<CronJob>, runs: list<CronRun>, recommendationModelRuns: list<RecommendationModelRun>}
      */
     private static function cronsPayload(): array {
         return [
@@ -474,13 +498,19 @@ class Admin extends \OmegaUp\Controllers\Controller {
             'runs' => self::cronRunsPayload(
                 \OmegaUp\DAO\CronRuns::getRecent(self::CRON_RUNS_LIMIT)
             ),
+            'recommendationModelRuns' => self::recommendationModelRunsPayload(
+                \OmegaUp\DAO\RecommendationModelRuns::getRecent(
+                    self::RECOMMENDATION_MODEL_RUNS_LIMIT
+                )
+            ),
         ];
     }
 
     /**
-     * Lists the registered cron jobs and their most recent runs.
+     * Lists the registered cron jobs, their most recent runs and the quality of
+     * the recommendation models the training job produced.
      *
-     * @return array{jobs: list<CronJob>, runs: list<CronRun>}
+     * @return array{jobs: list<CronJob>, runs: list<CronRun>, recommendationModelRuns: list<RecommendationModelRun>}
      */
     public static function apiGetCrons(\OmegaUp\Request $r): array {
         $r->ensureMainUserIdentity();

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -353,14 +353,16 @@ Returns the detail of a single cron run.
 
 ### Description
 
-Lists the registered cron jobs and their most recent runs.
+Lists the registered cron jobs, their most recent runs and the quality of
+the recommendation models the training job produced.
 
 ### Returns
 
-| Name   | Type                  |
-| ------ | --------------------- |
-| `jobs` | `List[types.CronJob]` |
-| `runs` | `List[types.CronRun]` |
+| Name                      | Type                                 |
+| ------------------------- | ------------------------------------ |
+| `jobs`                    | `List[types.CronJob]`                |
+| `recommendationModelRuns` | `List[types.RecommendationModelRun]` |
+| `runs`                    | `List[types.CronRun]`                |
 
 ## `/api/admin/getMaintenanceMode/`
 

--- a/frontend/server/src/CronJobName.php
+++ b/frontend/server/src/CronJobName.php
@@ -12,6 +12,7 @@ namespace OmegaUp;
 enum CronJobName: string {
     case AggregateFeedback = 'aggregate_feedback.py';
     case AssignBadges = 'assign_badges.py';
+    case BuildProblemRecModel = 'build_problem_rec_model.py';
     case ProblemHealthCheck = 'problem_health_check.py';
     case UpdateRanks = 'update_ranks.py';
 }

--- a/frontend/server/src/DAO/Base/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/Base/RecommendationModelRuns.php
@@ -1,0 +1,399 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** RecommendationModelRuns Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+ * @access public
+ * @abstract
+ */
+abstract class RecommendationModelRuns {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El objeto de tipo RecommendationModelRuns a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): int {
+        $sql = '
+            UPDATE
+                `Recommendation_Model_Runs`
+            SET
+                `cron_run_id` = ?,
+                `map_score` = ?,
+                `dataset_size` = ?,
+                `num_followups` = ?,
+                `followup_decay` = ?,
+                `train_fraction` = ?,
+                `rng_seed` = ?,
+                `output_path` = ?,
+                `published` = ?,
+                `skip_reason` = ?,
+                `created_at` = ?
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [
+            (
+                is_null($Recommendation_Model_Runs->cron_run_id) ?
+                null :
+                intval($Recommendation_Model_Runs->cron_run_id)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->map_score) ?
+                null :
+                floatval($Recommendation_Model_Runs->map_score)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->dataset_size) ?
+                null :
+                intval($Recommendation_Model_Runs->dataset_size)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->num_followups) ?
+                null :
+                intval($Recommendation_Model_Runs->num_followups)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->followup_decay) ?
+                null :
+                floatval($Recommendation_Model_Runs->followup_decay)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->train_fraction) ?
+                null :
+                floatval($Recommendation_Model_Runs->train_fraction)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->rng_seed) ?
+                null :
+                intval($Recommendation_Model_Runs->rng_seed)
+            ),
+            $Recommendation_Model_Runs->output_path,
+            intval($Recommendation_Model_Runs->published),
+            $Recommendation_Model_Runs->skip_reason,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Recommendation_Model_Runs->created_at
+            ),
+            intval($Recommendation_Model_Runs->model_run_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\RecommendationModelRuns} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\RecommendationModelRuns Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $model_run_id
+    ): ?\OmegaUp\DAO\VO\RecommendationModelRuns {
+        $sql = '
+            SELECT
+                `Recommendation_Model_Runs`.`model_run_id`,
+                `Recommendation_Model_Runs`.`cron_run_id`,
+                `Recommendation_Model_Runs`.`map_score`,
+                `Recommendation_Model_Runs`.`dataset_size`,
+                `Recommendation_Model_Runs`.`num_followups`,
+                `Recommendation_Model_Runs`.`followup_decay`,
+                `Recommendation_Model_Runs`.`train_fraction`,
+                `Recommendation_Model_Runs`.`rng_seed`,
+                `Recommendation_Model_Runs`.`output_path`,
+                `Recommendation_Model_Runs`.`published`,
+                `Recommendation_Model_Runs`.`skip_reason`,
+                `Recommendation_Model_Runs`.`created_at`
+            FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$model_run_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\RecommendationModelRuns($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\RecommendationModelRuns} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $model_run_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [$model_run_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `Recommendation_Model_Runs`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Recommendation_Model_Runs`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El
+     * objeto de tipo \OmegaUp\DAO\VO\RecommendationModelRuns a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [
+            $Recommendation_Model_Runs->model_run_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\RecommendationModelRuns> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'model_run_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `Recommendation_Model_Runs`.`model_run_id`,
+                `Recommendation_Model_Runs`.`cron_run_id`,
+                `Recommendation_Model_Runs`.`map_score`,
+                `Recommendation_Model_Runs`.`dataset_size`,
+                `Recommendation_Model_Runs`.`num_followups`,
+                `Recommendation_Model_Runs`.`followup_decay`,
+                `Recommendation_Model_Runs`.`train_fraction`,
+                `Recommendation_Model_Runs`.`rng_seed`,
+                `Recommendation_Model_Runs`.`output_path`,
+                `Recommendation_Model_Runs`.`published`,
+                `Recommendation_Model_Runs`.`skip_reason`,
+                `Recommendation_Model_Runs`.`created_at`
+            FROM
+                `Recommendation_Model_Runs`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\RecommendationModelRuns(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Recommendation_Model_Runs` (
+                    `cron_run_id`,
+                    `map_score`,
+                    `dataset_size`,
+                    `num_followups`,
+                    `followup_decay`,
+                    `train_fraction`,
+                    `rng_seed`,
+                    `output_path`,
+                    `published`,
+                    `skip_reason`,
+                    `created_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            (
+                is_null($Recommendation_Model_Runs->cron_run_id) ?
+                null :
+                intval($Recommendation_Model_Runs->cron_run_id)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->map_score) ?
+                null :
+                floatval($Recommendation_Model_Runs->map_score)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->dataset_size) ?
+                null :
+                intval($Recommendation_Model_Runs->dataset_size)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->num_followups) ?
+                null :
+                intval($Recommendation_Model_Runs->num_followups)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->followup_decay) ?
+                null :
+                floatval($Recommendation_Model_Runs->followup_decay)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->train_fraction) ?
+                null :
+                floatval($Recommendation_Model_Runs->train_fraction)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->rng_seed) ?
+                null :
+                intval($Recommendation_Model_Runs->rng_seed)
+            ),
+            $Recommendation_Model_Runs->output_path,
+            intval($Recommendation_Model_Runs->published),
+            $Recommendation_Model_Runs->skip_reason,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Recommendation_Model_Runs->created_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Recommendation_Model_Runs->model_run_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/RecommendationModelRuns.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * RecommendationModelRuns Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+ */
+class RecommendationModelRuns extends \OmegaUp\DAO\Base\RecommendationModelRuns {
+    /**
+     * Returns the most recent training runs, newest first. `created_at` only
+     * keeps seconds, so the id breaks the tie between two runs recorded within
+     * the same second.
+     *
+     * @return list<\OmegaUp\DAO\VO\RecommendationModelRuns>
+     */
+    public static function getRecent(int $limit = 20): array {
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\RecommendationModelRuns::FIELD_NAMES,
+            'Recommendation_Model_Runs'
+        );
+        $sql = "SELECT {$fields}
+                FROM Recommendation_Model_Runs
+                ORDER BY created_at DESC, model_run_id DESC
+                LIMIT ?;";
+        /** @var list<array{created_at: \OmegaUp\Timestamp, cron_run_id: int|null, dataset_size: int, followup_decay: float, map_score: float, model_run_id: int, num_followups: int, output_path: null|string, published: bool, rng_seed: int|null, skip_reason: null|string, train_fraction: float}> */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$limit]
+        );
+        $modelRuns = [];
+        foreach ($rs as $row) {
+            $modelRuns[] = new \OmegaUp\DAO\VO\RecommendationModelRuns($row);
+        }
+        return $modelRuns;
+    }
+}

--- a/frontend/server/src/DAO/VO/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/VO/RecommendationModelRuns.php
@@ -1,0 +1,200 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Recommendation_Model_Runs`.
+ *
+ * @access public
+ */
+class RecommendationModelRuns extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'model_run_id' => true,
+        'cron_run_id' => true,
+        'map_score' => true,
+        'dataset_size' => true,
+        'num_followups' => true,
+        'followup_decay' => true,
+        'train_fraction' => true,
+        'rng_seed' => true,
+        'output_path' => true,
+        'published' => true,
+        'skip_reason' => true,
+        'created_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['model_run_id'])) {
+            $this->model_run_id = intval(
+                $data['model_run_id']
+            );
+        }
+        if (isset($data['cron_run_id'])) {
+            $this->cron_run_id = intval(
+                $data['cron_run_id']
+            );
+        }
+        if (isset($data['map_score'])) {
+            $this->map_score = floatval(
+                $data['map_score']
+            );
+        }
+        if (isset($data['dataset_size'])) {
+            $this->dataset_size = intval(
+                $data['dataset_size']
+            );
+        }
+        if (isset($data['num_followups'])) {
+            $this->num_followups = intval(
+                $data['num_followups']
+            );
+        }
+        if (isset($data['followup_decay'])) {
+            $this->followup_decay = floatval(
+                $data['followup_decay']
+            );
+        }
+        if (isset($data['train_fraction'])) {
+            $this->train_fraction = floatval(
+                $data['train_fraction']
+            );
+        }
+        if (isset($data['rng_seed'])) {
+            $this->rng_seed = intval(
+                $data['rng_seed']
+            );
+        }
+        if (isset($data['output_path'])) {
+            $this->output_path = is_scalar(
+                $data['output_path']
+            ) ? strval($data['output_path']) : '';
+        }
+        if (isset($data['published'])) {
+            $this->published = boolval(
+                $data['published']
+            );
+        }
+        if (isset($data['skip_reason'])) {
+            $this->skip_reason = is_scalar(
+                $data['skip_reason']
+            ) ? strval($data['skip_reason']) : '';
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $model_run_id = 0;
+
+    /**
+     * La ejecución de cron que entrenó este modelo, NULL si se corrió a mano
+     *
+     * @var int|null
+     */
+    public $cron_run_id = null;
+
+    /**
+     * MAP@k sobre los usuarios de prueba, la medida con la que se compara contra el último modelo publicado
+     *
+     * @var float|null
+     */
+    public $map_score = null;
+
+    /**
+     * Cuántos envíos aceptados se usaron para entrenar
+     *
+     * @var int|null
+     */
+    public $dataset_size = null;
+
+    /**
+     * Parámetro de entrenamiento: cuántos problemas siguientes se consideran por usuario
+     *
+     * @var int|null
+     */
+    public $num_followups = null;
+
+    /**
+     * Parámetro de entrenamiento: qué tan rápido pierde peso cada problema siguiente
+     *
+     * @var float|null
+     */
+    public $followup_decay = null;
+
+    /**
+     * Parámetro de entrenamiento: qué fracción de los usuarios se usa para entrenar
+     *
+     * @var float|null
+     */
+    public $train_fraction = null;
+
+    /**
+     * Parámetro de entrenamiento: la semilla con la que se partieron los usuarios entre entrenamiento y prueba, NULL si no se fijó ninguna
+     *
+     * @var int|null
+     */
+    public $rng_seed = null;
+
+    /**
+     * Dónde quedó el modelo entrenado
+     *
+     * @var string|null
+     */
+    public $output_path = null;
+
+    /**
+     * Si este modelo reemplazó al que estaba en uso
+     *
+     * @var bool
+     */
+    public $published = false;
+
+    /**
+     * Por qué no se publicó, NULL si sí se publicó
+     *
+     * @var string|null
+     */
+    public $skip_reason = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+}

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -212,4 +212,133 @@ class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame(7, $runs[0]['rows_affected']);
         $this->assertSame([], $runs[0]['phases']);
     }
+
+    private function createModelRun(
+        float $mapScore,
+        bool $published,
+        int $createdAt,
+        ?string $skipReason = null
+    ): void {
+        \OmegaUp\DAO\RecommendationModelRuns::create(
+            new \OmegaUp\DAO\VO\RecommendationModelRuns([
+                'map_score' => $mapScore,
+                'dataset_size' => 4096,
+                'num_followups' => 3,
+                'followup_decay' => 0.4,
+                'train_fraction' => 0.8,
+                'rng_seed' => 42,
+                'output_path' => '/tmp/model.db',
+                'published' => $published,
+                'skip_reason' => $skipReason,
+                'created_at' => new \OmegaUp\Timestamp($createdAt),
+            ])
+        );
+    }
+
+    /**
+     * @param list<array{map_score: float, dataset_size: int, rng_seed: int|null, published: bool, skip_reason: null|string, created_at: \OmegaUp\Timestamp}> $modelRuns
+     * @param list<float> $scores
+     *
+     * @return list<array{map_score: float, dataset_size: int, rng_seed: int|null, published: bool, skip_reason: null|string, created_at: \OmegaUp\Timestamp}>
+     */
+    private function onlyTheseRuns(array $modelRuns, array $scores): array {
+        // The database is shared, so match only the runs this test created.
+        return array_values(array_filter(
+            $modelRuns,
+            function (array $modelRun) use ($scores): bool {
+                foreach ($scores as $score) {
+                    if (abs($modelRun['map_score'] - $score) < 1e-9) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        ));
+    }
+
+    public function testGetCronsIncludesTheRecommendationModelRuns() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(
+            0.111111,
+            published: false,
+            createdAt: $now - 200,
+            skipReason: 'MAP score 0.1111 below minimum 0.3000'
+        );
+        $this->createModelRun(0.222222, published: true, createdAt: $now - 100);
+
+        $response = \OmegaUp\Controllers\Admin::apiGetCrons(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
+
+        $modelRuns = $this->onlyTheseRuns(
+            $response['recommendationModelRuns'],
+            [0.222222, 0.111111]
+        );
+        $this->assertCount(2, $modelRuns);
+        // Newest first.
+        $this->assertEqualsWithDelta(
+            0.222222,
+            $modelRuns[0]['map_score'],
+            1e-9
+        );
+        $this->assertTrue($modelRuns[0]['published']);
+        $this->assertNull($modelRuns[0]['skip_reason']);
+        $this->assertSame(4096, $modelRuns[0]['dataset_size']);
+        $this->assertSame(42, $modelRuns[0]['rng_seed']);
+        $this->assertSame($now - 100, $modelRuns[0]['created_at']->time);
+        $this->assertEqualsWithDelta(
+            0.111111,
+            $modelRuns[1]['map_score'],
+            1e-9
+        );
+        $this->assertFalse($modelRuns[1]['published']);
+        $this->assertSame(
+            'MAP score 0.1111 below minimum 0.3000',
+            $modelRuns[1]['skip_reason']
+        );
+    }
+
+    public function testGetCronsListsTheTrainingJob() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        $response = \OmegaUp\Controllers\Admin::apiGetCrons(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
+
+        $names = array_map(fn ($job) => $job['name'], $response['jobs']);
+        $this->assertContains(
+            \OmegaUp\CronJobName::BuildProblemRecModel->value,
+            $names
+        );
+    }
+
+    public function testGetCronsForTypeScriptCarriesTheSameModelRuns() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+        $this->createModelRun(
+            0.333333,
+            published: true,
+            createdAt: \OmegaUp\Time::get() - 100
+        );
+
+        $page = \OmegaUp\Controllers\Admin::getCronsForTypeScript(
+            new \OmegaUp\Request(['auth_token' => $login->auth_token])
+        );
+        $api = \OmegaUp\Controllers\Admin::apiGetCrons(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+        ]));
+
+        $fromPage = $this->onlyTheseRuns(
+            $page['templateProperties']['payload']['recommendationModelRuns'],
+            [0.333333]
+        );
+        $this->assertCount(1, $fromPage);
+        $this->assertEquals(
+            $this->onlyTheseRuns($api['recommendationModelRuns'], [0.333333]),
+            $fromPage
+        );
+    }
 }

--- a/frontend/tests/controllers/RecommendationModelRunsDAOTest.php
+++ b/frontend/tests/controllers/RecommendationModelRunsDAOTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\RecommendationModelRuns data access object and for
+ * the registry entry of the recommendation model training job.
+ */
+class RecommendationModelRunsDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    private function createModelRun(
+        float $mapScore,
+        bool $published,
+        int $createdAt,
+        ?string $skipReason = null,
+        ?int $rngSeed = null
+    ): \OmegaUp\DAO\VO\RecommendationModelRuns {
+        $modelRun = new \OmegaUp\DAO\VO\RecommendationModelRuns([
+            'map_score' => $mapScore,
+            'dataset_size' => 1000,
+            'num_followups' => 3,
+            'followup_decay' => 0.4,
+            'train_fraction' => 0.8,
+            'rng_seed' => $rngSeed,
+            'output_path' => '/tmp/model.db',
+            'published' => $published,
+            'skip_reason' => $skipReason,
+            'created_at' => new \OmegaUp\Timestamp($createdAt),
+        ]);
+        \OmegaUp\DAO\RecommendationModelRuns::create($modelRun);
+        return $modelRun;
+    }
+
+    public function testTrainingJobIsRegistered() {
+        $job = \OmegaUp\DAO\CronJobs::getByName(
+            \OmegaUp\CronJobName::BuildProblemRecModel->value
+        );
+
+        $this->assertNotNull($job);
+        $this->assertTrue($job->enabled);
+        $this->assertSame('0 4 * * 0', $job->schedule);
+    }
+
+    public function testGetRecentReturnsRunsNewestFirst() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(0.30, published: true, createdAt: $now - 300);
+        $this->createModelRun(
+            0.35,
+            published: false,
+            createdAt: $now - 200,
+            skipReason: 'regressed'
+        );
+        $this->createModelRun(0.50, published: true, createdAt: $now - 100);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertCount(3, $recent);
+        $this->assertEqualsWithDelta(0.50, $recent[0]->map_score, 1e-9);
+        $this->assertEqualsWithDelta(0.35, $recent[1]->map_score, 1e-9);
+        $this->assertEqualsWithDelta(0.30, $recent[2]->map_score, 1e-9);
+        $this->assertSame('regressed', $recent[1]->skip_reason);
+        $this->assertNull($recent[0]->skip_reason);
+    }
+
+    public function testGetRecentOrdersRunsRecordedInTheSameSecond() {
+        $sameSecond = \OmegaUp\Time::get() - 100;
+        $older = $this->createModelRun(
+            0.10,
+            published: false,
+            createdAt: $sameSecond,
+            skipReason: 'below minimum'
+        );
+        $newer = $this->createModelRun(
+            0.20,
+            published: true,
+            createdAt: $sameSecond
+        );
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertSame($newer->model_run_id, $recent[0]->model_run_id);
+        $this->assertSame($older->model_run_id, $recent[1]->model_run_id);
+    }
+
+    public function testGetRecentHonorsTheLimit() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(0.30, published: true, createdAt: $now - 300);
+        $this->createModelRun(0.40, published: true, createdAt: $now - 200);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(1);
+
+        $this->assertCount(1, $recent);
+        $this->assertEqualsWithDelta(0.40, $recent[0]->map_score, 1e-9);
+    }
+
+    public function testGetRecentKeepsAFixedSeedOfZeroApartFromNoSeed() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(
+            0.30,
+            published: true,
+            createdAt: $now - 200,
+            rngSeed: 0
+        );
+        $this->createModelRun(0.40, published: true, createdAt: $now - 100);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertNull($recent[0]->rng_seed);
+        $this->assertSame(0, $recent[1]->rng_seed);
+    }
+
+    public function testGetRecentKeepsEveryTrainingParameter() {
+        $this->createModelRun(
+            0.42,
+            published: true,
+            createdAt: \OmegaUp\Time::get() - 100,
+            rngSeed: 7
+        );
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(1);
+
+        $this->assertSame(1000, $recent[0]->dataset_size);
+        $this->assertSame(3, $recent[0]->num_followups);
+        $this->assertEqualsWithDelta(0.4, $recent[0]->followup_decay, 1e-9);
+        $this->assertEqualsWithDelta(0.8, $recent[0]->train_fraction, 1e-9);
+        $this->assertSame(7, $recent[0]->rng_seed);
+        $this->assertSame('/tmp/model.db', $recent[0]->output_path);
+        $this->assertTrue($recent[0]->published);
+    }
+}

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -118,6 +118,15 @@ export const Admin = {
     messages._AdminGetCronsServerResponse,
     messages.AdminGetCronsResponse
   >('/api/admin/getCrons/', (x) => {
+    x.recommendationModelRuns = ((x) => {
+      if (!Array.isArray(x)) {
+        return x;
+      }
+      return x.map((x) => {
+        x.created_at = ((x: number) => new Date(x * 1000))(x.created_at);
+        return x;
+      });
+    })(x.recommendationModelRuns);
     x.runs = ((x) => {
       if (!Array.isArray(x)) {
         return x;

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -1606,6 +1606,15 @@ export namespace types {
       elementId: string = 'payload',
     ): types.CronsDetailsPayload {
       return ((x) => {
+        x.recommendationModelRuns = ((x) => {
+          if (!Array.isArray(x)) {
+            return x;
+          }
+          return x.map((x) => {
+            x.created_at = ((x: number) => new Date(x * 1000))(x.created_at);
+            return x;
+          });
+        })(x.recommendationModelRuns);
         x.runs = ((x) => {
           if (!Array.isArray(x)) {
             return x;
@@ -3843,6 +3852,7 @@ export namespace types {
 
   export interface CronsDetailsPayload {
     jobs: types.CronJob[];
+    recommendationModelRuns: types.RecommendationModelRun[];
     runs: types.CronRun[];
   }
 
@@ -4678,6 +4688,15 @@ export namespace types {
     score: number;
   }
 
+  export interface RecommendationModelRun {
+    created_at: Date;
+    dataset_size: number;
+    map_score: number;
+    published: boolean;
+    rng_seed?: number;
+    skip_reason?: string;
+  }
+
   export interface Run {
     alias: string;
     classname: string;
@@ -5415,6 +5434,7 @@ export namespace messages {
   export type _AdminGetCronsServerResponse = any;
   export type AdminGetCronsResponse = {
     jobs: types.CronJob[];
+    recommendationModelRuns: types.RecommendationModelRun[];
     runs: types.CronRun[];
   };
   export type AdminGetMaintenanceModeRequest = { [key: string]: any };


### PR DESCRIPTION
# Description

the server half of #10052, split off the way you asked on #10069 and on #10008.

`apiGetCrons` now returns `recommendationModelRuns` next to the jobs and the runs, read through `RecommendationModelRuns::getRecent` from #10150, newest first. each row carries the MAP score, how many submissions it trained on, the seed, whether it was published and, when it was not, why.

the seed is in there because of your comment on #10050. storing it is only half the point, an admin comparing two runs has to be able to see it, so it comes back in the payload and the dashboard shows it.

both `apiGetCrons` and `getCronsForTypeScript` read it through the private `cronsPayload` helper, and the limit is a constant next to `CRON_RUNS_LIMIT` rather than a literal.

part of #10049. the ui that renders this is #10052, and that is what closes the issue.

# Comments

this and #10153 both add a key to `cronsPayload`, so whichever lands second needs a one line resolve there. nothing else overlaps.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
