### PR TITLE
feat: expose full tag distribution in profile statistics

### DIFF
--- a/frontend/server/src/Controllers/README.md
+++ b/frontend/server/src/Controllers/README.md
@@ -5631,6 +5631,12 @@ types.UserProfileInfo;
 
 Get profile statistics including solved problems by difficulty and tags distribution.
 
+`tags` is the capped distribution: at most 10 entries, with every
+remaining tag aggregated into a single 'Others' entry. `tagsFull` is
+the complete distribution with no cap and no aggregation, so `tags` is
+not simply a subset of `tagsFull`: the tail entries are merged into
+the 'Others' entry instead of appearing on their own.
+
 ### Parameters
 
 | Name       | Type           | Description | Required |
@@ -5644,7 +5650,8 @@ Get profile statistics including solved problems by difficulty and tags distribu
 | `attempting` | `number`                                                              |
 | `difficulty` | `{ easy: number; hard: number; medium: number; unlabelled: number; }` |
 | `solved`     | `number`                                                              |
-| `tags`       | `List[{ count: number; name: string; }]`                              |
+| `tags`       | `List[types.TagDistribution]`                                         |
+| `tagsFull`   | `List[types.TagDistribution]`                                         |
 
 ## `/api/user/removeExperiment/`
 

--- a/frontend/server/src/Controllers/User.php
+++ b/frontend/server/src/Controllers/User.php
@@ -7,6 +7,7 @@ namespace OmegaUp\Controllers;
  *
  * @psalm-type PageItem=array{class: string, label: string, page: int, url?: string}
  * @psalm-type AuthorsRank=array{ranking: list<array{author_ranking: int|null, author_score: float, classname: string, country_id: null|string, name: null|string, username: string}>, total: int}
+ * @psalm-type TagDistribution=array{name: string, count: int}
  * @psalm-type AuthorRankTablePayload=array{length: int, page: int, ranking: AuthorsRank, pagerItems: list<PageItem>}
  * @psalm-type Badge=array{assignation_time: \OmegaUp\Timestamp|null, badge_alias: string, first_assignation: \OmegaUp\Timestamp|null, owners_count: int, total_users: int}
  * @psalm-type ApiToken=array{name: string, timestamp: \OmegaUp\Timestamp, last_used: \OmegaUp\Timestamp, rate_limit: array{reset: \OmegaUp\Timestamp, limit: int, remaining: int}}
