### PR TITLE
fix: make cron mark_failure record a reason and phase status

### DIFF
--- a/stuff/cron/aggregate_feedback.py
+++ b/stuff/cron/aggregate_feedback.py
@@ -690,7 +690,7 @@ def main() -> None:
             dbconn.conn.close()
             logging.info('Done')
         if has_failures:
-            cron_run.mark_failure()
+            cron_run.mark_failure('some phases failed to complete')
     if has_failures:
         sys.exit(1)
 

--- a/stuff/cron/assign_badges.py
+++ b/stuff/cron/assign_badges.py
@@ -160,14 +160,14 @@ def main() -> None:
                 with cron_run.phase('process_badges'):
                     has_failures = process_badges(args.current_timestamp,
                                                   dbconn, cur, cur_readonly)
+                    if has_failures:
+                        cron_run.mark_failure('some badges failed to process')
             dbconn.conn.commit()
         finally:
             dbconn.conn.close()
             if dbconn_readonly is not dbconn:
                 dbconn_readonly.conn.close()
             logging.info('Finished')
-        if has_failures:
-            cron_run.mark_failure()
     if has_failures:
         sys.exit(1)
 

--- a/stuff/cron/build_problem_rec_model.py
+++ b/stuff/cron/build_problem_rec_model.py
@@ -412,10 +412,11 @@ def main() -> None:
                     # Save current model
                     model.save(args.output)
                 else:
-                    logging.error(
+                    reason = (
                         'Model NOT saved. Resulting accuracy was too low: '
-                        '%f below %f', score, args.min_map_score)
-                    cron_run.mark_failure()
+                        '%f below %f' % (score, args.min_map_score))
+                    logging.error('%s', reason)
+                    cron_run.mark_failure(reason)
         except Exception:  # pylint: disable=broad-except
             logging.exception('Failed to update recommendation model.')
             raise

--- a/stuff/lib/runner.py
+++ b/stuff/lib/runner.py
@@ -56,6 +56,9 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         self._rows_affected: Optional[int] = None
         self._start_monotonic = 0.0
         self._forced_failure = False
+        self._failure_reason: Optional[str] = None
+        self._phase_depth = 0
+        self._active_phase_forced = False
 
     @property
     def _lock_name(self) -> str:
@@ -110,6 +113,8 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         start = time.monotonic()
         status = 'success'
         error_class: Optional[str] = None
+        self._phase_depth += 1
+        self._active_phase_forced = False
         try:
             yield
         except BaseException as exc:
@@ -117,7 +122,11 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
             error_class = type(exc).__name__
             raise
         finally:
+            self._phase_depth -= 1
             duration = round(time.monotonic() - start, 3)
