### PR TITLE
add cron rerun dispatcher

### DIFF
--- a/frontend/database/00282_cron_run_requests.sql
+++ b/frontend/database/00282_cron_run_requests.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `Cron_Run_Requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) NOT NULL COMMENT 'Nombre del script cuya reejecución se solicita',
+  `requested_by` int DEFAULT NULL COMMENT 'El administrador que la solicitó, NULL si su cuenta ya no existe',
+  `status` enum('pending','picked','done','failed') NOT NULL DEFAULT 'pending' COMMENT 'pending mientras espera al despachador, picked mientras corre',
+  `requested_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `picked_at` datetime DEFAULT NULL COMMENT 'Cuando el despachador tomó la solicitud',
+  `finished_at` datetime DEFAULT NULL COMMENT 'Cuando terminó la ejecución, haya salido bien o mal',
+  `run_id` int DEFAULT NULL COMMENT 'La ejecución que produjo, NULL si el trabajo no llegó a correr',
+  `error_text` text COMMENT 'El final de stderr cuando la ejecución falló',
+  PRIMARY KEY (`request_id`),
+  KEY `idx_cron_run_requests_status` (`status`),
+  KEY `idx_cron_run_requests_name` (`name`),
+  CONSTRAINT `fk_crr_requested_by` FOREIGN KEY (`requested_by`) REFERENCES `Users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Solicitudes de reejecución manual de trabajos cron';

--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -402,6 +402,25 @@ CREATE TABLE `Cron_Jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Cron_Run_Requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) NOT NULL COMMENT 'Nombre del script cuya reejecución se solicita',
+  `requested_by` int DEFAULT NULL COMMENT 'El administrador que la solicitó, NULL si su cuenta ya no existe',
+  `status` enum('pending','picked','done','failed') NOT NULL DEFAULT 'pending' COMMENT 'pending mientras espera al despachador, picked mientras corre',
+  `requested_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `picked_at` datetime DEFAULT NULL COMMENT 'Cuando el despachador tomó la solicitud',
+  `finished_at` datetime DEFAULT NULL COMMENT 'Cuando terminó la ejecución, haya salido bien o mal',
+  `run_id` int DEFAULT NULL COMMENT 'La ejecución que produjo, NULL si el trabajo no llegó a correr',
+  `error_text` text COMMENT 'El final de stderr cuando la ejecución falló',
+  PRIMARY KEY (`request_id`),
+  KEY `idx_cron_run_requests_status` (`status`),
+  KEY `idx_cron_run_requests_name` (`name`),
+  KEY `fk_crr_requested_by` (`requested_by`),
+  CONSTRAINT `fk_crr_requested_by` FOREIGN KEY (`requested_by`) REFERENCES `Users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Solicitudes de reejecución manual de trabajos cron';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Cron_Runs` (
   `run_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL COMMENT 'Nombre del script (parser.prog). Denormalizado a propósito: el historial se registra aunque el trabajo no esté en Cron_Jobs y sobrevive a renombres o borrados del registro',

--- a/frontend/database/dao_schema.sql
+++ b/frontend/database/dao_schema.sql
@@ -1067,6 +1067,25 @@ CREATE TABLE `QualityNominations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Recommendation_Model_Runs` (
+  `model_run_id` int NOT NULL AUTO_INCREMENT,
+  `cron_run_id` int DEFAULT NULL COMMENT 'La ejecución de cron que entrenó este modelo, NULL si se corrió a mano',
+  `map_score` double NOT NULL COMMENT 'MAP@k sobre los usuarios de prueba, la medida con la que se compara contra el último modelo publicado',
+  `dataset_size` int NOT NULL COMMENT 'Cuántos envíos aceptados se usaron para entrenar',
+  `num_followups` int NOT NULL COMMENT 'Parámetro de entrenamiento: cuántos problemas siguientes se consideran por usuario',
+  `followup_decay` double NOT NULL COMMENT 'Parámetro de entrenamiento: qué tan rápido pierde peso cada problema siguiente',
+  `train_fraction` double NOT NULL COMMENT 'Parámetro de entrenamiento: qué fracción de los usuarios se usa para entrenar',
+  `rng_seed` int DEFAULT NULL COMMENT 'Parámetro de entrenamiento: la semilla con la que se partieron los usuarios entre entrenamiento y prueba, NULL si no se fijó ninguna',
+  `output_path` varchar(255) DEFAULT NULL COMMENT 'Dónde quedó el modelo entrenado',
+  `published` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'Si este modelo reemplazó al que estaba en uso',
+  `skip_reason` varchar(255) DEFAULT NULL COMMENT 'Por qué no se publicó, NULL si sí se publicó',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`model_run_id`),
+  KEY `idx_rec_model_runs_published_created` (`published`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Historial de entrenamientos del modelo de recomendación de problemas';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Roles` (
   `role_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL COMMENT 'El nombre corto del rol.',

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -402,6 +402,25 @@ CREATE TABLE `Cron_Jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Cron_Run_Requests` (
+  `request_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(64) NOT NULL COMMENT 'Nombre del script cuya reejecución se solicita',
+  `requested_by` int DEFAULT NULL COMMENT 'El administrador que la solicitó, NULL si su cuenta ya no existe',
+  `status` enum('pending','picked','done','failed') NOT NULL DEFAULT 'pending' COMMENT 'pending mientras espera al despachador, picked mientras corre',
+  `requested_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `picked_at` datetime DEFAULT NULL COMMENT 'Cuando el despachador tomó la solicitud',
+  `finished_at` datetime DEFAULT NULL COMMENT 'Cuando terminó la ejecución, haya salido bien o mal',
+  `run_id` int DEFAULT NULL COMMENT 'La ejecución que produjo, NULL si el trabajo no llegó a correr',
+  `error_text` text COMMENT 'El final de stderr cuando la ejecución falló',
+  PRIMARY KEY (`request_id`),
+  KEY `idx_cron_run_requests_status` (`status`),
+  KEY `idx_cron_run_requests_name` (`name`),
+  KEY `fk_crr_requested_by` (`requested_by`),
+  CONSTRAINT `fk_crr_requested_by` FOREIGN KEY (`requested_by`) REFERENCES `Users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Solicitudes de reejecución manual de trabajos cron';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Cron_Runs` (
   `run_id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL COMMENT 'Nombre del script (parser.prog). Denormalizado a propósito: el historial se registra aunque el trabajo no esté en Cron_Jobs y sobrevive a renombres o borrados del registro',

--- a/frontend/server/src/ApiCaller.php
+++ b/frontend/server/src/ApiCaller.php
@@ -215,7 +215,7 @@ class ApiCaller {
             'delete', 'disqualify', 'execute', 'expire', 'forfeit',
             'generate', 'invalidate', 'login', 'logout', 'open',
             'read', 'refresh', 'register', 'rejudge', 'remove',
-            'requalify', 'resolve', 'revoke', 'select', 'set',
+            'requalify', 'rerun', 'resolve', 'revoke', 'select', 'set',
             'toggle', 'update', 'verify',
         ];
         foreach ($mutatingPatterns as $pattern) {

--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -510,6 +510,44 @@ class Admin extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * Queues a manual rerun of a registered cron job for a worker to pick up.
+     *
+     * @return array{status: string}
+     *
+     * @omegaup-request-param string $name
+     */
+    public static function apiRerunCron(\OmegaUp\Request $r): array {
+        $r->ensureMainUserIdentity();
+        if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException();
+        }
+        $jobName = \OmegaUp\CronJobName::tryFrom($r->ensureString('name'));
+        if (is_null($jobName)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'name'
+            );
+        }
+        // The dispatcher runs whatever is queued, so a job that is already
+        // waiting or in flight does not get a second row.
+        if (
+            !is_null(
+                \OmegaUp\DAO\CronRunRequests::getActiveByName($jobName->value)
+            )
+        ) {
+            return ['status' => 'ok'];
+        }
+        \OmegaUp\DAO\CronRunRequests::create(
+            new \OmegaUp\DAO\VO\CronRunRequests([
+                'name' => $jobName->value,
+                'requested_by' => $r->user->user_id,
+                'status' => \OmegaUp\CronRunRequestStatus::Pending->value,
+            ])
+        );
+        return ['status' => 'ok'];
+    }
+
+    /**
      * @return array{entrypoint: string, templateProperties: array{payload: CronsDetailsPayload, title: \OmegaUp\TranslationString}}
      */
     public static function getCronsForTypeScript(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -6,6 +6,7 @@
   - [`/api/admin/getMaintenanceMode/`](#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](#apiadminplatformreportstats)
+  - [`/api/admin/rerunCron/`](#apiadminreruncron)
   - [`/api/admin/setMaintenanceMode/`](#apiadminsetmaintenancemode)
   - [`/api/admin/updateSystemSettings/`](#apiadminupdatesystemsettings)
 - [AiEditorial](#aieditorial)
@@ -404,6 +405,22 @@ Get stats for an overall platform report.
 | Name     | Type                                                                                                                                                                                                     |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `report` | `{ acceptedSubmissions: number; activeSchools: number; activeUsers: { [key: string]: number; }; courses: number; omiCourse: { attemptedUsers: number; completedUsers: number; passedUsers: number; }; }` |
+
+## `/api/admin/rerunCron/`
+
+### Description
+
+Queues a manual rerun of a registered cron job for a worker to pick up.
+
+### Parameters
+
+| Name   | Type     | Description | Required |
+| ------ | -------- | ----------- | -------- |
+| `name` | `string` |             | ✓        |
+
+### Returns
+
+_Nothing_
 
 ## `/api/admin/setMaintenanceMode/`
 

--- a/frontend/server/src/CronJobName.php
+++ b/frontend/server/src/CronJobName.php
@@ -12,6 +12,7 @@ namespace OmegaUp;
 enum CronJobName: string {
     case AggregateFeedback = 'aggregate_feedback.py';
     case AssignBadges = 'assign_badges.py';
+    case BuildProblemRecModel = 'build_problem_rec_model.py';
     case ProblemHealthCheck = 'problem_health_check.py';
     case UpdateRanks = 'update_ranks.py';
 }

--- a/frontend/server/src/CronRunRequestStatus.php
+++ b/frontend/server/src/CronRunRequestStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OmegaUp;
+
+/**
+ * The states a manual rerun request can be in, mirroring the
+ * `Cron_Run_Requests.status` column.
+ */
+enum CronRunRequestStatus: string {
+    case Pending = 'pending';
+    case Picked = 'picked';
+    case Done = 'done';
+    case Failed = 'failed';
+}

--- a/frontend/server/src/DAO/Base/CronRunRequests.php
+++ b/frontend/server/src/DAO/Base/CronRunRequests.php
@@ -1,0 +1,346 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** CronRunRequests Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+ * @access public
+ * @abstract
+ */
+abstract class CronRunRequests {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests El objeto de tipo CronRunRequests a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests
+    ): int {
+        $sql = '
+            UPDATE
+                `Cron_Run_Requests`
+            SET
+                `name` = ?,
+                `requested_by` = ?,
+                `status` = ?,
+                `requested_at` = ?,
+                `picked_at` = ?,
+                `finished_at` = ?,
+                `run_id` = ?,
+                `error_text` = ?
+            WHERE
+                (
+                    `request_id` = ?
+                );';
+        $params = [
+            $Cron_Run_Requests->name,
+            (
+                is_null($Cron_Run_Requests->requested_by) ?
+                null :
+                intval($Cron_Run_Requests->requested_by)
+            ),
+            $Cron_Run_Requests->status,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->requested_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->picked_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->finished_at
+            ),
+            (
+                is_null($Cron_Run_Requests->run_id) ?
+                null :
+                intval($Cron_Run_Requests->run_id)
+            ),
+            $Cron_Run_Requests->error_text,
+            intval($Cron_Run_Requests->request_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\CronRunRequests} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\CronRunRequests Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\CronRunRequests} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $request_id
+    ): ?\OmegaUp\DAO\VO\CronRunRequests {
+        $sql = '
+            SELECT
+                `Cron_Run_Requests`.`request_id`,
+                `Cron_Run_Requests`.`name`,
+                `Cron_Run_Requests`.`requested_by`,
+                `Cron_Run_Requests`.`status`,
+                `Cron_Run_Requests`.`requested_at`,
+                `Cron_Run_Requests`.`picked_at`,
+                `Cron_Run_Requests`.`finished_at`,
+                `Cron_Run_Requests`.`run_id`,
+                `Cron_Run_Requests`.`error_text`
+            FROM
+                `Cron_Run_Requests`
+            WHERE
+                (
+                    `request_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$request_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\CronRunRequests($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\CronRunRequests} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $request_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Cron_Run_Requests`
+            WHERE
+                (
+                    `request_id` = ?
+                );';
+        $params = [$request_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `Cron_Run_Requests`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Cron_Run_Requests`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\CronRunRequests} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests El
+     * objeto de tipo \OmegaUp\DAO\VO\CronRunRequests a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Cron_Run_Requests`
+            WHERE
+                (
+                    `request_id` = ?
+                );';
+        $params = [
+            $Cron_Run_Requests->request_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\CronRunRequests> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'request_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `Cron_Run_Requests`.`request_id`,
+                `Cron_Run_Requests`.`name`,
+                `Cron_Run_Requests`.`requested_by`,
+                `Cron_Run_Requests`.`status`,
+                `Cron_Run_Requests`.`requested_at`,
+                `Cron_Run_Requests`.`picked_at`,
+                `Cron_Run_Requests`.`finished_at`,
+                `Cron_Run_Requests`.`run_id`,
+                `Cron_Run_Requests`.`error_text`
+            FROM
+                `Cron_Run_Requests`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\CronRunRequests(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\CronRunRequests}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\CronRunRequests $Cron_Run_Requests
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Cron_Run_Requests` (
+                    `name`,
+                    `requested_by`,
+                    `status`,
+                    `requested_at`,
+                    `picked_at`,
+                    `finished_at`,
+                    `run_id`,
+                    `error_text`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            $Cron_Run_Requests->name,
+            (
+                is_null($Cron_Run_Requests->requested_by) ?
+                null :
+                intval($Cron_Run_Requests->requested_by)
+            ),
+            $Cron_Run_Requests->status,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->requested_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->picked_at
+            ),
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Cron_Run_Requests->finished_at
+            ),
+            (
+                is_null($Cron_Run_Requests->run_id) ?
+                null :
+                intval($Cron_Run_Requests->run_id)
+            ),
+            $Cron_Run_Requests->error_text,
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Cron_Run_Requests->request_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/Base/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/Base/RecommendationModelRuns.php
@@ -1,0 +1,399 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\Base;
+
+/** RecommendationModelRuns Data Access Object (DAO) Base.
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+ * @access public
+ * @abstract
+ */
+abstract class RecommendationModelRuns {
+    /**
+     * Actualizar registros.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El objeto de tipo RecommendationModelRuns a actualizar.
+     *
+     * @return int Número de filas afectadas
+     */
+    final public static function update(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): int {
+        $sql = '
+            UPDATE
+                `Recommendation_Model_Runs`
+            SET
+                `cron_run_id` = ?,
+                `map_score` = ?,
+                `dataset_size` = ?,
+                `num_followups` = ?,
+                `followup_decay` = ?,
+                `train_fraction` = ?,
+                `rng_seed` = ?,
+                `output_path` = ?,
+                `published` = ?,
+                `skip_reason` = ?,
+                `created_at` = ?
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [
+            (
+                is_null($Recommendation_Model_Runs->cron_run_id) ?
+                null :
+                intval($Recommendation_Model_Runs->cron_run_id)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->map_score) ?
+                null :
+                floatval($Recommendation_Model_Runs->map_score)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->dataset_size) ?
+                null :
+                intval($Recommendation_Model_Runs->dataset_size)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->num_followups) ?
+                null :
+                intval($Recommendation_Model_Runs->num_followups)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->followup_decay) ?
+                null :
+                floatval($Recommendation_Model_Runs->followup_decay)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->train_fraction) ?
+                null :
+                floatval($Recommendation_Model_Runs->train_fraction)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->rng_seed) ?
+                null :
+                intval($Recommendation_Model_Runs->rng_seed)
+            ),
+            $Recommendation_Model_Runs->output_path,
+            intval($Recommendation_Model_Runs->published),
+            $Recommendation_Model_Runs->skip_reason,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Recommendation_Model_Runs->created_at
+            ),
+            intval($Recommendation_Model_Runs->model_run_id),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        return \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+    }
+
+    /**
+     * Obtener {@link \OmegaUp\DAO\VO\RecommendationModelRuns} por llave primaria.
+     *
+     * Este método cargará un objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * de la base de datos usando sus llaves primarias.
+     *
+     * @return ?\OmegaUp\DAO\VO\RecommendationModelRuns Un objeto del tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns} o NULL si no hay tal
+     * registro.
+     */
+    final public static function getByPK(
+        int $model_run_id
+    ): ?\OmegaUp\DAO\VO\RecommendationModelRuns {
+        $sql = '
+            SELECT
+                `Recommendation_Model_Runs`.`model_run_id`,
+                `Recommendation_Model_Runs`.`cron_run_id`,
+                `Recommendation_Model_Runs`.`map_score`,
+                `Recommendation_Model_Runs`.`dataset_size`,
+                `Recommendation_Model_Runs`.`num_followups`,
+                `Recommendation_Model_Runs`.`followup_decay`,
+                `Recommendation_Model_Runs`.`train_fraction`,
+                `Recommendation_Model_Runs`.`rng_seed`,
+                `Recommendation_Model_Runs`.`output_path`,
+                `Recommendation_Model_Runs`.`published`,
+                `Recommendation_Model_Runs`.`skip_reason`,
+                `Recommendation_Model_Runs`.`created_at`
+            FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                )
+            LIMIT 1;';
+        $params = [$model_run_id];
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, $params);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\RecommendationModelRuns($row);
+    }
+
+    /**
+     * Verificar si existe un {@link \OmegaUp\DAO\VO\RecommendationModelRuns} por llave primaria.
+     *
+     * Este método verifica la existencia de un objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * de la base de datos usando sus llaves primarias **sin necesidad de cargar sus campos**.
+     *
+     * Este método es más eficiente que una llamada a getByPK cuando no se van a utilizar
+     * los campos.
+     *
+     * @return bool Si existe o no tal registro.
+     */
+    final public static function existsByPK(
+        int $model_run_id
+    ): bool {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [$model_run_id];
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, $params);
+        return $count > 0;
+    }
+
+    /**
+     * Contar todos los registros en `Recommendation_Model_Runs`.
+     *
+     * Este método obtiene el número total de filas de la tabla **sin cargar campos**,
+     * útil para pruebas donde sólo se valida el conteo.
+     *
+     * @return int Número total de registros.
+     */
+    final public static function countAll(): int {
+        $sql = '
+            SELECT
+                COUNT(*)
+            FROM
+                `Recommendation_Model_Runs`;';
+        /** @var int */
+        $count = \OmegaUp\MySQLConnection::getInstance()->GetOne($sql, []);
+        return intval($count);
+    }
+
+    /**
+     * Eliminar registros.
+     *
+     * Este metodo eliminará el registro identificado por la llave primaria en
+     * el objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns} suministrado.
+     * Una vez que se ha eliminado un objeto, este no puede ser restaurado
+     * llamando a {@link replace()}, ya que este último creará un nuevo
+     * registro con una llave primaria distinta a la que estaba en el objeto
+     * eliminado.
+     *
+     * Si no puede encontrar el registro a eliminar,
+     * {@link \OmegaUp\Exceptions\NotFoundException} será arrojada.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El
+     * objeto de tipo \OmegaUp\DAO\VO\RecommendationModelRuns a eliminar
+     *
+     * @throws \OmegaUp\Exceptions\NotFoundException Se arroja cuando no se
+     * encuentra el objeto a eliminar en la base de datos.
+     */
+    final public static function delete(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): void {
+        $sql = '
+            DELETE FROM
+                `Recommendation_Model_Runs`
+            WHERE
+                (
+                    `model_run_id` = ?
+                );';
+        $params = [
+            $Recommendation_Model_Runs->model_run_id
+        ];
+
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        if (\OmegaUp\MySQLConnection::getInstance()->Affected_Rows() == 0) {
+            throw new \OmegaUp\Exceptions\NotFoundException('recordNotFound');
+        }
+    }
+
+    /**
+     * Obtener todas las filas.
+     *
+     * Esta funcion leerá todos los contenidos de la tabla en la base de datos
+     * y construirá un arreglo que contiene objetos de tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+     * Este método consume una cantidad de memoria proporcional al número de
+     * registros regresados, así que sólo debe usarse cuando la tabla en
+     * cuestión es pequeña o se proporcionan parámetros para obtener un menor
+     * número de filas.
+     *
+     * @param ?int $pagina Página a ver.
+     * @param int $filasPorPagina Filas por página.
+     * @param string $orden Debe ser una cadena con el nombre de una columna en la base de datos.
+     * @param string $tipoDeOrden 'ASC' o 'DESC' el default es 'ASC'
+     *
+     * @return list<\OmegaUp\DAO\VO\RecommendationModelRuns> Un arreglo que contiene objetos del tipo
+     * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+     */
+    final public static function getAll(
+        ?int $pagina = null,
+        int $filasPorPagina = 100,
+        string $orden = 'model_run_id',
+        string $tipoDeOrden = 'ASC'
+    ): array {
+        $sanitizedOrder = \OmegaUp\MySQLConnection::getInstance()->escape(
+            $orden
+        );
+        \OmegaUp\Validators::validateInEnum(
+            $tipoDeOrden,
+            'order_type',
+            [
+                'ASC',
+                'DESC',
+            ]
+        );
+        $sql = "
+            SELECT
+                `Recommendation_Model_Runs`.`model_run_id`,
+                `Recommendation_Model_Runs`.`cron_run_id`,
+                `Recommendation_Model_Runs`.`map_score`,
+                `Recommendation_Model_Runs`.`dataset_size`,
+                `Recommendation_Model_Runs`.`num_followups`,
+                `Recommendation_Model_Runs`.`followup_decay`,
+                `Recommendation_Model_Runs`.`train_fraction`,
+                `Recommendation_Model_Runs`.`rng_seed`,
+                `Recommendation_Model_Runs`.`output_path`,
+                `Recommendation_Model_Runs`.`published`,
+                `Recommendation_Model_Runs`.`skip_reason`,
+                `Recommendation_Model_Runs`.`created_at`
+            FROM
+                `Recommendation_Model_Runs`
+            ORDER BY
+                `{$sanitizedOrder}` {$tipoDeOrden}
+        ";
+        if (!is_null($pagina)) {
+            $sql .= (
+                ' LIMIT ' .
+                (($pagina - 1) * $filasPorPagina) .
+                ', ' .
+                intval($filasPorPagina)
+            );
+        }
+        $allData = [];
+        foreach (
+            \OmegaUp\MySQLConnection::getInstance()->GetAll($sql) as $row
+        ) {
+            $allData[] = new \OmegaUp\DAO\VO\RecommendationModelRuns(
+                $row
+            );
+        }
+        return $allData;
+    }
+
+    /**
+     * Crear registros.
+     *
+     * Este metodo creará una nueva fila en la base de datos de acuerdo con los
+     * contenidos del objeto {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * suministrado.
+     *
+     * @param \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs El
+     * objeto de tipo {@link \OmegaUp\DAO\VO\RecommendationModelRuns}
+     * a crear.
+     *
+     * @return int Un entero mayor o igual a cero identificando el número de
+     *             filas afectadas.
+     */
+    final public static function create(
+        \OmegaUp\DAO\VO\RecommendationModelRuns $Recommendation_Model_Runs
+    ): int {
+        $sql = '
+            INSERT INTO
+                `Recommendation_Model_Runs` (
+                    `cron_run_id`,
+                    `map_score`,
+                    `dataset_size`,
+                    `num_followups`,
+                    `followup_decay`,
+                    `train_fraction`,
+                    `rng_seed`,
+                    `output_path`,
+                    `published`,
+                    `skip_reason`,
+                    `created_at`
+                ) VALUES (
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?
+                );';
+        $params = [
+            (
+                is_null($Recommendation_Model_Runs->cron_run_id) ?
+                null :
+                intval($Recommendation_Model_Runs->cron_run_id)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->map_score) ?
+                null :
+                floatval($Recommendation_Model_Runs->map_score)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->dataset_size) ?
+                null :
+                intval($Recommendation_Model_Runs->dataset_size)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->num_followups) ?
+                null :
+                intval($Recommendation_Model_Runs->num_followups)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->followup_decay) ?
+                null :
+                floatval($Recommendation_Model_Runs->followup_decay)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->train_fraction) ?
+                null :
+                floatval($Recommendation_Model_Runs->train_fraction)
+            ),
+            (
+                is_null($Recommendation_Model_Runs->rng_seed) ?
+                null :
+                intval($Recommendation_Model_Runs->rng_seed)
+            ),
+            $Recommendation_Model_Runs->output_path,
+            intval($Recommendation_Model_Runs->published),
+            $Recommendation_Model_Runs->skip_reason,
+            \OmegaUp\DAO\DAO::toMySQLTimestamp(
+                $Recommendation_Model_Runs->created_at
+            ),
+        ];
+        \OmegaUp\MySQLConnection::getInstance()->Execute($sql, $params);
+        $affectedRows = \OmegaUp\MySQLConnection::getInstance()->Affected_Rows();
+        if ($affectedRows == 0) {
+            return 0;
+        }
+        $Recommendation_Model_Runs->model_run_id = (
+            \OmegaUp\MySQLConnection::getInstance()->Insert_ID()
+        );
+
+        return $affectedRows;
+    }
+}