@@ -2381,9 +2382,15 @@ class User extends \OmegaUp\Controllers\Controller {
     /**
      * Get profile statistics including solved problems by difficulty and tags distribution.
      *
+     * `tags` is the capped distribution: at most 10 entries, with every
+     * remaining tag aggregated into a single 'Others' entry. `tagsFull` is
+     * the complete distribution with no cap and no aggregation, so `tags` is
+     * not simply a subset of `tagsFull`: the tail entries are merged into
+     * the 'Others' entry instead of appearing on their own.
+     *
      * @throws \OmegaUp\Exceptions\ForbiddenAccessException
      *
-     * @return array{solved: int, attempting: int, difficulty: array{easy: int, medium: int, hard: int, unlabelled: int}, tags: list<array{name: string, count: int}>}
+     * @return array{solved: int, attempting: int, difficulty: array{easy: int, medium: int, hard: int, unlabelled: int}, tags: list<TagDistribution>, tagsFull: list<TagDistribution>}
      *
      * @omegaup-request-param null|string $username
      */
@@ -2412,8 +2419,11 @@ class User extends \OmegaUp\Controllers\Controller {
         $attemptingCount = \OmegaUp\DAO\Problems::getAttemptingCount(
             $identity->identity_id
         );
-        $tagsDistribution = \OmegaUp\DAO\ProblemsTags::getTagsDistributionForSolvedProblems(
+        $tagsFullDistribution = \OmegaUp\DAO\ProblemsTags::getTagsDistributionForSolvedProblems(
             $identity->identity_id
+        );
+        $tagsDistribution = \OmegaUp\DAO\ProblemsTags::capTagsDistribution(
+            $tagsFullDistribution
         );
 
         return [
@@ -2426,6 +2436,7 @@ class User extends \OmegaUp\Controllers\Controller {
                 'unlabelled' => $difficultyStats['unlabelled'],
             ],
             'tags' => $tagsDistribution,
+            'tagsFull' => $tagsFullDistribution,
         ];
     }
 

--- a/frontend/server/src/DAO/ProblemsTags.php
+++ b/frontend/server/src/DAO/ProblemsTags.php
@@ -79,15 +79,49 @@ class ProblemsTags extends \OmegaUp\DAO\Base\ProblemsTags {
     }
 
     /**
-     * Get tag distribution for problems solved by an identity.
-     * Returns tags sorted by count descending.
-     * If there are more than $maxTags, the remaining tags are grouped under 'Others'.
+     * Derive the capped tag distribution from the full one: the first
+     * $maxTags entries are kept as is, and the remaining tags are
+     * aggregated into a single 'Others' entry.
+     *
+     * @param list<array{name: string, count: int}> $allTags
+     *
+     * @return list<array{name: string, count: int}>
+     */
+    public static function capTagsDistribution(
+        array $allTags,
+        int $maxTags = 10
+    ): array {
+        if (count($allTags) <= $maxTags) {
+            return $allTags;
+        }
+
+        $topTags = array_slice($allTags, 0, $maxTags);
+        $othersCount = 0;
+        foreach (array_slice($allTags, $maxTags) as $tag) {
+            $othersCount += $tag['count'];
+        }
+
+        if ($othersCount > 0) {
+            $topTags[] = [
+                'name' => 'Others',
+                'count' => $othersCount,
+            ];
+        }
+
+        return $topTags;
+    }
+
+    /**
+     * Get the full tag distribution for problems solved by an identity:
+     * every public, non-meta tag with its solved count, sorted by count
+     * descending, then by tag name. The capped variant with the remaining
+     * tags grouped under 'Others' can be derived from this list with
+     * capTagsDistribution().
      *
      * @return list<array{name: string, count: int}>
      */
     public static function getTagsDistributionForSolvedProblems(
-        int $identityId,
-        int $maxTags = 10
+        int $identityId
     ): array {
         $sql = "
             SELECT
@@ -125,33 +159,12 @@ class ProblemsTags extends \OmegaUp\DAO\Base\ProblemsTags {
         ";
 
         /** @var list<array{count: int, name: string}> */
-        $allTags = \OmegaUp\MySQLConnection::getInstance()->GetAll(
+        $rows = \OmegaUp\MySQLConnection::getInstance()->GetAll(
             $sql,
             [$identityId]
         );
 
-        // If there are fewer or equal tags than the limit, return as is
-        if (count($allTags) <= $maxTags) {
-            return $allTags;
-        }
-
-        // Take the top N tags and group the rest under 'Others'
-        $topTags = array_slice($allTags, 0, $maxTags);
-        $remainingTags = array_slice($allTags, $maxTags);
-
-        $othersCount = 0;
-        foreach ($remainingTags as $tag) {
-            $othersCount += $tag['count'];
-        }
-
-        if ($othersCount > 0) {
-            $topTags[] = [
-                'name' => 'Others',
-                'count' => $othersCount,
-            ];
-        }
-
-        return $topTags;
+        return $rows;
     }
 
     public static function clearRestrictedTags(\OmegaUp\DAO\VO\Problems $problem): void {

--- a/frontend/tests/controllers/UserProfileStatisticsTest.php
+++ b/frontend/tests/controllers/UserProfileStatisticsTest.php
@@ -230,7 +230,7 @@ class UserProfileStatisticsTest extends \OmegaUp\Test\ControllerTestCase {
     }
 
     /**
-     * Test profile statistics throws NotFoundException for non-existent user
+     * Test that profile statistics throws NotFoundException for non-existent user
      */
     public function testProfileStatisticsUserNotFound() {
         ['identity' => $identity] = \OmegaUp\Test\Factories\User::createUser();
@@ -247,5 +247,170 @@ class UserProfileStatisticsTest extends \OmegaUp\Test\ControllerTestCase {
         } catch (\OmegaUp\Exceptions\NotFoundException $e) {
             $this->assertSame('userNotExist', $e->getMessage());
         }
+    }
+
+    /**
+     * A user with more than the $maxTags cap of public tags should still
+     * see all of them in tagsFull, while tags keeps the top-10-plus-Others shape.
+     */
+    public function testProfileStatisticsTagsFullExposesAllTags() {
+        ['identity' => $solver] = \OmegaUp\Test\Factories\User::createUser();
+
+        $tagNames = [
+            'problemTagGreedyAlgorithms',
+            'problemTagDynamicProgramming',
+            'problemTagBinarySearch',
+            'problemTagHashing',
+            'problemTagTries',
+            'problemTagBruteForce',
+            'problemTagBacktracking',
+            'problemTagLocalSearch',
+            'problemTagDivideAndConquer',
+            'problemTagMemorization',
+            'problemTagSubArraySearch',
+            'problemTagSubsequenceSearch',
+        ];
+        foreach ($tagNames as $tagName) {
+            $problem = \OmegaUp\Test\Factories\Problem::createProblem();
+            \OmegaUp\Test\Factories\Problem::addTag(
+                $problem,
+                $tagName,
+                public: true,
+            );
+            $login = self::login($solver);
+            $run = \OmegaUp\Test\Factories\Run::createRunToProblem(
+                $problem,
+                $solver,
+                $login,
+            );
+            \OmegaUp\Test\Factories\Run::gradeRun($run);
+        }
+
+        $login = self::login($solver);
+        $response = \OmegaUp\Controllers\User::apiProfileStatistics(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ])
+        );
+
+        $this->assertArrayHasKey('tags', $response);
+        $this->assertArrayHasKey('tagsFull', $response);
+
+        $this->assertCount(
+            count($tagNames),
+            $response['tagsFull'],
+        );
+        $returnedFullNames = array_map(
+            fn ($t) => $t['name'],
+            $response['tagsFull'],
+        );
+        foreach ($tagNames as $expected) {
+            $this->assertContains($expected, $returnedFullNames);
+        }
+
+        $this->assertCount(11, $response['tags']);
+        $cappedNames = array_map(
+            fn ($t) => $t['name'],
+            $response['tags'],
+        );
+        $this->assertContains('Others', $cappedNames);
+        $this->assertCount(
+            10,
+            array_values(array_filter(
+                $cappedNames,
+                fn ($name) => $name !== 'Others',
+            )),
+        );
+    }
+
+    /**
+     * tagsFull must be sorted by count descending so the front-end can
+     * render an initial sort without an extra server round-trip.
+     */
+    public function testProfileStatisticsTagsFullSortedByCount() {
+        ['identity' => $solver] = \OmegaUp\Test\Factories\User::createUser();
+
+        $tagsBySolved = [
+            'problemTagGreedyAlgorithms' => 1,
+            'problemTagDynamicProgramming' => 5,
+            'problemTagBinarySearch' => 3,
+        ];
+        foreach ($tagsBySolved as $tagName => $numSolved) {
+            for ($j = 0; $j < $numSolved; $j++) {
+                $problem = \OmegaUp\Test\Factories\Problem::createProblem();
+                \OmegaUp\Test\Factories\Problem::addTag(
+                    $problem,
+                    $tagName,
+                    public: true,
+                );
+                $login = self::login($solver);
+                $run = \OmegaUp\Test\Factories\Run::createRunToProblem(
+                    $problem,
+                    $solver,
+                    $login,
+                );
+                \OmegaUp\Test\Factories\Run::gradeRun($run);
+            }
+        }
+
+        $login = self::login($solver);
+        $response = \OmegaUp\Controllers\User::apiProfileStatistics(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ])
+        );
+
+        $counts = array_map(
+            fn ($t) => $t['count'],
+            $response['tagsFull'],
+        );
+        $sorted = $counts;
+        rsort($sorted);
+        $this->assertSame($sorted, $counts);
+    }
+
+    /**
+     * When two tags have the same count, the distribution must break
+     * the tie alphabetically by tag name.
+     */
+    public function testProfileStatisticsTagsFullTieBreaksByName() {
+        ['identity' => $solver] = \OmegaUp\Test\Factories\User::createUser();
+
+        $tagsBySolved = [
+            'problemTagDynamicProgramming' => 2,
+            'problemTagBinarySearch' => 2,
+        ];
+        foreach ($tagsBySolved as $tagName => $numSolved) {
+            for ($j = 0; $j < $numSolved; $j++) {
+                $problem = \OmegaUp\Test\Factories\Problem::createProblem();
+                \OmegaUp\Test\Factories\Problem::addTag(
+                    $problem,
+                    $tagName,
+                    public: true,
+                );
+                $login = self::login($solver);
+                $run = \OmegaUp\Test\Factories\Run::createRunToProblem(
+                    $problem,
+                    $solver,
+                    $login,
+                );
+                \OmegaUp\Test\Factories\Run::gradeRun($run);
+            }
+        }
+
+        $login = self::login($solver);
+        $response = \OmegaUp\Controllers\User::apiProfileStatistics(
+            new \OmegaUp\Request([
+                'auth_token' => $login->auth_token,
+            ])
+        );
+
+        $this->assertSame(
+            [
+                ['name' => 'problemTagBinarySearch', 'count' => 2],
+                ['name' => 'problemTagDynamicProgramming', 'count' => 2],
+            ],
+            $response['tagsFull'],
+        );
     }
 }

