### PR TITLE
add cron rerun api

### DIFF
--- a/frontend/database/00282_cron_run_requests.sql
+++ b/frontend/database/00282_cron_run_requests.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `Cron_Run_Requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) NOT NULL COMMENT 'Nombre del script cuya reejecución se solicita',
+  `requested_by` int DEFAULT NULL COMMENT 'El administrador que la solicitó, NULL si su cuenta ya no existe',
+  `status` enum('pending','picked','done','failed') NOT NULL DEFAULT 'pending' COMMENT 'pending mientras espera al despachador, picked mientras corre',
+  `requested_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `picked_at` datetime DEFAULT NULL COMMENT 'Cuando el despachador tomó la solicitud',
+  `finished_at` datetime DEFAULT NULL COMMENT 'Cuando terminó la ejecución, haya salido bien o mal',
+  `run_id` int DEFAULT NULL COMMENT 'La ejecución que produjo, NULL si el trabajo no llegó a correr',
+  `error_text` text COMMENT 'El final de stderr cuando la ejecución falló',
+  PRIMARY KEY (`request_id`),
+  KEY `idx_cron_run_requests_status` (`status`),
+  KEY `idx_cron_run_requests_name` (`name`),
+  CONSTRAINT `fk_crr_requested_by` FOREIGN KEY (`requested_by`) REFERENCES `Users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Solicitudes de reejecución manual de trabajos cron';

--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -402,6 +402,25 @@ CREATE TABLE `Cron_Jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Cron_Run_Requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) NOT NULL COMMENT 'Nombre del script cuya reejecución se solicita',
+  `requested_by` int DEFAULT NULL COMMENT 'El administrador que la solicitó, NULL si su cuenta ya no existe',
+  `status` enum('pending','picked','done','failed') NOT NULL DEFAULT 'pending' COMMENT 'pending mientras espera al despachador, picked mientras corre',
+  `requested_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `picked_at` datetime DEFAULT NULL COMMENT 'Cuando el despachador tomó la solicitud',
+  `finished_at` datetime DEFAULT NULL COMMENT 'Cuando terminó la ejecución, haya salido bien o mal',
+  `run_id` int DEFAULT NULL COMMENT 'La ejecución que produjo, NULL si el trabajo no llegó a correr',
+  `error_text` text COMMENT 'El final de stderr cuando la ejecución falló',
+  PRIMARY KEY (`request_id`),
+  KEY `idx_cron_run_requests_status` (`status`),
+  KEY `idx_cron_run_requests_name` (`name`),
+  KEY `fk_crr_requested_by` (`requested_by`),
+  CONSTRAINT `fk_crr_requested_by` FOREIGN KEY (`requested_by`) REFERENCES `Users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Solicitudes de reejecución manual de trabajos cron';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Cron_Runs` (
   `run_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL COMMENT 'Nombre del script (parser.prog). Denormalizado a propósito: el historial se registra aunque el trabajo no esté en Cron_Jobs y sobrevive a renombres o borrados del registro',

--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -1067,6 +1067,25 @@ CREATE TABLE `QualityNominations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Recommendation_Model_Runs` (
+  `model_run_id` int NOT NULL AUTO_INCREMENT,
+  `cron_run_id` int DEFAULT NULL COMMENT 'La ejecución de cron que entrenó este modelo, NULL si se corrió a mano',
+  `map_score` double NOT NULL COMMENT 'MAP@k sobre los usuarios de prueba, la medida con la que se compara contra el último modelo publicado',
+  `dataset_size` int NOT NULL COMMENT 'Cuántos envíos aceptados se usaron para entrenar',
+  `num_followups` int NOT NULL COMMENT 'Parámetro de entrenamiento: cuántos problemas siguientes se consideran por usuario',
+  `followup_decay` double NOT NULL COMMENT 'Parámetro de entrenamiento: qué tan rápido pierde peso cada problema siguiente',
+  `train_fraction` double NOT NULL COMMENT 'Parámetro de entrenamiento: qué fracción de los usuarios se usa para entrenar',
+  `rng_seed` int DEFAULT NULL COMMENT 'Parámetro de entrenamiento: la semilla con la que se partieron los usuarios entre entrenamiento y prueba, NULL si no se fijó ninguna',
+  `output_path` varchar(255) DEFAULT NULL COMMENT 'Dónde quedó el modelo entrenado',
+  `published` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Si este modelo reemplazó al que estaba en uso',
+  `skip_reason` varchar(255) DEFAULT NULL COMMENT 'Por qué no se publicó, NULL si sí se publicó',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`model_run_id`),
+  KEY `idx_rec_model_runs_published_created` (`published`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Historial de entrenamientos del modelo de recomendación de problemas';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Roles` (
   `role_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL COMMENT 'El nombre corto del rol.',

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -402,6 +402,25 @@ CREATE TABLE `Cron_Jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Cron_Run_Requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) NOT NULL COMMENT 'Nombre del script cuya reejecución se solicita',
+  `requested_by` int DEFAULT NULL COMMENT 'El administrador que la solicitó, NULL si su cuenta ya no existe',
+  `status` enum('pending','picked','done','failed') NOT NULL DEFAULT 'pending' COMMENT 'pending mientras espera al despachador, picked mientras corre',
+  `requested_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `picked_at` datetime DEFAULT NULL COMMENT 'Cuando el despachador tomó la solicitud',
+  `finished_at` datetime DEFAULT NULL COMMENT 'Cuando terminó la ejecución, haya salido bien o mal',
+  `run_id` int DEFAULT NULL COMMENT 'La ejecución que produjo, NULL si el trabajo no llegó a correr',
+  `error_text` text COMMENT 'El final de stderr cuando la ejecución falló',
+  PRIMARY KEY (`request_id`),
+  KEY `idx_cron_run_requests_status` (`status`),
+  KEY `idx_cron_run_requests_name` (`name`),
+  KEY `fk_crr_requested_by` (`requested_by`),
+  CONSTRAINT `fk_crr_requested_by` FOREIGN KEY (`requested_by`) REFERENCES `Users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Solicitudes de reejecución manual de trabajos cron';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Cron_Runs` (
   `run_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL COMMENT 'Nombre del script (parser.prog). Denormalizado a propósito: el historial se registra aunque el trabajo no esté en Cron_Jobs y sobrevive a renombres o borrados del registro',

--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -215,7 +215,7 @@ class ApiCaller {
             'delete', 'disqualify', 'execute', 'expire', 'forfeit',
             'generate', 'invalidate', 'login', 'logout', 'open',
             'read', 'refresh', 'register', 'rejudge', 'remove',
-            'requalify', 'resolve', 'revoke', 'select', 'set',
+            'requalify', 'rerun', 'resolve', 'revoke', 'select', 'set',
             'toggle', 'update', 'verify',
         ];
         foreach ($mutatingPatterns as $pattern) {

--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -510,6 +510,44 @@ class Admin extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * Queues a manual rerun of a registered cron job for a worker to pick up.
+     *
+     * @return array{status: string}
+     *
+     * @omegaup-request-param string $name
+     */
+    public static function apiRerunCron(\OmegaUp\Request $r): array {
+        $r->ensureMainUserIdentity();
+        if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException();
+        }
+        $jobName = \OmegaUp\CronJobName::tryFrom($r->ensureString('name'));
+        if (is_null($jobName)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'name'
+            );
+        }
+        // The dispatcher runs whatever is queued, so a job that is already
+        // waiting or in flight does not get a second row.
+        if (
+            !is_null(
+                \OmegaUp\DAO\CronRunRequests::getActiveByName($jobName->value)
+            )
+        ) {
+            return ['status' => 'ok'];
+        }
+        \OmegaUp\DAO\CronRunRequests::create(
+            new \OmegaUp\DAO\VO\CronRunRequests([
+                'name' => $jobName->value,
+                'requested_by' => $r->user->user_id,
+                'status' => \OmegaUp\CronRunRequestStatus::Pending->value,
+            ])
+        );
+        return ['status' => 'ok'];
+    }
+
+    /**
      * @return array{entrypoint: string, templateProperties: array{payload: CronsDetailsPayload, title: \OmegaUp\TranslationString}}
      */
     public static function getCronsForTypeScript(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -6,6 +6,7 @@
   - [`/api/admin/getMaintenanceMode/`](#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](#apiadminplatformreportstats)
+  - [`/api/admin/rerunCron/`](#apiadminreruncron)
   - [`/api/admin/setMaintenanceMode/`](#apiadminsetmaintenancemode)
   - [`/api/admin/updateSystemSettings/`](#apiadminupdatesystemsettings)
 - [AiEditorial](#aieditorial)
@@ -404,6 +405,22 @@ Get stats for an overall platform report.
 | Name     | Type                                                                                                                                                                                                     |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `report` | `{ acceptedSubmissions: number; activeSchools: number; activeUsers: { [key: string]: number; }; courses: number; omiCourse: { attemptedUsers: number; completedUsers: number; passedUsers: number; }; }` |
+
+## `/api/admin/rerunCron/`
+
+### Description
+
+Queues a manual rerun of a registered cron job for a worker to pick up.
+
+### Parameters
+
+| Name   | Type     | Description | Required |
+| ------ | -------- | ----------- | -------- |
+| `name` | `string` |             | ✓        |
+
+### Returns
+
+_Nothing_
 
 ## `/api/admin/setMaintenanceMode/`
 

--- a/frontend/server/src/CronJobName.php
+++ b/frontend/server/src/CronJobName.php
@@ -12,6 +12,7 @@ namespace OmegaUp;
 enum CronJobName: string {
     case AggregateFeedback = 'aggregate_feedback.py';
     case AssignBadges = 'assign_badges.py';
+    case BuildProblemRecModel = 'build_problem_rec_model.py';
     case ProblemHealthCheck = 'problem_health_check.py';
     case UpdateRanks = 'update_ranks.py';
 }

--- a/frontend/server/src/CronRunRequestStatus.php
+++ b/frontend/server/src/CronRunRequestStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * The states a manual rerun request can be in, mirroring the
+ * `Cron_Run_Requests.status` column.
+ */
+enum CronRunRequestStatus: string {
+    case Pending = 'pending';
+    case Picked = 'picked';
+    case Done = 'done';
+    case Failed = 'failed';
+}

--- a/frontend/server/src/DAO/Base/CronRunRequests.php
+++ b/frontend/server/src/DAO/Base/CronRunRequests.php
@@ -1,0 +1,346 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** CronRunRequests Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+ * @access public
+ * @abstract
+ */
+abstract class CronRunRequests {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests El objeto de tipo CronRunRequests a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests
+    ): int {
+        $sql = '
+            UPDATE
+                `Cron_Run_Requests`
+            SET
+                `name` = ?,
+                `requested_by` = ?,
+                `status` = ?,
+                `requested_at` = ?,
+                `picked_at` = ?,
+                `finished_at` = ?,
+                `run_id` = ?,
+                `error_text` = ?
+            WHERE
+                (
+                    `request_id` = ?
+                );';
+        $params = [
+            $Cron_Run_Requests->name,
+            (
+                is_null($Cron_Run_Requests->requested_by) ?
+                null :
+                intval($Cron_Run_Requests->requested_by)
+            ),
+            $Cron_Run_Requests->status,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->requested_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->picked_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->finished_at
+            ),
+            (
+                is_null($Cron_Run_Requests->run_id) ?
+                null :
+                intval($Cron_Run_Requests->run_id)
+            ),
+            $Cron_Run_Requests->error_text,
+            intval($Cron_Run_Requests->request_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\CronRunRequests} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\CronRunRequests Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\CronRunRequests} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $request_id
+    ): ?\OmegaUp\DAO\VO\CronRunRequests {
+        $sql = '
+            SELECT
+                `Cron_Run_Requests`.`request_id`,
+                `Cron_Run_Requests`.`name`,
+                `Cron_Run_Requests`.`requested_by`,
+                `Cron_Run_Requests`.`status`,
+                `Cron_Run_Requests`.`requested_at`,
+                `Cron_Run_Requests`.`picked_at`,
+                `Cron_Run_Requests`.`finished_at`,
+                `Cron_Run_Requests`.`run_id`,
+                `Cron_Run_Requests`.`error_text`
+            FROM
+                `Cron_Run_Requests`
+            WHERE
+                (
+                    `request_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$request_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\CronRunRequests($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\CronRunRequests} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $request_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Cron_Run_Requests`
+            WHERE
+                (
+                    `request_id` = ?
+                );';
+        $params = [$request_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `Cron_Run_Requests`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Cron_Run_Requests`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\CronRunRequests} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests El
+     * objeto de tipo \OmegaUp\DAO\VO\CronRunRequests a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Cron_Run_Requests`
+            WHERE
+                (
+                    `request_id` = ?
+                );';
+        $params = [
+            $Cron_Run_Requests->request_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\CronRunRequests> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'request_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `Cron_Run_Requests`.`request_id`,
+                `Cron_Run_Requests`.`name`,
+                `Cron_Run_Requests`.`requested_by`,
+                `Cron_Run_Requests`.`status`,
+                `Cron_Run_Requests`.`requested_at`,
+                `Cron_Run_Requests`.`picked_at`,
+                `Cron_Run_Requests`.`finished_at`,
+                `Cron_Run_Requests`.`run_id`,
+                `Cron_Run_Requests`.`error_text`
+            FROM
+                `Cron_Run_Requests`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\CronRunRequests(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Cron_Run_Requests` (
+                    `name`,
+                    `requested_by`,
+                    `status`,
+                    `requested_at`,
+                    `picked_at`,
+                    `finished_at`,
+                    `run_id`,
+                    `error_text`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            $Cron_Run_Requests->name,
+            (
+                is_null($Cron_Run_Requests->requested_by) ?
+                null :
+                intval($Cron_Run_Requests->requested_by)
+            ),
+            $Cron_Run_Requests->status,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->requested_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->picked_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->finished_at
+            ),
+            (
+                is_null($Cron_Run_Requests->run_id) ?
+                null :
+                intval($Cron_Run_Requests->run_id)
+            ),
+            $Cron_Run_Requests->error_text,
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Cron_Run_Requests->request_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/Base/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/Base/RecommendationModelRuns.php
@@ -1,0 +1,399 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** RecommendationModelRuns Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+ * @access public
+ * @abstract
+ */
+abstract class RecommendationModelRuns {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El objeto de tipo RecommendationModelRuns a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): int {
+        $sql = '
+            UPDATE
+                `Recommendation_Model_Runs`
+            SET
+                `cron_run_id` = ?,
+                `map_score` = ?,
+                `dataset_size` = ?,
+                `num_followups` = ?,
+                `followup_decay` = ?,
+                `train_fraction` = ?,
+                `rng_seed` = ?,
+                `output_path` = ?,
+                `published` = ?,
+                `skip_reason` = ?,
+                `created_at` = ?
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [
+            (
+                is_null($Recommendation_Model_Runs->cron_run_id) ?
+                null :
+                intval($Recommendation_Model_Runs->cron_run_id)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->map_score) ?
+                null :
+                floatval($Recommendation_Model_Runs->map_score)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->dataset_size) ?
+                null :
+                intval($Recommendation_Model_Runs->dataset_size)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->num_followups) ?
+                null :
+                intval($Recommendation_Model_Runs->num_followups)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->followup_decay) ?
+                null :
+                floatval($Recommendation_Model_Runs->followup_decay)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->train_fraction) ?
+                null :
+                floatval($Recommendation_Model_Runs->train_fraction)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->rng_seed) ?
+                null :
+                intval($Recommendation_Model_Runs->rng_seed)
+            ),
+            $Recommendation_Model_Runs->output_path,
+            intval($Recommendation_Model_Runs->published),
+            $Recommendation_Model_Runs->skip_reason,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Recommendation_Model_Runs->created_at
+            ),
+            intval($Recommendation_Model_Runs->model_run_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\RecommendationModelRuns} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\RecommendationModelRuns Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $model_run_id
+    ): ?\OmegaUp\DAO\VO\RecommendationModelRuns {
+        $sql = '
+            SELECT
+                `Recommendation_Model_Runs`.`model_run_id`,
+                `Recommendation_Model_Runs`.`cron_run_id`,
+                `Recommendation_Model_Runs`.`map_score`,
+                `Recommendation_Model_Runs`.`dataset_size`,
+                `Recommendation_Model_Runs`.`num_followups`,
+                `Recommendation_Model_Runs`.`followup_decay`,
+                `Recommendation_Model_Runs`.`train_fraction`,
+                `Recommendation_Model_Runs`.`rng_seed`,
+                `Recommendation_Model_Runs`.`output_path`,
+                `Recommendation_Model_Runs`.`published`,
+                `Recommendation_Model_Runs`.`skip_reason`,
+                `Recommendation_Model_Runs`.`created_at`
+            FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$model_run_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\RecommendationModelRuns($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\RecommendationModelRuns} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $model_run_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [$model_run_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `Recommendation_Model_Runs`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Recommendation_Model_Runs`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El
+     * objeto de tipo \OmegaUp\DAO\VO\RecommendationModelRuns a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [
+            $Recommendation_Model_Runs->model_run_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\RecommendationModelRuns> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'model_run_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `Recommendation_Model_Runs`.`model_run_id`,
+                `Recommendation_Model_Runs`.`cron_run_id`,
+                `Recommendation_Model_Runs`.`map_score`,
+                `Recommendation_Model_Runs`.`dataset_size`,
+                `Recommendation_Model_Runs`.`num_followups`,
+                `Recommendation_Model_Runs`.`followup_decay`,
+                `Recommendation_Model_Runs`.`train_fraction`,
+                `Recommendation_Model_Runs`.`rng_seed`,
+                `Recommendation_Model_Runs`.`output_path`,
+                `Recommendation_Model_Runs`.`published`,
+                `Recommendation_Model_Runs`.`skip_reason`,
+                `Recommendation_Model_Runs`.`created_at`
+            FROM
+                `Recommendation_Model_Runs`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\RecommendationModelRuns(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Recommendation_Model_Runs` (
+                    `cron_run_id`,
+                    `map_score`,
+                    `dataset_size`,
+                    `num_followups`,
+                    `followup_decay`,
+                    `train_fraction`,
+                    `rng_seed`,
+                    `output_path`,
+                    `published`,
+                    `skip_reason`,
+                    `created_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            (
+                is_null($Recommendation_Model_Runs->cron_run_id) ?
+                null :
+                intval($Recommendation_Model_Runs->cron_run_id)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->map_score) ?
+                null :
+                floatval($Recommendation_Model_Runs->map_score)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->dataset_size) ?
+                null :
+                intval($Recommendation_Model_Runs->dataset_size)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->num_followups) ?
+                null :
+                intval($Recommendation_Model_Runs->num_followups)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->followup_decay) ?
+                null :
+                floatval($Recommendation_Model_Runs->followup_decay)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->train_fraction) ?
+                null :
+                floatval($Recommendation_Model_Runs->train_fraction)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->rng_seed) ?
+                null :
+                intval($Recommendation_Model_Runs->rng_seed)
+            ),
+            $Recommendation_Model_Runs->output_path,
+            intval($Recommendation_Model_Runs->published),
+            $Recommendation_Model_Runs->skip_reason,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Recommendation_Model_Runs->created_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Recommendation_Model_Runs->model_run_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/CronRunRequests.php
+++ b/frontend/server/src/DAO/CronRunRequests.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * CronRunRequests Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+ */
+class CronRunRequests extends \OmegaUp\DAO\Base\CronRunRequests {
+    /**
+     * Returns the pending or in-flight request for a job, if any.
+     */
+    public static function getActiveByName(
+        string $name
+    ): ?\OmegaUp\DAO\VO\CronRunRequests {
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\CronRunRequests::FIELD_NAMES,
+            'Cron_Run_Requests'
+        );
+        $sql = "SELECT {$fields}
+                FROM Cron_Run_Requests
+                WHERE name = ? AND status IN (?, ?)
+                ORDER BY requested_at DESC
+                LIMIT 1;";
+        /** @var array{error_text: null|string, finished_at: \OmegaUp\Timestamp|null, name: string, picked_at: \OmegaUp\Timestamp|null, request_id: int, requested_at: \OmegaUp\Timestamp, requested_by: int|null, run_id: int|null, status: string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [
+            $name,
+            \OmegaUp\CronRunRequestStatus::Pending->value,
+            \OmegaUp\CronRunRequestStatus::Picked->value,
+        ]);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\CronRunRequests($row);
+    }
+}

--- a/frontend/server/src/DAO/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/RecommendationModelRuns.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * RecommendationModelRuns Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+ */
+class RecommendationModelRuns extends \OmegaUp\DAO\Base\RecommendationModelRuns {
+    /**
+     * Returns the most recent training runs, newest first. `created_at` only
+     * keeps seconds, so the id breaks the tie between two runs recorded within
+     * the same second.
+     *
+     * @return list<\OmegaUp\DAO\VO\RecommendationModelRuns>
+     */
+    public static function getRecent(int $limit = 20): array {
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\RecommendationModelRuns::FIELD_NAMES,
+            'Recommendation_Model_Runs'
+        );
+        $sql = "SELECT {$fields}
+                FROM Recommendation_Model_Runs
+                ORDER BY created_at DESC, model_run_id DESC
+                LIMIT ?;";
+        /** @var list<array{created_at: \OmegaUp\Timestamp, cron_run_id: int|null, dataset_size: int, followup_decay: float, map_score: float, model_run_id: int, num_followups: int, output_path: null|string, published: bool, rng_seed: int|null, skip_reason: null|string, train_fraction: float}> */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$limit]
+        );
+        $modelRuns = [];
+        foreach ($rs as $row) {
+            $modelRuns[] = new \OmegaUp\DAO\VO\RecommendationModelRuns($row);
+        }
+        return $modelRuns;
+    }
+}

--- a/frontend/server/src/DAO/VO/CronRunRequests.php
+++ b/frontend/server/src/DAO/VO/CronRunRequests.php
@@ -1,0 +1,173 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Cron_Run_Requests`.
+ *
+ * @access public
+ */
+class CronRunRequests extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'request_id' => true,
+        'name' => true,
+        'requested_by' => true,
+        'status' => true,
+        'requested_at' => true,
+        'picked_at' => true,
+        'finished_at' => true,
+        'run_id' => true,
+        'error_text' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['request_id'])) {
+            $this->request_id = intval(
+                $data['request_id']
+            );
+        }
+        if (isset($data['name'])) {
+            $this->name = is_scalar(
+                $data['name']
+            ) ? strval($data['name']) : '';
+        }
+        if (isset($data['requested_by'])) {
+            $this->requested_by = intval(
+                $data['requested_by']
+            );
+        }
+        if (isset($data['status'])) {
+            $this->status = is_scalar(
+                $data['status']
+            ) ? strval($data['status']) : '';
+        }
+        if (isset($data['requested_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['requested_at']
+             * @var \OmegaUp\Timestamp $this->requested_at
+             */
+            $this->requested_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['requested_at']
+                )
+            );
+        } else {
+            $this->requested_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['picked_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['picked_at']
+             * @var \OmegaUp\Timestamp $this->picked_at
+             */
+            $this->picked_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['picked_at']
+                )
+            );
+        }
+        if (isset($data['finished_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['finished_at']
+             * @var \OmegaUp\Timestamp $this->finished_at
+             */
+            $this->finished_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['finished_at']
+                )
+            );
+        }
+        if (isset($data['run_id'])) {
+            $this->run_id = intval(
+                $data['run_id']
+            );
+        }
+        if (isset($data['error_text'])) {
+            $this->error_text = is_scalar(
+                $data['error_text']
+            ) ? strval($data['error_text']) : '';
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $request_id = 0;
+
+    /**
+     * Nombre del script cuya reejecución se solicita
+     *
+     * @var string|null
+     */
+    public $name = null;
+
+    /**
+     * El administrador que la solicitó, NULL si su cuenta ya no existe
+     *
+     * @var int|null
+     */
+    public $requested_by = null;
+
+    /**
+     * pending mientras espera al despachador, picked mientras corre
+     *
+     * @var string
+     */
+    public $status = 'pending';
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $requested_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * Cuando el despachador tomó la solicitud
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $picked_at = null;
+
+    /**
+     * Cuando terminó la ejecución, haya salido bien o mal
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $finished_at = null;
+
+    /**
+     * La ejecución que produjo, NULL si el trabajo no llegó a correr
+     *
+     * @var int|null
+     */
+    public $run_id = null;
+
+    /**
+     * El final de stderr cuando la ejecución falló
+     *
+     * @var string|null
+     */
+    public $error_text = null;
+}

