### PR TITLE
fix: query Identities instead of User_Rank in getUserIdsByUsername

### DIFF
--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -143,15 +143,30 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         }
         // Create placeholders (?, ?, ?) for each username
         $placeholders = implode(',', array_fill(0, count($usernames), '?'));
-        $sql = "SELECT user_id FROM User_Rank WHERE username IN ({$placeholders})";
+        // `Identities` is the canonical username -> user_id mapping and
+        // contains every registered user, including admins, private
+        // users, and users who have only ever created problems.
+        // `User_Rank` is a denormalized cache populated only from users
+        // with at least one AC solution, so querying it here caused the
+        // `author=` filter to silently drop for everyone else.
+        $sql = "SELECT user_id FROM Identities WHERE username IN ({$placeholders})";
 
-        /** @var list<array{user_id: int}> */
+        /** @var list<array{user_id: int|null}> */
         $results = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             $usernames
         );
 
-        return array_map(fn($row) => intval($row['user_id']), $results);
+        return array_map(
+            fn($row) => intval($row['user_id']),
+            // Some identities are not linked to a Users row yet
+            // (`Identities.user_id` is nullable); those cannot own
+            // problems and must be skipped.
+            array_filter(
+                $results,
+                fn($row) => !is_null($row['user_id'])
+            )
+        );
     }
 
     /**
@@ -560,6 +575,13 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
                     'pa_acl.owner_id IN (' . $placeholders . ')',
                     $authorUserIds,
                 ];
+            } else {
+                // Every requested author username failed to resolve to a
+                // user id. This can only happen when the username does
+                // not exist in `Identities`; an empty result set is the
+                // correct answer rather than silently dropping the
+                // filter and returning every visible problem.
+                $clauses[] = ['0 = 1', []];
             }
         }
 

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -157,16 +157,16 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
             $usernames
         );
 
-        return array_map(
+        // Some identities are not linked to a Users row yet
+        // (`Identities.user_id` is nullable); those cannot own
+        // problems and must be skipped.
+        return array_values(array_map(
             fn($row) => intval($row['user_id']),
-            // Some identities are not linked to a Users row yet
-            // (`Identities.user_id` is nullable); those cannot own
-            // problems and must be skipped.
             array_filter(
                 $results,
                 fn($row) => !is_null($row['user_id'])
             )
-        );
+        ));
     }
 
     /**

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -149,24 +149,15 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         // `User_Rank` is a denormalized cache populated only from users
         // with at least one AC solution, so querying it here caused the
         // `author=` filter to silently drop for everyone else.
-        $sql = "SELECT user_id FROM Identities WHERE username IN ({$placeholders})";
+        $sql = "SELECT user_id FROM Identities WHERE username IN ({$placeholders}) AND user_id IS NOT NULL";
 
-        /** @var list<array{user_id: int|null}> */
-        $results = \OmegaUp\MySQLConnection::getInstance()->GetAll(
-            $sql,
-            $usernames
-        );
-
-        // Some identities are not linked to a Users row yet
-        // (`Identities.user_id` is nullable); those cannot own
-        // problems and must be skipped.
-        return array_values(array_map(
+        return array_map(
             fn($row) => intval($row['user_id']),
-            array_filter(
-                $results,
-                fn($row) => !is_null($row['user_id'])
+            \OmegaUp\MySQLConnection::getInstance()->GetAll(
+                $sql,
+                $usernames
             )
-        ));
+        );
     }
 
     /**

--- a/frontend/server/src/DAO/Problems.php
+++ b/frontend/server/src/DAO/Problems.php
@@ -151,12 +151,15 @@ class Problems extends \OmegaUp\DAO\Base\Problems {
         // `author=` filter to silently drop for everyone else.
         $sql = "SELECT user_id FROM Identities WHERE username IN ({$placeholders}) AND user_id IS NOT NULL";
 
+        /** @var list<array{user_id: int|null}> */
+        $results = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+            $sql,
+            $usernames
+        );
+
         return array_map(
             fn($row) => intval($row['user_id']),
-            \OmegaUp\MySQLConnection::getInstance()->GetAll(
-                $sql,
-                $usernames
-            )
+            $results
         );
     }
 

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -1989,4 +1989,82 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
             $this->assertSame('parameterNotInExpectedSet', $e->getMessage());
         }
     }
