### PR TITLE
Fix getPlaceSuffix to handle 111/112/113 and beyond

### DIFF
--- a/frontend/server/src/Controllers/Certificate.php
+++ b/frontend/server/src/Controllers/Certificate.php
@@ -377,11 +377,24 @@ class Certificate extends \OmegaUp\Controllers\Controller {
         }
         return base64_encode($output);
     }
-
+    /**
+     * Returns the ordinal suffix (st/nd/rd/th) for a given place number,
+     * e.g. 1 -> "st", 2 -> "nd", 3 -> "rd", 4 -> "th", 11 -> "th".
+     *
+     * Numbers ending in 11, 12, or 13 always use "th", regardless of
+     * hundreds/thousands digits (11, 12, 13, 111, 112, 113, 211, 212,
+     * 213, ...). This is checked via $n % 100 rather than $n directly,
+     * since checking $n directly only caught literal 11-13 and
+     * incorrectly fell through to "st"/"nd"/"rd" for 111, 112, 113, etc.
+     *
+     * @see CertificatesTest::testGetPlaceSuffixTeensException() in
+     *      frontend/tests/controllers/CertificatesTest.php for the
+     *      regression test covering this fix.
+     */
     public static function getPlaceSuffix(int $n): string {
         $translator = \OmegaUp\Translations::getInstance();
-
-        if ($n >= 11 && $n <= 13) {
+        
+        if ($n % 100 >= 11 && $n % 100 <= 13) {
             return $translator->get('certificatePdfContestPlaceTh');
         }
 

--- a/frontend/tests/controllers/CertificatesTest.php
+++ b/frontend/tests/controllers/CertificatesTest.php
@@ -414,4 +414,46 @@ class CertificatesTest extends \OmegaUp\Test\ControllerTestCase {
             );
         }
     }
+
+    /**
+     * getPlaceSuffix() should append the correct ordinal suffix
+     * (st/nd/rd/th) for a contest placement number.
+     *
+     * The test forces English via the "lang" request var and resets the
+     * Translations singleton, because in Spanish (the default test
+     * locale) all four ordinal suffixes collapse to the same string
+     * ("° lugar"), which would make this bug undetectable.
+     */
+    public function testGetPlaceSuffixTeensException() {
+        // In Spanish, all four ordinal suffixes collapse to the same text ("° lugar").
+        // So this bug is literally invisible to a test that only compares Spanish output.
+        $_REQUEST['lang'] = 'en';
+        $reflection = new \ReflectionClass(\OmegaUp\Translations::class);
+        $instanceProperty = $reflection->getProperty('_instance');
+        $instanceProperty->setAccessible(true);
+        $instanceProperty->setValue(null, null);
+
+        $translator = \OmegaUp\Translations::getInstance();
+        $th = $translator->get('certificatePdfContestPlaceTh');
+        $st = $translator->get('certificatePdfContestPlaceSt');
+        $nd = $translator->get('certificatePdfContestPlaceNd');
+        $rd = $translator->get('certificatePdfContestPlaceRd');
+
+        // Numbers ending in 11, 12, or 13 (in any hundred) must always use "th"
+        $this->assertSame($th, \OmegaUp\Controllers\Certificate::getPlaceSuffix(11));
+        $this->assertSame($th, \OmegaUp\Controllers\Certificate::getPlaceSuffix(12));
+        $this->assertSame($th, \OmegaUp\Controllers\Certificate::getPlaceSuffix(13));
+        $this->assertSame($th, \OmegaUp\Controllers\Certificate::getPlaceSuffix(111));
+        $this->assertSame($th, \OmegaUp\Controllers\Certificate::getPlaceSuffix(112));
+        $this->assertSame($th, \OmegaUp\Controllers\Certificate::getPlaceSuffix(113));
+
+        // Regular numbers should still follow st/nd/rd/th correctly
+        $this->assertSame($st, \OmegaUp\Controllers\Certificate::getPlaceSuffix(1));
+        $this->assertSame($st, \OmegaUp\Controllers\Certificate::getPlaceSuffix(101));
+        $this->assertSame($nd, \OmegaUp\Controllers\Certificate::getPlaceSuffix(2));
+        $this->assertSame($nd, \OmegaUp\Controllers\Certificate::getPlaceSuffix(102));
+        $this->assertSame($rd, \OmegaUp\Controllers\Certificate::getPlaceSuffix(3));
+        $this->assertSame($rd, \OmegaUp\Controllers\Certificate::getPlaceSuffix(103));
+        $this->assertSame($st, \OmegaUp\Controllers\Certificate::getPlaceSuffix(21));
+    }
 }


### PR DESCRIPTION
# Description
`Certificate::getPlaceSuffix()` decides the ordinal suffix (st/nd/rd/th) shown on contest certificates based on a contestant's placement number. The special case for "th" only checked if the number itself was between 11 and 13 (`$n >= 11 && $n <= 13`), so it correctly handled placements 11, 12, and 13, but incorrectly fell through to the regular `%10` logic for any other number ending in 11, 12, or 13 — such as 111, 112, 113, 211, 212, 213, etc. This produced incorrect output like "111st" and "112nd" instead of "111th" and "112th".

The fix checks `$n % 100` instead of `$n` directly, so the "th" exception correctly applies to any number whose last two digits are 11, 12, or 13, regardless of the hundreds/thousands digits.

A regression test (`testGetPlaceSuffixTeensException`) was added to `CertificatesTest.php`, covering both the teens exception (11, 12, 13, 111, 112, 113) and normal cases (1, 2, 3, 21, 101, 102, 103) to confirm the fix doesn't break standard st/nd/rd behavior.

Fixes: #10191

# Comments
The test forces English via the `lang` request variable and resets the `Translations` singleton before asserting, because in Spanish (the default test locale) all four ordinal suffix translations collapse to the same string ("° lugar"), which would make this bug undetectable through translated output alone.

# Checklist:
- [x] The code follows the coding guidelines of omegaUp.
- [x] The tests were executed and all of them passed.
- [x] If you are creating a feature, the new tests were added.
- [x] If the change is large (> 200 lines), this PR was split into various Pull Requests. It's preferred to create one PR for changes in controllers + unit tests in PHPUnit, and then another Pull Request for UI + tests in Jest, Cypress or both.

<details>
<summary>Test output (click to expand)</summary>

**Before the fix (failing):**
<img width="505" height="190" alt="starter test" src="https://github.com/user-attachments/assets/96cfc2ff-4b8a-4aa9-88b2-df7e234c3c2e" />


**After the fix (passing):**
<img width="505" height="78" alt="particular test result" src="https://github.com/user-attachments/assets/44a3546c-bf85-4692-a135-8f95841f47ff" />

</details>

All 7 existing tests in `CertificatesTest.php` still pass with this change.