### PR TITLE
add cron job enable api

### DIFF
--- a/frontend/server/src/Controllers/Admin.php
+++ b/frontend/server/src/Controllers/Admin.php
@@ -510,6 +510,33 @@ class Admin extends \OmegaUp\Controllers\Controller {
     }
 
     /**
+     * Enables or disables a cron job. A disabled job skips its scheduled runs.
+     *
+     * @return array{status: string}
+     *
+     * @omegaup-request-param bool $enabled
+     * @omegaup-request-param string $name
+     */
+    public static function apiSetCronJobEnabled(\OmegaUp\Request $r): array {
+        $r->ensureMainUserIdentity();
+        if (!\OmegaUp\Authorization::isSystemAdmin($r->identity)) {
+            throw new \OmegaUp\Exceptions\ForbiddenAccessException();
+        }
+        $name = $r->ensureString('name');
+        $enabled = $r->ensureBool('enabled');
+        $job = \OmegaUp\DAO\CronJobs::getByName($name);
+        if (is_null($job)) {
+            throw new \OmegaUp\Exceptions\InvalidParameterException(
+                'parameterInvalid',
+                'name'
+            );
+        }
+        $job->enabled = $enabled;
+        \OmegaUp\DAO\CronJobs::update($job);
+        return ['status' => 'ok'];
+    }
+
+    /**
      * @return array{entrypoint: string, templateProperties: array{payload: CronsDetailsPayload, title: \OmegaUp\TranslationString}}
      */
     public static function getCronsForTypeScript(\OmegaUp\Request $r): array {

--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -6,6 +6,7 @@
   - [`/api/admin/getMaintenanceMode/`](#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](#apiadminplatformreportstats)
+  - [`/api/admin/setCronJobEnabled/`](#apiadminsetcronjobenabled)
   - [`/api/admin/setMaintenanceMode/`](#apiadminsetmaintenancemode)
   - [`/api/admin/updateSystemSettings/`](#apiadminupdatesystemsettings)
 - [AiEditorial](#aieditorial)
@@ -404,6 +405,23 @@ Get stats for an overall platform report.
 | Name     | Type                                                                                                                                                                                                     |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `report` | `{ acceptedSubmissions: number; activeSchools: number; activeUsers: { [key: string]: number; }; courses: number; omiCourse: { attemptedUsers: number; completedUsers: number; passedUsers: number; }; }` |
+
+## `/api/admin/setCronJobEnabled/`
+
+### Description
+
+Enables or disables a cron job. A disabled job skips its scheduled runs.
+
+### Parameters
+
+| Name      | Type     | Description | Required |
+| --------- | -------- | ----------- | -------- |
+| `enabled` | `bool`   |             | ✓        |
+| `name`    | `string` |             | ✓        |
+
+### Returns
+
+_Nothing_
 
 ## `/api/admin/setMaintenanceMode/`
 

--- a/frontend/tests/controllers/CronControlPlaneAdminTest.php
+++ b/frontend/tests/controllers/CronControlPlaneAdminTest.php
@@ -212,4 +212,71 @@ class CronControlPlaneAdminTest extends \OmegaUp\Test\ControllerTestCase {
         $this->assertSame(7, $runs[0]['rows_affected']);
         $this->assertSame([], $runs[0]['phases']);
     }
+
+    public function testSetCronJobEnabledRequiresAdmin() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiSetCronJobEnabled(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+                    'enabled' => false,
+                ])
+            );
+            $this->fail('Should not have allowed access to non-admin');
+        } catch (\OmegaUp\Exceptions\ForbiddenAccessException $e) {
+            $this->assertSame('userNotAllowed', $e->getMessage());
+        }
+    }
+
+    public function testSetCronJobEnabledTogglesTheJob() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        \OmegaUp\Controllers\Admin::apiSetCronJobEnabled(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+                'enabled' => false,
+            ])
+        );
+        $disabled = \OmegaUp\DAO\CronJobs::getByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+        $this->assertNotNull($disabled);
+        $this->assertFalse($disabled->enabled);
+
+        \OmegaUp\Controllers\Admin::apiSetCronJobEnabled(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+                'name' => \OmegaUp\CronJobName::UpdateRanks->value,
+                'enabled' => true,
+            ])
+        );
+        $enabled = \OmegaUp\DAO\CronJobs::getByName(
+            \OmegaUp\CronJobName::UpdateRanks->value
+        );
+        $this->assertNotNull($enabled);
+        $this->assertTrue($enabled->enabled);
+    }
+
+    public function testSetCronJobEnabledRejectsUnknownJob() {
+        ['identity' => $identity] = \OmegaUp\Test\Factories\User::createAdminUser();
+        $login = \OmegaUp\Test\ControllerTestCase::login($identity);
+
+        try {
+            \OmegaUp\Controllers\Admin::apiSetCronJobEnabled(
+                new \OmegaUp\Request([
+                    'auth_token' => $login->auth_token,
+                    'name' => 'not_a_real_job.py',
+                    'enabled' => false,
+                ])
+            );
+            $this->fail('Should not have accepted an unknown job');
+        } catch (\OmegaUp\Exceptions\InvalidParameterException $e) {
+            $this->assertSame('parameterInvalid', $e->getMessage());
+        }
+    }
 }