--- a/frontend/www/js/omegaup/api_types.ts
+++ b/frontend/www/js/omegaup/api_types.ts
@@ -5183,6 +5183,11 @@ export namespace types {
     name: string;
   }
 
+  export interface TagDistribution {
+    count: number;
+    name: string;
+  }
+
   export interface TagWithProblemCount {
     name: string;
     problemCount: number;
@@ -6429,7 +6434,8 @@ export namespace messages {
       unlabelled: number;
     };
     solved: number;
-    tags: { count: number; name: string }[];
+    tags: types.TagDistribution[];
+    tagsFull: types.TagDistribution[];
   };
   export type UserRemoveExperimentRequest = { [key: string]: any };
   export type UserRemoveExperimentResponse = {};


### PR DESCRIPTION
## Summary

The profile statistics API only exposed a capped tag distribution (top 10 with the rest folded into 'Others'). This adds `tagsFull` with the complete distribution so clients can render every tag without losing the tail.

- `apiProfileStatistics` now returns both `tags` (capped, unchanged) and `tagsFull` (complete).
- The DAO fetches the full list once via `getTagsDistributionForSolvedProblems`, and the new `capTagsDistribution` derives the capped variant with the 'Others' grouping, so the query runs only once per request.
- The `TagDistribution` psalm type alias documents the shared shape, and the docblock spells out the `tags`/`tagsFull` semantic difference.

Part of #10138

## Test plan

- [x] PHPUnit: `UserProfileStatisticsTest` covers the new payload field, the capped shape with 10 entries plus 'Others', and the alphabetical tie-break for equal counts (10 tests, 138 assertions)
- [x] Psalm passes with no errors
- [x] `api_types.ts` and the controllers README regenerated through the api linter

The UI half of the original change (the chart/table toggle in `TagsSolvedChart`, its translations and its Jest tests) will follow in a separate PR so each part stays reviewable on its own.