--- a/frontend/server/src/DAO/CronRunRequests.php
+++ b/frontend/server/src/DAO/CronRunRequests.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * CronRunRequests Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\CronRunRequests}.
+ */
+class CronRunRequests extends \OmegaUp\DAO\Base\CronRunRequests {
+    /**
+     * Returns the pending or in-flight request for a job, if any.
+     */
+    public static function getActiveByName(
+        string $name
+    ): ?\OmegaUp\DAO\VO\CronRunRequests {
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\CronRunRequests::FIELD_NAMES,
+            'Cron_Run_Requests'
+        );
+        $sql = "SELECT {$fields}
+                FROM Cron_Run_Requests
+                WHERE name = ? AND status IN (?, ?)
+                ORDER BY requested_at DESC
+                LIMIT 1;";
+        /** @var array{error_text: null|string, finished_at: \OmegaUp\Timestamp|null, name: string, picked_at: \OmegaUp\Timestamp|null, request_id: int, requested_at: \OmegaUp\Timestamp, requested_by: int|null, run_id: int|null, status: string}|null */
+        $row = \OmegaUp\MySQLConnection::getInstance()->GetRow($sql, [
+            $name,
+            \OmegaUp\CronRunRequestStatus::Pending->value,
+            \OmegaUp\CronRunRequestStatus::Picked->value,
+        ]);
+        if (empty($row)) {
+            return null;
+        }
+        return new \OmegaUp\DAO\VO\CronRunRequests($row);
+    }
+}