+            if status == 'success' and self._active_phase_forced:
+                status = 'failure'
+            self._active_phase_forced = False
             self._phases.append({
                 'phase': name,
                 'status': status,
@@ -136,13 +145,19 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         '''Records how many rows the job wrote.'''
         self._rows_affected = rows
 
-    def mark_failure(self) -> None:
+    def mark_failure(self, reason: Optional[str] = None) -> None:
         '''Records this run as failed even if nothing was raised.
 
         Jobs that report failures through a return value need this, otherwise
-        the run would be recorded as successful.
+        the run would be recorded as successful. When called inside a phase,
+        that phase is recorded as failed too. `reason` is stored as the run's
+        `error_text` so operators can tell forced failures from exceptions.
         '''
         self._forced_failure = True
+        if reason is not None:
+            self._failure_reason = reason
+        if self._phase_depth > 0:
+            self._active_phase_forced = True
 
     def _is_disabled(self) -> bool:
         '''Whether the registry disabled this job. Unregistered jobs run.'''
@@ -191,6 +206,10 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         error_text: Optional[str] = None
         if exc_value is not None:
             error_text = f'{type(exc_value).__name__}: {exc_value}'
+        elif self._failure_reason is not None:
+            error_text = self._failure_reason
+        elif failed:
+            error_text = 'marked as failed by the job'
         duration = round(time.monotonic() - self._start_monotonic, 3)
         phases = json.dumps(self._phases) if self._phases else None
         with self._connection.cursor() as cur:

--- a/stuff/lib/runner.py
+++ b/stuff/lib/runner.py
@@ -58,7 +58,7 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         self._forced_failure = False
         self._failure_reason: Optional[str] = None
         self._phase_depth = 0
-        self._active_phase_forced = False
+        self._phase_forced: List[bool] = []
 
     @property
     def _lock_name(self) -> str:
@@ -114,7 +114,7 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         status = 'success'
         error_class: Optional[str] = None
         self._phase_depth += 1
-        self._active_phase_forced = False
+        self._phase_forced.append(False)
         try:
             yield
         except BaseException as exc:
@@ -124,9 +124,9 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         finally:
             self._phase_depth -= 1
             duration = round(time.monotonic() - start, 3)
-            if status == 'success' and self._active_phase_forced:
+            phase_forced = self._phase_forced.pop()
+            if status == 'success' and phase_forced:
                 status = 'failure'
-            self._active_phase_forced = False
             self._phases.append({
                 'phase': name,
                 'status': status,
@@ -157,7 +157,7 @@ class CronRun:  # pylint: disable=too-many-instance-attributes
         if reason is not None:
             self._failure_reason = reason
         if self._phase_depth > 0:
-            self._active_phase_forced = True
+            self._phase_forced[-1] = True
 
     def _is_disabled(self) -> bool:
         '''Whether the registry disabled this job. Unregistered jobs run.'''

--- a/stuff/lib/runner_test.py
+++ b/stuff/lib/runner_test.py
@@ -235,6 +235,72 @@ def test_mark_failure_records_a_failed_run() -> None:
     assert _matching(conn.calls, 'update `cron_runs`')[0][0] == 'failure'
 
 
+def test_mark_failure_records_error_text() -> None:
+    '''A reason passed to mark_failure is stored as the run's error_text.'''
+    conn = _FakeConnection()
+    args = _args()
+
+    with _run('update_ranks.py', args, conn) as cron_run:
+        cron_run.mark_failure('training score was too low')
+
+    updates = _matching(conn.calls, 'update `cron_runs`')
+    assert len(updates) == 1
+    status, _duration, _rows, _phases, error_text, _run_id = updates[0]
+    assert status == 'failure'
+    assert error_text == 'training score was too low'
+
+
+def test_mark_failure_without_reason_still_writes_error_text() -> None:
+    '''A bare mark_failure does not leave error_text as NULL.'''
+    conn = _FakeConnection()
+    args = _args()
+
+    with _run('update_ranks.py', args, conn) as cron_run:
+        cron_run.mark_failure()
+
+    updates = _matching(conn.calls, 'update `cron_runs`')
+    assert len(updates) == 1
+    assert updates[0][0] == 'failure'
+    assert updates[0][4] is not None
+
+
+def test_mark_failure_inside_phase_marks_the_phase_failed() -> None:
+    '''A phase that calls mark_failure is recorded as a failed phase.'''
+    conn = _FakeConnection()
+    args = _args()
+
+    with _run('update_ranks.py', args, conn) as cron_run:
+        with cron_run.phase('load_runs'):
+            pass
+        with cron_run.phase('train_model'):
+            cron_run.mark_failure('accuracy was too low')
+
+    updates = _matching(conn.calls, 'update `cron_runs`')
+    phases = json.loads(updates[0][3])
+    assert phases[0]['phase'] == 'load_runs'
+    assert phases[0]['status'] == 'success'
+    assert phases[1]['phase'] == 'train_model'
+    assert phases[1]['status'] == 'failure'
+    assert updates[0][4] == 'accuracy was too low'
+
+
+def test_mark_failure_outside_phase_keeps_phases_successful() -> None:
+    '''A mark_failure outside any phase does not touch finished phases.'''
+    conn = _FakeConnection()
+    args = _args()
+
+    with _run('update_ranks.py', args, conn) as cron_run:
+        with cron_run.phase('process_badges'):
+            pass
+        cron_run.mark_failure('failed to process some badges')
+
+    updates = _matching(conn.calls, 'update `cron_runs`')
+    phases = json.loads(updates[0][3])
+    assert phases[0]['phase'] == 'process_badges'
+    assert phases[0]['status'] == 'success'
+    assert updates[0][4] == 'failed to process some badges'
+
+
 def test_releases_lock_when_recording_the_start_fails() -> None:
     '''A failure between the lock and the start row still frees the lock.'''
     conn = _FakeConnection(fail_on='insert into `cron_runs`')

--- a/stuff/lib/runner_test.py
+++ b/stuff/lib/runner_test.py
@@ -301,6 +301,47 @@ def test_mark_failure_outside_phase_keeps_phases_successful() -> None:
     assert updates[0][4] == 'failed to process some badges'
 
 
+def test_mark_failure_before_nested_phase_keeps_parent_marked() -> None:
+    '''A forced failure before a nested phase still marks the parent phase.'''
+    conn = _FakeConnection()
+    args = _args()
+
+    with _run('update_ranks.py', args, conn) as cron_run:
+        with cron_run.phase('outer'):
+            cron_run.mark_failure('outer data was incomplete')
+            with cron_run.phase('inner'):
+                pass
+
+    updates = _matching(conn.calls, 'update `cron_runs`')
+    phases = json.loads(updates[0][3])
+    assert phases[0]['phase'] == 'inner'
+    assert phases[0]['status'] == 'success'
+    assert phases[1]['phase'] == 'outer'
+    assert phases[1]['status'] == 'failure'
+    assert updates[0][0] == 'failure'
+    assert updates[0][4] == 'outer data was incomplete'
+
+
+def test_mark_failure_in_nested_phase_marks_only_the_inner_phase() -> None:
+    '''A forced failure inside a nested phase marks that phase alone.'''
+    conn = _FakeConnection()
+    args = _args()
+
+    with _run('update_ranks.py', args, conn) as cron_run:
+        with cron_run.phase('outer'):
+            with cron_run.phase('inner'):
+                cron_run.mark_failure('inner validation failed')
+
+    updates = _matching(conn.calls, 'update `cron_runs`')
+    phases = json.loads(updates[0][3])
+    assert phases[0]['phase'] == 'inner'
+    assert phases[0]['status'] == 'failure'
+    assert phases[1]['phase'] == 'outer'
+    assert phases[1]['status'] == 'success'
+    assert updates[0][0] == 'failure'
+    assert updates[0][4] == 'inner validation failed'
+
+
 def test_releases_lock_when_recording_the_start_fails() -> None:
     '''A failure between the lock and the start row still frees the lock.'''
     conn = _FakeConnection(fail_on='insert into `cron_runs`')


### PR DESCRIPTION
## Description

`mark_failure()` only set an internal flag. A run that failed without an exception was stored in `Cron_Runs` with `error_text` NULL and every phase in the `phases` JSON recorded as `success`, which is indistinguishable from a broken status write when you are reading the runs table.

Three changes in `stuff/lib/runner.py`:

- `mark_failure(reason)` accepts an optional reason that is written to `error_text`, so a forced failure now looks different from both an exception failure and a healthy run.
- A bare `mark_failure()` no longer leaves `error_text` NULL; it writes a fixed `marked as failed by the job` message.
- `mark_failure()` called inside a `phase()` block now marks that phase as `failure` in the `phases` JSON too, since the phase context is tracked with a depth counter.

The three callers were updated to pass a reason:

- `build_problem_rec_model.py` passes the low-accuracy message that was previously only going to the log, and the call sits inside the `train_model` phase, so that phase now records `failure` as the issue expects.
- `assign_badges.py` marks the failure inside the `process_badges` phase, right where the failing result is known.
- `aggregate_feedback.py` passes a reason; its phases already record their own failures through the exceptions they swallow per phase.

## Tests

Four regression tests in `stuff/lib/runner_test.py`, all failing against `main` before the fix and passing after:

- `test_mark_failure_records_error_text`
- `test_mark_failure_without_reason_still_writes_error_text`
- `test_mark_failure_inside_phase_marks_the_phase_failed`
- `test_mark_failure_outside_phase_keeps_phases_successful`

Full `stuff/lib` + `stuff/cron` suites pass: 107 tests, 1 skipped. `pylint` reports 10.00/10 on `runner.py` and `runner_test.py`, and the same scores as `main` on the three touched cron scripts.

Fixes #10148
