### PR TITLE
fix: allow more time for the arena problem link to appear in cypress helper

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -279,7 +279,9 @@ Cypress.Commands.add(
         return;
       }
       cy.visit(`/arena/${contestAlias}/#problems`);
-      cy.get(`a[data-problem="${problem.problemAlias}"]`).click();
+      cy.get(`a[data-problem="${problem.problemAlias}"]`, {
+        timeout: 10000,
+      }).click();
 
       // Mocking date just a few seconds after to allow create new run
       cy.clock(new Date(), ['Date']).then((clock) => clock.tick(9000));


### PR DESCRIPTION
The arena navbar renders the problem links only after the contest details request comes back, so right after `cy.visit` the `a[data-problem]` element is not in the DOM yet. The lookup in `createRunsInsideContest` used the default 4 second command timeout, which turned into a race against the backend under CI load and showed up as intermittent failures across the cypress matrix.

The same helper already waits up to 10 seconds for the language selector a few lines below, so the problem link now gets the same window:

```ts
cy.get(`a[data-problem="${problem.problemAlias}"]`, { timeout: 10000 }).click();
```

No behavioral change on a healthy run; the extra window only matters when the backend is slow to answer.

Testing: exercised the helper through the contest specs that call `createRunsInsideContest` against a local stack; passes consistently.

Fixes #10161