--- a/frontend/server/src/DAO/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/RecommendationModelRuns.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OmegaUp\DAO;
+
+/**
+ * RecommendationModelRuns Data Access Object (DAO).
+ *
+ * Esta clase contiene toda la manipulacion de bases de datos que se necesita
+ * para almacenar de forma permanente y recuperar instancias de objetos
+ * {@link \OmegaUp\DAO\VO\RecommendationModelRuns}.
+ */
+class RecommendationModelRuns extends \OmegaUp\DAO\Base\RecommendationModelRuns {
+    /**
+     * Returns the most recent training runs, newest first. `created_at` only
+     * keeps seconds, so the id breaks the tie between two runs recorded within
+     * the same second.
+     *
+     * @return list<\OmegaUp\DAO\VO\RecommendationModelRuns>
+     */
+    public static function getRecent(int $limit = 20): array {
+        $fields = \OmegaUp\DAO\DAO::getFields(
+            \OmegaUp\DAO\VO\RecommendationModelRuns::FIELD_NAMES,
+            'Recommendation_Model_Runs'
+        );
+        $sql = "SELECT {$fields}
+                FROM Recommendation_Model_Runs
+                ORDER BY created_at DESC, model_run_id DESC
+                LIMIT ?;";
+        /** @var list<array{created_at: \OmegaUp\Timestamp, cron_run_id: int|null, dataset_size: int, followup_decay: float, map_score: float, model_run_id: int, num_followups: int, output_path: null|string, published: bool, rng_seed: int|null, skip_reason: null|string, train_fraction: float}> */
+        $rs = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            [$limit]
+        );
+        $modelRuns = [];
+        foreach ($rs as $row) {
+            $modelRuns[] = new \OmegaUp\DAO\VO\RecommendationModelRuns($row);
+        }
+        return $modelRuns;
+    }
+}