--- a/frontend/www/docs/Controllers.md
+++ b/frontend/www/docs/Controllers.md
@@ -12,6 +12,7 @@ For more information about the API controllers, please refer to the [Controllers
   - [`/api/admin/getMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetmaintenancemode)
   - [`/api/admin/getSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadmingetsystemsettings)
   - [`/api/admin/platformReportStats/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminplatformreportstats)
+  - [`/api/admin/setCronJobEnabled/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminsetcronjobenabled)
   - [`/api/admin/setMaintenanceMode/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminsetmaintenancemode)
   - [`/api/admin/updateSystemSettings/`](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#apiadminupdatesystemsettings)
 - [AiEditorial](https://github.com/omegaup/omegaup/blob/main/frontend/server/src/Controllers/README.md#aieditorial)

--- a/frontend/www/js/omegaup/api.ts
+++ b/frontend/www/js/omegaup/api.ts
@@ -144,6 +144,10 @@ export const Admin = {
     messages.AdminPlatformReportStatsRequest,
     messages.AdminPlatformReportStatsResponse
   >('/api/admin/platformReportStats/'),
+  setCronJobEnabled: apiCall<
+    messages.AdminSetCronJobEnabledRequest,
+    messages.AdminSetCronJobEnabledResponse
+  >('/api/admin/setCronJobEnabled/'),
   setMaintenanceMode: apiCall<
     messages.AdminSetMaintenanceModeRequest,
     messages.AdminSetMaintenanceModeResponse

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5437,6 +5437,8 @@ export namespace messages {
       };
     };
   };
+  export type AdminSetCronJobEnabledRequest = { [key: string]: any };
+  export type AdminSetCronJobEnabledResponse = {};
   export type AdminSetMaintenanceModeRequest = { [key: string]: any };
   export type AdminSetMaintenanceModeResponse = {};
   export type AdminUpdateSystemSettingsRequest = { [key: string]: any };
@@ -6453,6 +6455,9 @@ export namespace controllers {
     platformReportStats: (
       params?: messages.AdminPlatformReportStatsRequest,
     ) => Promise<messages.AdminPlatformReportStatsResponse>;
+    setCronJobEnabled: (
+      params?: messages.AdminSetCronJobEnabledRequest,
+    ) => Promise<messages.AdminSetCronJobEnabledResponse>;
     setMaintenanceMode: (
       params?: messages.AdminSetMaintenanceModeRequest,
     ) => Promise<messages.AdminSetMaintenanceModeResponse>;


### PR DESCRIPTION
# Description

`Admin::apiSetCronJobEnabled`, a system admin only endpoint that flips `Cron_Jobs.enabled`. a disabled job skips its scheduled runs, so this is the switch behind turning a job off without a deploy. it takes the job name and the new value, refuses a name that is not in the registry, and returns ok.

the endpoint is small and stands on its own, so it is here rather than inside the dashboard pull request that uses it. nothing calls it yet, the switch that does is in #10048.

part of #10047.

# Comments

split out of #10048 so the server side can be reviewed and merged without waiting on the ui, the same way #10149 was split out of #10069. this one is based straight on main and does not depend on the rerun chain.

`api.ts`, `api_types.ts`, `Controllers/README.md` and `www/docs/Controllers.md` are the linter's output, not hand written.

the name is validated by looking the row up rather than against `\OmegaUp\CronJobName`, because the row is what gets updated and the registry can hold jobs the enum does not name yet.

what i ran: `CronControlPlaneAdminTest` under phpunit, 12 tests green, and `./stuff/lint.sh`, clean.

# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