--- a/frontend/server/src/DAO/VO/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/VO/RecommendationModelRuns.php
@@ -1,0 +1,200 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Recommendation_Model_Runs`.
+ *
+ * @access public
+ */
+class RecommendationModelRuns extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'model_run_id' => true,
+        'cron_run_id' => true,
+        'map_score' => true,
+        'dataset_size' => true,
+        'num_followups' => true,
+        'followup_decay' => true,
+        'train_fraction' => true,
+        'rng_seed' => true,
+        'output_path' => true,
+        'published' => true,
+        'skip_reason' => true,
+        'created_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['model_run_id'])) {
+            $this->model_run_id = intval(
+                $data['model_run_id']
+            );
+        }
+        if (isset($data['cron_run_id'])) {
+            $this->cron_run_id = intval(
+                $data['cron_run_id']
+            );
+        }
+        if (isset($data['map_score'])) {
+            $this->map_score = floatval(
+                $data['map_score']
+            );
+        }
+        if (isset($data['dataset_size'])) {
+            $this->dataset_size = intval(
+                $data['dataset_size']
+            );
+        }
+        if (isset($data['num_followups'])) {
+            $this->num_followups = intval(
+                $data['num_followups']
+            );
+        }
+        if (isset($data['followup_decay'])) {
+            $this->followup_decay = floatval(
+                $data['followup_decay']
+            );
+        }
+        if (isset($data['train_fraction'])) {
+            $this->train_fraction = floatval(
+                $data['train_fraction']
+            );
+        }
+        if (isset($data['rng_seed'])) {
+            $this->rng_seed = intval(
+                $data['rng_seed']
+            );
+        }
+        if (isset($data['output_path'])) {
+            $this->output_path = is_scalar(
+                $data['output_path']
+            ) ? strval($data['output_path']) : '';
+        }
+        if (isset($data['published'])) {
+            $this->published = boolval(
+                $data['published']
+            );
+        }
+        if (isset($data['skip_reason'])) {
+            $this->skip_reason = is_scalar(
+                $data['skip_reason']
+            ) ? strval($data['skip_reason']) : '';
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $model_run_id = 0;
+
+    /**
+     * La ejecución de cron que entrenó este modelo, NULL si se corrió a mano
+     *
+     * @var int|null
+     */
+    public $cron_run_id = null;
+
+    /**
+     * MAP@k sobre los usuarios de prueba, la medida con la que se compara contra el último modelo publicado
+     *
+     * @var float|null
+     */
+    public $map_score = null;
+
+    /**
+     * Cuántos envíos aceptados se usaron para entrenar
+     *
+     * @var int|null
+     */
+    public $dataset_size = null;
+
+    /**
+     * Parámetro de entrenamiento: cuántos problemas siguientes se consideran por usuario
+     *
+     * @var int|null
+     */
+    public $num_followups = null;
+
+    /**
+     * Parámetro de entrenamiento: qué tan rápido pierde peso cada problema siguiente
+     *
+     * @var float|null
+     */
+    public $followup_decay = null;
+
+    /**
+     * Parámetro de entrenamiento: qué fracción de los usuarios se usa para entrenar
+     *
+     * @var float|null
+     */
+    public $train_fraction = null;
+
+    /**
+     * Parámetro de entrenamiento: la semilla con la que se partieron los usuarios entre entrenamiento y prueba, NULL si no se fijó ninguna
+     *
+     * @var int|null
+     */
+    public $rng_seed = null;
+
+    /**
+     * Dónde quedó el modelo entrenado
+     *
+     * @var string|null
+     */
+    public $output_path = null;
+
+    /**
+     * Si este modelo reemplazó al que estaba en uso
+     *
+     * @var bool
+     */
+    public $published = false;
+
+    /**
+     * Por qué no se publicó, NULL si sí se publicó
+     *
+     * @var string|null
+     */
+    public $skip_reason = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+}

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -4,6 +4,14 @@
  * Tests for the cron control plane admin endpoints.
  */
 class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        // The table survives the shared cleanup, so each test starts empty.
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            'DELETE FROM `Cron_Run_Requests`;'
+        );
+    }
+
     public function testGetCronsRequiresAdmin() {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);
@@ -211,5 +219,99 @@ class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame(1.5, $runs[0]['duration_seconds']);
         $this->assertSame(7, $runs[0]['rows_affected']);
         $this->assertSame([], $runs[0]['phases']);
+    }
+
+    public function testRerunCronRequiresAdmin() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+            ]));
+            $this->fail('Should not have allowed access to non-admin');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertSame('userNotAllowed', $e->getMessage());
+        }
+    }
+
+    public function testRerunCronQueuesPendingRequest() {
+        [
+            'identity' => $identity,
+            'user' => $user,
+        ] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+        ]));
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+        $this->assertNotNull($request);
+        $this->assertSame(
+            \OmegaUp\CronRunRequestStatus::Pending->value,
+            $request->status
+        );
+        $this->assertSame($user->user_id, $request->requested_by);
+    }
+
+    public function testRerunCronRejectsAJobThatIsNotInTheRegistry() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => 'not_a_real_job.py',
+            ]));
+            $this->fail('Should not have queued an unknown job');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('parameterInvalid', $e->getMessage());
+        }
+        $this->assertNull(
+            \OmegaUp\DAO\CronRunRequests::getActiveByName('not_a_real_job.py')
+        );
+    }
+
+    public function testRerunCronDoesNotQueueDuplicates() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'name' => \OmegaUp\CronJobName::AssignBadges->value,
+        ]));
+        $first = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::AssignBadges->value
+        );
+
+        \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'name' => \OmegaUp\CronJobName::AssignBadges->value,
+        ]));
+        $second = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::AssignBadges->value
+        );
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame($first->request_id, $second->request_id);
+    }
+
+    public function testEveryJobNameTheApiAcceptsIsInTheRegistry() {
+        // apiRerunCron validates against CronJobName and the dispatcher only
+        // launches what Cron_Jobs lists, so the two have to agree.
+        $registered = array_map(
+            fn ($job) => $job->name,
+            \OmegaUp\DAO\CronJobs::getAllOrdered()
+        );
+
+        foreach (\OmegaUp\CronJobName::cases() as $case) {
+            $this->assertContains($case->value, $registered);
+        }
     }
 }

--- a/frontend/tests/controllers/CronRunRequestsDAOTest.php
+++ b/frontend/tests/controllers/CronRunRequestsDAOTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\CronRunRequests data access object.
+ */
+class CronRunRequestsDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        // The table survives the shared cleanup, so each test starts empty.
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            'DELETE FROM `Cron_Run_Requests`;'
+        );
+    }
+
+    private function createRequest(
+        string $name,
+        \OmegaUp\CronRunRequestStatus $status,
+        int $requestedAt
+    ): int {
+        $request = new \OmegaUp\DAO\VO\CronRunRequests([
+            'name' => $name,
+            'status' => $status->value,
+            'requested_at' => new \OmegaUp\Timestamp($requestedAt),
+        ]);
+        \OmegaUp\DAO\CronRunRequests::create($request);
+        return intval($request->request_id);
+    }
+
+    public function testGetActiveByNameFindsAPendingRequest() {
+        $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Pending,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+
+        $this->assertNotNull($request);
+        $this->assertSame(
+            \OmegaUp\CronRunRequestStatus::Pending->value,
+            $request->status
+        );
+    }
+
+    public function testGetActiveByNameFindsARequestThatIsAlreadyRunning() {
+        $this->createRequest(
+            \OmegaUp\CronJobName::AssignBadges->value,
+            \OmegaUp\CronRunRequestStatus::Picked,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::AssignBadges->value
+        );
+
+        $this->assertNotNull($request);
+        $this->assertSame(
+            \OmegaUp\CronRunRequestStatus::Picked->value,
+            $request->status
+        );
+    }
+
+    public function testGetActiveByNameIgnoresFinishedRequests() {
+        $now = \OmegaUp\Time::get();
+        $this->createRequest(
+            \OmegaUp\CronJobName::AggregateFeedback->value,
+            \OmegaUp\CronRunRequestStatus::Done,
+            $now - 200
+        );
+        $this->createRequest(
+            \OmegaUp\CronJobName::AggregateFeedback->value,
+            \OmegaUp\CronRunRequestStatus::Failed,
+            $now - 100
+        );
+
+        $this->assertNull(
+            \OmegaUp\DAO\CronRunRequests::getActiveByName(
+                \OmegaUp\CronJobName::AggregateFeedback->value
+            )
+        );
+    }
+
+    public function testGetActiveByNameIgnoresOtherJobs() {
+        $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Pending,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $this->assertNull(
+            \OmegaUp\DAO\CronRunRequests::getActiveByName(
+                \OmegaUp\CronJobName::AssignBadges->value
+            )
+        );
+    }
+
+    public function testGetActiveByNameReturnsTheNewestRequest() {
+        $now = \OmegaUp\Time::get();
+        $older = $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Pending,
+            $now - 500
+        );
+        $newer = $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Picked,
+            $now - 10
+        );
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+
+        $this->assertNotNull($request);
+        $this->assertNotSame($older, $request->request_id);
+        $this->assertSame($newer, $request->request_id);
+    }
+
+    public function testTheColumnAcceptsEveryStatusOfTheEnum() {
+        foreach (\OmegaUp\CronRunRequestStatus::cases() as $case) {
+            $requestId = $this->createRequest(
+                \OmegaUp\CronJobName::UpdateRanks->value,
+                $case,
+                \OmegaUp\Time::get() - 100
+            );
+            $request = \OmegaUp\DAO\CronRunRequests::getByPK($requestId);
+            $this->assertNotNull($request);
+            $this->assertSame($case->value, $request->status);
+        }
+    }
+}

--- a/frontend/tests/controllers/RecommendationModelRunsDAOTest.php
+++ b/frontend/tests/controllers/RecommendationModelRunsDAOTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\RecommendationModelRuns data access object and for
+ * the registry entry of the recommendation model training job.
+ */
+class RecommendationModelRunsDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    private function createModelRun(
+        float $mapScore,
+        bool $published,
+        int $createdAt,
+        ?string $skipReason = null,
+        ?int $rngSeed = null
+    ): \OmegaUp\DAO\VO\RecommendationModelRuns {
+        $modelRun = new \OmegaUp\DAO\VO\RecommendationModelRuns([
+            'map_score' => $mapScore,
+            'dataset_size' => 1000,
+            'num_followups' => 3,
+            'followup_decay' => 0.4,
+            'train_fraction' => 0.8,
+            'rng_seed' => $rngSeed,
+            'output_path' => '/tmp/model.db',
+            'published' => $published,
+            'skip_reason' => $skipReason,
+            'created_at' => new \OmegaUp\Timestamp($createdAt),
+        ]);
+        \OmegaUp\DAO\RecommendationModelRuns::create($modelRun);
+        return $modelRun;
+    }
+
+    public function testTrainingJobIsRegistered() {
+        $job = \OmegaUp\DAO\CronJobs::getByName(
+            \OmegaUp\CronJobName::BuildProblemRecModel->value
+        );
+
+        $this->assertNotNull($job);
+        $this->assertTrue($job->enabled);
+        $this->assertSame('0 4 * * 0', $job->schedule);
+    }
+
+    public function testGetRecentReturnsRunsNewestFirst() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(0.30, published: true, createdAt: $now - 300);
+        $this->createModelRun(
+            0.35,
+            published: false,
+            createdAt: $now - 200,
+            skipReason: 'regressed'
+        );
+        $this->createModelRun(0.50, published: true, createdAt: $now - 100);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertCount(3, $recent);
+        $this->assertEqualsWithDelta(0.50, $recent[0]->map_score, 1e-9);
+        $this->assertEqualsWithDelta(0.35, $recent[1]->map_score, 1e-9);
+        $this->assertEqualsWithDelta(0.30, $recent[2]->map_score, 1e-9);
+        $this->assertSame('regressed', $recent[1]->skip_reason);
+        $this->assertNull($recent[0]->skip_reason);
+    }
+
+    public function testGetRecentOrdersRunsRecordedInTheSameSecond() {
+        $sameSecond = \OmegaUp\Time::get() - 100;
+        $older = $this->createModelRun(
+            0.10,
+            published: false,
+            createdAt: $sameSecond,
+            skipReason: 'below minimum'
+        );
+        $newer = $this->createModelRun(
+            0.20,
+            published: true,
+            createdAt: $sameSecond
+        );
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertSame($newer->model_run_id, $recent[0]->model_run_id);
+        $this->assertSame($older->model_run_id, $recent[1]->model_run_id);
+    }
+
+    public function testGetRecentHonorsTheLimit() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(0.30, published: true, createdAt: $now - 300);
+        $this->createModelRun(0.40, published: true, createdAt: $now - 200);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(1);
+
+        $this->assertCount(1, $recent);
+        $this->assertEqualsWithDelta(0.40, $recent[0]->map_score, 1e-9);
+    }
+
+    public function testGetRecentKeepsAFixedSeedOfZeroApartFromNoSeed() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(
+            0.30,
+            published: true,
+            createdAt: $now - 200,
+            rngSeed: 0
+        );
+        $this->createModelRun(0.40, published: true, createdAt: $now - 100);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertNull($recent[0]->rng_seed);
+        $this->assertSame(0, $recent[1]->rng_seed);
+    }
+
+    public function testGetRecentKeepsEveryTrainingParameter() {
+        $this->createModelRun(
+            0.42,
+            published: true,
+            createdAt: \OmegaUp\Time::get() - 100,
+            rngSeed: 7
+        );
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(1);
+
+        $this->assertSame(1000, $recent[0]->dataset_size);
+        $this->assertSame(3, $recent[0]->num_followups);
+        $this->assertEqualsWithDelta(0.4, $recent[0]->followup_decay, 1e-9);
+        $this->assertEqualsWithDelta(0.8, $recent[0]->train_fraction, 1e-9);
+        $this->assertSame(7, $recent[0]->rng_seed);
+        $this->assertSame('/tmp/model.db', $recent[0]->output_path);
+        $this->assertTrue($recent[0]->published);
+    }
+}

--- a/frontend/www/docs/Controllers.md
+++ b/frontend/www/docs/Controllers.md
@@ -12,6 +12,7 @@ For more information about the API controllers, please refer to the [Controllers
   - [`/api/admin/getMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminplatformreportstats)