--- a/frontend/server/src/DAO/VO/CronRunRequests.php
+++ b/frontend/server/src/DAO/VO/CronRunRequests.php
@@ -1,0 +1,173 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Cron_Run_Requests`.
+ *
+ * @access public
+ */
+class CronRunRequests extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'request_id' => true,
+        'name' => true,
+        'requested_by' => true,
+        'status' => true,
+        'requested_at' => true,
+        'picked_at' => true,
+        'finished_at' => true,
+        'run_id' => true,
+        'error_text' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['request_id'])) {
+            $this->request_id = intval(
+                $data['request_id']
+            );
+        }
+        if (isset($data['name'])) {
+            $this->name = is_scalar(
+                $data['name']
+            ) ? strval($data['name']) : '';
+        }
+        if (isset($data['requested_by'])) {
+            $this->requested_by = intval(
+                $data['requested_by']
+            );
+        }
+        if (isset($data['status'])) {
+            $this->status = is_scalar(
+                $data['status']
+            ) ? strval($data['status']) : '';
+        }
+        if (isset($data['requested_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['requested_at']
+             * @var \OmegaUp\Timestamp $this->requested_at
+             */
+            $this->requested_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['requested_at']
+                )
+            );
+        } else {
+            $this->requested_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+        if (isset($data['picked_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['picked_at']
+             * @var \OmegaUp\Timestamp $this->picked_at
+             */
+            $this->picked_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['picked_at']
+                )
+            );
+        }
+        if (isset($data['finished_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['finished_at']
+             * @var \OmegaUp\Timestamp $this->finished_at
+             */
+            $this->finished_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['finished_at']
+                )
+            );
+        }
+        if (isset($data['run_id'])) {
+            $this->run_id = intval(
+                $data['run_id']
+            );
+        }
+        if (isset($data['error_text'])) {
+            $this->error_text = is_scalar(
+                $data['error_text']
+            ) ? strval($data['error_text']) : '';
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $request_id = 0;
+
+    /**
+     * Nombre del script cuya reejecución se solicita
+     *
+     * @var string|null
+     */
+    public $name = null;
+
+    /**
+     * El administrador que la solicitó, NULL si su cuenta ya no existe
+     *
+     * @var int|null
+     */
+    public $requested_by = null;
+
+    /**
+     * pending mientras espera al despachador, picked mientras corre
+     *
+     * @var string
+     */
+    public $status = 'pending';
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $requested_at;  // CURRENT_TIMESTAMP
+
+    /**
+     * Cuando el despachador tomó la solicitud
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $picked_at = null;
+
+    /**
+     * Cuando terminó la ejecución, haya salido bien o mal
+     *
+     * @var \OmegaUp\Timestamp|null
+     */
+    public $finished_at = null;
+
+    /**
+     * La ejecución que produjo, NULL si el trabajo no llegó a correr
+     *
+     * @var int|null
+     */
+    public $run_id = null;
+
+    /**
+     * El final de stderr cuando la ejecución falló
+     *
+     * @var string|null
+     */
+    public $error_text = null;
+}

--- a/frontend/server/src/DAO/VO/RecommendationModelRuns.php
+++ b/frontend/server/src/DAO/VO/RecommendationModelRuns.php
@@ -1,0 +1,200 @@
+<?php
+/** ************************************************************************ *
+ *                    !ATENCION!                                             *
+ *                                                                           *
+ * Este codigo es generado automáticamente. Si lo modificas, tus cambios     *
+ * serán reemplazados la proxima vez que se autogenere el código.            *
+ *                                                                           *
+ * ************************************************************************* */
+
+namespace OmegaUp\DAO\VO;
+
+/**
+ * Value Object class for table `Recommendation_Model_Runs`.
+ *
+ * @access public
+ */
+class RecommendationModelRuns extends \OmegaUp\DAO\VO\VO {
+    const FIELD_NAMES = [
+        'model_run_id' => true,
+        'cron_run_id' => true,
+        'map_score' => true,
+        'dataset_size' => true,
+        'num_followups' => true,
+        'followup_decay' => true,
+        'train_fraction' => true,
+        'rng_seed' => true,
+        'output_path' => true,
+        'published' => true,
+        'skip_reason' => true,
+        'created_at' => true,
+    ];
+
+    public function __construct(?array $data = null) {
+        if (empty($data)) {
+            return;
+        }
+        $unknownColumns = array_diff_key($data, self::FIELD_NAMES);
+        if (!empty($unknownColumns)) {
+            throw new \Exception(
+                'Unknown columns: ' . join(', ', array_keys($unknownColumns))
+            );
+        }
+        if (isset($data['model_run_id'])) {
+            $this->model_run_id = intval(
+                $data['model_run_id']
+            );
+        }
+        if (isset($data['cron_run_id'])) {
+            $this->cron_run_id = intval(
+                $data['cron_run_id']
+            );
+        }
+        if (isset($data['map_score'])) {
+            $this->map_score = floatval(
+                $data['map_score']
+            );
+        }
+        if (isset($data['dataset_size'])) {
+            $this->dataset_size = intval(
+                $data['dataset_size']
+            );
+        }
+        if (isset($data['num_followups'])) {
+            $this->num_followups = intval(
+                $data['num_followups']
+            );
+        }
+        if (isset($data['followup_decay'])) {
+            $this->followup_decay = floatval(
+                $data['followup_decay']
+            );
+        }
+        if (isset($data['train_fraction'])) {
+            $this->train_fraction = floatval(
+                $data['train_fraction']
+            );
+        }
+        if (isset($data['rng_seed'])) {
+            $this->rng_seed = intval(
+                $data['rng_seed']
+            );
+        }
+        if (isset($data['output_path'])) {
+            $this->output_path = is_scalar(
+                $data['output_path']
+            ) ? strval($data['output_path']) : '';
+        }
+        if (isset($data['published'])) {
+            $this->published = boolval(
+                $data['published']
+            );
+        }
+        if (isset($data['skip_reason'])) {
+            $this->skip_reason = is_scalar(
+                $data['skip_reason']
+            ) ? strval($data['skip_reason']) : '';
+        }
+        if (isset($data['created_at'])) {
+            /**
+             * @var \OmegaUp\Timestamp|string|int|float $data['created_at']
+             * @var \OmegaUp\Timestamp $this->created_at
+             */
+            $this->created_at = (
+                \OmegaUp\DAO\DAO::fromMySQLTimestamp(
+                    $data['created_at']
+                )
+            );
+        } else {
+            $this->created_at = new \OmegaUp\Timestamp(
+                \OmegaUp\Time::get()
+            );
+        }
+    }
+
+    /**
+     * [Campo no documentado]
+     * Llave Primaria
+     * Auto Incremento
+     *
+     * @var int|null
+     */
+    public $model_run_id = 0;
+
+    /**
+     * La ejecución de cron que entrenó este modelo, NULL si se corrió a mano
+     *
+     * @var int|null
+     */
+    public $cron_run_id = null;
+
+    /**
+     * MAP@k sobre los usuarios de prueba, la medida con la que se compara contra el último modelo publicado
+     *
+     * @var float|null
+     */
+    public $map_score = null;
+
+    /**
+     * Cuántos envíos aceptados se usaron para entrenar
+     *
+     * @var int|null
+     */
+    public $dataset_size = null;
+
+    /**
+     * Parámetro de entrenamiento: cuántos problemas siguientes se consideran por usuario
+     *
+     * @var int|null
+     */
+    public $num_followups = null;
+
+    /**
+     * Parámetro de entrenamiento: qué tan rápido pierde peso cada problema siguiente
+     *
+     * @var float|null
+     */
+    public $followup_decay = null;
+
+    /**
+     * Parámetro de entrenamiento: qué fracción de los usuarios se usa para entrenar
+     *
+     * @var float|null
+     */
+    public $train_fraction = null;
+
+    /**
+     * Parámetro de entrenamiento: la semilla con la que se partieron los usuarios entre entrenamiento y prueba, NULL si no se fijó ninguna
+     *
+     * @var int|null
+     */
+    public $rng_seed = null;
+
+    /**
+     * Dónde quedó el modelo entrenado
+     *
+     * @var string|null
+     */
+    public $output_path = null;
+
+    /**
+     * Si este modelo reemplazó al que estaba en uso
+     *
+     * @var bool
+     */
+    public $published = false;
+
+    /**
+     * Por qué no se publicó, NULL si sí se publicó
+     *
+     * @var string|null
+     */
+    public $skip_reason = null;
+
+    /**
+     * [Campo no documentado]
+     *
+     * @var \OmegaUp\Timestamp
+     */
+    public $created_at;  // CURRENT_TIMESTAMP
+}

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -4,6 +4,14 @@
  * Tests for the cron control plane admin endpoints.
  */
 class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        // The table survives the shared cleanup, so each test starts empty.
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            'DELETE FROM `Cron_Run_Requests`;'
+        );
+    }
+
     public function testGetCronsRequiresAdmin() {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
         $login = \OmegaUp\Test\ControllerTestCase::login($identity);
@@ -211,5 +219,99 @@ class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame(1.5, $runs[0]['duration_seconds']);
         $this->assertSame(7, $runs[0]['rows_affected']);
         $this->assertSame([], $runs[0]['phases']);
+    }
+
+    public function testRerunCronRequiresAdmin() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+            ]));
+            $this->fail('Should not have allowed access to non-admin');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertSame('userNotAllowed', $e->getMessage());
+        }
+    }
+
+    public function testRerunCronQueuesPendingRequest() {
+        [
+            'identity' => $identity,
+            'user' => $user,
+        ] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+        ]));
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+        $this->assertNotNull($request);
+        $this->assertSame(
+            \OmegaUp\CronRunRequestStatus::Pending->value,
+            $request->status
+        );
+        $this->assertSame($user->user_id, $request->requested_by);
+    }
+
+    public function testRerunCronRejectsAJobThatIsNotInTheRegistry() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => 'not_a_real_job.py',
+            ]));
+            $this->fail('Should not have queued an unknown job');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('parameterInvalid', $e->getMessage());
+        }
+        $this->assertNull(
+            \OmegaUp\DAO\CronRunRequests::getActiveByName('not_a_real_job.py')
+        );
+    }
+
+    public function testRerunCronDoesNotQueueDuplicates() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'name' => \OmegaUp\CronJobName::AssignBadges->value,
+        ]));
+        $first = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::AssignBadges->value
+        );
+
+        \OmegaUp\Controllers\Admin::apiRerunCron(new \OmegaUp\Request([
+            'auth_token' => $login->auth_token,
+            'name' => \OmegaUp\CronJobName::AssignBadges->value,
+        ]));
+        $second = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::AssignBadges->value
+        );
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame($first->request_id, $second->request_id);
+    }
+
+    public function testEveryJobNameTheApiAcceptsIsInTheRegistry() {
+        // apiRerunCron validates against CronJobName and the dispatcher only
+        // launches what Cron_Jobs lists, so the two have to agree.
+        $registered = array_map(
+            fn ($job) => $job->name,
+            \OmegaUp\DAO\CronJobs::getAllOrdered()
+        );
+
+        foreach (\OmegaUp\CronJobName::cases() as $case) {
+            $this->assertContains($case->value, $registered);
+        }
     }
 }

--- a/frontend/tests/controllers/CronRunRequestsDAOTest.php
+++ b/frontend/tests/controllers/CronRunRequestsDAOTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\CronRunRequests data access object.
+ */
+class CronRunRequestsDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        // The table survives the shared cleanup, so each test starts empty.
+        \OmegaUp\MySQLConnection::getInstance()->Execute(
+            'DELETE FROM `Cron_Run_Requests`;'
+        );
+    }
+
+    private function createRequest(
+        string $name,
+        \OmegaUp\CronRunRequestStatus $status,
+        int $requestedAt
+    ): int {
+        $request = new \OmegaUp\DAO\VO\CronRunRequests([
+            'name' => $name,
+            'status' => $status->value,
+            'requested_at' => new \OmegaUp\Timestamp($requestedAt),
+        ]);
+        \OmegaUp\DAO\CronRunRequests::create($request);
+        return intval($request->request_id);
+    }
+
+    public function testGetActiveByNameFindsAPendingRequest() {
+        $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Pending,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+
+        $this->assertNotNull($request);
+        $this->assertSame(
+            \OmegaUp\CronRunRequestStatus::Pending->value,
+            $request->status
+        );
+    }
+
+    public function testGetActiveByNameFindsARequestThatIsAlreadyRunning() {
+        $this->createRequest(
+            \OmegaUp\CronJobName::AssignBadges->value,
+            \OmegaUp\CronRunRequestStatus::Picked,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::AssignBadges->value
+        );
+
+        $this->assertNotNull($request);
+        $this->assertSame(
+            \OmegaUp\CronRunRequestStatus::Picked->value,
+            $request->status
+        );
+    }
+
+    public function testGetActiveByNameIgnoresFinishedRequests() {
+        $now = \OmegaUp\Time::get();
+        $this->createRequest(
+            \OmegaUp\CronJobName::AggregateFeedback->value,
+            \OmegaUp\CronRunRequestStatus::Done,
+            $now - 200
+        );
+        $this->createRequest(
+            \OmegaUp\CronJobName::AggregateFeedback->value,
+            \OmegaUp\CronRunRequestStatus::Failed,
+            $now - 100
+        );
+
+        $this->assertNull(
+            \OmegaUp\DAO\CronRunRequests::getActiveByName(
+                \OmegaUp\CronJobName::AggregateFeedback->value
+            )
+        );
+    }
+
+    public function testGetActiveByNameIgnoresOtherJobs() {
+        $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Pending,
+            \OmegaUp\Time::get() - 100
+        );
+
+        $this->assertNull(
+            \OmegaUp\DAO\CronRunRequests::getActiveByName(
+                \OmegaUp\CronJobName::AssignBadges->value
+            )
+        );
+    }
+
+    public function testGetActiveByNameReturnsTheNewestRequest() {
+        $now = \OmegaUp\Time::get();
+        $older = $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Pending,
+            $now - 500
+        );
+        $newer = $this->createRequest(
+            \OmegaUp\CronJobName::UpdateRanks->value,
+            \OmegaUp\CronRunRequestStatus::Picked,
+            $now - 10
+        );
+
+        $request = \OmegaUp\DAO\CronRunRequests::getActiveByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+
+        $this->assertNotNull($request);
+        $this->assertNotSame($older, $request->request_id);
+        $this->assertSame($newer, $request->request_id);
+    }
+
+    public function testTheColumnAcceptsEveryStatusOfTheEnum() {
+        foreach (\OmegaUp\CronRunRequestStatus::cases() as $case) {
+            $requestId = $this->createRequest(
+                \OmegaUp\CronJobName::UpdateRanks->value,
+                $case,
+                \OmegaUp\Time::get() - 100
+            );
+            $request = \OmegaUp\DAO\CronRunRequests::getByPK($requestId);
+            $this->assertNotNull($request);
+            $this->assertSame($case->value, $request->status);
+        }
+    }
+}

--- a/frontend/tests/controllers/RecommendationModelRunsDAOTest.php
+++ b/frontend/tests/controllers/RecommendationModelRunsDAOTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Tests for the \OmegaUp\DAO\RecommendationModelRuns data access object and for
+ * the registry entry of the recommendation model training job.
+ */
+class RecommendationModelRunsDAOTest extends \OmegaUp\Test\ControllerTestCase {
+    private function createModelRun(
+        float $mapScore,
+        bool $published,
+        int $createdAt,
+        ?string $skipReason = null,
+        ?int $rngSeed = null
+    ): \OmegaUp\DAO\VO\RecommendationModelRuns {
+        $modelRun = new \OmegaUp\DAO\VO\RecommendationModelRuns([
+            'map_score' => $mapScore,
+            'dataset_size' => 1000,
+            'num_followups' => 3,
+            'followup_decay' => 0.4,
+            'train_fraction' => 0.8,
+            'rng_seed' => $rngSeed,
+            'output_path' => '/tmp/model.db',
+            'published' => $published,
+            'skip_reason' => $skipReason,
+            'created_at' => new \OmegaUp\Timestamp($createdAt),
+        ]);
+        \OmegaUp\DAO\RecommendationModelRuns::create($modelRun);
+        return $modelRun;
+    }
+
+    public function testTrainingJobIsRegistered() {
+        $job = \OmegaUp\DAO\CronJobs::getByName(
+            \OmegaUp\CronJobName::BuildProblemRecModel->value
+        );
+
+        $this->assertNotNull($job);
+        $this->assertTrue($job->enabled);
+        $this->assertSame('0 4 * * 0', $job->schedule);
+    }
+
+    public function testGetRecentReturnsRunsNewestFirst() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(0.30, published: true, createdAt: $now - 300);
+        $this->createModelRun(
+            0.35,
+            published: false,
+            createdAt: $now - 200,
+            skipReason: 'regressed'
+        );
+        $this->createModelRun(0.50, published: true, createdAt: $now - 100);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertCount(3, $recent);
+        $this->assertEqualsWithDelta(0.50, $recent[0]->map_score, 1e-9);
+        $this->assertEqualsWithDelta(0.35, $recent[1]->map_score, 1e-9);
+        $this->assertEqualsWithDelta(0.30, $recent[2]->map_score, 1e-9);
+        $this->assertSame('regressed', $recent[1]->skip_reason);
+        $this->assertNull($recent[0]->skip_reason);
+    }
+
+    public function testGetRecentOrdersRunsRecordedInTheSameSecond() {
+        $sameSecond = \OmegaUp\Time::get() - 100;
+        $older = $this->createModelRun(
+            0.10,
+            published: false,
+            createdAt: $sameSecond,
+            skipReason: 'below minimum'
+        );
+        $newer = $this->createModelRun(
+            0.20,
+            published: true,
+            createdAt: $sameSecond
+        );
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertSame($newer->model_run_id, $recent[0]->model_run_id);
+        $this->assertSame($older->model_run_id, $recent[1]->model_run_id);
+    }
+
+    public function testGetRecentHonorsTheLimit() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(0.30, published: true, createdAt: $now - 300);
+        $this->createModelRun(0.40, published: true, createdAt: $now - 200);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(1);
+
+        $this->assertCount(1, $recent);
+        $this->assertEqualsWithDelta(0.40, $recent[0]->map_score, 1e-9);
+    }
+
+    public function testGetRecentKeepsAFixedSeedOfZeroApartFromNoSeed() {
+        $now = \OmegaUp\Time::get();
+        $this->createModelRun(
+            0.30,
+            published: true,
+            createdAt: $now - 200,
+            rngSeed: 0
+        );
+        $this->createModelRun(0.40, published: true, createdAt: $now - 100);
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(20);
+
+        $this->assertNull($recent[0]->rng_seed);
+        $this->assertSame(0, $recent[1]->rng_seed);
+    }
+
+    public function testGetRecentKeepsEveryTrainingParameter() {
+        $this->createModelRun(
+            0.42,
+            published: true,
+            createdAt: \OmegaUp\Time::get() - 100,
+            rngSeed: 7
+        );
+
+        $recent = \OmegaUp\DAO\RecommendationModelRuns::getRecent(1);
+
+        $this->assertSame(1000, $recent[0]->dataset_size);
+        $this->assertSame(3, $recent[0]->num_followups);
+        $this->assertEqualsWithDelta(0.4, $recent[0]->followup_decay, 1e-9);
+        $this->assertEqualsWithDelta(0.8, $recent[0]->train_fraction, 1e-9);
+        $this->assertSame(7, $recent[0]->rng_seed);
+        $this->assertSame('/tmp/model.db', $recent[0]->output_path);
+        $this->assertTrue($recent[0]->published);
+    }
+}

--- a/frontend/www/docs/Controllers.md
+++ b/frontend/www/docs/Controllers.md
@@ -12,6 +12,7 @@ For more information about the API controllers, please refer to the [Controllers
   - [`/api/admin/getMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminplatformreportstats)