+
+    /**
+     * Regression test for #10160: authors that are not present in
+     * `User_Rank` (e.g. admins, users who only create problems, private
+     * users) must still filter the problem list correctly when used as
+     * the `author` parameter. The previous implementation queried
+     * `User_Rank` and silently dropped the filter when no rows matched.
+     */
+    public function testAuthorFilterWorksForUsersAbsentFromUserRank() {
+        // Author that has never solved a problem, so they will be
+        // missing from the denormalized `User_Rank` table.
+        ['identity' => $author] = \OmegaUp\Test\Factories\User::createUser(
+            new \OmegaUp\Test\Factories\UserParams(
+                ['username' => 'author_without_solutions']
+            )
+        );
+        // A second author that has solved at least one problem, so they
+        // would be present in `User_Rank` and serve as a control.
+        ['identity' => $otherAuthor] = \OmegaUp\Test\Factories\User::createUser();
+        $otherRunData = \OmegaUp\Test\Factories\Run::createRunToProblem(
+            \OmegaUp\Test\Factories\Problem::createProblem(),
+            $otherAuthor
+        );
+        \OmegaUp\Test\Factories\Run::gradeRun($otherRunData);
+
+        $ownProblem = \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'visibility' => 'promoted',
+                'author' => $author,
+            ])
+        );
+        $otherProblem = \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'visibility' => 'promoted',
+                'author' => $otherAuthor,
+            ])
+        );
+
+        $response = \OmegaUp\Controllers\Problem::apiList(
+            new \OmegaUp\Request([
+                'author' => 'author_without_solutions',
+            ])
+        );
+        $aliases = array_column($response['results'], 'alias');
+        $this->assertContains(
+            $ownProblem['request']['problem_alias'],
+            $aliases
+        );
+        $this->assertNotContains(
+            $otherProblem['request']['problem_alias'],
+            $aliases
+        );
+    }
+
+    /**
+     * Regression test for #10160: when the `author` parameter refers to
+     * a username that does not exist in the platform, the problem list
+     * must be empty rather than silently returning every visible
+     * problem. The previous implementation queried `User_Rank` and the
+     * empty result caused the WHERE clause to be omitted entirely.
+     */
+    public function testAuthorFilterWithNonexistentUsernameReturnsEmpty() {
+        // Seed at least one visible problem so we can tell the filter
+        // is actually being applied rather than the platform having
+        // no problems at all.
+        \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'visibility' => 'promoted',
+            ])
+        );
+
+        $response = \OmegaUp\Controllers\Problem::apiList(
+            new \OmegaUp\Request([
+                'author' => 'definitely_does_not_exist',
+            ])
+        );
+        $this->assertEmpty($response['results']);
+    }
 }

--- a/frontend/tests/controllers/ProblemListTest.php
+++ b/frontend/tests/controllers/ProblemListTest.php
@@ -2005,25 +2005,21 @@ class ProblemListTest extends \OmegaUp\Test\ControllerTestCase {
                 ['username' => 'author_without_solutions']
             )
         );
-        // A second author that has solved at least one problem, so they
-        // would be present in `User_Rank` and serve as a control.
+        // A second author with a promoted problem of their own so the
+        // test detects a silently dropped `author` filter: if the filter
+        // is dropped, both problems leak into the results.
         ['identity' => $otherAuthor] = \OmegaUp\Test\Factories\User::createUser();
-        $otherRunData = \OmegaUp\Test\Factories\Run::createRunToProblem(
-            \OmegaUp\Test\Factories\Problem::createProblem(),
-            $otherAuthor
+        $otherProblem = \OmegaUp\Test\Factories\Problem::createProblem(
+            new \OmegaUp\Test\Factories\ProblemParams([
+                'visibility' => 'promoted',
+                'author' => $otherAuthor,
+            ])
         );
-        \OmegaUp\Test\Factories\Run::gradeRun($otherRunData);
 
         $ownProblem = \OmegaUp\Test\Factories\Problem::createProblem(
             new \OmegaUp\Test\Factories\ProblemParams([
                 'visibility' => 'promoted',
                 'author' => $author,
-            ])
-        );
-        $otherProblem = \OmegaUp\Test\Factories\Problem::createProblem(
-            new \OmegaUp\Test\Factories\ProblemParams([
-                'visibility' => 'promoted',
-                'author' => $otherAuthor,
             ])
         );
 


### PR DESCRIPTION
## Description

`getUserIdsByUsername()` in `DAO/Problems.php` was translating usernames to `user_id` by querying `User_Rank`, which is a denormalized cache populated only by `stuff/cron/update_ranks.py` from users that have at least one AC solution, are not private, and are not site admins. Any other user (admins, private users, users who only create problems) was simply absent from the table, so the function returned an empty array and the caller in `searchProblems` skipped the `author` filter entirely. The endpoint then returned every visible problem instead of the author's.

Two changes:

- The query now reads from `Identities`, the canonical username → `user_id` mapping that contains every registered user. Identities without a linked `Users` row are filtered out, since they cannot own anything.
- When authors are specified but resolve to no user_ids (e.g. the username does not exist at all), the search adds a never-true clause instead of silently dropping the filter. A nonexistent author now returns an empty problem list, as expected.

## Tests

Two regression tests in `frontend/tests/controllers/ProblemListTest.php`, both failing against `main` before the fix and passing after:

- `testAuthorFilterWorksForUsersAbsentFromUserRank` — creates an author who has never solved a problem (so they are absent from `User_Rank`), creates a second author who has, calls `apiList` with the first author's username, and asserts the result contains the first author's problem and not the second's. On `main` the second author's problem leaks into the results because the filter is silently dropped.
- `testAuthorFilterWithNonexistentUsernameReturnsEmpty` — seeds a visible problem, calls `apiList` with a username that does not exist, and asserts the result is empty. On `main` the seeded problem is returned.

Full `controllers/ProblemListTest.php` suite passes: 55 tests, 626 assertions. `controllers/ProblemListCourseTest.php` also passes (2 tests, 52 assertions). `phpcs` and `stuff/lint.sh validate --all` are clean on the changed files.

Fixes #10160