+  - [`/api/admin/rerunCron/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminreruncron)
   - [`/api/admin/setMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminsetmaintenancemode)
   - [`/api/admin/updateSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminupdatesystemsettings)
 - [AiEditorial](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#aieditorial)

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -144,6 +144,10 @@ export const Admin = {
     messages.AdminPlatformReportStatsRequest,
     messages.AdminPlatformReportStatsResponse
   >('/api/admin/platformReportStats/'),
+  rerunCron: apiCall<
+    messages.AdminRerunCronRequest,
+    messages.AdminRerunCronResponse
+  >('/api/admin/rerunCron/'),
   setMaintenanceMode: apiCall<
     messages.AdminSetMaintenanceModeRequest,
     messages.AdminSetMaintenanceModeResponse

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5437,6 +5437,8 @@ export namespace messages {
       };
     };
   };
+  export type AdminRerunCronRequest = { [key: string]: any };
+  export type AdminRerunCronResponse = {};
   export type AdminSetMaintenanceModeRequest = { [key: string]: any };
   export type AdminSetMaintenanceModeResponse = {};
   export type AdminUpdateSystemSettingsRequest = { [key: string]: any };
@@ -6453,6 +6455,9 @@ export namespace controllers {
     platformReportStats: (
       params?: messages.AdminPlatformReportStatsRequest,
     ) => Promise<messages.AdminPlatformReportStatsResponse>;
+    rerunCron: (
+      params?: messages.AdminRerunCronRequest,
+    ) => Promise<messages.AdminRerunCronResponse>;
     setMaintenanceMode: (
       params?: messages.AdminSetMaintenanceModeRequest,
     ) => Promise<messages.AdminSetMaintenanceModeResponse>;


### PR DESCRIPTION
# Description

`Admin::apiRerunCron`, the endpoint the rerun button calls. it takes a job name, checks the caller is a system admin, and queues a `pending` row in `Cron_Run_Requests`. it never runs anything itself, it only records the intent, so a request cannot trigger work directly.

the job name is validated against `\OmegaUp\CronJobName` rather than against a string the caller supplies or a list written out again here. that enum is the registry mirror, so anything the api accepts is a row the dispatcher will find in `Cron_Jobs`, and a new test asserts exactly that: every case of the enum is a registered job. if the two ever drift the test fails instead of the rerun failing in production.

a job that already has a request pending or in flight does not get a second row, so clicking twice is harmless. `rerun` joins the mutating verbs in `ApiCaller`, so a GET is rejected.

part of #10018.

# Comments

part of the cron control plane epic #9992, the third of five pull requests that used to be the single #10021. the chain is #10155, #10156, this one, #10158 and #10021. it is stacked on #10155 and #10156, so their files show in the diff until they merge.

`api.ts`, `api_types.ts`, `Controllers/README.md` and `www/docs/Controllers.md` are the linter's output, not hand written.

the dedupe is best effort rather than a constraint: two admins clicking at the same moment can both pass the check and queue two rows, and the job would then run twice. that is the same outcome as the job being scheduled twice, so i left it rather than adding a generated column and a unique index for it, but say the word if you would rather have the constraint.

what i ran: `CronControlPlaneAdminTest` and `CronRunRequestsDAOTest` under phpunit, both green, and `./stuff/lint.sh`, clean.

`database_schema.py` refuses `schema.sql` and `dao_schema.sql` in the same diff, and a stacked pull request based on main carries its parent's files, so the php job here fails on the "Validate database schema" step until #10155 merges, and stops there without reaching the tests. that is why this is a draft: once the table is in main i rebase and the step has nothing to complain about. i ran the php tests locally against the same tree and they pass.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