+  - [`/api/admin/rerunCron/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminreruncron)
   - [`/api/admin/setMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminsetmaintenancemode)
   - [`/api/admin/updateSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminupdatesystemsettings)
 - [AiEditorial](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#aieditorial)

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -144,6 +144,10 @@ export const Admin = {
     messages.AdminPlatformReportStatsRequest,
     messages.AdminPlatformReportStatsResponse
   >('/api/admin/platformReportStats/'),
+  rerunCron: apiCall<
+    messages.AdminRerunCronRequest,
+    messages.AdminRerunCronResponse
+  >('/api/admin/rerunCron/'),
   setMaintenanceMode: apiCall<
     messages.AdminSetMaintenanceModeRequest,
     messages.AdminSetMaintenanceModeResponse

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5437,6 +5437,8 @@ export namespace messages {
       };
     };
   };
+  export type AdminRerunCronRequest = { [key: string]: any };
+  export type AdminRerunCronResponse = {};
   export type AdminSetMaintenanceModeRequest = { [key: string]: any };
   export type AdminSetMaintenanceModeResponse = {};
   export type AdminUpdateSystemSettingsRequest = { [key: string]: any };
@@ -6453,6 +6455,9 @@ export namespace controllers {
     platformReportStats: (
       params?: messages.AdminPlatformReportStatsRequest,
     ) => Promise<messages.AdminPlatformReportStatsResponse>;
+    rerunCron: (
+      params?: messages.AdminRerunCronRequest,
+    ) => Promise<messages.AdminRerunCronResponse>;
     setMaintenanceMode: (
       params?: messages.AdminSetMaintenanceModeRequest,
     ) => Promise<messages.AdminSetMaintenanceModeResponse>;

--- a/stuff/cron/cron_dispatcher.py
+++ b/stuff/cron/cron_dispatcher.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+'''Dispatches manual cron rerun requests.
+
+The web layer only enqueues rows in `Cron_Run_Requests`; this trusted worker is
+the single place that actually launches a job.
+'''
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+
+import enum
+from typing import Callable, Iterator, List, NamedTuple, Optional, Set, Tuple
+
+import mysql.connector.cursor
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+                 "."))
+import lib.db  # pylint: disable=wrong-import-position
+import lib.logs  # pylint: disable=wrong-import-position
+
+_CRON_DIR = os.path.dirname(os.path.realpath(__file__))
+
+_MAX_ERROR_LENGTH = 1000
+
+# A dispatcher that dies mid-run would otherwise leave the job unrunnable.
+STALE_PICK_HOURS = 6
+
+_STALE_PICK_ERROR = 'the dispatcher did not finish this run'
+_UNREGISTERED_ERROR = 'job is not registered'
+
+
+class RequestStatus(enum.Enum):
+    '''The states a rerun request can be in, as stored in `status`.
+
+    Mirrors `\\OmegaUp\\CronRunRequestStatus` on the PHP side.
+    '''
+    PENDING = 'pending'
+    PICKED = 'picked'
+    DONE = 'done'
+    FAILED = 'failed'
+
+
+class RerunRequest(NamedTuple):
+    '''A queued manual rerun request.'''
+    request_id: int
+    name: str
+    requested_by: Optional[int]
+
+
+RunCommand = Callable[[argparse.Namespace, str], Tuple[int, Optional[str]]]
+
+
+def get_pending_requests(
+    cur: mysql.connector.cursor.MySQLCursorDict,
+) -> List[RerunRequest]:
+    '''Returns the queued rerun requests, oldest first.'''
+    cur.execute(
+        '''
+        SELECT
+            request_id, name, requested_by
+        FROM
+            Cron_Run_Requests
+        WHERE
+            status = %s
+        ORDER BY
+            requested_at ASC;''',
+        (RequestStatus.PENDING.value,))
+    return [
+        RerunRequest(row['request_id'], row['name'], row['requested_by'])
+        for row in cur.fetchall()
+    ]
+
+
+def get_registered_jobs(
+    cur: mysql.connector.cursor.MySQLCursorDict,
+) -> Set[str]:
+    '''Returns the job names the registry knows about.'''
+    cur.execute('SELECT name FROM Cron_Jobs;')
+    return {row['name'] for row in cur.fetchall()}
+
+
+def is_launchable(name: str, registered: Set[str]) -> bool:
+    '''Whether a request names a registered script installed in this checkout.
+
+    `Cron_Jobs` is the registry `\\OmegaUp\\CronJobName` mirrors, so this is
+    the same allowlist the API validates against, and the filename check
+    keeps a tampered row from reaching anything else.
+    '''
+    return (name in registered
+            and name.endswith('.py')
+            and os.path.basename(name) == name
+            and os.path.isfile(os.path.join(_CRON_DIR, name)))
+
+
+def fail_stale_requests(
+    dbconn: lib.db.Connection,
+    cur: mysql.connector.cursor.MySQLCursorDict,
+) -> None:
+    '''Releases requests left behind by a dispatcher that died mid-run.'''
+    cur.execute(
+        '''
+        UPDATE
+            Cron_Run_Requests
+        SET
+            status = %s, finished_at = NOW(), error_text = %s
+        WHERE
+            status = %s
+            AND picked_at < DATE_SUB(NOW(), INTERVAL %s HOUR);''',
+        (RequestStatus.FAILED.value, _STALE_PICK_ERROR,
+         RequestStatus.PICKED.value, STALE_PICK_HOURS))
+    dbconn.conn.commit()
+
+
+def _claim_request(
+    dbconn: lib.db.Connection,
+    cur: mysql.connector.cursor.MySQLCursorDict,
+    request_id: int,
+) -> bool:
+    '''Takes a request, or returns False if another dispatcher got it first.
+
+    The status the row is expected to be in is part of the UPDATE, so only the
+    dispatcher whose UPDATE changed the row goes on to run the job.
+    '''
+    cur.execute(
+        '''
+        UPDATE Cron_Run_Requests
+        SET status = %s, picked_at = NOW()
+        WHERE request_id = %s AND status = %s;''',
+        (RequestStatus.PICKED.value, request_id, RequestStatus.PENDING.value))
+    claimed = cur.rowcount == 1
+    dbconn.conn.commit()
+    return claimed
+
+
+def _latest_run_id(
+    cur: mysql.connector.cursor.MySQLCursorDict,
+    name: str,
+) -> Optional[int]:
+    '''Returns the newest run recorded for a job, if any.'''
+    cur.execute(
+        'SELECT MAX(run_id) AS run_id FROM Cron_Runs WHERE name = %s;',
+        (name,))
+    row = cur.fetchone()
+    if row is None or row['run_id'] is None:
+        return None
+    return int(row['run_id'])
+
+
+@contextlib.contextmanager
+def db_command_args(args: argparse.Namespace) -> Iterator[List[str]]:
+    '''Yields the DB flags to hand down to the child script.'''
+    command = ['--host', args.host, '--port', str(args.port),
+               '--database', args.database]
+    if args.password is None or args.user is None:
+        if args.mysql_config_file:
+            command.extend(['--mysql-config-file', args.mysql_config_file])
+        if args.user:
+            command.extend(['--user', args.user])
+        yield command
+        return
+    # Anyone on the machine can read a process' command line, so the password
+    # travels down in a file only this user can open.
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.cnf') as config_file:
+        config_file.write(f'[client]\n'
+                          f'host={args.host}\n'
+                          f'port={args.port}\n'
+                          f'user={args.user}\n'
+                          f'password={args.password}\n')
+        config_file.flush()
+        yield command + ['--mysql-config-file', config_file.name]
+
+
+def run_script(
+    args: argparse.Namespace,
+    name: str,
+) -> Tuple[int, Optional[str]]:
+    '''Runs a registered cron script as a subprocess.'''
+    with db_command_args(args) as db_args:
+        command = [sys.executable, os.path.join(_CRON_DIR, name)] + db_args
+        result = subprocess.run(command, check=False, capture_output=True,
+                                text=True)
+    if result.returncode == 0:
+        return (0, None)
+    return (result.returncode, (result.stderr or '')[-_MAX_ERROR_LENGTH:])
+
+
+def _notify_requester(
+    cur: mysql.connector.cursor.MySQLCursorDict,
+    user_id: Optional[int],
+    name: str,
+    status: RequestStatus,
+) -> None:
+    '''Notifies the admin who requested the rerun of its outcome.'''
+    if user_id is None:
+        return
+    succeeded = status is RequestStatus.DONE
+    localization_string = (
+        'notificationCronRerunSucceeded'
+        if succeeded else 'notificationCronRerunFailed')
+    cur.execute(
+        '''
+        INSERT INTO
+            Notifications (user_id, contents)
+        VALUES (%s, %s);''',
+        (user_id,
+         json.dumps({
+             'type': 'cron_rerun',
+             'status': status.value,
+             'body': {
+                 'localizationString': localization_string,
+                 'localizationParams': {'jobName': name},
+                 'url': '/admin/crons/',
+                 'iconUrl': '/media/info.png',
+             },
+         })))
+
+
+def _reject_request(
+    dbconn: lib.db.Connection,
+    cur: mysql.connector.cursor.MySQLCursorDict,
+    request_id: int,
+    error_text: str,
+) -> None:
+    '''Fails a request that must not be launched at all.'''
+    cur.execute(
+        '''
+        UPDATE Cron_Run_Requests
+        SET status = %s, finished_at = NOW(), error_text = %s
+        WHERE request_id = %s AND status = %s;''',
+        (RequestStatus.FAILED.value, error_text, request_id,
+         RequestStatus.PENDING.value))
+    dbconn.conn.commit()
+
+
+def process_requests(
+    dbconn: lib.db.Connection,
+    cur: mysql.connector.cursor.MySQLCursorDict,
+    args: argparse.Namespace,
+    run_command: RunCommand = run_script,
+) -> int:
+    '''Claims and runs every pending request. Returns the number processed.'''
+    fail_stale_requests(dbconn, cur)
+    registered = get_registered_jobs(cur)
+    processed = 0
+    for request in get_pending_requests(cur):
+        if not is_launchable(request.name, registered):
+            _reject_request(dbconn, cur, request.request_id,
+                            _UNREGISTERED_ERROR)
+            logging.warning('Skipped unregistered job %s', request.name)
+            processed += 1
+            continue
+
+        if not _claim_request(dbconn, cur, request.request_id):
+            logging.info('Request %d was already claimed', request.request_id)
+            continue
+
+        previous_run_id = _latest_run_id(cur, request.name)
+        logging.info('Running rerun of %s', request.name)
+        try:
+            returncode, error_text = run_command(args, request.name)
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.exception('Rerun of %s raised', request.name)
+            returncode, error_text = (1, str(exc)[-_MAX_ERROR_LENGTH:])
+        status = (RequestStatus.DONE
+                  if returncode == 0 else RequestStatus.FAILED)
+        run_id = _latest_run_id(cur, request.name)
+        if run_id == previous_run_id:
+            # The job was disabled or already running, so it produced no run.
+            run_id = None
+
+        cur.execute(
+            '''
+            UPDATE Cron_Run_Requests
+            SET status = %s, finished_at = NOW(), run_id = %s, error_text = %s
+            WHERE request_id = %s;''',
+            (status.value, run_id, error_text, request.request_id))
+        _notify_requester(cur, request.requested_by, request.name, status)
+        dbconn.conn.commit()
+        processed += 1
+
+    return processed
+
+
+def main() -> None:
+    '''Main entrypoint.'''
+    parser = argparse.ArgumentParser(
+        description='Dispatch manual cron rerun requests.')
+    lib.db.configure_parser(parser)
+    lib.logs.configure_parser(parser)
+    args = parser.parse_args()
+    lib.logs.init(parser.prog, args)
+
+    logging.info('Started')
+    dbconn = lib.db.connect(
+        lib.db.DatabaseConnectionArguments.from_args(args))
+    try:
+        with dbconn.cursor(buffered=True, dictionary=True) as cur:
+            processed = process_requests(dbconn, cur, args)
+        logging.info('Processed %d rerun request(s)', processed)
+    finally:
+        dbconn.conn.close()
+        logging.info('Finished')
+
+
+if __name__ == '__main__':
+    main()

--- a/stuff/cron/cron_dispatcher_test.py
+++ b/stuff/cron/cron_dispatcher_test.py
@@ -1,0 +1,395 @@
+'''Unittests for the cron_dispatcher script.
+
+These use in-memory fakes so neither a real database nor a subprocess is
+required. The script under test is injected with a fake run command, so the
+tests exercise the request lifecycle (claim, run, record, notify) in isolation.
+'''
+
+import argparse
+import json
+import os
+import unittest
+
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from cron import cron_dispatcher
+from cron.cron_dispatcher import RequestStatus
+
+RunResult = Tuple[int, Optional[str]]
+Params = Optional[Tuple[Any, ...]]
+
+_REGISTERED = ('update_ranks.py', 'assign_badges.py', 'aggregate_feedback.py')
+
+
+def _normalize(query: str) -> str:
+    '''Collapses a query to a single lowercase line.'''
+    return ' '.join(query.lower().split())
+
+
+class _FakeCursor:
+    '''Answers dispatcher queries from scripted data and records calls.'''
+
+    def __init__(self, connection: '_FakeConnection') -> None:
+        self._connection = connection
+        self._mode: Optional[str] = None
+        self.rowcount = -1
+
+    def execute(self, query: str, params: Any = None) -> None:
+        '''Records the call and remembers what the next fetch should return.'''
+        self._connection.calls.append((query, params))
+        normalized = _normalize(query)
+        self.rowcount = 1
+        if 'from cron_run_requests' in normalized:
+            self._mode = 'pending'
+        elif 'from cron_jobs' in normalized:
+            self._mode = 'jobs'
+        elif 'max(run_id)' in normalized:
+            self._mode = 'run_id'
+        elif 'picked_at = now()' in normalized:
+            self._mode = None
+            self.rowcount = 1 if self._connection.claim_succeeds else 0
+        else:
+            self._mode = None
+
+    def fetchall(self) -> List[Dict[str, Any]]:
+        '''Returns the scripted rows for the query that was just run.'''
+        if self._mode == 'pending':
+            return self._connection.pending
+        if self._mode == 'jobs':
+            return [{'name': name} for name in self._connection.registered]
+        return []
+
+    def fetchone(self) -> Optional[Dict[str, Any]]:
+        '''Returns the scripted answer for the query that was just run.'''
+        if self._mode == 'run_id':
+            return {'run_id': self._connection.next_run_id()}
+        return None
+
+
+class _FakeConnection:
+    '''Minimal stand-in for lib.db.Connection.'''
+
+    registered = _REGISTERED
+
+    def __init__(self, pending: List[Dict[str, Any]],
+                 run_id: Optional[int] = 7,
+                 previous_run_id: Optional[int] = None,
+                 claim_succeeds: bool = True) -> None:
+        self.pending = pending
+        self.run_id = run_id
+        self.previous_run_id = previous_run_id
+        self.claim_succeeds = claim_succeeds
+        self.run_id_queries = 0
+        self.calls: List[Tuple[str, Any]] = []
+        self.conn = self
+
+    def next_run_id(self) -> Optional[int]:
+        '''Answers the run_id lookups made before and after the script runs.'''
+        self.run_id_queries += 1
+        if self.run_id_queries % 2 == 1:
+            return self.previous_run_id
+        return self.run_id
+
+    def commit(self) -> None:
+        '''Commits are a no-op against the fakes.'''
+
+
+def _matching(calls: List[Tuple[str, Any]], needle: str) -> List[Params]:
+    '''Returns the params of every query whose text contains `needle`.'''
+    return [
+        cast(Params, params) for query, params in calls
+        if needle in _normalize(query)
+    ]
+
+
+def _final_update(calls: List[Tuple[str, Any]]) -> Params:
+    '''Returns the params of the done/failed UPDATE, if any.'''
+    matches = _matching(calls, 'run_id = %s, error_text = %s')
+    return matches[0] if matches else None
+
+
+def _claim_update(calls: List[Tuple[str, Any]]) -> Params:
+    '''Returns the params of the conditional claim UPDATE, if any.'''
+    matches = _matching(calls, 'picked_at = now()')
+    return matches[0] if matches else None
+
+
+def _notifications(calls: List[Tuple[str, Any]]) -> List[Tuple[Any, ...]]:
+    '''Returns the params of every Notifications insert.'''
+    return [
+        params for query, params in calls
+        if 'insert into notifications' in _normalize(query)
+    ]
+
+
+def _fake_run(args: argparse.Namespace, name: str) -> RunResult:
+    '''A run command that always succeeds.'''
+    del args, name
+    return (0, None)
+
+
+class CronDispatcherTest(unittest.TestCase):
+    '''Tests for cron_dispatcher.process_requests.'''
+
+    def _run(
+        self,
+        pending: List[Dict[str, Any]],
+        run_command: cron_dispatcher.RunCommand,
+        **kwargs: Any,
+    ) -> Tuple[int, _FakeConnection]:
+        connection = _FakeConnection(pending, **kwargs)
+        cursor = _FakeCursor(connection)
+        processed = cron_dispatcher.process_requests(
+            connection, cursor, argparse.Namespace(),  # type: ignore
+            run_command=run_command)
+        return processed, connection
+
+    def test_records_successful_rerun(self) -> None:
+        '''A successful run is marked done, linked and notified.'''
+        launched: List[str] = []
+
+        def fake_run(args: argparse.Namespace, name: str) -> RunResult:
+            del args
+            launched.append(name)
+            return (0, None)
+
+        processed, connection = self._run(
+            [{'request_id': 1, 'name': 'update_ranks.py', 'requested_by': 5}],
+            fake_run)
+
+        self.assertEqual(processed, 1)
+        self.assertEqual(launched, ['update_ranks.py'])
+        params = _final_update(connection.calls)
+        assert params is not None
+        self.assertEqual(params[0], RequestStatus.DONE.value)
+        self.assertEqual(params[1], 7)
+        notifications = _notifications(connection.calls)
+        self.assertEqual(len(notifications), 1)
+        user_id, contents = notifications[0]
+        self.assertEqual(user_id, 5)
+        self.assertEqual(
+            json.loads(contents)['status'], RequestStatus.DONE.value)
+
+    def test_records_failed_rerun_with_error(self) -> None:
+        '''A non-zero exit marks the request failed and stores the error.'''
+        def fake_run(args: argparse.Namespace, name: str) -> RunResult:
+            del args, name
+            return (1, 'boom')
+
+        processed, connection = self._run(
+            [{'request_id': 2, 'name': 'assign_badges.py', 'requested_by': 9}],
+            fake_run)
+
+        self.assertEqual(processed, 1)
+        params = _final_update(connection.calls)
+        assert params is not None
+        self.assertEqual(params[0], RequestStatus.FAILED.value)
+        self.assertEqual(params[2], 'boom')
+        notifications = _notifications(connection.calls)
+        self.assertEqual(
+            json.loads(notifications[0][1])['status'],
+            RequestStatus.FAILED.value)
+
+    def test_records_failed_rerun_when_the_run_raises(self) -> None:
+        '''An exception leaves the request failed instead of stuck picked.'''
+        def fake_run(args: argparse.Namespace, name: str) -> RunResult:
+            del args, name
+            raise OSError('no such file')
+
+        processed, connection = self._run(
+            [{'request_id': 8, 'name': 'update_ranks.py', 'requested_by': 5}],
+            fake_run)
+
+        self.assertEqual(processed, 1)
+        params = _final_update(connection.calls)
+        assert params is not None
+        self.assertEqual(params[0], RequestStatus.FAILED.value)
+        self.assertEqual(params[2], 'no such file')
+
+    def test_skips_unregistered_job(self) -> None:
+        '''A request for an unknown script is never launched.'''
+        launched: List[str] = []
+
+        def fake_run(args: argparse.Namespace, name: str) -> RunResult:
+            del args
+            launched.append(name)
+            return (0, None)
+
+        processed, connection = self._run(
+            [{'request_id': 3, 'name': 'rm_rf.py', 'requested_by': 1}],
+            fake_run)
+
+        self.assertEqual(processed, 1)
+        self.assertEqual(launched, [])
+        self.assertEqual(
+            _matching(connection.calls, 'error_text = %s where request_id'),
+            [(RequestStatus.FAILED.value, 'job is not registered', 3,
+              RequestStatus.PENDING.value)])
+        self.assertEqual(_notifications(connection.calls), [])
+
+    def test_claims_only_a_request_that_is_still_pending(self) -> None:
+        '''The claim names the status it expects, so two cannot both win.'''
+        _, connection = self._run(
+            [{'request_id': 9, 'name': 'update_ranks.py', 'requested_by': 5}],
+            _fake_run)
+
+        self.assertEqual(
+            _claim_update(connection.calls),
+            (RequestStatus.PICKED.value, 9, RequestStatus.PENDING.value))
+
+    def test_skips_request_claimed_by_another_dispatcher(self) -> None:
+        '''A request another dispatcher already took is left alone.'''
+        launched: List[str] = []
+
+        def fake_run(args: argparse.Namespace, name: str) -> RunResult:
+            del args
+            launched.append(name)
+            return (0, None)
+
+        processed, connection = self._run(
+            [{'request_id': 9, 'name': 'update_ranks.py', 'requested_by': 5}],
+            fake_run, claim_succeeds=False)
+
+        self.assertEqual(processed, 0)
+        self.assertEqual(launched, [])
+        self.assertIsNone(_final_update(connection.calls))
+        self.assertEqual(_notifications(connection.calls), [])
+
+    def test_fails_requests_left_behind_by_a_dead_dispatcher(self) -> None:
+        '''Requests stuck in picked are released before anything else runs.'''
+        _, connection = self._run([], _fake_run)
+
+        self.assertEqual(
+            _matching(connection.calls, 'date_sub'),
+            [(RequestStatus.FAILED.value,
+              'the dispatcher did not finish this run',
+              RequestStatus.PICKED.value,
+              cron_dispatcher.STALE_PICK_HOURS)])
+
+    def test_no_run_link_when_the_job_produced_no_run(self) -> None:
+        '''A job that skipped itself is not linked to its previous run.'''
+        _, connection = self._run(
+            [{'request_id': 5, 'name': 'update_ranks.py', 'requested_by': 5}],
+            _fake_run, run_id=7, previous_run_id=7)
+
+        params = _final_update(connection.calls)
+        assert params is not None
+        self.assertEqual(params[0], RequestStatus.DONE.value)
+        self.assertIsNone(params[1])
+
+    def test_only_pending_requests_are_picked_up(self) -> None:
+        '''The queue query asks for the pending status by name.'''
+        _, connection = self._run([], _fake_run)
+
+        self.assertEqual(
+            _matching(connection.calls, 'from cron_run_requests'),
+            [(RequestStatus.PENDING.value,)])
+
+    def test_notification_carries_a_renderable_body(self) -> None:
+        '''The notification uses the generic body the UI knows how to show.'''
+        _, connection = self._run(
+            [{'request_id': 6, 'name': 'update_ranks.py', 'requested_by': 5}],
+            _fake_run)
+
+        contents = json.loads(_notifications(connection.calls)[0][1])
+        self.assertEqual(
+            contents['body']['localizationString'],
+            'notificationCronRerunSucceeded')
+        self.assertEqual(
+            contents['body']['localizationParams'],
+            {'jobName': 'update_ranks.py'})
+
+    def test_no_notification_without_requester(self) -> None:
+        '''No notification is created when the requester is unknown.'''
+        _, connection = self._run(
+            [{
+                'request_id': 4,
+                'name': 'aggregate_feedback.py',
+                'requested_by': None,
+            }],
+            _fake_run)
+
+        self.assertEqual(_notifications(connection.calls), [])
+
+
+class IsLaunchableTest(unittest.TestCase):
+    '''Tests for the check that guards what can be launched.'''
+
+    def test_accepts_a_registered_script_that_exists(self) -> None:
+        '''The happy path is a registry entry with a file behind it.'''
+        self.assertTrue(
+            cron_dispatcher.is_launchable('update_ranks.py',
+                                          set(_REGISTERED)))
+
+    def test_rejects_a_script_that_is_not_registered(self) -> None:
+        '''A file in stuff/cron is not enough on its own.'''
+        self.assertFalse(
+            cron_dispatcher.is_launchable('update_ranks.py', set()))
+
+    def test_rejects_a_registered_name_with_no_file(self) -> None:
+        '''A registry row for a job this checkout does not have is skipped.'''
+        self.assertFalse(
+            cron_dispatcher.is_launchable('not_here.py', {'not_here.py'}))
+
+    def test_rejects_a_path_that_escapes_the_cron_directory(self) -> None:
+        '''A tampered row cannot reach anything outside stuff/cron.'''
+        # stuff/update-dao.py really exists, so only the basename check
+        # keeps this from being launched.
+        escaping = '../update-dao.py'
+        self.assertFalse(
+            cron_dispatcher.is_launchable(escaping, {escaping}))
+
+    def test_rejects_a_name_that_is_not_a_script(self) -> None:
+        '''Only python scripts are ever launched.'''
+        self.assertFalse(
+            cron_dispatcher.is_launchable('testdata.db', {'testdata.db'}))
+
+
+class RequestStatusTest(unittest.TestCase):
+    '''Tests for the status enum.'''
+
+    def test_matches_the_column(self) -> None:
+        '''The enum mirrors the `Cron_Run_Requests.status` column exactly.'''
+        self.assertEqual(
+            [status.value for status in RequestStatus],
+            ['pending', 'picked', 'done', 'failed'])
+
+
+class DbCommandArgsTest(unittest.TestCase):
+    '''Tests for the flags handed down to the child script.'''
+
+    @staticmethod
+    def _args(password: Optional[str]) -> argparse.Namespace:
+        return argparse.Namespace(host='localhost', port=13306,
+                                  database='omegaup', user='omegaup',
+                                  password=password, mysql_config_file=None)
+
+    def test_forwards_the_config_file_when_there_is_no_password(self) -> None:
+        '''Without a password there is nothing to hide.'''
+        args = self._args(None)
+        args.mysql_config_file = '/home/omegaup/.my.cnf'
+        with cron_dispatcher.db_command_args(args) as command:
+            self.assertIn('--mysql-config-file', command)
+            self.assertIn('/home/omegaup/.my.cnf', command)
+            self.assertIn('--user', command)
+
+    def test_keeps_the_password_out_of_the_command_line(self) -> None:
+        '''The password reaches the child through a file, not through argv.'''
+        with cron_dispatcher.db_command_args(self._args('hunter2')) as command:
+            self.assertNotIn('--password', command)
+            self.assertNotIn('hunter2', command)
+            config_file = command[command.index('--mysql-config-file') + 1]
+            with open(config_file, encoding='utf-8') as f:
+                contents = f.read()
+            self.assertIn('password=hunter2', contents)
+            self.assertEqual(os.stat(config_file).st_mode & 0o077, 0)
+
+    def test_the_child_reads_the_config_file_instead_of_the_flags(
+            self) -> None:
+        '''lib.db only reads the config file when --user is absent.'''
+        with cron_dispatcher.db_command_args(self._args('hunter2')) as command:
+            self.assertNotIn('--user', command)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/stuff/mysql/connector/cursor.pyi
+++ b/stuff/mysql/connector/cursor.pyi
@@ -4,6 +4,7 @@ from typing import Any, Iterator, Iterable, Mapping, Optional, Sequence, Text, T
 
 class BaseCursor:
     lastrowid: int
+    rowcount: int
 
     def close(self) -> None:
         ...


### PR DESCRIPTION
# Description

`cron_dispatcher.py`, the trusted worker that drains the rerun queue. it is the only thing that actually launches a job, so everything that can go wrong when two of them run at once, or when one of them dies, is handled here.

the claim is a single conditional update. it sets `picked` only `WHERE request_id = %s AND status = %s` with `pending` as the expected status, and reads `cur.rowcount` to decide whether this dispatcher won the row. a dispatcher that did not change the row moves on without running anything, so a request cannot be run twice. the same shape guards the update that fails an unregistered job.

a dispatcher that dies mid run leaves a row in `picked` with nobody to finish it, so the next run of the dispatcher fails any request that has been picked for more than six hours before it looks at the queue. an exception out of the child is caught and recorded as a failure with the message, rather than being allowed to leave the row stuck.

the allowlist is the `Cron_Jobs` registry read from the database, not a set written out again in python, which is the same list `apiRerunCron` validates against through `\OmegaUp\CronJobName`, plus a check that the name is a bare `.py` filename that exists under `stuff/cron`, so a tampered row cannot reach anything else.

the four status values are a `RequestStatus` enum mirroring `\OmegaUp\CronRunRequestStatus` and the column, following the shape already used in `stuff/editorial_generator`, so no query names a status as a literal.

when the dispatcher is given a password it writes a `[client]` block to a temporary `.cnf` that only its own user can read and hands the child that file instead of the password, so the password never reaches the child's command line where `ps` would show it. the child ends up reading the file because `lib.db.connect` only falls back to the config file when `--user` is absent, which is why the flag is left off deliberately.

`stuff/mysql/connector/cursor.pyi` gains `rowcount`, which the real cursor has always had as a documented `int` property but the stub was missing.

part of #10018.

# Comments

part of the cron control plane epic #9992, the fourth of five pull requests that used to be the single #10021. the chain is #10155, #10156, #10157, this one and #10021. it is stacked on the first three, so their files show in the diff until they merge.

the dispatcher needs a crontab entry on the ops side to actually drain the queue, since scheduling lives outside this repo. until it is scheduled the button records the request and nothing runs it.

the two notification strings it names are added in #10021 on top of this one, together with the change that lets the unused string linter see strings named by python.

what i ran: the 20 tests in `cron_dispatcher_test.py` and the whole of `stuff/cron` under pytest, 112 passed and 1 skipped, and `./stuff/lint.sh`, clean. i also mutation tested the claim: dropping the expected status from the where clause, ignoring `rowcount`, accepting any `rowcount`, removing the reaper, removing the exception handler, putting the password back on the command line, dropping the registry check and dropping the bare filename check each make a test fail, so the ten mutants i tried were all caught.

`database_schema.py` refuses `schema.sql` and `dao_schema.sql` in the same diff, and a stacked pull request based on main carries its parent's files, so the php job here fails on the "Validate database schema" step until #10155 merges, and stops there without reaching the tests. that is why this is a draft: once the table is in main i rebase and the step has nothing to complain about. i ran the php tests locally against the same tree and they pass.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
