### PR TITLE
Add user follow relationship schema with follower and followed identity references

### DIFF
--- a/frontend/database/00283_create_user_followers_table.sql
+++ b/frontend/database/00283_create_user_followers_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `User_Connections` (
+  `follower_id` int NOT NULL AUTO_INCREMENT,
+  `follower_identity_id` int NOT NULL,
+  `followed_identity_id` int NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`follower_id`),
+  UNIQUE KEY `unique_follow_relationship` (`follower_identity_id`, `followed_identity_id`),
+  KEY `idx_follower_identity_id` (`follower_identity_id`),
+  KEY `idx_followed_identity_id` (`followed_identity_id`),
+  CONSTRAINT `fk_follower_identity_id` FOREIGN KEY (`follower_identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_followed_identity_id` FOREIGN KEY (`followed_identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Stores user follow relationships for the Friends/Following system';

--- a/frontend/database/schema.sql
+++ b/frontend/database/schema.sql
@@ -1389,6 +1389,21 @@ CREATE TABLE `Teams_Group_Roles` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `User_Connections` (
+  `follower_id` int NOT NULL AUTO_INCREMENT,
+  `follower_identity_id` int NOT NULL,
+  `followed_identity_id` int NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`follower_id`),
+  UNIQUE KEY `unique_follow_relationship` (`follower_identity_id`,`followed_identity_id`),
+  KEY `idx_follower_identity_id` (`follower_identity_id`),
+  KEY `idx_followed_identity_id` (`followed_identity_id`),
+  CONSTRAINT `fk_followed_identity_id` FOREIGN KEY (`followed_identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_follower_identity_id` FOREIGN KEY (`follower_identity_id`) REFERENCES `Identities` (`identity_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Stores user follow relationships for the Friends/Following system';
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `User_Rank` (
   `user_id` int NOT NULL,
   `ranking` int DEFAULT NULL,


### PR DESCRIPTION

# Description

This adds the user connection table.

It stores who follows whom, prevents duplicate follows, and links to identities so we can quickly check followers and following relationships.

Part of: #8683 


# Checklist:

- [x] The code follows the [coding guidelines](https://github.com/omegaup/omegaup/blob/main/frontend/www/docs/Coding-guidelines.md) of omegaUp.
- [ ] The tests were executed and all of them passed.
- [ ] If you are creating a feature, the new tests were added.
- [ ] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit,  and then another Pull Request for UI + tests in Jest, Cypress or both.
